### PR TITLE
feat: add source summary extract policies

### DIFF
--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -407,8 +407,8 @@ Planning note:
 
 Scope:
 
-- add config for excerpt strategy
-- default in-repo summaries to short excerpt or none
+- activate config-driven extract strategy during ingest
+- default in-repo summaries to short excerpts
 - preserve fuller extracts for external or transformed sources
 - update tests for deterministic page rendering
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -335,6 +335,8 @@ sources.
 - configuration for storage policy defaults
 - CLI overrides for source storage behavior
 - manifest migration path for older workspaces
+- config-driven source-summary rendering that defaults in-repo text sources to excerpts and
+  external/copied text sources to fuller extracts
 
 ### Exit criteria
 - in-repo docs and code stop being duplicated into `raw/sources/` by default

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -607,6 +607,13 @@ Recommended default behavior:
 - reserve full extracted text for cases where the source is external, transformed, or otherwise not
   directly readable from the repository
 
+Current implementation:
+
+- workspace-backed in-repo text sources default to `excerpt`
+- copied or external text sources default to `full`
+- projects may set either class to `none`, `excerpt`, or `full` through `sources.*extracts_as`
+- when the mode is `none`, the `## Extract` section is omitted entirely
+
 Later optional support:
 - PDF
 - image-based sources

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -611,7 +611,8 @@ Current implementation:
 
 - workspace-backed in-repo text sources default to `excerpt`
 - copied or external text sources default to `full`
-- projects may set either class to `none`, `excerpt`, or `full` through `sources.*extracts_as`
+- projects may set either class to `none`, `excerpt`, or `full` through
+  `sources.summarize_in_repo_extracts_as` and `sources.summarize_external_extracts_as`
 - when the mode is `none`, the `## Extract` section is omitted entirely
 
 Later optional support:

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -335,7 +335,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
                     f"- Source ID: `{source.source_id}`",
                     f"- Source type: `{source.source_type}`",
                     f"- Registered path: `{registered_path}`",
-                    f"- Source file: `{registered_path}`",
+                    f"- Source file: `{resolved_source.resolved_ref}`",
                 ]
             ),
             summary=_build_summary(source),

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -10,6 +10,7 @@ from splendor import __version__
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord, SourceRecord
+from splendor.schemas.types import SummaryMode
 from splendor.state.runtime import (
     load_queue_item,
     load_run_record,
@@ -20,6 +21,7 @@ from splendor.state.runtime import (
 )
 from splendor.state.source_compat import (
     canonical_source_ref,
+    effective_source_ref_kind,
     effective_storage_mode,
     effective_stored_path,
 )
@@ -101,6 +103,23 @@ def _build_extract(text: str) -> str:
         char_count = projected_count
 
     return "\n".join(extract_lines).rstrip()
+
+
+def _summary_mode_for(config, source: SourceRecord) -> SummaryMode:
+    if (
+        effective_storage_mode(source) == "none"
+        and effective_source_ref_kind(source) == "workspace_path"
+    ):
+        return config.sources.summarize_in_repo_extracts_as
+    return config.sources.summarize_external_extracts_as
+
+
+def _rendered_extract(text: str, mode: SummaryMode) -> str | None:
+    if mode == "none":
+        return None
+    if mode == "excerpt":
+        return _build_extract(text)
+    return text
 
 
 def _build_summary(source: SourceRecord) -> str:
@@ -294,6 +313,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
         except UnicodeDecodeError as exc:
             msg = f"Source file is not valid UTF-8 text: {resolved_source.resolved_path}"
             raise ValueError(msg) from exc
+        extract_mode = _summary_mode_for(config, source)
 
         page_path = _page_path_for(layout.wiki_sources_dir, source_id)
         page_relpath = _relative_to_root(root, page_path)
@@ -315,6 +335,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
                     f"- Source ID: `{source.source_id}`",
                     f"- Source type: `{source.source_type}`",
                     f"- Registered path: `{registered_path}`",
+                    f"- Source file: `{registered_path}`",
                 ]
             ),
             summary=_build_summary(source),
@@ -326,7 +347,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
                 f"Added at: `{source.added_at}`",
                 f"Ingested at: `{now}`",
             ],
