### PR TITLE
Implement deterministic single-source ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ planning objects inside version control instead of rebuilding context from scrat
 ## Status
 
 This repository is in the bootstrap phase. Milestone 0 is established and the earliest Milestone 1
-surface is implemented:
+surface plus the first deterministic Milestone 2 ingest path are implemented:
 
 - Python package scaffold with `src/` layout and a minimal CLI
 - `splendor init` for repository layout creation
 - `splendor add-source <path>` for deterministic source registration
+- `splendor ingest <source-id>` for deterministic single-source ingestion into `wiki/sources/`
 - Pydantic schema foundations for source, wiki, planning, queue, and run records
 - unit tests, linting, coverage, pre-commit, and GitHub Actions automation
 
 Not implemented yet:
 
-- ingestion pipeline
 - OCR and derived extraction workflows
 - query engine
 - planning-object creation commands
@@ -65,6 +65,12 @@ uv run splendor init
 uv run splendor add-source docs/splendor_product_spec.md
 ```
 
+### Ingest a registered source
+
+```bash
+uv run splendor ingest <source-id>
+```
+
 ### Run checks
 
 ```bash
@@ -86,13 +92,15 @@ uv run pre-commit run --all-files
 - `src/splendor/commands/init.py` creates the baseline Splendor layout safely and idempotently
 - `src/splendor/commands/add_source.py` registers immutable source files and writes validated
   source manifests
+- `src/splendor/commands/ingest.py` performs deterministic single-source ingestion and writes queue,
+  run, and wiki updates
 - `src/splendor/schemas/` defines the initial schema contracts
 - `.github/workflows/` contains CI, PR context, autofix-trigger, and weekly repo-review workflows
 
 ## What comes next
 
-The next milestone should add one-source-at-a-time ingestion with queue items, run records, and
-basic wiki updates rooted in the registered source manifests created here.
+The next milestone should expand deterministic ingestion into pending-queue draining, then layer on
+query and planning-object CLI support.
 
 ## Additional documentation
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -63,10 +63,15 @@ renderers and CLI creation commands.
 
 ## Queue and run records
 
-The runtime contracts are drafted now even though the execution engine is intentionally deferred.
+The runtime contracts are now used by deterministic single-source ingestion.
 
 - `QueueItemRecord` captures item lifecycle, retries, and leases.
 - `RunRecord` captures pipeline inputs, outputs, warnings, and failures.
+
+Current persisted locations:
+
+- `state/queue/<job_id>.json`
+- `state/runs/<run_id>.json`
 
 ## Current storage decision
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -6,6 +6,7 @@ import argparse
 from pathlib import Path
 
 from splendor.commands.add_source import add_source
+from splendor.commands.ingest import ingest_source
 from splendor.commands.init import initialize_workspace
 
 
@@ -25,6 +26,10 @@ def build_parser() -> argparse.ArgumentParser:
     add_source_parser = subparsers.add_parser("add-source", help="Register a new immutable source")
     add_source_parser.add_argument("path", type=Path, help="Path to the source file to register")
     add_source_parser.set_defaults(handler=handle_add_source)
+
+    ingest_parser = subparsers.add_parser("ingest", help="Ingest a registered source into the wiki")
+    ingest_parser.add_argument("source_id", help="Registered source identifier to ingest")
+    ingest_parser.set_defaults(handler=handle_ingest)
     return parser
 
 
@@ -45,6 +50,27 @@ def handle_add_source(args: argparse.Namespace) -> int:
     print(f"{action} source {result.source_id}")
     print(f"Manifest: {result.manifest_path}")
     print(f"Stored copy: {result.stored_path}")
