### PR TITLE
Render Copilot comments explicitly in PR context template

### DIFF
--- a/.github/pr-agent-context-template.md
+++ b/.github/pr-agent-context-template.md
@@ -9,6 +9,7 @@ Repository focus:
 
 {{ opening_instructions }}
 
+{{ copilot_comments_section }}
 {{ review_comments_section }}
 {{ failing_checks_section }}
 {{ patch_coverage_section }}


### PR DESCRIPTION
## Summary
- add the dedicated `copilot_comments_section` placeholder to the repo's custom `pr-agent-context` template
- keep Copilot comments rendered ahead of the general review-comments section
- stop relying on legacy-template fallback behavior for this PR branch

## Testing
- template-only change