-            extract=_build_extract(source_text),
+            extract=_rendered_extract(source_text, extract_mode),
             provenance=[
                 f"Manifest: `{_relative_to_root(root, manifest_path)}`",
                 f"{resolved_source.content_origin_label}: `{resolved_source.resolved_ref}`",

--- a/src/splendor/utils/wiki.py
+++ b/src/splendor/utils/wiki.py
@@ -44,11 +44,14 @@ def render_source_summary_page(
     source_section: str,
     summary: str,
     key_facts: list[str],
-    extract: str,
+    extract: str | None,
     provenance: list[str],
 ) -> str:
     key_fact_lines = "\n".join(f"- {line}" for line in key_facts)
     provenance_lines = "\n".join(f"- {line}" for line in provenance)
+    extract_section = ""
+    if extract is not None:
+        extract_section = f"## Extract\n\n{_fenced_extract_block(extract)}\n\n"
     return (
         f"---\n{render_frontmatter(frontmatter)}\n---\n\n"
         f"# {frontmatter.title}\n\n"
@@ -58,8 +61,7 @@ def render_source_summary_page(
         f"{summary}\n\n"
         "## Key Facts\n\n"
         f"{key_fact_lines}\n\n"
-        "## Extract\n\n"
-        f"{_fenced_extract_block(extract)}\n\n"
+        f"{extract_section}"
         "## Provenance\n\n"
         f"{provenance_lines}\n"
     )

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -9,6 +9,7 @@ from splendor.commands.ingest import ingest_source
 from splendor.commands.init import initialize_workspace
 from splendor.config import load_config, write_config
 from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord
+from splendor.schemas.types import SummaryMode
 from splendor.state.runtime import load_queue_item, load_run_record
 from splendor.state.source_registry import load_source_record, write_source_record
 
@@ -22,7 +23,10 @@ def parse_frontmatter(page_path: Path) -> tuple[KnowledgePageFrontmatter, str]:
 
 
 def update_summary_modes(
-    root: Path, *, in_repo: str | None = None, external: str | None = None
+    root: Path,
+    *,
+    in_repo: SummaryMode | None = None,
+    external: SummaryMode | None = None,
 ) -> None:
     config = load_config(root)
     if in_repo is not None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -7,6 +7,7 @@ import yaml
 from splendor.commands.add_source import add_source
 from splendor.commands.ingest import ingest_source
 from splendor.commands.init import initialize_workspace
+from splendor.config import load_config, write_config
 from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord
 from splendor.state.runtime import load_queue_item, load_run_record
 from splendor.state.source_registry import load_source_record, write_source_record
@@ -18,6 +19,17 @@ def parse_frontmatter(page_path: Path) -> tuple[KnowledgePageFrontmatter, str]:
     frontmatter_text, body = raw.removeprefix("---\n").split("\n---\n", maxsplit=1)
     frontmatter = KnowledgePageFrontmatter.model_validate(yaml.safe_load(frontmatter_text))
     return frontmatter, body
+
+
+def update_summary_modes(
+    root: Path, *, in_repo: str | None = None, external: str | None = None
+) -> None:
+    config = load_config(root)
+    if in_repo is not None:
+        config.sources.summarize_in_repo_extracts_as = in_repo
+    if external is not None:
+        config.sources.summarize_external_extracts_as = external
+    write_config(root, config)
 
 
 def test_ingest_source_happy_path(tmp_path: Path) -> None:
@@ -339,6 +351,94 @@ def test_ingest_source_extract_uses_safe_fence_for_backticks(tmp_path: Path) -> 
     page_content = result.page_path.read_text(encoding="utf-8")
     assert "````text" in page_content
     assert "\n````\n\n## Provenance" in page_content
+
+
+def test_ingest_source_workspace_backed_default_uses_excerpt(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text(
+        "# Brief\n\n" + "\n".join(f"line {i}" for i in range(120)),
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "## Extract" in body
+    assert "line 10" in body
+    assert "line 119" not in body
+
+
+def test_ingest_source_workspace_backed_none_omits_extract_section(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    update_summary_modes(tmp_path, in_repo="none")
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "## Extract" not in body
+    assert "Workspace source: `brief.md`" in body
+    assert "Source file: `brief.md`" in body
+
+
+def test_ingest_source_workspace_backed_full_renders_full_text(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    update_summary_modes(tmp_path, in_repo="full")
+    source = tmp_path / "brief.md"
+    source.write_text(
+        "# Brief\n\n" + "\n".join(f"line {i}" for i in range(120)),
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "## Extract" in body
+    assert "line 119" in body
+
+
+def test_ingest_source_copied_default_renders_full_text(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text(
+        "# Brief\n\n" + "\n".join(f"line {i}" for i in range(120)),
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source, storage_mode="copy")
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "## Extract" in body
+    assert "line 119" in body
+
+
+def test_ingest_source_external_excerpt_override_uses_bounded_preview(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    update_summary_modes(tmp_path, external="excerpt")
+    source = tmp_path / "brief.md"
+    source.write_text(
+        "# Brief\n\n" + "\n".join(f"line {i}" for i in range(120)),
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source, storage_mode="copy")
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "## Extract" in body
+    assert "line 10" in body
+    assert "line 119" not in body
 
 
 def test_ingest_source_rolls_back_wiki_on_success_commit_failure(


### PR DESCRIPTION
## Summary
- activate config-driven source-summary extract policies during ingest
- omit the extract section entirely for `none` mode and preserve deterministic fenced rendering for excerpt/full modes
- document the shipped SR-6 behavior and add coverage for in-repo and copied-source defaults plus config overrides

## Testing
- uv run ruff format --check .
- uv run ruff check src tests
- PYTHONPATH=src pytest tests/test_ingest.py tests/test_config.py tests/test_cli.py tests/test_add_source.py tests/test_source_resolver.py tests/test_schemas.py tests/test_init.py