### PR TITLE
feat: add source resolver for ingest

### DIFF
--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -21,12 +21,10 @@ from splendor.state.runtime import (
 from splendor.state.source_registry import (
     load_source_record,
     manifest_path_for,
-    resolve_manifest_storage_path,
-    validate_stored_source_location,
     write_source_record,
 )
+from splendor.state.source_resolver import resolve_source_content
 from splendor.utils.fs import write_text_atomic
-from splendor.utils.hashing import sha256_file
 from splendor.utils.time import utc_now_iso
 from splendor.utils.wiki import (
     WikiUpdatePayload,
@@ -101,7 +99,7 @@ def _build_extract(text: str) -> str:
 
 
 def _build_summary(source: SourceRecord) -> str:
-    path_fragment = source.original_path or source.path
+    path_fragment = source.source_ref or source.original_path or source.path
     return (
         f"This page records deterministic ingestion output for source `{source.source_id}`, "
         f"a `{source.source_type}` file registered from `{path_fragment}`."
@@ -256,38 +254,36 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
         job_type="ingest_source",
         started_at=now,
         status="running",
-        input_refs=[_relative_to_root(root, manifest_path), source.path],
+        input_refs=[_relative_to_root(root, manifest_path)],
         pipeline_version=__version__,
     )
     write_run_record(run_path, run)
 
     try:
-        stored_path = resolve_manifest_storage_path(root, source.path)
-        validate_stored_source_location(
-            stored_path,
-            layout.raw_sources_dir,
-            source.source_id,
-            source.path,
+        resolved_source = resolve_source_content(root, source, layout.raw_sources_dir)
+        run = run.model_copy(
+            update={
+                "input_refs": [
+                    _relative_to_root(root, manifest_path),
+                    resolved_source.resolved_ref,
+                ]
+            }
         )
-        if not stored_path.exists():
-            msg = f"Stored source copy is missing: {stored_path}"
-            raise ValueError(msg)
-        if sha256_file(stored_path) != source.checksum:
-            msg = f"Stored source checksum mismatch for ingestion: {stored_path}"
-            raise ValueError(msg)
+        write_run_record(run_path, run)
 
         if source.source_type not in SUPPORTED_SOURCE_TYPES:
             msg = f"Unsupported source type for ingestion: {source.source_type}"
             raise ValueError(msg)
 
         try:
-            source_text = stored_path.read_text(encoding="utf-8")
+            source_text = resolved_source.resolved_path.read_text(encoding="utf-8")
         except UnicodeDecodeError as exc:
-            msg = f"Source file is not valid UTF-8 text: {stored_path}"
+            msg = f"Source file is not valid UTF-8 text: {resolved_source.resolved_path}"
             raise ValueError(msg) from exc
 
         page_path = _page_path_for(layout.wiki_sources_dir, source_id)
         page_relpath = _relative_to_root(root, page_path)
+        registered_path = source.source_ref or source.original_path or source.path
         frontmatter = KnowledgePageFrontmatter(
             kind="source-summary",
             title=source.title,
@@ -304,7 +300,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
                 [
                     f"- Source ID: `{source.source_id}`",
                     f"- Source type: `{source.source_type}`",
-                    f"- Registered path: `{source.original_path or source.path}`",
+                    f"- Registered path: `{registered_path}`",
                 ]
             ),
             summary=_build_summary(source),
@@ -319,7 +315,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
             extract=_build_extract(source_text),
             provenance=[
                 f"Manifest: `{_relative_to_root(root, manifest_path)}`",
-                f"Stored source: `{source.path}`",
+                f"{resolved_source.content_origin_label}: `{resolved_source.resolved_ref}`",
                 f"Run ID: `{run_id}`",
                 f"Pipeline version: `{__version__}`",
             ],

--- a/src/splendor/state/source_resolver.py
+++ b/src/splendor/state/source_resolver.py
@@ -108,11 +108,4 @@ def resolve_source_content(
     if source.storage_mode == "copy":
         return _resolve_copied_source(root, source, raw_sources_dir)
 
-    return ResolvedSource(
-        canonical_ref=source.original_path or source.path,
-        canonical_ref_kind="stored_artifact",
-        storage_mode="copy",
-        resolved_path=_resolve_copied_source(root, source, raw_sources_dir).resolved_path,
-        resolved_ref=source.path,
-        content_origin_label="Stored source",
-    )
+    return _resolve_copied_source(root, source, raw_sources_dir)

--- a/src/splendor/state/source_resolver.py
+++ b/src/splendor/state/source_resolver.py
@@ -1,0 +1,118 @@
+"""Source content resolution for ingestion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from splendor.schemas import SourceRecord
+from splendor.state.source_registry import (
+    resolve_manifest_storage_path,
+    validate_stored_source_location,
+)
+from splendor.utils.hashing import sha256_file
+
+
+@dataclass(frozen=True)
+class ResolvedSource:
+    canonical_ref: str
+    canonical_ref_kind: str
+    storage_mode: str
+    resolved_path: Path
+    resolved_ref: str
+    content_origin_label: str
+
+
+def _resolve_workspace_source(root: Path, source: SourceRecord) -> ResolvedSource:
+    if not source.source_ref:
+        msg = "Workspace-backed source is missing source_ref"
+        raise ValueError(msg)
+    if source.source_ref_kind != "workspace_path":
+        msg = (
+            "Workspace-backed source must use source_ref_kind=workspace_path; "
+            f"got {source.source_ref_kind!r}"
+        )
+        raise ValueError(msg)
+
+    source_ref_path = Path(source.source_ref)
+    if source_ref_path.is_absolute():
+        msg = f"Workspace source path must be repo-relative: {source.source_ref}"
+        raise ValueError(msg)
+    if ".." in source_ref_path.parts:
+        msg = f"Workspace source path escapes workspace root: {source.source_ref}"
+        raise ValueError(msg)
+
+    resolved_path = (root / source_ref_path).resolve()
+    workspace_root = root.resolve()
+    try:
+        resolved_path.relative_to(workspace_root)
+    except ValueError as exc:
+        msg = f"Workspace source path escapes workspace root: {source.source_ref}"
+        raise ValueError(msg) from exc
+
+    if not resolved_path.exists():
+        msg = f"Workspace source is missing: {source.source_ref}"
+        raise ValueError(msg)
+    if sha256_file(resolved_path) != source.checksum:
+        msg = f"Workspace source checksum mismatch for ingestion: {source.source_ref}"
+        raise ValueError(msg)
+
+    return ResolvedSource(
+        canonical_ref=source.source_ref,
+        canonical_ref_kind="workspace_path",
+        storage_mode="none",
+        resolved_path=resolved_path,
+        resolved_ref=source.source_ref,
+        content_origin_label="Workspace source",
+    )
+
+
+def _resolve_copied_source(
+    root: Path, source: SourceRecord, raw_sources_dir: Path
+) -> ResolvedSource:
+    stored_path_value = source.storage_path or source.path
+    resolved_path = resolve_manifest_storage_path(root, stored_path_value)
+    validate_stored_source_location(
+        resolved_path,
+        raw_sources_dir,
+        source.source_id,
+        stored_path_value,
+    )
+    if not resolved_path.exists():
+        msg = f"Stored source copy is missing: {resolved_path}"
+        raise ValueError(msg)
+    if sha256_file(resolved_path) != source.checksum:
+        msg = f"Stored source checksum mismatch for ingestion: {resolved_path}"
+        raise ValueError(msg)
+
+    return ResolvedSource(
+        canonical_ref=source.source_ref or source.original_path or source.path,
+        canonical_ref_kind=source.source_ref_kind or "stored_artifact",
+        storage_mode="copy",
+        resolved_path=resolved_path,
+        resolved_ref=stored_path_value,
+        content_origin_label="Stored source",
+    )
+
+
+def resolve_source_content(
+    root: Path, source: SourceRecord, raw_sources_dir: Path
+) -> ResolvedSource:
+    if source.storage_mode in {"symlink", "pointer"}:
+        msg = f"Unsupported storage mode for ingestion: {source.storage_mode}"
+        raise ValueError(msg)
+
+    if source.storage_mode == "none":
+        return _resolve_workspace_source(root, source)
+
+    if source.storage_mode == "copy":
+        return _resolve_copied_source(root, source, raw_sources_dir)
+
+    return ResolvedSource(
+        canonical_ref=source.original_path or source.path,
+        canonical_ref_kind="stored_artifact",
+        storage_mode="copy",
+        resolved_path=_resolve_copied_source(root, source, raw_sources_dir).resolved_path,
+        resolved_ref=source.path,
+        content_origin_label="Stored source",
+    )

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -9,7 +9,7 @@ from splendor.commands.ingest import ingest_source
 from splendor.commands.init import initialize_workspace
 from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord
 from splendor.state.runtime import load_queue_item, load_run_record
-from splendor.state.source_registry import load_source_record
+from splendor.state.source_registry import load_source_record, write_source_record
 
 
 def parse_frontmatter(page_path: Path) -> tuple[KnowledgePageFrontmatter, str]:
@@ -302,6 +302,120 @@ def test_ingest_source_rolls_back_wiki_on_success_commit_failure(
     assert (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8") == original_index
     assert (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8") == original_log
     assert not (tmp_path / "wiki" / "sources" / f"{added.source_id}.md").exists()
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
+    assert load_queue_item(queue_path).status == "failed"
+    assert len(run_paths) == 1
+    assert load_run_record(run_paths[0]).status == "failed"
+
+
+def test_ingest_source_workspace_backed_manifest_happy_path(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={
+            "source_ref": "brief.md",
+            "source_ref_kind": "workspace_path",
+            "storage_mode": "none",
+            "storage_path": None,
+        }
+    )
+    write_source_record(added.manifest_path, source_record)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "Workspace source: `brief.md`" in body
+    assert "registered from `brief.md`" in body
+    run_record = load_run_record(result.run_path)
+    assert run_record.input_refs == [
+        added.manifest_path.relative_to(tmp_path).as_posix(),
+        "brief.md",
+    ]
+
+
+def test_ingest_source_workspace_backed_manifest_missing_file(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={
+            "source_ref": "brief.md",
+            "source_ref_kind": "workspace_path",
+            "storage_mode": "none",
+            "storage_path": None,
+        }
+    )
+    write_source_record(added.manifest_path, source_record)
+    source.unlink()
+
+    with pytest.raises(ValueError, match="Workspace source is missing"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
+    assert load_queue_item(queue_path).status == "failed"
+    assert len(run_paths) == 1
+    assert load_run_record(run_paths[0]).status == "failed"
+
+
+def test_ingest_source_workspace_backed_manifest_checksum_drift(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={
+            "source_ref": "brief.md",
+            "source_ref_kind": "workspace_path",
+            "storage_mode": "none",
+            "storage_path": None,
+        }
+    )
+    write_source_record(added.manifest_path, source_record)
+    source.write_text("# Brief\n\nchanged\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Workspace source checksum mismatch"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
+    assert load_queue_item(queue_path).status == "failed"
+    assert len(run_paths) == 1
+    assert load_run_record(run_paths[0]).status == "failed"
+
+
+@pytest.mark.parametrize("mode", ["pointer", "symlink"])
+def test_ingest_source_rejects_unsupported_storage_mode(tmp_path: Path, mode: str) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={
+            "source_ref": "brief.md",
+            "source_ref_kind": "workspace_path",
+            "storage_mode": mode,
+        }
+    )
+    write_source_record(added.manifest_path, source_record)
+
+    with pytest.raises(ValueError, match=f"Unsupported storage mode for ingestion: {mode}"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
     queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
     run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
     assert load_queue_item(queue_path).status == "failed"

--- a/tests/test_source_resolver.py
+++ b/tests/test_source_resolver.py
@@ -1,0 +1,156 @@
+from pathlib import Path
+
+import pytest
+
+from splendor.schemas import SourceRecord
+from splendor.state.source_resolver import resolve_source_content
+
+
+def make_source_record(**overrides: object) -> SourceRecord:
+    payload: dict[str, object] = {
+        "source_id": "src-1234567890abcdef",
+        "title": "Spec",
+        "source_type": "md",
+        "path": "raw/sources/src-1234567890abcdef/spec.md",
+        "checksum": "a" * 64,
+        "added_at": "2026-04-10T15:00:00+00:00",
+        "pipeline_version": "0.1.0a0",
+    }
+    payload.update(overrides)
+    return SourceRecord(**payload)
+
+
+def test_resolve_source_content_legacy_manifest_uses_stored_copy(tmp_path: Path) -> None:
+    stored_path = tmp_path / "raw" / "sources" / "src-1234567890abcdef" / "spec.md"
+    stored_path.parent.mkdir(parents=True)
+    stored_path.write_text("hello\n", encoding="utf-8")
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/spec.md",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+        original_path="docs/spec.md",
+    )
+
+    resolved = resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+    assert resolved.canonical_ref == "docs/spec.md"
+    assert resolved.canonical_ref_kind == "stored_artifact"
+    assert resolved.storage_mode == "copy"
+    assert resolved.resolved_path == stored_path.resolve()
+    assert resolved.resolved_ref == "raw/sources/src-1234567890abcdef/spec.md"
+    assert resolved.content_origin_label == "Stored source"
+
+
+def test_resolve_source_content_explicit_copy_uses_storage_path(tmp_path: Path) -> None:
+    stored_path = tmp_path / "raw" / "sources" / "src-1234567890abcdef" / "copy.md"
+    stored_path.parent.mkdir(parents=True)
+    stored_path.write_text("hello\n", encoding="utf-8")
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/spec.md",
+        storage_mode="copy",
+        storage_path="raw/sources/src-1234567890abcdef/copy.md",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+
+    resolved = resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+    assert resolved.resolved_ref == "raw/sources/src-1234567890abcdef/copy.md"
+    assert resolved.canonical_ref == "docs/spec.md"
+
+
+def test_resolve_source_content_explicit_copy_falls_back_to_path(tmp_path: Path) -> None:
+    stored_path = tmp_path / "raw" / "sources" / "src-1234567890abcdef" / "spec.md"
+    stored_path.parent.mkdir(parents=True)
+    stored_path.write_text("hello\n", encoding="utf-8")
+    source = make_source_record(
+        storage_mode="copy",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+
+    resolved = resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+    assert resolved.resolved_ref == "raw/sources/src-1234567890abcdef/spec.md"
+
+
+def test_resolve_source_content_workspace_source_uses_repo_relative_ref(tmp_path: Path) -> None:
+    source_file = tmp_path / "docs" / "spec.md"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("hello\n", encoding="utf-8")
+    source = make_source_record(
+        storage_mode="none",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+
+    resolved = resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+    assert resolved.canonical_ref == "docs/spec.md"
+    assert resolved.canonical_ref_kind == "workspace_path"
+    assert resolved.storage_mode == "none"
+    assert resolved.resolved_path == source_file.resolve()
+    assert resolved.resolved_ref == "docs/spec.md"
+    assert resolved.content_origin_label == "Workspace source"
+
+
+def test_resolve_source_content_workspace_source_rejects_absolute_ref(tmp_path: Path) -> None:
+    source = make_source_record(
+        storage_mode="none",
+        source_ref="/tmp/spec.md",
+        source_ref_kind="workspace_path",
+    )
+
+    with pytest.raises(ValueError, match="repo-relative"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_workspace_source_rejects_escaping_ref(tmp_path: Path) -> None:
+    source = make_source_record(
+        storage_mode="none",
+        source_ref="../spec.md",
+        source_ref_kind="workspace_path",
+    )
+
+    with pytest.raises(ValueError, match="escapes workspace root"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_workspace_source_rejects_missing_file(tmp_path: Path) -> None:
+    source = make_source_record(
+        storage_mode="none",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+    )
+
+    with pytest.raises(ValueError, match="Workspace source is missing"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_workspace_source_rejects_checksum_mismatch(tmp_path: Path) -> None:
+    source_file = tmp_path / "docs" / "spec.md"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("changed\n", encoding="utf-8")
+    source = make_source_record(
+        storage_mode="none",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+
+    with pytest.raises(ValueError, match="Workspace source checksum mismatch"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+@pytest.mark.parametrize("mode", ["pointer", "symlink"])
+def test_resolve_source_content_rejects_unsupported_storage_modes(
+    tmp_path: Path, mode: str
+) -> None:
+    source = make_source_record(
+        storage_mode=mode,
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+    )
+
+    with pytest.raises(ValueError, match=f"Unsupported storage mode for ingestion: {mode}"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")


### PR DESCRIPTION
## Summary
- add a source resolver abstraction so ingest no longer assumes all source bytes live under `raw/sources/`
- support workspace-backed manifests during ingest while keeping current `add-source` behavior unchanged
- add resolver and ingest coverage for legacy copied sources, workspace-backed sources, and unsupported future storage modes

## Testing
- `uv run ruff format --check .`
- `uv run ruff check src tests`
- `PYTHONPATH=src pytest tests/test_source_resolver.py tests/test_ingest.py`