### PR TITLE
feat: scaffold source resolution schema and config

### DIFF
--- a/src/splendor/config.py
+++ b/src/splendor/config.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import yaml
 from pydantic import BaseModel, Field
+
 from splendor.schemas.types import StorageMode, SummaryMode
 
 CONFIG_FILENAME = "splendor.yaml"

--- a/src/splendor/config.py
+++ b/src/splendor/config.py
@@ -7,10 +7,10 @@ registration and ingest do not consume it yet in this release.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
 
 import yaml
 from pydantic import BaseModel, Field
+from splendor.schemas.types import StorageMode, SummaryMode
 
 CONFIG_FILENAME = "splendor.yaml"
 
@@ -33,12 +33,12 @@ class LayoutConfig(BaseModel):
 
 
 class SourcesConfig(BaseModel):
-    in_repo_storage_mode: Literal["none", "copy", "symlink", "pointer"] = "none"
-    external_storage_mode: Literal["none", "copy", "symlink", "pointer"] = "copy"
-    imported_storage_mode: Literal["none", "copy", "symlink", "pointer"] = "copy"
+    in_repo_storage_mode: StorageMode = "none"
+    external_storage_mode: StorageMode = "copy"
+    imported_storage_mode: StorageMode = "copy"
     capture_source_commit: bool = True
-    summarize_in_repo_extracts_as: Literal["none", "excerpt", "full"] = "excerpt"
-    summarize_external_extracts_as: Literal["none", "excerpt", "full"] = "full"
+    summarize_in_repo_extracts_as: SummaryMode = "excerpt"
+    summarize_external_extracts_as: SummaryMode = "full"
 
 
 class SplendorConfig(BaseModel):

