### PR TITLE
docs: define source resolution refactor

### DIFF
--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -14,7 +14,7 @@ Milestone 1. The implementation lives in `src/splendor/schemas/` and currently u
 
 Stored today as JSON sidecars under `state/manifests/sources/`.
 
-Core fields:
+Current implementation fields:
 
 - `schema_version`
 - `kind: source`
@@ -32,6 +32,93 @@ Core fields:
 - `review_state`
 - `origin_url`
 - `original_path`
+
+### Planned source-record evolution
+
+The current single-`path` contract is sufficient for the initial copy-everything MVP, but it
+mixes together three different concerns:
+
+- the canonical source the user wants tracked
+- the storage mechanism Splendor used to make it available
+- the current location from which ingest reads bytes
+
+The next source-record revision should split those concerns explicitly.
+
+Proposed fields:
+
+- `schema_version`
+- `kind: source`
+- `source_id`
+- `title`
+- `source_type`
+- `source_ref`
+- `source_ref_kind`
+- `storage_mode`
+- `storage_path`
+- `checksum`
+- `added_at`
+- `status`
+- `pipeline_version`
+- `derived_artifacts`
+- `linked_pages`
+- `last_run_id`
+- `review_state`
+- `origin_url`
+- `original_path`
+- `materialized_at`
+- `source_commit`
+
+### Proposed field semantics
+
+- `source_ref`
+  - Canonical source identifier.
+  - Examples:
+    - `docs/spec.md`
+    - `/Users/alice/Desktop/notes.md`
+    - `https://example.com/spec`
+- `source_ref_kind`
+  - One of:
+    - `workspace_path`
+    - `external_path`
+    - `url`
+    - `imported`
+    - `stored_artifact`
+- `storage_mode`
+  - One of:
+    - `none`
+    - `copy`
+    - `symlink`
+    - `pointer`
+- `storage_path`
+  - Optional path under `raw/sources/` when Splendor materializes an artifact.
+- `materialized_at`
+  - Timestamp indicating when `storage_path` was created or last refreshed.
+- `source_commit`
+  - Optional git commit SHA captured for clean tracked workspace files.
+
+### Default policy encoded by the schema
+
+Recommended defaults:
+
+- workspace file inside repo:
+  - `source_ref_kind: workspace_path`
+  - `storage_mode: none`
+  - `storage_path: null`
+- external local file:
+  - `source_ref_kind: external_path`
+  - `storage_mode: copy`
+- URL/imported source:
+  - `storage_mode: copy` or `pointer`, depending on downloader semantics
+
+### Migration note
+
+The easiest migration path is:
+
+1. Continue reading existing manifests with `path`.
+2. Introduce compatibility mapping:
+   - old `path` -> `storage_path`
+   - old `original_path` -> `source_ref` when it is repo-relative or otherwise available
+3. Write only the new fields once the resolver layer is in place.
 
 ## Knowledge page frontmatter
 
@@ -79,3 +166,7 @@ The schemas are implemented as Python-native models first, with JSON sidecars fo
 to exist before markdown renderers and richer file contracts are ready. That keeps the initial
 implementation small while preserving deterministic validation and future compatibility with YAML
 frontmatter or richer sidecar layouts.
+
+The next storage-oriented schema change should preserve that philosophy: keep manifests
+filesystem-native and explicit, but make source resolution policy first-class instead of baking a
+copy-under-`raw/sources/` assumption into a single `path` field.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -96,7 +96,7 @@ Proposed fields:
 - `source_commit`
   - Optional git commit SHA captured for clean tracked workspace files.
 
-### Default policy encoded by the schema
+### Recommended default policy
 
 Recommended defaults:
 