+    return 0
+
+
+def handle_ingest(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = ingest_source(root, args.source_id)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    if result.no_op:
+        print(f"Source {result.source_id} is already ingested for the current pipeline version")
+        print(f"Page: {result.page_path}")
+        return 0
+
+    print(f"Ingested source {result.source_id}")
+    print(f"Run: {result.run_id}")
+    print(f"Page: {result.page_path}")
+    print(f"Queue record: {result.queue_path}")
+    print(f"Run record: {result.run_path}")
     return 0
 
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -57,7 +57,7 @@ def handle_ingest(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     try:
         result = ingest_source(root, args.source_id)
-    except (FileNotFoundError, ValueError) as exc:
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
         print(f"Error: {exc}")
         return 1
 

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -1,0 +1,316 @@
+"""Implementation for `splendor ingest`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from splendor import __version__
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord, SourceRecord
+from splendor.state.runtime import (
+    load_queue_item,
+    load_run_record,
+    queue_item_path_for,
+    run_record_path_for,
+    write_queue_item,
+    write_run_record,
+)
+from splendor.state.source_registry import (
+    load_source_record,
+    manifest_path_for,
+    resolve_manifest_storage_path,
+    validate_stored_source_location,
+    write_source_record,
+)
+from splendor.utils.hashing import sha256_file
+from splendor.utils.time import utc_now_iso
+from splendor.utils.wiki import (
+    WikiUpdatePayload,
+    append_log_entry,
+    apply_wiki_updates,
+    render_source_summary_page,
+    update_index_content,
+)
+
+SUPPORTED_SOURCE_TYPES = {
+    "md",
+    "txt",
+    "json",
+    "yaml",
+    "yml",
+    "py",
+    "js",
+    "ts",
+    "tsx",
+    "rs",
+    "go",
+    "java",
+    "c",
+    "cpp",
+    "h",
+    "hpp",
+    "sh",
+}
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    source_id: str
+    run_id: str | None
+    queue_path: Path | None
+    run_path: Path | None
+    page_path: Path | None
+    no_op: bool
+
+
+def _make_run_id(source_id: str) -> str:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+    return f"run-{source_id}-{stamp}"
+
+
+def _relative_to_root(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _page_path_for(layout_root: Path, source_id: str) -> Path:
+    return layout_root / f"{source_id}.md"
+
+
+def _build_extract(text: str) -> str:
+    lines = text.splitlines()
+    start_index = 0
+    for index, line in enumerate(lines):
+        if line.strip():
+            start_index = index
+            break
+
+    extract_lines: list[str] = []
+    char_count = 0
+    for line in lines[start_index : start_index + 80]:
+        projected_count = char_count + len(line) + 1
+        if projected_count > 4000 and extract_lines:
+            break
+        extract_lines.append(line)
+        char_count = projected_count
+
+    return "\n".join(extract_lines).rstrip()
+
+
+def _build_summary(source: SourceRecord) -> str:
+    path_fragment = source.original_path or source.path
+    return (
+        f"This page records deterministic ingestion output for source `{source.source_id}`, "
+        f"a `{source.source_type}` file registered from `{path_fragment}`."
+    )
+
+
+def _is_no_op(root: Path, layout, source: SourceRecord) -> bool:
+    if source.status != "ingested" or not source.last_run_id:
+        return False
+
+    page_relpath = f"wiki/sources/{source.source_id}.md"
+    if page_relpath not in source.linked_pages:
+        return False
+
+    page_path = root / page_relpath
+    if not page_path.exists():
+        return False
+
+    run_path = layout.runs_dir / f"{source.last_run_id}.json"
+    if not run_path.exists():
+        return False
+
+    run = load_run_record(run_path)
+    return run.status == "succeeded" and run.pipeline_version == __version__
+
+
+def ingest_source(root: Path, source_id: str) -> IngestResult:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    manifest_path = manifest_path_for(root, source_id)
+    if not manifest_path.exists():
+        msg = f"Unknown source ID: {source_id}"
+        raise FileNotFoundError(msg)
+
+    source = load_source_record(manifest_path)
+    if source.source_id != source_id:
+        msg = f"Source manifest ID does not match requested source: {source_id}"
+        raise ValueError(msg)
+
+    stored_path = resolve_manifest_storage_path(root, source.path)
+    validate_stored_source_location(
+        stored_path,
+        layout.raw_sources_dir,
+        source.source_id,
+        source.path,
+    )
+    if not stored_path.exists():
+        msg = f"Stored source copy is missing: {stored_path}"
+        raise FileNotFoundError(msg)
+    if sha256_file(stored_path) != source.checksum:
+        msg = f"Stored source checksum mismatch for ingestion: {stored_path}"
+        raise ValueError(msg)
+
+    if _is_no_op(root, layout, source):
+        return IngestResult(
+            source_id=source_id,
+            run_id=None,
+            queue_path=None,
+            run_path=None,
+            page_path=layout.wiki_sources_dir / f"{source_id}.md",
+            no_op=True,
+        )
+
+    now = utc_now_iso()
+    job_id = f"ingest-{source_id}"
+    queue_path = queue_item_path_for(layout, job_id)
+    existing_queue = load_queue_item(queue_path) if queue_path.exists() else None
+    attempt_count = 1 if existing_queue is None else existing_queue.attempt_count + 1
+    queue_item = QueueItemRecord(
+        job_id=job_id,
+        job_type="ingest_source",
+        status="pending",
+        created_at=now if existing_queue is None else existing_queue.created_at,
+        updated_at=now,
+        attempt_count=attempt_count,
+        max_attempts=3,
+        payload_ref=_relative_to_root(root, manifest_path),
+        last_error=None,
+    )
+    write_queue_item(queue_path, queue_item)
+
+    run_id = _make_run_id(source_id)
+    run_path = run_record_path_for(layout, run_id)
+    run = RunRecord(
+        run_id=run_id,
+        job_id=job_id,
+        job_type="ingest_source",
+        started_at=now,
+        status="running",
+        input_refs=[_relative_to_root(root, manifest_path), source.path],
+        pipeline_version=__version__,
+    )
+    write_run_record(run_path, run)
+
+    try:
+        if source.source_type not in SUPPORTED_SOURCE_TYPES:
+            msg = f"Unsupported source type for ingestion: {source.source_type}"
+            raise ValueError(msg)
+
+        try:
+            source_text = stored_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            msg = f"Source file is not valid UTF-8 text: {stored_path}"
+            raise ValueError(msg) from exc
+
+        page_path = _page_path_for(layout.wiki_sources_dir, source_id)
+        page_relpath = _relative_to_root(root, page_path)
+        frontmatter = KnowledgePageFrontmatter(
+            kind="source-summary",
+            title=source.title,
+            page_id=source_id,
+            status="active",
+            source_refs=[source_id],
+            generated_by_run_ids=[run_id],
+            confidence=1.0,
+            tags=["source-summary", source.source_type],
+        )
+        page_content = render_source_summary_page(
+            frontmatter,
+            source_section="\n".join(
+                [
+                    f"- Source ID: `{source.source_id}`",
+                    f"- Source type: `{source.source_type}`",
+                    f"- Registered path: `{source.original_path or source.path}`",
+                ]
+            ),
+            summary=_build_summary(source),
+            key_facts=[
+                f"Source ID: `{source.source_id}`",
+                f"Source type: `{source.source_type}`",
+                f"Checksum: `{source.checksum}`",
+                f"Original path: `{source.original_path or source.path}`",
+                f"Added at: `{source.added_at}`",
+                f"Ingested at: `{now}`",
+            ],
+            extract=_build_extract(source_text),
+            provenance=[
+                f"Manifest: `{_relative_to_root(root, manifest_path)}`",
+                f"Stored source: `{source.path}`",
+                f"Run ID: `{run_id}`",
+                f"Pipeline version: `{__version__}`",
+            ],
+        )
+        index_content = update_index_content(
+            layout.index_file.read_text(encoding="utf-8"),
+            source_id=source_id,
+            title=source.title,
+            page_name=page_path.name,
+        )
+        log_entry = (
+            f"- {now} Ingested source `{source_id}` via run `{run_id}` into `{page_relpath}`."
+        )
+        log_content = append_log_entry(layout.log_file.read_text(encoding="utf-8"), log_entry)
+        apply_wiki_updates(
+            layout,
+            WikiUpdatePayload(
+                page_path=page_path,
+                page_content=page_content,
+                index_content=index_content,
+                log_content=log_content,
+            ),
+        )
+
+        updated_source = source.model_copy(
+            update={
+                "status": "ingested",
+                "last_run_id": run_id,
+                "linked_pages": sorted(set([*source.linked_pages, page_relpath])),
+            }
+        )
+        write_source_record(manifest_path, updated_source)
+        run = run.model_copy(
+            update={
+                "finished_at": utc_now_iso(),
+                "status": "succeeded",
+                "output_refs": [
+                    page_relpath,
+                    _relative_to_root(root, layout.index_file),
+                    _relative_to_root(root, layout.log_file),
+                ],
+            }
+        )
+        write_run_record(run_path, run)
+        queue_item = queue_item.model_copy(update={"status": "done", "updated_at": utc_now_iso()})
+        write_queue_item(queue_path, queue_item)
+        return IngestResult(
+            source_id=source_id,
+            run_id=run_id,
+            queue_path=queue_path,
+            run_path=run_path,
+            page_path=page_path,
+            no_op=False,
+        )
+    except Exception as exc:
+        failed_source = source.model_copy(update={"status": "failed", "last_run_id": run_id})
+        write_source_record(manifest_path, failed_source)
+        failed_run = run.model_copy(
+            update={
+                "finished_at": utc_now_iso(),
+                "status": "failed",
+                "errors": [str(exc)],
+            }
+        )
+        write_run_record(run_path, failed_run)
+        failed_queue = queue_item.model_copy(
+            update={
+                "status": "failed",
+                "updated_at": utc_now_iso(),
+                "last_error": str(exc),
+            }
+        )
+        write_queue_item(queue_path, failed_queue)
+        raise

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -341,7 +341,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
                 "linked_pages": sorted(set([*source.linked_pages, page_relpath])),
             }
         )
-        run = run.model_copy(
+        success_run = run.model_copy(
             update={
                 "finished_at": utc_now_iso(),
                 "status": "succeeded",
@@ -358,7 +358,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
             manifest_path=manifest_path,
             success_source=updated_source,
             run_path=run_path,
-            success_run=run,
+            success_run=success_run,
             queue_path=queue_path,
             success_queue=queue_item,
             wiki_payload=WikiUpdatePayload(

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -111,11 +111,11 @@ def _is_no_op(root: Path, layout, source: SourceRecord) -> bool:
     if source.status != "ingested" or not source.last_run_id:
         return False
 
-    page_relpath = f"wiki/sources/{source.source_id}.md"
+    page_path = _page_path_for(layout.wiki_sources_dir, source.source_id)
+    page_relpath = _relative_to_root(root, page_path)
     if page_relpath not in source.linked_pages:
         return False
 
-    page_path = root / page_relpath
     if not page_path.exists():
         return False
 
@@ -127,9 +127,88 @@ def _is_no_op(root: Path, layout, source: SourceRecord) -> bool:
     return run.status == "succeeded" and run.pipeline_version == __version__
 
 
+def _validate_workspace_files(layout) -> None:
+    required_files = [layout.index_file, layout.log_file]
+    missing = [path for path in required_files if not path.exists()]
+    if missing:
+        joined = ", ".join(str(path) for path in missing)
+        msg = f"Workspace is missing required wiki files: {joined}. Run `splendor init`."
+        raise RuntimeError(msg)
+
+
+def _mark_attempt_failed(
+    *,
+    queue_path: Path,
+    queue_item: QueueItemRecord,
+    run_path: Path,
+    run: RunRecord,
+    error_message: str,
+    manifest_path: Path | None = None,
+    source: SourceRecord | None = None,
+    run_id: str | None = None,
+) -> None:
+    failed_run = run.model_copy(
+        update={
+            "finished_at": utc_now_iso(),
+            "status": "failed",
+            "errors": [error_message],
+        }
+    )
+    write_run_record(run_path, failed_run)
+    failed_queue = queue_item.model_copy(
+        update={
+            "status": "failed",
+            "updated_at": utc_now_iso(),
+            "last_error": error_message,
+        }
+    )
+    write_queue_item(queue_path, failed_queue)
+    if manifest_path is not None and source is not None and run_id is not None:
+        failed_source = source.model_copy(update={"status": "failed", "last_run_id": run_id})
+        write_source_record(manifest_path, failed_source)
+
+
+def _commit_success(
+    *,
+    layout,
+    manifest_path: Path,
+    success_source: SourceRecord,
+    run_path: Path,
+    success_run: RunRecord,
+    queue_path: Path,
+    success_queue: QueueItemRecord,
+    wiki_payload: WikiUpdatePayload,
+) -> None:
+    tracked_paths = [
+        manifest_path,
+        run_path,
+        queue_path,
+        wiki_payload.page_path,
+        layout.index_file,
+        layout.log_file,
+    ]
+    previous_content: dict[Path, str | None] = {}
+    for path in tracked_paths:
+        previous_content[path] = path.read_text(encoding="utf-8") if path.exists() else None
+
+    try:
+        apply_wiki_updates(layout, wiki_payload)
+        write_source_record(manifest_path, success_source)
+        write_run_record(run_path, success_run)
+        write_queue_item(queue_path, success_queue)
+    except Exception:
+        for path, content in previous_content.items():
+            if content is None:
+                path.unlink(missing_ok=True)
+            else:
+                path.write_text(content, encoding="utf-8")
+        raise
+
+
 def ingest_source(root: Path, source_id: str) -> IngestResult:
     config = load_config(root)
     layout = resolve_layout(root, config)
+    _validate_workspace_files(layout)
     manifest_path = manifest_path_for(root, source_id)
     if not manifest_path.exists():
         msg = f"Unknown source ID: {source_id}"
@@ -254,16 +333,6 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
             f"- {now} Ingested source `{source_id}` via run `{run_id}` into `{page_relpath}`."
         )
         log_content = append_log_entry(layout.log_file.read_text(encoding="utf-8"), log_entry)
-        apply_wiki_updates(
-            layout,
-            WikiUpdatePayload(
-                page_path=page_path,
-                page_content=page_content,
-                index_content=index_content,
-                log_content=log_content,
-            ),
-        )
-
         updated_source = source.model_copy(
             update={
                 "status": "ingested",
@@ -283,9 +352,22 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
                 ],
             }
         )
-        write_run_record(run_path, run)
         queue_item = queue_item.model_copy(update={"status": "done", "updated_at": utc_now_iso()})
-        write_queue_item(queue_path, queue_item)
+        _commit_success(
+            layout=layout,
+            manifest_path=manifest_path,
+            success_source=updated_source,
+            run_path=run_path,
+            success_run=run,
+            queue_path=queue_path,
+            success_queue=queue_item,
+            wiki_payload=WikiUpdatePayload(
+                page_path=page_path,
+                page_content=page_content,
+                index_content=index_content,
+                log_content=log_content,
+            ),
+        )
         return IngestResult(
             source_id=source_id,
             run_id=run_id,
@@ -294,23 +376,24 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
             page_path=page_path,
             no_op=False,
         )
-    except Exception as exc:
-        failed_source = source.model_copy(update={"status": "failed", "last_run_id": run_id})
-        write_source_record(manifest_path, failed_source)
-        failed_run = run.model_copy(
-            update={
-                "finished_at": utc_now_iso(),
-                "status": "failed",
-                "errors": [str(exc)],
-            }
+    except ValueError as exc:
+        _mark_attempt_failed(
+            queue_path=queue_path,
+            queue_item=queue_item,
+            run_path=run_path,
+            run=run,
+            error_message=str(exc),
+            manifest_path=manifest_path,
+            source=source,
+            run_id=run_id,
         )
-        write_run_record(run_path, failed_run)
-        failed_queue = queue_item.model_copy(
-            update={
-                "status": "failed",
-                "updated_at": utc_now_iso(),
-                "last_error": str(exc),
-            }
-        )
-        write_queue_item(queue_path, failed_queue)
         raise
+    except Exception as exc:
+        _mark_attempt_failed(
+            queue_path=queue_path,
+            queue_item=queue_item,
+            run_path=run_path,
+            run=run,
+            error_message=str(exc),
+        )
+        raise RuntimeError(f"Ingestion failed while committing outputs: {exc}") from exc

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -25,6 +25,7 @@ from splendor.state.source_registry import (
     validate_stored_source_location,
     write_source_record,
 )
+from splendor.utils.fs import write_text_atomic
 from splendor.utils.hashing import sha256_file
 from splendor.utils.time import utc_now_iso
 from splendor.utils.wiki import (
@@ -201,7 +202,7 @@ def _commit_success(
             if content is None:
                 path.unlink(missing_ok=True)
             else:
-                path.write_text(content, encoding="utf-8")
+                write_text_atomic(path, content)
         raise
 
 
@@ -217,20 +218,6 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
     source = load_source_record(manifest_path)
     if source.source_id != source_id:
         msg = f"Source manifest ID does not match requested source: {source_id}"
-        raise ValueError(msg)
-
-    stored_path = resolve_manifest_storage_path(root, source.path)
-    validate_stored_source_location(
-        stored_path,
-        layout.raw_sources_dir,
-        source.source_id,
-        source.path,
-    )
-    if not stored_path.exists():
-        msg = f"Stored source copy is missing: {stored_path}"
-        raise FileNotFoundError(msg)
-    if sha256_file(stored_path) != source.checksum:
-        msg = f"Stored source checksum mismatch for ingestion: {stored_path}"
         raise ValueError(msg)
 
     if _is_no_op(root, layout, source):
@@ -275,6 +262,20 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
     write_run_record(run_path, run)
 
     try:
+        stored_path = resolve_manifest_storage_path(root, source.path)
+        validate_stored_source_location(
+            stored_path,
+            layout.raw_sources_dir,
+            source.source_id,
+            source.path,
+        )
+        if not stored_path.exists():
+            msg = f"Stored source copy is missing: {stored_path}"
+            raise ValueError(msg)
+        if sha256_file(stored_path) != source.checksum:
+            msg = f"Stored source checksum mismatch for ingestion: {stored_path}"
+            raise ValueError(msg)
+
         if source.source_type not in SUPPORTED_SOURCE_TYPES:
             msg = f"Unsupported source type for ingestion: {source.source_type}"
             raise ValueError(msg)
@@ -340,7 +341,6 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
                 "linked_pages": sorted(set([*source.linked_pages, page_relpath])),
             }
         )
-        write_source_record(manifest_path, updated_source)
         run = run.model_copy(
             update={
                 "finished_at": utc_now_iso(),

--- a/src/splendor/layout.py
+++ b/src/splendor/layout.py
@@ -13,7 +13,7 @@ This wiki is maintained by Splendor.
 
 ## Navigation
 
-- `wiki/sources/` for source summary pages once ingestion starts.
+- `wiki/sources/` for deterministic source summary pages.
 - `planning/` for milestones, tasks, decisions, and questions.
 - `state/` for machine-readable queue, run, and manifest records.
 """
@@ -51,6 +51,18 @@ class ResolvedLayout:
     @property
     def log_file(self) -> Path:
         return self.wiki_dir / "log.md"
+
+    @property
+    def wiki_sources_dir(self) -> Path:
+        return self.wiki_dir / "sources"
+
+    @property
+    def queue_dir(self) -> Path:
+        return self.state_dir / "queue"
+
+    @property
+    def runs_dir(self) -> Path:
+        return self.state_dir / "runs"
 
 
 def resolve_layout(root: Path, config: SplendorConfig) -> ResolvedLayout:

--- a/src/splendor/state/runtime.py
+++ b/src/splendor/state/runtime.py
@@ -1,0 +1,44 @@
+"""Runtime record persistence for queue items and runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from splendor.layout import ResolvedLayout
+from splendor.schemas import QueueItemRecord, RunRecord
+from splendor.utils.fs import ensure_directory, write_text_atomic
+
+
+def queue_item_path_for(layout: ResolvedLayout, job_id: str) -> Path:
+    return layout.queue_dir / f"{job_id}.json"
+
+
+def run_record_path_for(layout: ResolvedLayout, run_id: str) -> Path:
+    return layout.runs_dir / f"{run_id}.json"
+
+
+def load_queue_item(path: Path) -> QueueItemRecord:
+    return QueueItemRecord.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def load_run_record(path: Path) -> RunRecord:
+    return RunRecord.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def write_queue_item(path: Path, record: QueueItemRecord) -> Path:
+    ensure_directory(path.parent)
+    write_text_atomic(
+        path,
+        json.dumps(record.model_dump(mode="json"), indent=2, sort_keys=True) + "\n",
+    )
+    return path
+
+
+def write_run_record(path: Path, record: RunRecord) -> Path:
+    ensure_directory(path.parent)
+    write_text_atomic(
+        path,
+        json.dumps(record.model_dump(mode="json"), indent=2, sort_keys=True) + "\n",
+    )
+    return path

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -10,7 +10,7 @@ from splendor import __version__
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import SourceRecord
-from splendor.utils.fs import copy_file_if_missing, ensure_directory
+from splendor.utils.fs import copy_file_if_missing, ensure_directory, write_text_atomic
 from splendor.utils.hashing import sha256_file
 from splendor.utils.ids import stable_source_id
 from splendor.utils.time import utc_now_iso
@@ -33,6 +33,14 @@ def manifest_path_for(root: Path, source_id: str) -> Path:
 
 def load_source_record(path: Path) -> SourceRecord:
     return SourceRecord.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def write_source_record(path: Path, record: SourceRecord) -> Path:
+    write_text_atomic(
+        path,
+        json.dumps(record.model_dump(mode="json"), indent=2, sort_keys=True) + "\n",
+    )
+    return path
 
 
 def resolve_manifest_storage_path(root: Path, stored_path_value: str) -> Path:
@@ -152,10 +160,7 @@ def register_source(root: Path, source_path: Path) -> RegisteredSource:
         pipeline_version=__version__,
         original_path=manifest_original_path(root, source_path),
     )
-    manifest_path.write_text(
-        json.dumps(record.model_dump(mode="json"), indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    write_source_record(manifest_path, record)
     return RegisteredSource(
         record=record,
         manifest_path=manifest_path,

--- a/src/splendor/utils/fs.py
+++ b/src/splendor/utils/fs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import tempfile
 from pathlib import Path
 
 
@@ -25,3 +26,17 @@ def copy_file_if_missing(source: Path, destination: Path) -> bool:
     destination.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(source, destination)
     return True
+
+
+def write_text_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        delete=False,
+    ) as handle:
+        handle.write(content)
+        temp_path = Path(handle.name)
+
+    temp_path.replace(path)

--- a/src/splendor/utils/fs.py
+++ b/src/splendor/utils/fs.py
@@ -39,4 +39,8 @@ def write_text_atomic(path: Path, content: str) -> None:
         handle.write(content)
         temp_path = Path(handle.name)
 
-    temp_path.replace(path)
+    try:
+        temp_path.replace(path)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise

--- a/src/splendor/utils/wiki.py
+++ b/src/splendor/utils/wiki.py
@@ -24,6 +24,20 @@ def render_frontmatter(record: KnowledgePageFrontmatter) -> str:
     return yaml.safe_dump(record.model_dump(mode="json"), sort_keys=False).strip()
 
 
+def _fenced_extract_block(extract: str) -> str:
+    max_backtick_run = 0
+    current_run = 0
+    for char in extract:
+        if char == "`":
+            current_run += 1
+            max_backtick_run = max(max_backtick_run, current_run)
+        else:
+            current_run = 0
+
+    fence = "`" * max(3, max_backtick_run + 1)
+    return f"{fence}text\n{extract}\n{fence}"
+
+
 def render_source_summary_page(
     frontmatter: KnowledgePageFrontmatter,
     *,
@@ -45,9 +59,7 @@ def render_source_summary_page(
         "## Key Facts\n\n"
         f"{key_fact_lines}\n\n"
         "## Extract\n\n"
-        "```text\n"
-        f"{extract}\n"
-        "```\n\n"
+        f"{_fenced_extract_block(extract)}\n\n"
         "## Provenance\n\n"
         f"{provenance_lines}\n"
     )

--- a/src/splendor/utils/wiki.py
+++ b/src/splendor/utils/wiki.py
@@ -1,0 +1,109 @@
+"""Deterministic wiki page and index/log writers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from splendor.layout import ResolvedLayout
+from splendor.schemas import KnowledgePageFrontmatter
+from splendor.utils.fs import write_text_atomic
+
+
+@dataclass(frozen=True)
+class WikiUpdatePayload:
+    page_path: Path
+    page_content: str
+    index_content: str
+    log_content: str
+
+
+def render_frontmatter(record: KnowledgePageFrontmatter) -> str:
+    return yaml.safe_dump(record.model_dump(mode="json"), sort_keys=False).strip()
+
+
+def render_source_summary_page(
+    frontmatter: KnowledgePageFrontmatter,
+    *,
+    source_section: str,
+    summary: str,
+    key_facts: list[str],
+    extract: str,
+    provenance: list[str],
+) -> str:
+    key_fact_lines = "\n".join(f"- {line}" for line in key_facts)
+    provenance_lines = "\n".join(f"- {line}" for line in provenance)
+    return (
+        f"---\n{render_frontmatter(frontmatter)}\n---\n\n"
+        f"# {frontmatter.title}\n\n"
+        "## Source\n\n"
+        f"{source_section}\n\n"
+        "## Summary\n\n"
+        f"{summary}\n\n"
+        "## Key Facts\n\n"
+        f"{key_fact_lines}\n\n"
+        "## Extract\n\n"
+        "```text\n"
+        f"{extract}\n"
+        "```\n\n"
+        "## Provenance\n\n"
+        f"{provenance_lines}\n"
+    )
+
+
+def update_index_content(index_content: str, *, source_id: str, title: str, page_name: str) -> str:
+    bullet = f"- [{title}](sources/{page_name}) (`{source_id}`)"
+    lines = index_content.rstrip().splitlines()
+    section_header = "## Sources"
+
+    try:
+        section_index = lines.index(section_header)
+    except ValueError:
+        lines.extend(["", section_header, "", bullet])
+        return "\n".join(lines) + "\n"
+
+    next_heading_index = len(lines)
+    for index in range(section_index + 1, len(lines)):
+        if lines[index].startswith("## "):
+            next_heading_index = index
+            break
+
+    existing_bullets = [
+        line
+        for line in lines[section_index + 1 : next_heading_index]
+        if line.startswith("- [") and f"(`{source_id}`)" not in line
+    ]
+    existing_bullets.append(bullet)
+    section_lines = ["", *sorted(existing_bullets)]
+    new_lines = lines[: section_index + 1] + section_lines + lines[next_heading_index:]
+    return "\n".join(new_lines).rstrip() + "\n"
+
+
+def append_log_entry(log_content: str, entry: str) -> str:
+    stripped = log_content.rstrip()
+    return f"{stripped}\n{entry}\n"
+
+
+def apply_wiki_updates(layout: ResolvedLayout, payload: WikiUpdatePayload) -> None:
+    targets = [
+        (payload.page_path, payload.page_content),
+        (layout.index_file, payload.index_content),
+        (layout.log_file, payload.log_content),
+    ]
+    previous_content: dict[Path, str | None] = {}
+
+    for path, _ in targets:
+        previous_content[path] = path.read_text(encoding="utf-8") if path.exists() else None
+
+    try:
+        for path, content in targets:
+            write_text_atomic(path, content)
+    except Exception:
+        for path, content in previous_content.items():
+            if content is None:
+                path.unlink(missing_ok=True)
+            else:
+                write_text_atomic(path, content)
+        raise

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,3 +55,44 @@ def test_cli_add_source_expands_user_paths(tmp_path: Path, capsys, monkeypatch) 
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "Registered source" in captured.out
+
+
+def test_cli_ingest_command(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+
+    manifest_paths = list((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source_id = manifest_paths[0].stem
+    exit_code = main(["--root", str(tmp_path), "ingest", source_id])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Ingested source" in captured.out
+
+
+def test_cli_ingest_command_no_op(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+
+    manifest_paths = list((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source_id = manifest_paths[0].stem
+    main(["--root", str(tmp_path), "ingest", source_id])
+    exit_code = main(["--root", str(tmp_path), "ingest", source_id])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "already ingested" in captured.out
+
+
+def test_cli_ingest_command_reports_missing_source(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "src-missing"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Unknown source ID" in captured.out

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -146,7 +146,9 @@ def test_ingest_source_rejects_unsupported_type(tmp_path: Path) -> None:
     run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
     assert load_queue_item(queue_path).status == "failed"
     assert len(run_paths) == 1
-    assert load_run_record(run_paths[0]).status == "failed"
+    run_record = load_run_record(run_paths[0])
+    assert run_record.status == "failed"
+    assert run_record.output_refs == []
     assert not (tmp_path / "wiki" / "sources" / f"{added.source_id}.md").exists()
 
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -111,6 +111,25 @@ def test_ingest_source_recreates_missing_page_without_duplicate_index_entries(
     assert log_content.count(f"Ingested source `{added.source_id}`") == 2
 
 
+def test_ingest_source_no_op_uses_configured_wiki_layout(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        "schema_version: '1'\nproject_name: custom\nlayout:\n  wiki_dir: knowledge\n",
+        encoding="utf-8",
+    )
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    first = ingest_source(tmp_path, added.source_id)
+    second = ingest_source(tmp_path, added.source_id)
+
+    assert first.page_path == tmp_path / "knowledge" / "sources" / f"{added.source_id}.md"
+    assert second.no_op is True
+    source_record = load_source_record(added.manifest_path)
+    assert f"knowledge/sources/{added.source_id}.md" in source_record.linked_pages
+
+
 def test_ingest_source_rejects_unsupported_type(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "diagram.bin"
@@ -150,6 +169,38 @@ def test_ingest_source_rejects_invalid_utf8_text(tmp_path: Path) -> None:
     assert load_run_record(run_paths[0]).status == "failed"
 
 
+def test_ingest_source_requires_workspace_index_file(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    (tmp_path / "wiki" / "index.md").unlink()
+
+    with pytest.raises(RuntimeError, match="missing required wiki files"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "registered"
+    assert list((tmp_path / "state" / "queue").glob("*.json")) == []
+    assert list((tmp_path / "state" / "runs").glob("*.json")) == []
+
+
+def test_ingest_source_requires_workspace_log_file(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    (tmp_path / "wiki" / "log.md").unlink()
+
+    with pytest.raises(RuntimeError, match="missing required wiki files"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "registered"
+    assert list((tmp_path / "state" / "queue").glob("*.json")) == []
+    assert list((tmp_path / "state" / "runs").glob("*.json")) == []
+
+
 def test_ingest_source_missing_source_id_does_not_create_runtime_state(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
 
@@ -171,3 +222,55 @@ def test_ingest_source_validates_stored_copy_checksum(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="Stored source checksum mismatch"):
         ingest_source(tmp_path, added.source_id)
+
+
+def test_ingest_source_extract_uses_safe_fence_for_backticks(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\n```python\nprint('hi')\n```\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    page_content = result.page_path.read_text(encoding="utf-8")
+    assert "````text" in page_content
+    assert "\n````\n\n## Provenance" in page_content
+
+
+def test_ingest_source_rolls_back_wiki_on_success_commit_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    original_index = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+    original_log = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
+
+    import splendor.commands.ingest as ingest_module
+
+    original_write_source_record = ingest_module.write_source_record
+
+    def fail_on_success_write(path: Path, record) -> Path:
+        if getattr(record, "status", None) == "ingested":
+            raise OSError("disk full")
+        return original_write_source_record(path, record)
+
+    monkeypatch.setattr(ingest_module, "write_source_record", fail_on_success_write)
+
+    with pytest.raises(RuntimeError, match="committing outputs"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "registered"
+    assert source_record.last_run_id is None
+    assert (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8") == original_index
+    assert (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8") == original_log
+    assert not (tmp_path / "wiki" / "sources" / f"{added.source_id}.md").exists()
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
+    assert load_queue_item(queue_path).status == "failed"
+    assert len(run_paths) == 1
+    assert load_run_record(run_paths[0]).status == "failed"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -223,6 +223,37 @@ def test_ingest_source_validates_stored_copy_checksum(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="Stored source checksum mismatch"):
         ingest_source(tmp_path, added.source_id)
 
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
+    assert load_queue_item(queue_path).status == "failed"
+    assert len(run_paths) == 1
+    assert load_run_record(run_paths[0]).status == "failed"
+
+
+def test_ingest_source_records_missing_stored_copy_as_failed_attempt(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    manifest = json.loads(added.manifest_path.read_text(encoding="utf-8"))
+    stored_path = tmp_path / manifest["path"]
+    stored_path.unlink()
+
+    with pytest.raises(ValueError, match="Stored source copy is missing"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
+    assert load_queue_item(queue_path).status == "failed"
+    assert len(run_paths) == 1
+    assert load_run_record(run_paths[0]).status == "failed"
+
 
 def test_ingest_source_extract_uses_safe_fence_for_backticks(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,173 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from splendor.commands.add_source import add_source
+from splendor.commands.ingest import ingest_source
+from splendor.commands.init import initialize_workspace
+from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord
+from splendor.state.runtime import load_queue_item, load_run_record
+from splendor.state.source_registry import load_source_record
+
+
+def parse_frontmatter(page_path: Path) -> tuple[KnowledgePageFrontmatter, str]:
+    raw = page_path.read_text(encoding="utf-8")
+    assert raw.startswith("---\n")
+    frontmatter_text, body = raw.removeprefix("---\n").split("\n---\n", maxsplit=1)
+    frontmatter = KnowledgePageFrontmatter.model_validate(yaml.safe_load(frontmatter_text))
+    return frontmatter, body
+
+
+def test_ingest_source_happy_path(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.no_op is False
+    assert result.page_path is not None and result.page_path.exists()
+    assert result.queue_path is not None and result.queue_path.exists()
+    assert result.run_path is not None and result.run_path.exists()
+
+    frontmatter, body = parse_frontmatter(result.page_path)
+    assert frontmatter.kind == "source-summary"
+    assert frontmatter.page_id == added.source_id
+    assert frontmatter.source_refs == [added.source_id]
+    assert frontmatter.generated_by_run_ids == [result.run_id]
+    assert frontmatter.confidence == 1.0
+    assert "## Source" in body
+    assert "## Summary" in body
+    assert "## Key Facts" in body
+    assert "## Extract" in body
+    assert "## Provenance" in body
+
+    queue_record = load_queue_item(result.queue_path)
+    assert isinstance(queue_record, QueueItemRecord)
+    assert queue_record.status == "done"
+    assert queue_record.job_type == "ingest_source"
+
+    run_record = load_run_record(result.run_path)
+    assert isinstance(run_record, RunRecord)
+    assert run_record.status == "succeeded"
+    assert result.page_path.relative_to(tmp_path).as_posix() in run_record.output_refs
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "ingested"
+    assert source_record.last_run_id == result.run_id
+    assert result.page_path.relative_to(tmp_path).as_posix() in source_record.linked_pages
+
+    index_content = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+    assert f"(`{added.source_id}`)" in index_content
+    log_content = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
+    assert added.source_id in log_content
+    assert result.run_id in log_content
+
+
+def test_ingest_source_is_idempotent_when_current_pipeline_already_succeeded(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    first = ingest_source(tmp_path, added.source_id)
+    second = ingest_source(tmp_path, added.source_id)
+
+    assert first.no_op is False
+    assert second.no_op is True
+    assert second.run_id is None
+    assert second.queue_path is None
+    assert len(list((tmp_path / "state" / "runs").glob("*.json"))) == 1
+    index_content = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+    assert index_content.count(f"(`{added.source_id}`)") == 1
+    log_content = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
+    assert log_content.count(f"Ingested source `{added.source_id}`") == 1
+
+
+def test_ingest_source_recreates_missing_page_without_duplicate_index_entries(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    first = ingest_source(tmp_path, added.source_id)
+    assert first.page_path is not None
+    first.page_path.unlink()
+
+    second = ingest_source(tmp_path, added.source_id)
+
+    assert second.no_op is False
+    assert second.page_path is not None and second.page_path.exists()
+    index_content = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+    assert index_content.count(f"(`{added.source_id}`)") == 1
+    log_content = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
+    assert log_content.count(f"Ingested source `{added.source_id}`") == 2
+
+
+def test_ingest_source_rejects_unsupported_type(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "diagram.bin"
+    source.write_bytes(b"\x00\x01\x02")
+    added = add_source(tmp_path, source)
+
+    with pytest.raises(ValueError, match="Unsupported source type"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
+    assert load_queue_item(queue_path).status == "failed"
+    assert len(run_paths) == 1
+    assert load_run_record(run_paths[0]).status == "failed"
+    assert not (tmp_path / "wiki" / "sources" / f"{added.source_id}.md").exists()
+
+
+def test_ingest_source_rejects_invalid_utf8_text(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "broken.txt"
+    source.write_bytes(b"\xff\xfe\xfa")
+    added = add_source(tmp_path, source)
+
+    with pytest.raises(ValueError, match="not valid UTF-8"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    assert load_queue_item(queue_path).status == "failed"
+    run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
+    assert len(run_paths) == 1
+    assert load_run_record(run_paths[0]).status == "failed"
+
+
+def test_ingest_source_missing_source_id_does_not_create_runtime_state(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="Unknown source ID"):
+        ingest_source(tmp_path, "src-missing")
+
+    assert list((tmp_path / "state" / "queue").glob("*.json")) == []
+    assert list((tmp_path / "state" / "runs").glob("*.json")) == []
+
+
+def test_ingest_source_validates_stored_copy_checksum(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    manifest = json.loads(added.manifest_path.read_text(encoding="utf-8"))
+    stored_path = tmp_path / manifest["path"]
+    stored_path.write_text("tampered\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Stored source checksum mismatch"):
+        ingest_source(tmp_path, added.source_id)


### PR DESCRIPTION
## Summary
- add `splendor ingest <source-id>` as the first end-to-end deterministic ingestion path
- persist queue/run state for single-source ingest attempts and write deterministic source-summary wiki pages
- update index/log and source manifest state with idempotent no-op behavior for already-ingested sources

## What was implemented
- new ingest command orchestration with support for text-native source types only
- file-based queue and run record persistence under `state/queue/` and `state/runs/`
- deterministic source-summary page generation under `wiki/sources/`
- deterministic updates to `wiki/index.md` and append-only success entries in `wiki/log.md`
- source-manifest status/last-run updates on successful and failed ingest attempts
- CLI coverage for success, no-op, and missing-source cases
- integration tests for happy path, idempotency, missing page rebuild, unsupported types, UTF-8 failures, and checksum validation
- README and schema-contract doc updates for the new command and runtime state

## Intentionally deferred
- `splendor ingest --pending`
- batching or worker/lease execution loops
- OCR, PDF/image/audio ingestion
- model-backed summarization or semantic page synthesis beyond the deterministic source summary
- query and planning-object write flows

## Assumptions
- deterministic ingestion remains local-only and model-free in this PR
- supported inputs are limited to text-native docs/config/code files
- no-op behavior is based on an existing succeeded run for the current pipeline version plus a present source page

## Verification
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest --cov=splendor --cov-report=term-missing --cov-report=xml`

## Follow-ups
- add `splendor ingest --pending` and simple sequential queue draining
- expand deterministic lint/health checks around queue/run/wiki integrity
- decide how far to take deterministic extraction before introducing optional model-assisted synthesis
