### PR TITLE
fix: retain source refs in failed ingest runs

### DIFF
--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -309,7 +309,11 @@ Make the core source manifest and ingest path understand canonical references an
 
 ### Recommended PR breakdown
 
-#### PR 1 — Docs and contract alignment
+Planning note:
+
+- the rollout steps below use `SR-n` labels (`Source Resolution`) to distinguish plan items from GitHub PR numbers
+
+#### SR-1 — Docs and contract alignment
 
 Scope:
 
@@ -322,7 +326,7 @@ Exit criteria:
 
 - docs agree on the target architecture before code changes begin
 
-#### PR 2 — Schema and config scaffolding
+#### SR-2 — Schema and config scaffolding
 
 Scope:
 
@@ -336,7 +340,7 @@ Exit criteria:
 - manifests can express source reference and storage policy
 - config defaults can encode workspace-vs-external behavior
 
-#### PR 3 — Source resolver abstraction
+#### SR-3 — Source resolver abstraction
 
 Scope:
 
@@ -351,7 +355,7 @@ Exit criteria:
 
 - ingest no longer assumes `raw/sources/` is always the place to read bytes from
 
-#### PR 4 — `add-source` default behavior switch
+#### SR-4 — `add-source` default behavior switch
 
 Scope:
 
@@ -365,7 +369,7 @@ Exit criteria:
 - in-repo files stop being copied by default
 - explicit overrides still work
 
-#### PR 5 — Migration and polish
+#### SR-5 — Migration and polish
 
 Scope:
 
@@ -393,7 +397,11 @@ Make the wiki output and storage options match the new source model ergonomicall
 
 ### Recommended PR breakdown
 
-#### PR 6 — Source-summary rendering policy
+Planning note:
+
+- phase 2 continues the same `SR-n` sequence rather than restarting with GitHub PR numbers
+
+#### SR-6 — Source-summary rendering policy
 
 Scope:
 
@@ -406,7 +414,7 @@ Exit criteria:
 
 - `wiki/sources/` becomes materially less noisy for in-repo docs and code
 
-#### PR 7 — Pointer storage mode
+#### SR-7 — Pointer storage mode
 
 Scope:
 
@@ -418,7 +426,7 @@ Exit criteria:
 
 - projects have a cross-platform materialization alternative that does not duplicate bytes
 
-#### PR 8 — Optional symlink mode
+#### SR-8 — Optional symlink mode
 
 Scope:
 
@@ -430,7 +438,7 @@ Exit criteria:
 
 - projects that prefer filesystem-level mirroring can opt in knowingly
 
-#### PR 9 — Materialization workflow polish
+#### SR-9 — Materialization workflow polish
 
 Scope:
 

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -106,6 +106,10 @@ def _build_summary(source: SourceRecord) -> str:
     )
 
 
+def _best_available_source_ref(source: SourceRecord) -> str:
+    return source.source_ref or source.storage_path or source.path
+
+
 def _is_no_op(root: Path, layout, source: SourceRecord) -> bool:
     if source.status != "ingested" or not source.last_run_id:
         return False
@@ -254,7 +258,10 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
         job_type="ingest_source",
         started_at=now,
         status="running",
-        input_refs=[_relative_to_root(root, manifest_path)],
+        input_refs=[
+            _relative_to_root(root, manifest_path),
+            _best_available_source_ref(source),
+        ],
         pipeline_version=__version__,
     )
     write_run_record(run_path, run)

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -107,7 +107,9 @@ def _build_summary(source: SourceRecord) -> str:
 
 
 def _best_available_source_ref(source: SourceRecord) -> str:
-    return source.source_ref or source.storage_path or source.path
+    if source.storage_mode == "none":
+        return source.source_ref or source.storage_path or source.path
+    return source.storage_path or source.path or source.source_ref
 
 
 def _is_no_op(root: Path, layout, source: SourceRecord) -> bool:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -267,6 +267,36 @@ def test_ingest_source_records_missing_stored_copy_as_failed_attempt(tmp_path: P
     ]
 
 
+def test_ingest_source_explicit_copy_manifest_failure_uses_storage_path(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    manifest = json.loads(added.manifest_path.read_text(encoding="utf-8"))
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={
+            "source_ref": "brief.md",
+            "source_ref_kind": "workspace_path",
+            "storage_mode": "copy",
+            "storage_path": manifest["path"],
+        }
+    )
+    write_source_record(added.manifest_path, source_record)
+    (tmp_path / manifest["path"]).unlink()
+
+    with pytest.raises(ValueError, match="Stored source copy is missing"):
+        ingest_source(tmp_path, added.source_id)
+
+    run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
+    assert len(run_paths) == 1
+    run_record = load_run_record(run_paths[0])
+    assert run_record.status == "failed"
+    assert run_record.input_refs == [
+        added.manifest_path.relative_to(tmp_path).as_posix(),
+        manifest["path"],
+    ]
+
+
 def test_ingest_source_extract_uses_safe_fence_for_backticks(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -232,7 +232,12 @@ def test_ingest_source_validates_stored_copy_checksum(tmp_path: Path) -> None:
     run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
     assert load_queue_item(queue_path).status == "failed"
     assert len(run_paths) == 1
-    assert load_run_record(run_paths[0]).status == "failed"
+    run_record = load_run_record(run_paths[0])
+    assert run_record.status == "failed"
+    assert run_record.input_refs == [
+        added.manifest_path.relative_to(tmp_path).as_posix(),
+        manifest["path"],
+    ]
 
 
 def test_ingest_source_records_missing_stored_copy_as_failed_attempt(tmp_path: Path) -> None:
@@ -254,7 +259,12 @@ def test_ingest_source_records_missing_stored_copy_as_failed_attempt(tmp_path: P
     run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
     assert load_queue_item(queue_path).status == "failed"
     assert len(run_paths) == 1
-    assert load_run_record(run_paths[0]).status == "failed"
+    run_record = load_run_record(run_paths[0])
+    assert run_record.status == "failed"
+    assert run_record.input_refs == [
+        added.manifest_path.relative_to(tmp_path).as_posix(),
+        manifest["path"],
+    ]
 
 
 def test_ingest_source_extract_uses_safe_fence_for_backticks(tmp_path: Path) -> None:
@@ -279,6 +289,7 @@ def test_ingest_source_rolls_back_wiki_on_success_commit_failure(
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
     added = add_source(tmp_path, source)
+    manifest = json.loads(added.manifest_path.read_text(encoding="utf-8"))
     original_index = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
     original_log = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
 
@@ -306,7 +317,12 @@ def test_ingest_source_rolls_back_wiki_on_success_commit_failure(
     run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
     assert load_queue_item(queue_path).status == "failed"
     assert len(run_paths) == 1
-    assert load_run_record(run_paths[0]).status == "failed"
+    run_record = load_run_record(run_paths[0])
+    assert run_record.status == "failed"
+    assert run_record.input_refs == [
+        added.manifest_path.relative_to(tmp_path).as_posix(),
+        manifest["path"],
+    ]
 
 
 def test_ingest_source_workspace_backed_manifest_happy_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- keep a best-effort source ref in `RunRecord.input_refs` before source resolution succeeds
- preserve stored-copy refs for copied-source failure cases and workspace refs for workspace-backed failure cases
- add ingest coverage so failed runs retain useful provenance for debugging

## Testing
- `uv run ruff format --check .`
- `uv run ruff check src tests`
- `PYTHONPATH=src pytest tests/test_source_resolver.py tests/test_ingest.py`