--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -1,0 +1,483 @@
+# Source Resolution Refactor Plan
+
+## 1. Purpose
+
+This document defines the planned refactor from Splendor's current copy-everything source model to
+a source-resolution model that separates:
+
+- the canonical source reference
+- the storage policy applied to that source
+- any optional materialized artifact created under `raw/sources/`
+
+The immediate driver is in-repo source handling. When a markdown file, code file, or config file
+already lives inside the tracked repository, Splendor should not duplicate it into `raw/sources/`
+by default. Instead, Splendor should register the repo file as the canonical source, verify it by
+checksum during ingest, and only materialize a snapshot when the project explicitly opts in.
+
+## 2. Problem Statement
+
+The current MVP source contract assumes that registration means "copy the file into
+`raw/sources/<source_id>/...` and treat that stored copy as the source of bytes for ingest." That
+has several problems for in-repo text sources:
+
+- it duplicates repo-native files that are already versioned by git
+- it creates noisy pull requests and bloated repository trees
+- it overfits the model to one storage strategy instead of a general source-resolution contract
+- it makes later support for pointers, symlinks, remote sources, and imported artifacts harder than
+  it needs to be
+
+The refactor should preserve provenance and determinism while making repo-native behavior the
+default for repo-native sources.
+
+## 3. Design Goals
+
+1. Make in-repo file registration repo-native by default.
+2. Preserve durable materialization for external local files and imported sources.
+3. Introduce one source-resolution layer used by registration, ingest, and later richer source
+   handlers.
+4. Keep the migration path incremental and compatibility-friendly.
+5. Reduce content duplication in `wiki/sources/` for sources that are already directly readable from
+   the repository.
+
+## 4. Non-Goals
+
+- Implement PDF, OCR, or remote fetch workflows in this change.
+- Replace the filesystem with a database-backed source registry.
+- Remove `raw/sources/` entirely.
+- Require companion-repo mode.
+
+## 5. Proposed Source Model
+
+### 5.1 Conceptual model
+
+Each source has:
+
+- a **canonical source reference**
+- a **source reference kind**
+- a **storage mode**
+- an optional **storage path**
+- a registered **checksum**
+
+### 5.2 Canonical source reference
+
+This is the thing the user intends Splendor to track.
+
+Examples:
+
+- `docs/spec.md`
+- `src/splendor/commands/ingest.py`
+- `/Users/alice/Desktop/reference-notes.md`
+- `https://example.com/paper`
+
+### 5.3 Storage mode
+
+This describes how Splendor makes the source available for ingest.
+
+Proposed initial values:
+
+- `none`
+  - No materialized artifact is created.
+  - Used by default for in-repo files.
+- `copy`
+  - Materialize a copy under `raw/sources/`.
+  - Default for external local files and imported sources.
+- `symlink`
+  - Optional project-selected mode for repos that want a `raw/sources/` directory without byte
+    duplication.
+- `pointer`
+  - Materialize a small metadata artifact under `raw/sources/` that points at the canonical source.
+  - Cross-platform alternative to `symlink`.
+
+### 5.4 Source-resolution rule
+
+Every command that needs source bytes should resolve them through one shared abstraction:
+
+`resolve_source_content(record) -> ResolvedSource`
+
+The resolved object should answer:
+
+- where bytes will be read from
+- whether the content came from the workspace or a materialized artifact
+- what validation was applied before use
+
+## 6. Proposed Schema Changes
+
+## 6.1 `SourceRecord`
+
+Current fields to keep:
+
+- `schema_version`
+- `kind`
+- `source_id`
+- `title`
+- `source_type`
+- `checksum`
+- `added_at`
+- `status`
+- `pipeline_version`
+- `derived_artifacts`
+- `linked_pages`
+- `last_run_id`
+- `review_state`
+- `origin_url`
+- `original_path`
+
+New fields to add:
+
+- `source_ref`
+- `source_ref_kind`
+- `storage_mode`
+- `storage_path`
+- `materialized_at`
+- `source_commit`
+
+Compatibility plan:
+
+- keep reading old manifests that only have `path`
+- treat old `path` as a legacy storage path
+- migrate on write once the new resolver is implemented
+
+## 6.2 Proposed field definitions
+
+### `source_ref`
+
+Canonical source identifier.
+
+Examples:
+
+- `docs/spec.md`
+- `/Users/alice/Desktop/notes.md`
+- `https://example.com/spec`
+
+### `source_ref_kind`
+
+Initial enum:
+
+- `workspace_path`
+- `external_path`
+- `url`
+- `imported`
+- `stored_artifact`
+
+### `storage_mode`
+
+Initial enum:
+
+- `none`
+- `copy`
+- `symlink`
+- `pointer`
+
+### `storage_path`
+
+Optional repo-relative path, usually under `raw/sources/`, used when a source is materialized.
+
+### `materialized_at`
+
+Timestamp capturing when the storage artifact was created or refreshed.
+
+### `source_commit`
+
+Optional git commit SHA captured for clean tracked workspace files when stronger repo-native
+provenance is desired.
+
+## 7. Proposed Config Changes
+
+Add a source-policy section to `splendor.yaml`.
+
+Example:
+
+```yaml
+schema_version: "1"
+project_name: "Splendor workspace"
+
+layout:
+  raw_sources_dir: "raw/sources"
+  wiki_dir: "wiki"
+  state_dir: "state"
+
+sources:
+  in_repo_storage_mode: none
+  external_storage_mode: copy
+  imported_storage_mode: copy
+  capture_source_commit: true
+  summarize_in_repo_extracts_as: excerpt
+  summarize_external_extracts_as: full
+```
+
+## 7.1 Config semantics
+
+- `in_repo_storage_mode`
+  - Default policy for repo-relative files.
+  - Initial supported values: `none`, `copy`, `symlink`, `pointer`.
+- `external_storage_mode`
+  - Default policy for local files outside the workspace root.
+- `imported_storage_mode`
+  - Default policy for future fetched or imported sources.
+- `capture_source_commit`
+  - If true, record the current git commit for clean tracked workspace files.
+- `summarize_in_repo_extracts_as`
+  - Initial values: `none`, `excerpt`, `full`.
+- `summarize_external_extracts_as`
+  - Initial values: `excerpt`, `full`.
+
+## 8. Proposed CLI Changes
+
+## 8.1 `splendor add-source`
+
+Current:
+
+```bash
+splendor add-source <path>
+```
+
+Proposed additions:
+
+```bash
+splendor add-source <path> [--storage-mode none|copy|symlink|pointer]
+splendor add-source <path> [--capture-source-commit/--no-capture-source-commit]
+```
+
+Behavior:
+
+- if `<path>` is inside the workspace and no override is provided:
+  - use `storage_mode=none`
+- if `<path>` is outside the workspace and no override is provided:
+  - use the configured external default, initially `copy`
+- if the requested mode conflicts with source kind or platform constraints:
+  - fail with a clear validation error
+
+## 8.2 `splendor ingest`
+
+Current:
+
+```bash
+splendor ingest <source-id>
+splendor ingest --pending
+```
+
+Proposed internal behavior changes:
+
+- ingest must no longer assume `raw/sources/` contains the source bytes
+- ingest must call the shared resolver and record the resolved input in run metadata
+- ingest should warn clearly if a workspace-backed source no longer matches the registered checksum
+
+## 8.3 Optional future command
+
+Not required in Phase 1, but likely useful later:
+
+```bash
+splendor materialize-source <source-id>
+```
+
+This would allow an existing workspace-backed source to be snapshotted on demand.
+
+## 9. Source Summary Page Policy
+
+The current source-summary pages include a large `## Extract` block. That is acceptable for external
+or transformed sources, but it is too noisy for in-repo text files.
+
+Proposed default policy:
+
+- for in-repo text sources:
+  - include metadata
+  - include provenance
+  - include the canonical source path
+  - include a short excerpt or no excerpt, based on config
+- for external or transformed sources:
+  - include a fuller extract when it materially helps with local readability and provenance
+
+This keeps `wiki/sources/` useful without turning it into a second docs tree.
+
+## 10. Detailed Implementation Plan
+
+The work should proceed in two phases. Each phase may span multiple PRs.
+
+## Phase 1 — Introduce the source-resolution model
+
+### Goal
+
+Make the core source manifest and ingest path understand canonical references and storage modes.
+
+### Phase 1 outcomes
+
+- new source schema fields exist
+- in-repo files default to `storage_mode=none`
+- external files continue to default to `copy`
+- ingest reads through a resolver abstraction
+- older manifests still work
+
+### Recommended PR breakdown
+
+#### PR 1 — Docs and contract alignment
+
+Scope:
+
+- update product spec
+- update roadmap
+- update schema contracts
+- add this implementation plan
+
+Exit criteria:
+
+- docs agree on the target architecture before code changes begin
+
+#### PR 2 — Schema and config scaffolding
+
+Scope:
+
+- add new `SourceRecord` fields
+- add new config surface under `sources`
+- keep compatibility with old manifests
+- add tests for schema parsing and defaults
+
+Exit criteria:
+
+- manifests can express source reference and storage policy
+- config defaults can encode workspace-vs-external behavior
+
+#### PR 3 — Source resolver abstraction
+
+Scope:
+
+- introduce a shared resolver module
+- resolve source bytes for:
+  - workspace-backed sources
+  - copied sources
+  - legacy manifests
+- update ingest to use the resolver
+
+Exit criteria:
+
+- ingest no longer assumes `raw/sources/` is always the place to read bytes from
+
+#### PR 4 — `add-source` default behavior switch
+
+Scope:
+
+- change in-repo registration default to `storage_mode=none`
+- preserve `copy` default for external local files
+- add CLI override flag for `--storage-mode`
+- add optional capture of git commit for clean tracked workspace files
+
+Exit criteria:
+
+- in-repo files stop being copied by default
+- explicit overrides still work
+
+#### PR 5 — Migration and polish
+
+Scope:
+
+- compatibility helpers for legacy manifests
+- upgrade notes
+- more fixture coverage
+- run metadata improvements for resolved input refs
+
+Exit criteria:
+
+- older workspaces continue to ingest cleanly
+- the new behavior is documented and tested
+
+## Phase 2 — Reduce rendered duplication and add optional materialization paths
+
+### Goal
+
+Make the wiki output and storage options match the new source model ergonomically.
+
+### Phase 2 outcomes
+
+- source-summary pages stop reproducing full in-repo docs by default
+- optional pointer and symlink materialization paths exist
+- projects can opt into stronger snapshot behavior where they need it
+
+### Recommended PR breakdown
+
+#### PR 6 — Source-summary rendering policy
+
+Scope:
+
+- add config for excerpt strategy
+- default in-repo summaries to short excerpt or none
+- preserve fuller extracts for external or transformed sources
+- update tests for deterministic page rendering
+
+Exit criteria:
+
+- `wiki/sources/` becomes materially less noisy for in-repo docs and code
+
+#### PR 7 — Pointer storage mode
+
+Scope:
+
+- define pointer artifact format
+- add `storage_mode=pointer`
+- teach resolver to follow pointer artifacts
+
+Exit criteria:
+
+- projects have a cross-platform materialization alternative that does not duplicate bytes
+
+#### PR 8 — Optional symlink mode
+
+Scope:
+
+- add guarded `storage_mode=symlink`
+- validate platform constraints
+- document operational caveats
+
+Exit criteria:
+
+- projects that prefer filesystem-level mirroring can opt in knowingly
+
+#### PR 9 — Materialization workflow polish
+
+Scope:
+
+- optional `materialize-source` command or equivalent workflow
+- better reporting of canonical source vs storage artifact
+- health/lint checks for invalid storage policies or broken pointers/symlinks
+
+Exit criteria:
+
+- source materialization is operationally understandable and repairable
+
+## 11. Risks and Tradeoffs
+
+### Risk: weaker immutability for workspace-backed sources
+
+Mitigation:
+
+- enforce checksum verification during ingest
+- optionally capture `source_commit`
+- provide explicit copy/pointer modes for projects that want stronger materialization
+
+### Risk: migration complexity
+
+Mitigation:
+
+- keep read compatibility for legacy manifests
+- split schema, resolver, and CLI behavior changes across multiple PRs
+
+### Risk: design drift between docs and implementation
+
+Mitigation:
+
+- land the documentation PR first
+- treat this file as the implementation sequence until Phase 2 is complete
+
+## 12. Recommended Default Decisions
+
+These should be treated as the proposed baseline unless implementation uncovers a blocking issue:
+
+- default in-repo storage mode: `none`
+- default external local storage mode: `copy`
+- source-summary rendering for in-repo text files: `excerpt`
+- source-summary rendering for external or transformed text: `full`
+- capture git commit for clean tracked workspace files: `true`
+
+## 13. Merge and Follow-up
+
+After this design PR is merged, implementation should proceed as the PR series described above. The
+first code PR should focus on schema and config scaffolding, not on UI polish or richer source
+types.

