### PR TITLE
refactor: stabilize mixed source manifest compatibility

### DIFF
--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -32,19 +32,22 @@ Current implementation fields:
 - `review_state`
 - `origin_url`
 - `original_path`
+- `source_ref`
+- `source_ref_kind`
+- `storage_mode`
+- `storage_path`
+- `materialized_at`
+- `source_commit`
 
-### Planned source-record evolution
+### Current source-record shape
 
-The current single-`path` contract is sufficient for the initial copy-everything MVP, but it
-mixes together three different concerns:
+The source record now splits three concerns explicitly:
 
 - the canonical source the user wants tracked
 - the storage mechanism Splendor used to make it available
 - the current location from which ingest reads bytes
 
-The next source-record revision should split those concerns explicitly.
-
-Proposed fields:
+Implemented fields:
 
 - `schema_version`
 - `kind: source`
@@ -66,9 +69,8 @@ Proposed fields:
 - `origin_url`
 - `original_path`
 - `materialized_at`
-- `source_commit`
 
-### Proposed field semantics
+### Field semantics
 
 - `source_ref`
   - Canonical source identifier.
@@ -110,15 +112,20 @@ Recommended defaults:
 - URL/imported source:
   - `storage_mode: copy` or `pointer`, depending on downloader semantics
 
-### Migration note
+### Compatibility note
 
-The easiest migration path is:
+Splendor currently supports both:
 
-1. Continue reading existing manifests with `path`.
-2. Introduce compatibility mapping:
-   - old `path` -> `storage_path`
-   - old `original_path` -> `source_ref` when it is repo-relative or otherwise available
-3. Write only the new fields once the resolver layer is in place.
+1. legacy manifests that only have `path` and are treated as copied-source records at read time
+2. new manifests that write `source_ref`, `source_ref_kind`, `storage_mode`, `storage_path`,
+   `materialized_at`, and `source_commit`
+
+In this release:
+
+- `path` remains required for compatibility
+- copied sources still use `path` as the stored artifact path
+- workspace-backed sources temporarily mirror `source_ref` into `path`
+- no automatic manifest rewrite or schema-version bump is performed yet
 
 ## Knowledge page frontmatter
 

--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -135,7 +135,9 @@ Compatibility plan:
 
 - keep reading old manifests that only have `path`
 - treat old `path` as a legacy storage path
-- migrate on write once the new resolver is implemented
+- keep `path` as a compatibility field while new registrations also write the explicit
+  source-resolution fields
+- defer any manifest rewrite or schema-version bump to a later release
 
 ### 6.2 Proposed field definitions
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -77,10 +77,10 @@ Examples:
 
 The source layer is append-oriented. Sources are not mutated by LLM workflows.
 
-In the initial MVP, Splendor materializes registered sources under `raw/sources/`. That behavior is
-useful for external and unstable inputs, but it is too blunt for repositories whose markdown, code,
-and configuration files already live inside git. The long-term source model must therefore
-distinguish between:
+Splendor now defaults to workspace-backed registration for in-repo files and materialized copies
+for external local files. Materialization under `raw/sources/` remains useful for external and
+unstable inputs, but it is too blunt for repositories whose markdown, code, and configuration files
+already live inside git. The source model therefore distinguishes between:
 
 - the **canonical source reference** the user means Splendor to track
 - the **storage policy** Splendor applies to make that source available to the pipeline

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -18,6 +18,11 @@ from splendor.state.runtime import (
     write_queue_item,
     write_run_record,
 )