--- a/src/splendor/config.py
+++ b/src/splendor/config.py
@@ -1,8 +1,13 @@
-"""Configuration loading for Splendor."""
+"""Configuration loading for Splendor.
+
+`SourcesConfig` captures policy defaults for the upcoming source-resolution model. Runtime
+registration and ingest do not consume it yet in this release.
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 import yaml
 from pydantic import BaseModel, Field
@@ -27,10 +32,20 @@ class LayoutConfig(BaseModel):
     source_records_dir: str = "state/manifests/sources"
 
 
+class SourcesConfig(BaseModel):
+    in_repo_storage_mode: Literal["none", "copy", "symlink", "pointer"] = "none"
+    external_storage_mode: Literal["none", "copy", "symlink", "pointer"] = "copy"
+    imported_storage_mode: Literal["none", "copy", "symlink", "pointer"] = "copy"
+    capture_source_commit: bool = True
+    summarize_in_repo_extracts_as: Literal["none", "excerpt", "full"] = "excerpt"
+    summarize_external_extracts_as: Literal["none", "excerpt", "full"] = "full"
+
+
 class SplendorConfig(BaseModel):
     schema_version: str = "1"
     project_name: str = "Splendor workspace"
     layout: LayoutConfig = Field(default_factory=LayoutConfig)
+    sources: SourcesConfig = Field(default_factory=SourcesConfig)
 
 
 def config_path_for(root: Path) -> Path:

--- a/src/splendor/config.py
+++ b/src/splendor/config.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from splendor.schemas.types import StorageMode, SummaryMode
 
@@ -17,6 +17,8 @@ CONFIG_FILENAME = "splendor.yaml"
 
 
 class LayoutConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     raw_dir: str = "raw"
     raw_sources_dir: str = "raw/sources"
     raw_assets_dir: str = "raw/assets"
@@ -34,6 +36,8 @@ class LayoutConfig(BaseModel):
 
 
 class SourcesConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     in_repo_storage_mode: StorageMode = "none"
     external_storage_mode: StorageMode = "copy"
     imported_storage_mode: StorageMode = "copy"
@@ -43,6 +47,8 @@ class SourcesConfig(BaseModel):
 
 
 class SplendorConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     schema_version: str = "1"
     project_name: str = "Splendor workspace"
     layout: LayoutConfig = Field(default_factory=LayoutConfig)

--- a/src/splendor/config.py
+++ b/src/splendor/config.py
@@ -17,8 +17,6 @@ CONFIG_FILENAME = "splendor.yaml"
 
 
 class LayoutConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
     raw_dir: str = "raw"
     raw_sources_dir: str = "raw/sources"
     raw_assets_dir: str = "raw/assets"
@@ -47,8 +45,6 @@ class SourcesConfig(BaseModel):
 
 
 class SplendorConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
     schema_version: str = "1"
     project_name: str = "Splendor workspace"
     layout: LayoutConfig = Field(default_factory=LayoutConfig)

--- a/src/splendor/schemas/__init__.py
+++ b/src/splendor/schemas/__init__.py
@@ -1,6 +1,5 @@
 """Schema exports."""
 
-from splendor.schemas.types import SourceRefKind, StorageMode, SummaryMode
 from splendor.schemas.planning import (
     DecisionRecord,
     MilestoneRecord,
@@ -9,6 +8,7 @@ from splendor.schemas.planning import (
 )
 from splendor.schemas.runtime import QueueItemRecord, RunRecord
 from splendor.schemas.source import SourceRecord
+from splendor.schemas.types import SourceRefKind, StorageMode, SummaryMode
 from splendor.schemas.wiki import KnowledgePageFrontmatter
 
 __all__ = [

--- a/src/splendor/schemas/__init__.py
+++ b/src/splendor/schemas/__init__.py
@@ -1,5 +1,6 @@
 """Schema exports."""
 
+from splendor.schemas.types import SourceRefKind, StorageMode, SummaryMode
 from splendor.schemas.planning import (
     DecisionRecord,
     MilestoneRecord,
@@ -17,6 +18,9 @@ __all__ = [
     "QuestionRecord",
     "QueueItemRecord",
     "RunRecord",
+    "SourceRefKind",
     "SourceRecord",
+    "StorageMode",
+    "SummaryMode",
     "TaskRecord",
 ]

--- a/src/splendor/schemas/source.py
+++ b/src/splendor/schemas/source.py
@@ -1,4 +1,8 @@
-"""Source schemas."""
+"""Source schemas.
+
+`path` remains the active runtime field in this release. The additional source-resolution fields are
+schema scaffolding for the upcoming resolver-based migration.
+"""
 
 from __future__ import annotations
 
@@ -14,6 +18,7 @@ class SourceRecord(StrictRecord):
     source_id: str
     title: str
     source_type: str
+    # Legacy runtime field. Current registration and ingest still read from `path`.
     path: str
     checksum: str = Field(min_length=64, max_length=64)
     added_at: str
@@ -25,3 +30,11 @@ class SourceRecord(StrictRecord):
     review_state: Literal["unreviewed", "human-reviewed", "stale"] = "unreviewed"
     origin_url: str | None = None
     original_path: str | None = None
+    source_ref: str | None = None
+    source_ref_kind: (
+        Literal["workspace_path", "external_path", "url", "imported", "stored_artifact"] | None
+    ) = None
+    storage_mode: Literal["none", "copy", "symlink", "pointer"] | None = None
+    storage_path: str | None = None
+    materialized_at: str | None = None
+    source_commit: str | None = None

--- a/src/splendor/schemas/source.py
+++ b/src/splendor/schemas/source.py
@@ -11,6 +11,7 @@ from typing import Literal
 from pydantic import Field
 
 from splendor.schemas.common import StrictRecord
+from splendor.schemas.types import SourceRefKind, StorageMode
 
 
 class SourceRecord(StrictRecord):
@@ -31,10 +32,8 @@ class SourceRecord(StrictRecord):
     origin_url: str | None = None
     original_path: str | None = None
     source_ref: str | None = None
-    source_ref_kind: (
-        Literal["workspace_path", "external_path", "url", "imported", "stored_artifact"] | None
-    ) = None
-    storage_mode: Literal["none", "copy", "symlink", "pointer"] | None = None
+    source_ref_kind: SourceRefKind | None = None
+    storage_mode: StorageMode | None = None
     storage_path: str | None = None
     materialized_at: str | None = None
     source_commit: str | None = None

--- a/src/splendor/schemas/types.py
+++ b/src/splendor/schemas/types.py
@@ -6,6 +6,4 @@ from typing import Literal
 
 StorageMode = Literal["none", "copy", "symlink", "pointer"]
 SummaryMode = Literal["none", "excerpt", "full"]
-SourceRefKind = Literal[
-    "workspace_path", "external_path", "url", "imported", "stored_artifact"
-]
+SourceRefKind = Literal["workspace_path", "external_path", "url", "imported", "stored_artifact"]

--- a/src/splendor/schemas/types.py
+++ b/src/splendor/schemas/types.py
@@ -1,0 +1,11 @@
+"""Shared schema and config type aliases."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+StorageMode = Literal["none", "copy", "symlink", "pointer"]
+SummaryMode = Literal["none", "excerpt", "full"]
+SourceRefKind = Literal[
+    "workspace_path", "external_path", "url", "imported", "stored_artifact"
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from splendor.config import default_config, load_config, write_config
+
+
+def test_default_config_includes_source_policy_defaults() -> None:
+    config = default_config(project_name="Example")
+
+    assert config.sources.in_repo_storage_mode == "none"
+    assert config.sources.external_storage_mode == "copy"
+    assert config.sources.imported_storage_mode == "copy"
+    assert config.sources.capture_source_commit is True
+    assert config.sources.summarize_in_repo_extracts_as == "excerpt"
+    assert config.sources.summarize_external_extracts_as == "full"
+
+
+def test_load_config_accepts_yaml_without_sources_block(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        "schema_version: '1'\nproject_name: Example\nlayout:\n  raw_dir: raw\n",
+        encoding="utf-8",
+    )
+
+    config = load_config(tmp_path)
+
+    assert config.project_name == "Example"
+    assert config.sources.in_repo_storage_mode == "none"
+    assert config.sources.external_storage_mode == "copy"
+
+
+def test_load_config_applies_defaults_for_missing_sources(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        "schema_version: '1'\nproject_name: Example\n",
+        encoding="utf-8",
+    )
+
+    config = load_config(tmp_path)
+
+    assert config.sources.imported_storage_mode == "copy"
+    assert config.sources.capture_source_commit is True
+
+
+def test_load_config_rejects_invalid_sources_values(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        (
+            "schema_version: '1'\n"
+            "project_name: Example\n"
+            "sources:\n"
+            "  in_repo_storage_mode: bogus\n"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError):
+        load_config(tmp_path)
+
+
+def test_write_config_serializes_sources_block(tmp_path: Path) -> None:
+    config = default_config(project_name="Example")
+
+    write_config(tmp_path, config)
+    written = (tmp_path / "splendor.yaml").read_text(encoding="utf-8")
+
+    assert "sources:" in written
+    assert "in_repo_storage_mode: none" in written
+    assert "external_storage_mode: copy" in written

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,6 +62,42 @@ def test_load_config_rejects_unknown_sources_keys(tmp_path: Path) -> None:
         load_config(tmp_path)
 
 
+def test_load_config_accepts_unknown_top_level_keys(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        (
+            "schema_version: '1'\n"
+            "project_name: Example\n"
+            "experimental_flag: true\n"
+            "sources:\n"
+            "  in_repo_storage_mode: none\n"
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(tmp_path)
+
+    assert config.project_name == "Example"
+    assert config.sources.in_repo_storage_mode == "none"
+
+
+def test_load_config_accepts_unknown_layout_keys(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        (
+            "schema_version: '1'\n"
+            "project_name: Example\n"
+            "layout:\n"
+            "  raw_dir: raw\n"
+            "  extra_layout_experiment: true\n"
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(tmp_path)
+
+    assert config.project_name == "Example"
+    assert config.layout.raw_dir == "raw"
+
+
 def test_write_config_serializes_sources_block(tmp_path: Path) -> None:
     config = default_config(project_name="Example")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,6 +52,16 @@ def test_load_config_rejects_invalid_sources_values(tmp_path: Path) -> None:
         load_config(tmp_path)
 
 
+def test_load_config_rejects_unknown_sources_keys(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        ("schema_version: '1'\nproject_name: Example\nsources:\n  external_storage_mdoe: copy\n"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError):
+        load_config(tmp_path)
+
+
 def test_write_config_serializes_sources_block(tmp_path: Path) -> None:
     config = default_config(project_name="Example")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,12 +44,7 @@ def test_load_config_applies_defaults_for_missing_sources(tmp_path: Path) -> Non
 
 def test_load_config_rejects_invalid_sources_values(tmp_path: Path) -> None:
     (tmp_path / "splendor.yaml").write_text(
-        (
-            "schema_version: '1'\n"
-            "project_name: Example\n"
-            "sources:\n"
-            "  in_repo_storage_mode: bogus\n"
-        ),
+        ("schema_version: '1'\nproject_name: Example\nsources:\n  in_repo_storage_mode: bogus\n"),
         encoding="utf-8",
     )
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -40,4 +40,6 @@ def test_initialize_workspace_repairs_blank_project_name(tmp_path: Path) -> None
     config = load_config(tmp_path)
     assert config.project_name == tmp_path.name
     assert config.sources.in_repo_storage_mode == "none"
-    assert "project_name: ''" not in (tmp_path / "splendor.yaml").read_text(encoding="utf-8")
+    assert "project_name: ''" not in (tmp_path / "splendor.yaml").read_text(
+        encoding="utf-8"
+    )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -40,6 +40,4 @@ def test_initialize_workspace_repairs_blank_project_name(tmp_path: Path) -> None
     config = load_config(tmp_path)
     assert config.project_name == tmp_path.name
     assert config.sources.in_repo_storage_mode == "none"
-    assert "project_name: ''" not in (tmp_path / "splendor.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "project_name: ''" not in (tmp_path / "splendor.yaml").read_text(encoding="utf-8")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,6 +13,9 @@ def test_initialize_workspace_creates_layout(tmp_path: Path) -> None:
     assert (tmp_path / "state" / "manifests" / "sources").exists()
     assert (tmp_path / "state" / "manifests" / ".gitkeep").exists()
     assert (tmp_path / "state" / "manifests" / "sources" / ".gitkeep").exists()
+    config = load_config(tmp_path)
+    assert config.sources.in_repo_storage_mode == "none"
+    assert config.sources.external_storage_mode == "copy"
     assert result.created_directories
     assert result.created_files
 
@@ -34,5 +37,7 @@ def test_initialize_workspace_repairs_blank_project_name(tmp_path: Path) -> None
     result = initialize_workspace(tmp_path)
 
     assert result.root == tmp_path
-    assert load_config(tmp_path).project_name == tmp_path.name
+    config = load_config(tmp_path)
+    assert config.project_name == tmp_path.name
+    assert config.sources.in_repo_storage_mode == "none"
     assert "project_name: ''" not in (tmp_path / "splendor.yaml").read_text(encoding="utf-8")

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -18,6 +18,27 @@ def test_source_record_validation_accepts_valid_payload() -> None:
     assert record.kind == "source"
 
 
+def test_source_record_validation_accepts_valid_expanded_payload() -> None:
+    record = SourceRecord(
+        source_id="src-1234567890abcdef",
+        title="Spec",
+        source_type="md",
+        path="raw/sources/src-123/spec.md",
+        checksum="a" * 64,
+        added_at="2026-04-10T15:00:00+00:00",
+        pipeline_version="0.1.0a0",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        storage_mode="none",
+        storage_path=None,
+        materialized_at="2026-04-10T15:01:00+00:00",
+        source_commit="abc123",
+    )
+
+    assert record.source_ref == "docs/spec.md"
+    assert record.storage_mode == "none"
+
+
 def test_source_record_validation_rejects_bad_checksum() -> None:
     with pytest.raises(ValidationError):
         SourceRecord(
@@ -28,6 +49,34 @@ def test_source_record_validation_rejects_bad_checksum() -> None:
             checksum="short",
             added_at="2026-04-10T15:00:00+00:00",
             pipeline_version="0.1.0a0",
+        )
+
+
+def test_source_record_validation_rejects_invalid_source_ref_kind() -> None:
+    with pytest.raises(ValidationError):
+        SourceRecord(
+            source_id="src-1234567890abcdef",
+            title="Spec",
+            source_type="md",
+            path="raw/sources/src-123/spec.md",
+            checksum="a" * 64,
+            added_at="2026-04-10T15:00:00+00:00",
+            pipeline_version="0.1.0a0",
+            source_ref_kind="bogus",
+        )
+
+
+def test_source_record_validation_rejects_invalid_storage_mode() -> None:
+    with pytest.raises(ValidationError):
+        SourceRecord(
+            source_id="src-1234567890abcdef",
+            title="Spec",
+            source_type="md",
+            path="raw/sources/src-123/spec.md",
+            checksum="a" * 64,
+            added_at="2026-04-10T15:00:00+00:00",
+            pipeline_version="0.1.0a0",
+            storage_mode="bogus",
         )
 
 


### PR DESCRIPTION
## Summary

This is PR 2 of the source-resolution refactor plan.

It adds schema and config scaffolding for the new source model while keeping the current copy-based runtime fully intact. There are no behavior changes to `add-source`, `register_source`, or `ingest` in this PR.

## What changed

- extends `SourceRecord` with optional source-resolution fields:
  - `source_ref`
  - `source_ref_kind`
  - `storage_mode`
  - `storage_path`
  - `materialized_at`
  - `source_commit`
- adds `SourcesConfig` and a `sources` block to `SplendorConfig`
- keeps `path` as the active runtime field for now
- adds targeted tests for:
  - legacy source manifests
  - expanded source manifest payloads
  - invalid enum values
  - config defaults and config validation
  - `init` loading the new config defaults

## Explicit non-goals for this PR

- no resolver abstraction yet
- no manifest migration helpers yet
- no runtime use of `SourcesConfig` yet
- no change to source registration behavior
- no change to ingest behavior

## Why this is split out

The next PRs need the schema/config surface to exist before runtime behavior can be migrated safely. This PR makes the source-resolution model representable without changing the current operational flow.

## Test plan

Ran:

```bash
PYTHONPATH=src pytest tests/test_schemas.py tests/test_config.py tests/test_init.py
```

All targeted tests passed.