--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -102,7 +102,7 @@ The resolved object should answer:
 
 ## 6. Proposed Schema Changes
 
-## 6.1 `SourceRecord`
+### 6.1 `SourceRecord`
 
 Current fields to keep:
 
@@ -137,7 +137,7 @@ Compatibility plan:
 - treat old `path` as a legacy storage path
 - migrate on write once the new resolver is implemented
 
-## 6.2 Proposed field definitions
+### 6.2 Proposed field definitions
 
 ### `source_ref`
 
@@ -205,7 +205,7 @@ sources:
   summarize_external_extracts_as: full
 ```
 
-## 7.1 Config semantics
+### 7.1 Config semantics
 
 - `in_repo_storage_mode`
   - Default policy for repo-relative files.
@@ -223,7 +223,7 @@ sources:
 
 ## 8. Proposed CLI Changes
 
-## 8.1 `splendor add-source`
+### 8.1 `splendor add-source`
 
 Current:
 
@@ -247,7 +247,7 @@ Behavior:
 - if the requested mode conflicts with source kind or platform constraints:
   - fail with a clear validation error
 
-## 8.2 `splendor ingest`
+### 8.2 `splendor ingest`
 
 Current:
 
@@ -262,7 +262,7 @@ Proposed internal behavior changes:
 - ingest must call the shared resolver and record the resolved input in run metadata
 - ingest should warn clearly if a workspace-backed source no longer matches the registered checksum
 
-## 8.3 Optional future command
+### 8.3 Optional future command
 
 Not required in Phase 1, but likely useful later:
 
@@ -293,7 +293,7 @@ This keeps `wiki/sources/` useful without turning it into a second docs tree.
 
 The work should proceed in two phases. Each phase may span multiple PRs.
 
-## Phase 1 — Introduce the source-resolution model
+### 10.1 Phase 1 — Introduce the source-resolution model
 
 ### Goal
 
@@ -379,7 +379,7 @@ Exit criteria:
 - older workspaces continue to ingest cleanly
 - the new behavior is documented and tested
 
-## Phase 2 — Reduce rendered duplication and add optional materialization paths
+### 10.2 Phase 2 — Reduce rendered duplication and add optional materialization paths
 
 ### Goal
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -167,6 +167,19 @@ Support the first useful end-to-end ingestion flow.
 - failed ingests do not corrupt state
 - repeated ingest commands behave predictably
 
+### Follow-on architecture correction
+
+The initial MVP intentionally uses a simple copy-based source materialization model. That choice is
+acceptable for bootstrapping, but it is not the right steady-state design for repositories whose
+primary sources already live in git. The next architecture correction should split:
+
+- canonical source reference
+- storage policy
+- optional materialized artifact
+
+That refactor should happen before richer source handling expands, so all later source types build
+on the same resolver contract.
+
 ---
 
 ## Milestone 3 — MVP core: query and planning objects
@@ -301,6 +314,33 @@ This milestone is especially important for sensitive, policy-heavy, or research-
 - users can inspect why a page says what it says
 - contested knowledge is surfaced instead of silently merged
 - provenance is visible enough to support trust and debugging
+
+---
+
+## Milestone 6.5 — Post-MVP: source-resolution and storage-policy refactor
+
+### Goal
+Make source handling repo-native by default without weakening provenance for external or unstable
+sources.
+
+### Scope
+- split canonical source reference from storage realization
+- default in-repo files to workspace-backed registration
+- preserve copy, pointer, and symlink options where projects need stronger materialization
+- reduce source-summary duplication for in-repo text sources
+
+### Deliverables
+- a source resolver abstraction
+- revised source manifest schema
+- configuration for storage policy defaults
+- CLI overrides for source storage behavior
+- manifest migration path for older workspaces
+
+### Exit criteria
+- in-repo docs and code stop being duplicated into `raw/sources/` by default
+- external sources still get durable materialization when appropriate
+- ingest reads through one resolver interface regardless of source origin
+- source-summary pages remain deterministic while becoming less noisy
 
 ---
 
@@ -446,6 +486,12 @@ Expand supported source types where they materially increase product value.
 
 ### Important constraint
 Harder source formats should remain optional. The text-native path must stay strong and simple.
+
+### Dependency note
+
+This milestone should build on the source-resolution refactor rather than bypass it. PDF, OCR, and
+other richer source types should enter the system through the same `source_ref` plus `storage_mode`
+model as text-native sources.
 
 ### Exit criteria
 - PDF/image workflows exist and are clearly separated from the core text flow

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -77,6 +77,16 @@ Examples:
 
 The source layer is append-oriented. Sources are not mutated by LLM workflows.
 
+In the initial MVP, Splendor materializes registered sources under `raw/sources/`. That behavior is
+useful for external and unstable inputs, but it is too blunt for repositories whose markdown, code,
+and configuration files already live inside git. The long-term source model must therefore
+distinguish between:
+
+- the **canonical source reference** the user means Splendor to track
+- the **storage policy** Splendor applies to make that source available to the pipeline
+- any optional **materialized snapshot or pointer artifact** Splendor creates for provenance,
+  portability, or repairability
+
 ### 4.2 Derived Extraction Artifacts
 
 Machine-generated extraction outputs derived from raw sources.
@@ -190,6 +200,7 @@ Splendor starts **without** a required SQLite database or local index database. 
 - **Repo truth first**
 - **File-based state first**
 - **Optional caches/indexes later**
+- **Canonical source reference first; snapshot second**
 
 ### 8.3 Why no SQLite in the initial core
 
@@ -198,6 +209,33 @@ Splendor starts **without** a required SQLite database or local index database. 
 - better git transparency
 - lower implementation weight
 - better fit for agent use and PR workflows
+
+### 8.4 Source-resolution model
+
+Splendor should treat source registration as a two-part contract:
+
+1. **Canonical reference**
+   - The repo-relative path, local external path, URL, or imported identifier that names the source
+     the user wants tracked.
+
+2. **Optional storage realization**
+   - A copy, symlink, pointer file, or no stored artifact at all, depending on policy and source
+     type.
+
+This is especially important for in-repo text sources. When the source already lives inside the git
+workspace, the default behavior should be to track that repo file directly rather than duplicate it
+into `raw/sources/`. Splendor should still be able to materialize a snapshot when the project
+explicitly opts in or when the source is external to the workspace.
+
+### 8.5 Default storage policy
+
+Recommended defaults:
+
+- **In-repo sources:** track the workspace file directly; do not copy by default
+- **External local files:** copy into `raw/sources/` by default
+- **Remote imports / fetched content:** materialize a local stored artifact by default
+- **Project override:** allow repositories to opt into copying in-repo files when strict snapshot
+  capture is preferred over tree cleanliness
 
 ## 9. Suggested Repository Layout
 
@@ -286,7 +324,7 @@ These remain markdown-first, but include standardized frontmatter for discoverab
 
 ## 11.1 Source record
 
-Purpose: identify an immutable source and its ingestion status.
+Purpose: identify a source, its canonical reference, its storage policy, and its ingestion status.
 
 Suggested fields:
 - `schema_version`
@@ -294,7 +332,10 @@ Suggested fields:
 - `source_id`
 - `title`
 - `source_type`
-- `path`
+- `source_ref`
+- `source_ref_kind`
+- `storage_mode`
+- `storage_path` (optional)
 - `origin_url` (optional)
 - `checksum`
 - `added_at`
@@ -304,6 +345,23 @@ Suggested fields:
 - `linked_pages`
 - `last_run_id`
 - `review_state`
+- `materialized_at` (optional)
+- `source_commit` (optional)
+
+Field meanings:
+
+- `source_ref`
+  - Canonical identifier for the source the user registered.
+  - For in-repo files this should usually be a repo-relative path.
+- `source_ref_kind`
+  - Expected initial values: `workspace_path`, `external_path`, `url`, `imported`, `stored_artifact`.
+- `storage_mode`
+  - Expected initial values: `none`, `copy`, `symlink`, `pointer`.
+- `storage_path`
+  - Optional path to the materialized artifact under `raw/sources/` when one exists.
+- `source_commit`
+  - Optional git commit SHA captured for clean tracked workspace files when the project wants
+    stronger repo-native provenance.
 
 ## 11.2 Knowledge page frontmatter
 
@@ -499,15 +557,17 @@ Not the preferred primary runtime for:
 
 ## 14.1 Core ingestion flow
 
-1. Source enters `raw/`
+1. Source is resolved to a canonical `source_ref`
 2. Source manifest/record is created
-3. A queue item is created
-4. A worker claims the job
-5. Optional extraction happens
-6. Relevant wiki pages are created/updated
-7. Index/log are updated
-8. Run record is written
-9. Job is marked complete or failed
+3. Optional storage realization happens according to `storage_mode`
+4. A queue item is created
+5. A worker claims the job
+6. Source content is resolved through a common source-resolution layer
+7. Optional extraction happens
+8. Relevant wiki pages are created/updated
+9. Index/log are updated
+10. Run record is written
+11. Job is marked complete or failed
 
 ## 14.2 Ingestion granularity
 
@@ -522,13 +582,38 @@ Initial preferred formats:
 - YAML/JSON
 - HTML saved locally
 
+## 14.4 In-repo source handling
+
+For in-repo text sources, Splendor should default to:
+
+- manifesting the repo-relative source path as the canonical `source_ref`
+- reading from the workspace path during ingest
+- validating that the current file still matches the registered checksum
+- optionally recording the current git commit when available
+- skipping `raw/sources/` duplication unless the project explicitly requests snapshot materialization
+
+This keeps the repository readable while preserving deterministic provenance.
+
+## 14.5 Source summary page policy
+
+Source-summary pages should remain deterministic, but the rendered markdown should avoid
+needlessly reproducing the full source text for files that already live in the same repository.
+
+Recommended default behavior:
+
+- include source metadata and provenance
+- include a short preview or bounded excerpt
+- link to the canonical source path
+- reserve full extracted text for cases where the source is external, transformed, or otherwise not
+  directly readable from the repository
+
 Later optional support:
 - PDF
 - image-based sources
 - OCR-derived flows
 - audio/transcript flows
 
-### 14.4 OCR/LLM-assisted extraction
+### 14.6 OCR/LLM-assisted extraction
 
 For harder formats, ingestion may optionally invoke:
 - OCR


### PR DESCRIPTION
## Summary

This PR documents the source-resolution redesign needed to stop duplicating in-repo sources into `raw/sources/` by default while preserving strong provenance for external and imported sources.

It updates the product, schema, and roadmap docs and adds a dedicated implementation plan for the refactor.

## What changed

- updates `docs/splendor_product_spec.md` to introduce the source-resolution model
- updates `docs/schema_contracts.md` with the proposed `SourceRecord` evolution
- updates `docs/splendor_mvp_to_v1_roadmap.md` to add the storage-policy refactor as a distinct milestone
- adds `docs/source_resolution_refactor_plan.md` with a detailed two-phase rollout plan

## Proposed design direction

The new model separates:

- canonical source reference
- storage policy
- optional materialized artifact

Recommended defaults documented here:

- in-repo files: `storage_mode=none`
- external local files: `storage_mode=copy`
- future imported sources: materialized by default

The docs also propose concrete additions for:

- `SourceRecord` fields such as `source_ref`, `source_ref_kind`, `storage_mode`, `storage_path`, `materialized_at`, and `source_commit`
- `splendor.yaml` source-policy defaults
- `splendor add-source` CLI overrides
- source-summary page rendering policy for in-repo versus external sources

## Implementation sequence

The new plan is split into two phases.

### Phase 1

- schema and config scaffolding
- resolver abstraction
- `add-source` default behavior switch
- ingest migration to the resolver
- legacy manifest compatibility

### Phase 2

- reduce source-summary duplication
- add pointer storage mode
- optionally add symlink storage mode
- add materialization workflow polish and health checks

Each phase is explicitly broken into multiple follow-up PRs in `docs/source_resolution_refactor_plan.md`.

## Why this should land before implementation

The current MVP contract bakes a copy-based assumption into the source model. Landing the docs first gives the code work a stable architectural target and keeps the implementation PRs focused on execution rather than design churn.

## Test plan

- reviewed the updated docs together for consistency across product, schema, roadmap, and implementation-plan layers
- no code changes or runtime behavior changes in this PR
