### PR TITLE
feat: switch add-source to workspace-native defaults

### DIFF
--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -31,19 +31,20 @@ def build_parser() -> argparse.ArgumentParser:
         choices=STORAGE_MODES,
         help="Override the configured storage mode for this source.",
     )
-    add_source_parser.add_argument(
+    capture_group = add_source_parser.add_mutually_exclusive_group()
+    capture_group.add_argument(
         "--capture-source-commit",
         dest="capture_source_commit",
         action="store_true",
-        default=None,
         help="Capture the current HEAD commit for clean tracked workspace files.",
     )
-    add_source_parser.add_argument(
+    capture_group.add_argument(
         "--no-capture-source-commit",
         dest="capture_source_commit",
         action="store_false",
         help="Do not capture git provenance for this registration.",
     )
+    add_source_parser.set_defaults(capture_source_commit=None)
     add_source_parser.set_defaults(handler=handle_add_source)
 
     ingest_parser = subparsers.add_parser("ingest", help="Ingest a registered source into the wiki")

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from splendor.commands.add_source import add_source
 from splendor.commands.ingest import ingest_source
 from splendor.commands.init import initialize_workspace
+from splendor.schemas.types import STORAGE_MODES
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -25,6 +26,24 @@ def build_parser() -> argparse.ArgumentParser:
 
     add_source_parser = subparsers.add_parser("add-source", help="Register a new immutable source")
     add_source_parser.add_argument("path", type=Path, help="Path to the source file to register")
+    add_source_parser.add_argument(
+        "--storage-mode",
+        choices=STORAGE_MODES,
+        help="Override the configured storage mode for this source.",
+    )
+    add_source_parser.add_argument(
+        "--capture-source-commit",
+        dest="capture_source_commit",
+        action="store_true",
+        default=None,
+        help="Capture the current HEAD commit for clean tracked workspace files.",
+    )
+    add_source_parser.add_argument(
+        "--no-capture-source-commit",
+        dest="capture_source_commit",
+        action="store_false",
+        help="Do not capture git provenance for this registration.",
+    )
     add_source_parser.set_defaults(handler=handle_add_source)
 
     ingest_parser = subparsers.add_parser("ingest", help="Ingest a registered source into the wiki")
@@ -45,11 +64,23 @@ def handle_add_source(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     candidate_path = args.path.expanduser()
     source_path = candidate_path if candidate_path.is_absolute() else root / candidate_path
-    result = add_source(root, source_path)
+    try:
+        result = add_source(
+            root,
+            source_path,
+            storage_mode=args.storage_mode,
+            capture_source_commit=args.capture_source_commit,
+        )
+    except (FileNotFoundError, IsADirectoryError, ValueError) as exc:
+        print(f"Error: {exc}")
+        return 1
     action = "Already registered" if result.already_registered else "Registered"
     print(f"{action} source {result.source_id}")
     print(f"Manifest: {result.manifest_path}")
-    print(f"Stored copy: {result.stored_path}")
+    print(f"Source ref: {result.source_ref}")
+    print(f"Storage mode: {result.storage_mode}")
+    if result.stored_path is not None:
+        print(f"Stored copy: {result.stored_path}")
     return 0
 
 

--- a/src/splendor/commands/add_source.py
+++ b/src/splendor/commands/add_source.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from splendor.schemas.types import StorageMode
 from splendor.state.source_registry import register_source
 
 
@@ -12,15 +13,30 @@ from splendor.state.source_registry import register_source
 class AddSourceResult:
     source_id: str
     manifest_path: Path
-    stored_path: Path
+    stored_path: Path | None
+    storage_mode: StorageMode
+    source_ref: str
     already_registered: bool
 
 
-def add_source(root: Path, source_path: Path) -> AddSourceResult:
-    registered = register_source(root, source_path)
+def add_source(
+    root: Path,
+    source_path: Path,
+    *,
+    storage_mode: StorageMode | None = None,
+    capture_source_commit: bool | None = None,
+) -> AddSourceResult:
+    registered = register_source(
+        root,
+        source_path,
+        storage_mode=storage_mode,
+        capture_source_commit=capture_source_commit,
+    )
     return AddSourceResult(
         source_id=registered.record.source_id,
         manifest_path=registered.manifest_path,
         stored_path=registered.stored_path,
+        storage_mode=registered.storage_mode,
+        source_ref=registered.source_ref,
         already_registered=registered.already_registered,
     )

--- a/src/splendor/config.py
+++ b/src/splendor/config.py
@@ -1,7 +1,6 @@
 """Configuration loading for Splendor.
 
-`SourcesConfig` captures policy defaults for the upcoming source-resolution model. Runtime
-registration and ingest do not consume it yet in this release.
+`SourcesConfig` captures source-registration defaults and source-summary rendering policy.
 """
 
 from __future__ import annotations

--- a/src/splendor/schemas/types.py
+++ b/src/splendor/schemas/types.py
@@ -7,3 +7,5 @@ from typing import Literal
 StorageMode = Literal["none", "copy", "symlink", "pointer"]
 SummaryMode = Literal["none", "excerpt", "full"]
 SourceRefKind = Literal["workspace_path", "external_path", "url", "imported", "stored_artifact"]
+
+STORAGE_MODES = ("none", "copy", "symlink", "pointer")

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -168,7 +168,14 @@ def _validated_existing_registration(
 ) -> tuple[Path | None, StorageMode, str]:
     from splendor.state.source_resolver import resolve_source_content
 
-    resolved = resolve_source_content(root, existing, layout.raw_sources_dir)
+    try:
+        resolved = resolve_source_content(root, existing, layout.raw_sources_dir)
+    except ValueError as exc:
+        msg = (
+            "Existing source manifest could not be validated during add-source "
+            f"for source {existing.source_id}: {exc}"
+        )
+        raise ValueError(msg) from exc
     stored_path = resolved.resolved_path if resolved.storage_mode == "copy" else None
     source_ref = existing.source_ref or existing.original_path or existing.path
     return stored_path, resolved.storage_mode, source_ref

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -10,7 +10,9 @@ from splendor import __version__
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import SourceRecord
+from splendor.schemas.types import StorageMode
 from splendor.utils.fs import copy_file_if_missing, ensure_directory, write_text_atomic
+from splendor.utils.git import captured_source_commit
 from splendor.utils.hashing import sha256_file
 from splendor.utils.ids import stable_source_id
 from splendor.utils.time import utc_now_iso
@@ -20,7 +22,9 @@ from splendor.utils.time import utc_now_iso
 class RegisteredSource:
     record: SourceRecord
     manifest_path: Path
-    stored_path: Path
+    stored_path: Path | None
+    storage_mode: StorageMode
+    source_ref: str
     copied: bool
     already_registered: bool
 
@@ -84,7 +88,99 @@ def manifest_original_path(root: Path, source_path: Path) -> str:
         return str(source_path.expanduser())
 
 
-def register_source(root: Path, source_path: Path) -> RegisteredSource:
+def _title_for(candidate: Path) -> str:
+    return candidate.stem.replace("_", " ").replace("-", " ").strip() or candidate.name
+
+
+def _source_reference(root: Path, candidate: Path) -> tuple[str, str]:
+    try:
+        return candidate.relative_to(root.resolve()).as_posix(), "workspace_path"
+    except ValueError:
+        return str(candidate), "external_path"
+
+
+def _effective_storage_mode(
+    *,
+    source_ref_kind: str,
+    configured_storage_mode: StorageMode,
+) -> StorageMode:
+    if source_ref_kind == "workspace_path":
+        if configured_storage_mode in {"none", "copy"}:
+            return configured_storage_mode
+        msg = (
+            f"Storage mode {configured_storage_mode!r} is not implemented yet for workspace sources"
+        )
+        raise ValueError(msg)
+
+    if configured_storage_mode == "copy":
+        return "copy"
+    if configured_storage_mode in {"pointer", "symlink"}:
+        msg = (
+            f"Storage mode {configured_storage_mode!r} is not implemented yet for external sources"
+        )
+        raise ValueError(msg)
+    msg = f"Storage mode {configured_storage_mode!r} is not supported for external sources"
+    raise ValueError(msg)
+
+
+def _storage_mode_for_source(
+    *,
+    source_ref_kind: str,
+    config,
+    storage_mode_override: StorageMode | None,
+) -> StorageMode:
+    configured = (
+        storage_mode_override
+        if storage_mode_override is not None
+        else (
+            config.sources.in_repo_storage_mode
+            if source_ref_kind == "workspace_path"
+            else config.sources.external_storage_mode
+        )
+    )
+    return _effective_storage_mode(
+        source_ref_kind=source_ref_kind,
+        configured_storage_mode=configured,
+    )
+
+
+def _source_commit_for_registration(
+    *,
+    root: Path,
+    candidate: Path,
+    source_ref_kind: str,
+    capture_source_commit_enabled: bool,
+) -> str | None:
+    if not capture_source_commit_enabled or source_ref_kind != "workspace_path":
+        return None
+    return captured_source_commit(root, candidate)
+
+
+def _stored_path_for(layout, source_id: str, candidate: Path) -> Path:
+    return layout.raw_sources_dir / source_id / candidate.name
+
+
+def _validated_existing_registration(
+    *,
+    root: Path,
+    layout,
+    existing: SourceRecord,
+) -> tuple[Path | None, StorageMode, str]:
+    from splendor.state.source_resolver import resolve_source_content
+
+    resolved = resolve_source_content(root, existing, layout.raw_sources_dir)
+    stored_path = resolved.resolved_path if resolved.storage_mode == "copy" else None
+    source_ref = existing.source_ref or existing.original_path or existing.path
+    return stored_path, resolved.storage_mode, source_ref
+
+
+def register_source(
+    root: Path,
+    source_path: Path,
+    *,
+    storage_mode: StorageMode | None = None,
+    capture_source_commit: bool | None = None,
+) -> RegisteredSource:
     candidate = source_path.expanduser().resolve()
     if not candidate.exists():
         msg = f"Source path does not exist: {source_path}"
@@ -101,7 +197,26 @@ def register_source(root: Path, source_path: Path) -> RegisteredSource:
     checksum = sha256_file(candidate)
     source_id = stable_source_id(checksum)
     manifest_path = layout.source_records_dir / f"{source_id}.json"
-    stored_path = layout.raw_sources_dir / source_id / candidate.name
+    source_ref, source_ref_kind = _source_reference(root, candidate)
+    selected_storage_mode = _storage_mode_for_source(
+        source_ref_kind=source_ref_kind,
+        config=config,
+        storage_mode_override=storage_mode,
+    )
+    capture_commit_enabled = (
+        capture_source_commit
+        if capture_source_commit is not None
+        else config.sources.capture_source_commit
+    )
+    source_commit = _source_commit_for_registration(
+        root=root,
+        candidate=candidate,
+        source_ref_kind=source_ref_kind,
+        capture_source_commit_enabled=capture_commit_enabled,
+    )
+    stored_path = (
+        _stored_path_for(layout, source_id, candidate) if selected_storage_mode == "copy" else None
+    )
 
     if manifest_path.exists():
         existing = load_source_record(manifest_path)
@@ -117,54 +232,56 @@ def register_source(root: Path, source_path: Path) -> RegisteredSource:
                 f"expected {existing.checksum}, got {checksum}"
             )
             raise ValueError(msg)
-        existing_stored_path = resolve_manifest_storage_path(root, existing.path)
-        validate_stored_source_location(
-            existing_stored_path,
-            layout.raw_sources_dir,
-            source_id,
-            existing.path,
+        existing_stored_path, existing_storage_mode, existing_source_ref = (
+            _validated_existing_registration(root=root, layout=layout, existing=existing)
         )
-        if not existing_stored_path.exists():
-            msg = f"Stored source copy is missing for existing manifest: {existing_stored_path}"
-            raise FileNotFoundError(msg)
-        existing_stored_checksum = sha256_file(existing_stored_path)
-        if existing_stored_checksum != existing.checksum:
-            msg = (
-                f"Stored source checksum mismatch for existing manifest {manifest_path}: "
-                f"expected {existing.checksum}, got {existing_stored_checksum}"
-            )
-            raise ValueError(msg)
         return RegisteredSource(
             record=existing,
             manifest_path=manifest_path,
             stored_path=existing_stored_path,
+            storage_mode=existing_storage_mode,
+            source_ref=existing_source_ref,
             copied=False,
             already_registered=True,
         )
 
-    copied = copy_file_if_missing(candidate, stored_path)
-    stored_checksum = sha256_file(stored_path)
-    if stored_checksum != checksum:
-        msg = (
-            f"Stored source checksum mismatch for {stored_path}: "
-            f"expected {checksum}, got {stored_checksum}"
-        )
-        raise ValueError(msg)
+    copied = False
+    if stored_path is not None:
+        copied = copy_file_if_missing(candidate, stored_path)
+        stored_checksum = sha256_file(stored_path)
+        if stored_checksum != checksum:
+            msg = (
+                f"Stored source checksum mismatch for {stored_path}: "
+                f"expected {checksum}, got {stored_checksum}"
+            )
+            raise ValueError(msg)
+
+    added_at = utc_now_iso()
     record = SourceRecord(
         source_id=source_id,
-        title=candidate.stem.replace("_", " ").replace("-", " ").strip() or candidate.name,
+        title=_title_for(candidate),
         source_type=candidate.suffix.lstrip(".") or "file",
-        path=stored_path.relative_to(root).as_posix(),
+        path=(stored_path.relative_to(root).as_posix() if stored_path is not None else source_ref),
         checksum=checksum,
-        added_at=utc_now_iso(),
+        added_at=added_at,
         pipeline_version=__version__,
         original_path=manifest_original_path(root, source_path),
+        source_ref=source_ref,
+        source_ref_kind=source_ref_kind,
+        storage_mode=selected_storage_mode,
+        storage_path=(
+            stored_path.relative_to(root).as_posix() if stored_path is not None else None
+        ),
+        materialized_at=(added_at if stored_path is not None else None),
+        source_commit=source_commit,
     )
     write_source_record(manifest_path, record)
     return RegisteredSource(
         record=record,
         manifest_path=manifest_path,
         stored_path=stored_path,
+        storage_mode=selected_storage_mode,
+        source_ref=source_ref,
         copied=copied,
         already_registered=False,
     )

--- a/src/splendor/utils/git.py
+++ b/src/splendor/utils/git.py
@@ -1,0 +1,47 @@
+"""Small git helpers for provenance capture."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def captured_source_commit(root: Path, source_path: Path) -> str | None:
+    """Return HEAD SHA for a clean tracked file, else ``None``."""
+
+    source_rel: str
+    try:
+        source_rel = source_path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return None
+
+    inside = _git(root, "rev-parse", "--is-inside-work-tree")
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        return None
+
+    head = _git(root, "rev-parse", "HEAD")
+    if head.returncode != 0:
+        return None
+    head_sha = head.stdout.strip()
+    if not head_sha:
+        return None
+
+    tracked = _git(root, "ls-files", "--error-unmatch", "--", source_rel)
+    if tracked.returncode != 0:
+        return None
+
+    status = _git(root, "status", "--porcelain", "--", source_rel)
+    if status.returncode != 0 or status.stdout.strip():
+        return None
+
+    return head_sha

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -176,7 +176,10 @@ def test_add_source_existing_workspace_manifest_missing_file_fails(tmp_path: Pat
     replacement = tmp_path / "replacement.txt"
     replacement.write_text("same-content\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="Workspace source is missing"):
+    with pytest.raises(
+        ValueError,
+        match="Existing source manifest could not be validated during add-source",
+    ):
         add_source(tmp_path, replacement)
 
     manifest = load_source_record(first.manifest_path)
@@ -193,7 +196,10 @@ def test_add_source_existing_workspace_manifest_checksum_drift_fails(tmp_path: P
     replacement = tmp_path / "replacement.txt"
     replacement.write_text("same-content\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="Workspace source checksum mismatch"):
+    with pytest.raises(
+        ValueError,
+        match="Existing source manifest could not be validated during add-source",
+    ):
         add_source(tmp_path, replacement)
 
     manifest = load_source_record(first.manifest_path)

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -1,13 +1,35 @@
-import json
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
+from splendor.state.source_registry import load_source_record, write_source_record
 
 
-def test_add_source_registers_and_copies_file(tmp_path: Path) -> None:
+def git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def init_git_repo(root: Path) -> None:
+    git(root, "init")
+    git(root, "config", "user.name", "Test User")
+    git(root, "config", "user.email", "test@example.com")
+
+
+def commit_all(root: Path, message: str) -> None:
+    git(root, "add", ".")
+    git(root, "commit", "-m", message)
+
+
+def test_add_source_registers_workspace_file_without_copy_by_default(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "note.md"
     source.write_text("# note\n", encoding="utf-8")
@@ -16,17 +38,23 @@ def test_add_source_registers_and_copies_file(tmp_path: Path) -> None:
 
     assert result.source_id.startswith("src-")
     assert result.manifest_path.exists()
-    assert result.stored_path.exists()
+    assert result.stored_path is None
+    assert result.storage_mode == "none"
+    assert result.source_ref == "note.md"
 
-    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
-    assert manifest["kind"] == "source"
-    assert manifest["path"].endswith("note.md")
-    assert "/" in manifest["path"]
-    assert manifest["checksum"]
-    assert manifest["original_path"] == "note.md"
+    manifest = load_source_record(result.manifest_path)
+    assert manifest.kind == "source"
+    assert manifest.path == "note.md"
+    assert manifest.source_ref == "note.md"
+    assert manifest.source_ref_kind == "workspace_path"
+    assert manifest.storage_mode == "none"
+    assert manifest.storage_path is None
+    assert manifest.materialized_at is None
+    assert manifest.original_path == "note.md"
+    assert not (tmp_path / "raw" / "sources" / result.source_id).exists()
 
 
-def test_add_source_stores_workspace_relative_original_path(tmp_path: Path) -> None:
+def test_add_source_stores_workspace_relative_source_ref_for_nested_sources(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     nested_dir = tmp_path / "docs"
     nested_dir.mkdir()
@@ -35,11 +63,13 @@ def test_add_source_stores_workspace_relative_original_path(tmp_path: Path) -> N
 
     result = add_source(tmp_path, source)
 
-    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
-    assert manifest["original_path"] == "docs/note.md"
+    manifest = load_source_record(result.manifest_path)
+    assert result.source_ref == "docs/note.md"
+    assert manifest.source_ref == "docs/note.md"
+    assert manifest.original_path == "docs/note.md"
 
 
-def test_add_source_stores_expanded_original_path_for_external_sources(tmp_path: Path) -> None:
+def test_add_source_registers_external_sources_as_copies_by_default(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     external_dir = tmp_path.parent / f"{tmp_path.name}-external"
     external_dir.mkdir()
@@ -48,14 +78,67 @@ def test_add_source_stores_expanded_original_path_for_external_sources(tmp_path:
 
     try:
         result = add_source(tmp_path, source)
-        manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
-        assert manifest["original_path"] == str(source)
+        manifest = load_source_record(result.manifest_path)
+        assert result.stored_path is not None and result.stored_path.exists()
+        assert result.storage_mode == "copy"
+        assert result.source_ref == str(source.resolve())
+        assert manifest.path == manifest.storage_path
+        assert manifest.source_ref == str(source.resolve())
+        assert manifest.source_ref_kind == "external_path"
+        assert manifest.storage_mode == "copy"
+        assert manifest.original_path == str(source)
+        assert manifest.materialized_at is not None
     finally:
         source.unlink(missing_ok=True)
         external_dir.rmdir()
 
 
-def test_add_source_is_deduplicated_by_checksum(tmp_path: Path) -> None:
+def test_add_source_supports_explicit_copy_for_workspace_sources(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+
+    result = add_source(tmp_path, source, storage_mode="copy")
+
+    manifest = load_source_record(result.manifest_path)
+    assert result.stored_path is not None and result.stored_path.exists()
+    assert result.storage_mode == "copy"
+    assert result.source_ref == "note.md"
+    assert manifest.path.startswith(f"raw/sources/{result.source_id}/")
+    assert manifest.storage_path == manifest.path
+    assert manifest.source_ref == "note.md"
+    assert manifest.source_ref_kind == "workspace_path"
+    assert manifest.storage_mode == "copy"
+
+
+def test_add_source_rejects_external_none_storage_mode(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    external_dir = tmp_path.parent / f"{tmp_path.name}-external"
+    external_dir.mkdir()
+    source = external_dir / "outside.md"
+    source.write_text("# outside\n", encoding="utf-8")
+
+    try:
+        with pytest.raises(ValueError, match="not supported for external sources"):
+            add_source(tmp_path, source, storage_mode="none")
+    finally:
+        source.unlink(missing_ok=True)
+        external_dir.rmdir()
+
+
+@pytest.mark.parametrize("storage_mode", ["pointer", "symlink"])
+def test_add_source_rejects_unimplemented_storage_modes(tmp_path: Path, storage_mode: str) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="not implemented yet"):
+        add_source(tmp_path, source, storage_mode=storage_mode)
+
+
+def test_add_source_is_deduplicated_by_checksum_for_workspace_backed_sources(
+    tmp_path: Path,
+) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "notes.txt"
     source.write_text("same-content\n", encoding="utf-8")
@@ -65,128 +148,145 @@ def test_add_source_is_deduplicated_by_checksum(tmp_path: Path) -> None:
 
     assert first.source_id == second.source_id
     assert second.already_registered is True
+    assert second.storage_mode == "none"
+    assert second.stored_path is None
 
 
-def test_add_source_reuses_existing_stored_copy_for_same_content(tmp_path: Path) -> None:
+def test_add_source_is_deduplicated_by_checksum_for_copied_sources(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
-    first_source = tmp_path / "notes.txt"
-    second_source = tmp_path / "renamed-notes.txt"
-    first_source.write_text("same-content\n", encoding="utf-8")
-    second_source.write_text("same-content\n", encoding="utf-8")
+    source = tmp_path / "notes.txt"
+    source.write_text("same-content\n", encoding="utf-8")
 
-    first = add_source(tmp_path, first_source)
-    second = add_source(tmp_path, second_source)
+    first = add_source(tmp_path, source, storage_mode="copy")
+    second = add_source(tmp_path, source, storage_mode="copy")
 
     assert first.source_id == second.source_id
+    assert second.already_registered is True
+    assert second.storage_mode == "copy"
     assert second.stored_path == first.stored_path
-    assert not (tmp_path / "raw" / "sources" / first.source_id / "renamed-notes.txt").exists()
 
 
-def test_add_source_raises_if_existing_manifest_checksum_mismatches(tmp_path: Path) -> None:
+def test_add_source_existing_workspace_manifest_missing_file_fails(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "notes.txt"
     source.write_text("same-content\n", encoding="utf-8")
 
     first = add_source(tmp_path, source)
-    manifest = json.loads(first.manifest_path.read_text(encoding="utf-8"))
-    manifest["checksum"] = "b" * 64
-    first.manifest_path.write_text(
-        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
+    source.unlink()
+    replacement = tmp_path / "replacement.txt"
+    replacement.write_text("same-content\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Workspace source is missing"):
+        add_source(tmp_path, replacement)
+
+    manifest = load_source_record(first.manifest_path)
+    assert manifest.storage_mode == "none"
+
+
+def test_add_source_existing_workspace_manifest_checksum_drift_fails(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "notes.txt"
+    source.write_text("same-content\n", encoding="utf-8")
+
+    first = add_source(tmp_path, source)
+    source.write_text("changed\n", encoding="utf-8")
+    replacement = tmp_path / "replacement.txt"
+    replacement.write_text("same-content\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Workspace source checksum mismatch"):
+        add_source(tmp_path, replacement)
+
+    manifest = load_source_record(first.manifest_path)
+    assert manifest.storage_mode == "none"
+
+
+def test_add_source_captures_head_for_clean_tracked_workspace_file(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    init_git_repo(tmp_path)
+    commit_all(tmp_path, "initial")
+    head = git(tmp_path, "rev-parse", "HEAD").stdout.strip()
+
+    result = add_source(tmp_path, source)
+
+    manifest = load_source_record(result.manifest_path)
+    assert manifest.source_commit == head
+
+
+def test_add_source_leaves_source_commit_null_for_untracked_workspace_file(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    init_git_repo(tmp_path)
+    commit_all(tmp_path, "initial")
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+
+    result = add_source(tmp_path, source)
+
+    manifest = load_source_record(result.manifest_path)
+    assert manifest.source_commit is None
+
+
+def test_add_source_leaves_source_commit_null_for_dirty_tracked_workspace_file(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    init_git_repo(tmp_path)
+    commit_all(tmp_path, "initial")
+    source.write_text("# changed\n", encoding="utf-8")
+
+    result = add_source(tmp_path, source)
+
+    manifest = load_source_record(result.manifest_path)
+    assert manifest.source_commit is None
+
+
+def test_add_source_leaves_source_commit_null_for_external_file(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    init_git_repo(tmp_path)
+    commit_all(tmp_path, "initial")
+    external_dir = tmp_path.parent / f"{tmp_path.name}-external"
+    external_dir.mkdir()
+    source = external_dir / "outside.md"
+    source.write_text("# outside\n", encoding="utf-8")
+
+    try:
+        result = add_source(tmp_path, source)
+        manifest = load_source_record(result.manifest_path)
+        assert manifest.source_commit is None
+    finally:
+        source.unlink(missing_ok=True)
+        external_dir.rmdir()
+
+
+def test_add_source_no_capture_override_suppresses_source_commit(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    init_git_repo(tmp_path)
+    commit_all(tmp_path, "initial")
+
+    result = add_source(tmp_path, source, capture_source_commit=False)
+
+    manifest = load_source_record(result.manifest_path)
+    assert manifest.source_commit is None
+
+
+def test_add_source_reuses_existing_manifest_authoritatively(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+
+    first = add_source(tmp_path, source, storage_mode="copy")
+    manifest = load_source_record(first.manifest_path).model_copy(
+        update={"source_ref": "docs/custom.md"}
     )
+    write_source_record(first.manifest_path, manifest)
 
-    with pytest.raises(ValueError, match="Checksum mismatch"):
-        add_source(tmp_path, source)
+    second = add_source(tmp_path, source)
 
-
-def test_add_source_rejects_existing_manifest_source_id_mismatch(tmp_path: Path) -> None:
-    initialize_workspace(tmp_path)
-    source = tmp_path / "notes.txt"
-    source.write_text("same-content\n", encoding="utf-8")
-
-    first = add_source(tmp_path, source)
-    manifest = json.loads(first.manifest_path.read_text(encoding="utf-8"))
-    manifest["source_id"] = "src-other"
-    first.manifest_path.write_text(
-        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-
-    with pytest.raises(ValueError, match="Source ID mismatch"):
-        add_source(tmp_path, source)
-
-
-def test_add_source_rejects_manifest_path_outside_workspace(tmp_path: Path) -> None:
-    initialize_workspace(tmp_path)
-    source = tmp_path / "notes.txt"
-    source.write_text("same-content\n", encoding="utf-8")
-
-    first = add_source(tmp_path, source)
-    manifest = json.loads(first.manifest_path.read_text(encoding="utf-8"))
-    manifest["path"] = "../escape.txt"
-    first.manifest_path.write_text(
-        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-
-    with pytest.raises(ValueError, match="escapes workspace root"):
-        add_source(tmp_path, source)
-
-
-def test_add_source_rejects_manifest_path_outside_raw_sources_dir(tmp_path: Path) -> None:
-    initialize_workspace(tmp_path)
-    source = tmp_path / "notes.txt"
-    source.write_text("same-content\n", encoding="utf-8")
-
-    first = add_source(tmp_path, source)
-    manifest = json.loads(first.manifest_path.read_text(encoding="utf-8"))
-    manifest["path"] = "wiki/index.md"
-    first.manifest_path.write_text(
-        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-
-    with pytest.raises(ValueError, match="outside the configured raw source storage area"):
-        add_source(tmp_path, source)
-
-
-def test_add_source_rejects_manifest_path_for_wrong_source_dir(tmp_path: Path) -> None:
-    initialize_workspace(tmp_path)
-    source = tmp_path / "notes.txt"
-    source.write_text("same-content\n", encoding="utf-8")
-
-    first = add_source(tmp_path, source)
-    manifest = json.loads(first.manifest_path.read_text(encoding="utf-8"))
-    manifest["path"] = "raw/sources/src-other/notes.txt"
-    first.manifest_path.write_text(
-        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-
-    with pytest.raises(ValueError, match="outside the expected source directory"):
-        add_source(tmp_path, source)
-
-
-def test_add_source_rejects_corrupted_existing_stored_copy(tmp_path: Path) -> None:
-    initialize_workspace(tmp_path)
-    source = tmp_path / "notes.txt"
-    source.write_text("same-content\n", encoding="utf-8")
-
-    first = add_source(tmp_path, source)
-    first.stored_path.write_text("tampered\n", encoding="utf-8")
-    first.manifest_path.unlink()
-
-    with pytest.raises(ValueError, match="Stored source checksum mismatch"):
-        add_source(tmp_path, source)
-
-
-def test_add_source_rejects_missing_existing_stored_copy(tmp_path: Path) -> None:
-    initialize_workspace(tmp_path)
-    source = tmp_path / "notes.txt"
-    source.write_text("same-content\n", encoding="utf-8")
-
-    first = add_source(tmp_path, source)
-    first.stored_path.unlink()
-
-    with pytest.raises(FileNotFoundError, match="Stored source copy is missing"):
-        add_source(tmp_path, source)
+    assert second.already_registered is True
+    assert second.source_ref == "docs/custom.md"
+    assert second.storage_mode == "copy"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,9 @@ def test_cli_init_command(tmp_path: Path, capsys) -> None:
     assert "Initialized Splendor workspace" in captured.out
 
 
-def test_cli_add_source_command(tmp_path: Path, capsys) -> None:
+def test_cli_add_source_command_reports_workspace_backed_registration(
+    tmp_path: Path, capsys
+) -> None:
     main(["--root", str(tmp_path), "init"])
     source = tmp_path / "brief.md"
     source.write_text("hello\n", encoding="utf-8")
@@ -22,6 +24,9 @@ def test_cli_add_source_command(tmp_path: Path, capsys) -> None:
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "Registered source" in captured.out
+    assert "Source ref: brief.md" in captured.out
+    assert "Storage mode: none" in captured.out
+    assert "Stored copy:" not in captured.out
 
 
 def test_cli_add_source_resolves_relative_paths_against_root(tmp_path: Path, capsys) -> None:
@@ -37,7 +42,8 @@ def test_cli_add_source_resolves_relative_paths_against_root(tmp_path: Path, cap
 
     assert exit_code == 0
     captured = capsys.readouterr()
-    assert "Registered source" in captured.out
+    assert "Source ref: docs/brief.md" in captured.out
+    assert "Storage mode: none" in captured.out
 
 
 def test_cli_add_source_expands_user_paths(tmp_path: Path, capsys, monkeypatch) -> None:
@@ -55,6 +61,40 @@ def test_cli_add_source_expands_user_paths(tmp_path: Path, capsys, monkeypatch) 
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "Registered source" in captured.out
+    assert "Storage mode: copy" in captured.out
+    assert "Stored copy:" in captured.out
+
+
+def test_cli_add_source_supports_explicit_copy_for_workspace_files(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+
+    exit_code = main(["--root", str(tmp_path), "add-source", "--storage-mode", "copy", str(source)])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Source ref: brief.md" in captured.out
+    assert "Storage mode: copy" in captured.out
+    assert "Stored copy:" in captured.out
+
+
+def test_cli_add_source_reports_unsupported_mode_combinations(tmp_path: Path, capsys) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    source = fake_home / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+
+    main(["--root", str(repo_root), "init"])
+    exit_code = main(
+        ["--root", str(repo_root), "add-source", "--storage-mode", "none", str(source)]
+    )
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "not supported for external sources" in captured.out
 
 
 def test_cli_ingest_command(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from splendor.cli import main
+from splendor.cli import build_parser, main
 
 
 def test_cli_init_command(tmp_path: Path, capsys) -> None:
@@ -10,6 +10,18 @@ def test_cli_init_command(tmp_path: Path, capsys) -> None:
     assert (tmp_path / "wiki" / "index.md").exists()
     captured = capsys.readouterr()
     assert "Initialized Splendor workspace" in captured.out
+
+
+def test_cli_add_source_capture_source_commit_flags_are_tri_state() -> None:
+    parser = build_parser()
+
+    no_flag = parser.parse_args(["add-source", "brief.md"])
+    yes_flag = parser.parse_args(["add-source", "--capture-source-commit", "brief.md"])
+    no_capture_flag = parser.parse_args(["add-source", "--no-capture-source-commit", "brief.md"])
+
+    assert no_flag.capture_source_commit is None
+    assert yes_flag.capture_source_commit is True
+    assert no_capture_flag.capture_source_commit is False
 
 
 def test_cli_add_source_command_reports_workspace_backed_registration(

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -24,7 +24,7 @@ def test_ingest_source_happy_path(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
-    added = add_source(tmp_path, source)
+    added = add_source(tmp_path, source, storage_mode="copy")
 
     result = ingest_source(tmp_path, added.source_id)
 
@@ -73,7 +73,7 @@ def test_ingest_source_is_idempotent_when_current_pipeline_already_succeeded(
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
-    added = add_source(tmp_path, source)
+    added = add_source(tmp_path, source, storage_mode="copy")
 
     first = ingest_source(tmp_path, added.source_id)
     second = ingest_source(tmp_path, added.source_id)
@@ -95,7 +95,7 @@ def test_ingest_source_recreates_missing_page_without_duplicate_index_entries(
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
-    added = add_source(tmp_path, source)
+    added = add_source(tmp_path, source, storage_mode="copy")
 
     first = ingest_source(tmp_path, added.source_id)
     assert first.page_path is not None
@@ -119,7 +119,7 @@ def test_ingest_source_no_op_uses_configured_wiki_layout(tmp_path: Path) -> None
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
-    added = add_source(tmp_path, source)
+    added = add_source(tmp_path, source, storage_mode="copy")
 
     first = ingest_source(tmp_path, added.source_id)
     second = ingest_source(tmp_path, added.source_id)
@@ -217,7 +217,7 @@ def test_ingest_source_validates_stored_copy_checksum(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
-    added = add_source(tmp_path, source)
+    added = add_source(tmp_path, source, storage_mode="copy")
     manifest = json.loads(added.manifest_path.read_text(encoding="utf-8"))
     stored_path = tmp_path / manifest["path"]
     stored_path.write_text("tampered\n", encoding="utf-8")
@@ -244,7 +244,7 @@ def test_ingest_source_records_missing_stored_copy_as_failed_attempt(tmp_path: P
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
-    added = add_source(tmp_path, source)
+    added = add_source(tmp_path, source, storage_mode="copy")
     manifest = json.loads(added.manifest_path.read_text(encoding="utf-8"))
     stored_path = tmp_path / manifest["path"]
     stored_path.unlink()
@@ -271,17 +271,8 @@ def test_ingest_source_explicit_copy_manifest_failure_uses_storage_path(tmp_path
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
-    added = add_source(tmp_path, source)
+    added = add_source(tmp_path, source, storage_mode="copy")
     manifest = json.loads(added.manifest_path.read_text(encoding="utf-8"))
-    source_record = load_source_record(added.manifest_path).model_copy(
-        update={
-            "source_ref": "brief.md",
-            "source_ref_kind": "workspace_path",
-            "storage_mode": "copy",
-            "storage_path": manifest["path"],
-        }
-    )
-    write_source_record(added.manifest_path, source_record)
     (tmp_path / manifest["path"]).unlink()
 
     with pytest.raises(ValueError, match="Stored source copy is missing"):
@@ -301,7 +292,7 @@ def test_ingest_source_extract_uses_safe_fence_for_backticks(tmp_path: Path) -> 
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\n```python\nprint('hi')\n```\n", encoding="utf-8")
-    added = add_source(tmp_path, source)
+    added = add_source(tmp_path, source, storage_mode="copy")
 
     result = ingest_source(tmp_path, added.source_id)
 


### PR DESCRIPTION
## Summary
- make in-repo `add-source` registrations default to workspace-backed manifests instead of copied raw sources
- keep external local files on copy-based storage and add mode-aware CLI output plus overrides
- capture `source_commit` for clean tracked workspace files and expand registration coverage for workspace/copy modes

## Testing
- `uv run ruff format --check .`
- `uv run ruff check src tests`
- `PYTHONPATH=src pytest tests/test_add_source.py tests/test_cli.py tests/test_ingest.py tests/test_config.py tests/test_schemas.py tests/test_init.py`