+from splendor.state.source_compat import (
+    canonical_source_ref,
+    effective_storage_mode,
+    effective_stored_path,
+)
 from splendor.state.source_registry import (
     load_source_record,
     manifest_path_for,
@@ -99,7 +104,7 @@ def _build_extract(text: str) -> str:
 
 
 def _build_summary(source: SourceRecord) -> str:
-    path_fragment = source.source_ref or source.original_path or source.path
+    path_fragment = canonical_source_ref(source)
     return (
         f"This page records deterministic ingestion output for source `{source.source_id}`, "
         f"a `{source.source_type}` file registered from `{path_fragment}`."
@@ -107,9 +112,9 @@ def _build_summary(source: SourceRecord) -> str:
 
 
 def _best_available_source_ref(source: SourceRecord) -> str:
-    if source.storage_mode == "none":
-        return source.source_ref or source.storage_path or source.path
-    return source.storage_path or source.path or source.source_ref
+    if effective_storage_mode(source) == "none":
+        return canonical_source_ref(source)
+    return effective_stored_path(source) or canonical_source_ref(source)
 
 
 def _is_no_op(root: Path, layout, source: SourceRecord) -> bool:
@@ -292,7 +297,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
 
         page_path = _page_path_for(layout.wiki_sources_dir, source_id)
         page_relpath = _relative_to_root(root, page_path)
-        registered_path = source.source_ref or source.original_path or source.path
+        registered_path = canonical_source_ref(source)
         frontmatter = KnowledgePageFrontmatter(
             kind="source-summary",
             title=source.title,
@@ -317,7 +322,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
                 f"Source ID: `{source.source_id}`",
                 f"Source type: `{source.source_type}`",
                 f"Checksum: `{source.checksum}`",
-                f"Original path: `{source.original_path or source.path}`",
+                f"Source ref: `{canonical_source_ref(source)}`",
                 f"Added at: `{source.added_at}`",
                 f"Ingested at: `{now}`",
             ],

--- a/src/splendor/schemas/source.py
+++ b/src/splendor/schemas/source.py
@@ -1,7 +1,8 @@
 """Source schemas.
 
-`path` remains the active runtime field in this release. The additional source-resolution fields are
-schema scaffolding for the upcoming resolver-based migration.
+`path` remains a required compatibility field in this release. New registrations now also write the
+source-resolution fields, while older manifests that only carry `path` remain supported at read
+time.
 """
 
 from __future__ import annotations
@@ -19,7 +20,8 @@ class SourceRecord(StrictRecord):
     source_id: str
     title: str
     source_type: str
-    # Legacy runtime field. Current registration and ingest still read from `path`.
+    # Compatibility field. For copied sources it is the stored artifact path; for workspace-backed
+    # sources it temporarily mirrors `source_ref`.
     path: str
     checksum: str = Field(min_length=64, max_length=64)
     added_at: str

--- a/src/splendor/state/source_compat.py
+++ b/src/splendor/state/source_compat.py
@@ -1,0 +1,34 @@
+"""Read-only compatibility helpers for mixed source manifest shapes."""
+
+from __future__ import annotations
+
+from splendor.schemas import SourceRecord
+from splendor.schemas.types import SourceRefKind, StorageMode
+
+
+def effective_storage_mode(source: SourceRecord) -> StorageMode:
+    return source.storage_mode or "copy"
+
+
+def effective_source_ref_kind(source: SourceRecord) -> SourceRefKind:
+    return source.source_ref_kind or "stored_artifact"
+
+
+def canonical_source_ref(source: SourceRecord) -> str:
+    return source.source_ref or source.original_path or source.path
+
+
+def effective_stored_path(source: SourceRecord) -> str | None:
+    if effective_storage_mode(source) != "copy":
+        return None
+    return source.storage_path or source.path
+
+
+def is_legacy_copied_manifest(source: SourceRecord) -> bool:
+    return source.storage_mode is None and source.source_ref is None
+
+
+def copied_source_error_label(source: SourceRecord) -> str:
+    if is_legacy_copied_manifest(source):
+        return "Legacy stored source copy"
+    return "Stored source copy"

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -11,6 +11,7 @@ from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import SourceRecord
 from splendor.schemas.types import StorageMode
+from splendor.state.source_compat import canonical_source_ref
 from splendor.utils.fs import copy_file_if_missing, ensure_directory, write_text_atomic
 from splendor.utils.git import captured_source_commit
 from splendor.utils.hashing import sha256_file
@@ -177,7 +178,7 @@ def _validated_existing_registration(
         )
         raise ValueError(msg) from exc
     stored_path = resolved.resolved_path if resolved.storage_mode == "copy" else None
-    source_ref = existing.source_ref or existing.original_path or existing.path
+    source_ref = canonical_source_ref(existing)
     return stored_path, resolved.storage_mode, source_ref
 
 

--- a/src/splendor/state/source_resolver.py
+++ b/src/splendor/state/source_resolver.py
@@ -6,6 +6,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from splendor.schemas import SourceRecord
+from splendor.state.source_compat import (
+    canonical_source_ref,
+    copied_source_error_label,
+    effective_source_ref_kind,
+    effective_storage_mode,
+    effective_stored_path,
+)
 from splendor.state.source_registry import (
     resolve_manifest_storage_path,
     validate_stored_source_location,
@@ -70,7 +77,10 @@ def _resolve_workspace_source(root: Path, source: SourceRecord) -> ResolvedSourc
 def _resolve_copied_source(
     root: Path, source: SourceRecord, raw_sources_dir: Path
 ) -> ResolvedSource:
-    stored_path_value = source.storage_path or source.path
+    stored_path_value = effective_stored_path(source)
+    if stored_path_value is None:
+        msg = f"Copied source is missing a stored path: {source.source_id}"
+        raise ValueError(msg)
     resolved_path = resolve_manifest_storage_path(root, stored_path_value)
     validate_stored_source_location(
         resolved_path,
@@ -78,16 +88,17 @@ def _resolve_copied_source(
         source.source_id,
         stored_path_value,
     )
+    source_label = copied_source_error_label(source)
     if not resolved_path.exists():
-        msg = f"Stored source copy is missing: {resolved_path}"
+        msg = f"{source_label} is missing: {resolved_path}"
         raise ValueError(msg)
     if sha256_file(resolved_path) != source.checksum:
-        msg = f"Stored source checksum mismatch for ingestion: {resolved_path}"
+        msg = f"{source_label} checksum mismatch for ingestion: {resolved_path}"
         raise ValueError(msg)
 
     return ResolvedSource(
-        canonical_ref=source.source_ref or source.original_path or source.path,
-        canonical_ref_kind=source.source_ref_kind or "stored_artifact",
+        canonical_ref=canonical_source_ref(source),
+        canonical_ref_kind=effective_source_ref_kind(source),
         storage_mode="copy",
         resolved_path=resolved_path,
         resolved_ref=stored_path_value,
@@ -98,14 +109,12 @@ def _resolve_copied_source(
 def resolve_source_content(
     root: Path, source: SourceRecord, raw_sources_dir: Path
 ) -> ResolvedSource:
-    if source.storage_mode in {"symlink", "pointer"}:
-        msg = f"Unsupported storage mode for ingestion: {source.storage_mode}"
+    storage_mode = effective_storage_mode(source)
+    if storage_mode in {"symlink", "pointer"}:
+        msg = f"Unsupported storage mode for ingestion: {storage_mode}"
         raise ValueError(msg)
 
-    if source.storage_mode == "none":
+    if storage_mode == "none":
         return _resolve_workspace_source(root, source)
-
-    if source.storage_mode == "copy":
-        return _resolve_copied_source(root, source, raw_sources_dir)
 
     return _resolve_copied_source(root, source, raw_sources_dir)

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -296,3 +296,48 @@ def test_add_source_reuses_existing_manifest_authoritatively(tmp_path: Path) -> 
     assert second.already_registered is True
     assert second.source_ref == "docs/custom.md"
     assert second.storage_mode == "copy"
+
+
+def test_add_source_reuses_mixed_manifest_shapes_authoritatively(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    legacy_source = tmp_path / "legacy.md"
+    legacy_source.write_text("# legacy\n", encoding="utf-8")
+    workspace_source = tmp_path / "workspace.md"
+    workspace_source.write_text("# workspace\n", encoding="utf-8")
+    copied_source = tmp_path / "copied.md"
+    copied_source.write_text("# copied\n", encoding="utf-8")
+
+    legacy_added = add_source(tmp_path, legacy_source, storage_mode="copy")
+    add_source(tmp_path, workspace_source)
+    add_source(tmp_path, copied_source, storage_mode="copy")
+
+    legacy_manifest = load_source_record(legacy_added.manifest_path).model_copy(
+        update={
+            "source_ref": None,
+            "source_ref_kind": None,
+            "storage_mode": None,
+            "storage_path": None,
+            "materialized_at": None,
+            "source_commit": None,
+        }
+    )
+    write_source_record(legacy_added.manifest_path, legacy_manifest)
+
+    legacy_repeat = add_source(tmp_path, legacy_source)
+    workspace_repeat = add_source(tmp_path, workspace_source, storage_mode="copy")
+    copied_repeat = add_source(tmp_path, copied_source)
+
+    assert legacy_repeat.already_registered is True
+    assert legacy_repeat.source_ref == "legacy.md"
+    assert legacy_repeat.storage_mode == "copy"
+
+    assert workspace_repeat.already_registered is True
+    assert workspace_repeat.source_ref == "workspace.md"
+    assert workspace_repeat.storage_mode == "none"
+    assert workspace_repeat.stored_path is None
+
+    assert copied_repeat.already_registered is True
+    assert copied_repeat.source_ref == "copied.md"
+    assert copied_repeat.storage_mode == "copy"
+    assert copied_repeat.stored_path is not None

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -222,7 +222,7 @@ def test_ingest_source_validates_stored_copy_checksum(tmp_path: Path) -> None:
     stored_path = tmp_path / manifest["path"]
     stored_path.write_text("tampered\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="Stored source checksum mismatch"):
+    with pytest.raises(ValueError, match="Stored source copy checksum mismatch"):
         ingest_source(tmp_path, added.source_id)
 
     source_record = load_source_record(added.manifest_path)
@@ -264,6 +264,45 @@ def test_ingest_source_records_missing_stored_copy_as_failed_attempt(tmp_path: P
     assert run_record.input_refs == [
         added.manifest_path.relative_to(tmp_path).as_posix(),
         manifest["path"],
+    ]
+
+
+def test_ingest_source_legacy_manifest_missing_stored_copy_is_shape_specific(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "legacy.md"
+    source.write_text("# Legacy\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="copy")
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={
+            "source_ref": None,
+            "source_ref_kind": None,
+            "storage_mode": None,
+            "storage_path": None,
+            "materialized_at": None,
+            "source_commit": None,
+        }
+    )
+    write_source_record(added.manifest_path, source_record)
+    stored_path = tmp_path / source_record.path
+    stored_path.unlink()
+
+    with pytest.raises(ValueError, match="Legacy stored source copy is missing"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
+    assert load_queue_item(queue_path).status == "failed"
+    assert len(run_paths) == 1
+    run_record = load_run_record(run_paths[0])
+    assert run_record.status == "failed"
+    assert run_record.input_refs == [
+        added.manifest_path.relative_to(tmp_path).as_posix(),
+        source_record.path,
     ]
 
 
@@ -371,6 +410,65 @@ def test_ingest_source_workspace_backed_manifest_happy_path(tmp_path: Path) -> N
     assert run_record.input_refs == [
         added.manifest_path.relative_to(tmp_path).as_posix(),
         "brief.md",
+    ]
+
+
+def test_ingest_source_supports_mixed_manifest_workspace(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    legacy_source = tmp_path / "legacy.md"
+    legacy_source.write_text("# Legacy\n\nold world\n", encoding="utf-8")
+    workspace_source = tmp_path / "workspace.md"
+    workspace_source.write_text("# Workspace\n\nnew world\n", encoding="utf-8")
+    copied_source = tmp_path / "copied.md"
+    copied_source.write_text("# Copied\n\nstored world\n", encoding="utf-8")
+
+    legacy_added = add_source(tmp_path, legacy_source, storage_mode="copy")
+    workspace_added = add_source(tmp_path, workspace_source)
+    copied_added = add_source(tmp_path, copied_source, storage_mode="copy")
+
+    legacy_manifest = load_source_record(legacy_added.manifest_path).model_copy(
+        update={
+            "source_ref": None,
+            "source_ref_kind": None,
+            "storage_mode": None,
+            "storage_path": None,
+            "materialized_at": None,
+            "source_commit": None,
+        }
+    )
+    write_source_record(legacy_added.manifest_path, legacy_manifest)
+
+    legacy_result = ingest_source(tmp_path, legacy_added.source_id)
+    workspace_result = ingest_source(tmp_path, workspace_added.source_id)
+    copied_result = ingest_source(tmp_path, copied_added.source_id)
+
+    legacy_body = legacy_result.page_path.read_text(encoding="utf-8")
+    assert "Stored source:" in legacy_body
+    assert "registered from `legacy.md`" in legacy_body
+    legacy_run = load_run_record(legacy_result.run_path)
+    assert legacy_run.input_refs == [
+        legacy_added.manifest_path.relative_to(tmp_path).as_posix(),
+        legacy_manifest.path,
+    ]
+
+    workspace_body = workspace_result.page_path.read_text(encoding="utf-8")
+    assert "Workspace source: `workspace.md`" in workspace_body
+    assert "registered from `workspace.md`" in workspace_body
+    workspace_run = load_run_record(workspace_result.run_path)
+    assert workspace_run.input_refs == [
+        workspace_added.manifest_path.relative_to(tmp_path).as_posix(),
+        "workspace.md",
+    ]
+
+    copied_manifest = load_source_record(copied_added.manifest_path)
+    copied_body = copied_result.page_path.read_text(encoding="utf-8")
+    assert "Stored source:" in copied_body
+    assert "registered from `copied.md`" in copied_body
+    copied_run = load_run_record(copied_result.run_path)
+    assert copied_run.input_refs == [
+        copied_added.manifest_path.relative_to(tmp_path).as_posix(),
+        copied_manifest.storage_path,
     ]
 
 


### PR DESCRIPTION
## Summary
- centralize read-only source compatibility helpers for mixed manifest shapes
- align ingest and registration with the shared compatibility layer and shape-specific errors
- update shipped docs/comments to reflect SR-3/SR-4 behavior and add mixed-manifest regression coverage

## Testing
- uv run ruff format --check .
- uv run ruff check src tests
- PYTHONPATH=src pytest tests/test_add_source.py tests/test_ingest.py tests/test_source_resolver.py tests/test_cli.py tests/test_config.py tests/test_schemas.py tests/test_init.py