### PR TITLE
SR-7: add pointer storage mode for workspace sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
       contents: read
       actions: read
       pull-requests: write
-    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4.0.16
+    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4.0.18
     with:
-      tool_ref: v4.0.16
+      tool_ref: v4.0.18
       include_patch_coverage: true
       patch_coverage_source_mode: coverage_xml_artifact
       coverage_report_artifact_name: coverage-xml

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -34,12 +34,13 @@ jobs:
        github.event.check_run.app.slug != 'github-actions' &&
        toJson(github.event.check_run.pull_requests) != '[]' &&
        github.event.check_run.pull_requests[0].head.repo.full_name == github.repository)
-    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4.0.16
+    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4.0.18
     with:
-      tool_ref: v4.0.16
+      tool_ref: v4.0.18
       execution_mode: refresh
       publish_mode: append
       publish_all_clear_comments_in_refresh: false
+      include_outdated_review_threads: true
       include_patch_coverage: true
       patch_coverage_source_mode: coverage_xml_artifact
       coverage_report_artifact_name: coverage-xml

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -51,6 +51,7 @@ What it does:
 - refreshes the managed PR context comment after review or check state changes
 - reuses the `coverage-xml` artifact from the matching CI run when possible
 - suppresses no-op refresh comments
+- includes outdated review threads when refreshing managed PR context
 
 Permissions:
 

--- a/docs/github_automation_architecture.md
+++ b/docs/github_automation_architecture.md
@@ -62,13 +62,16 @@ Caveats:
 
 Pinned reusable workflow:
 
-- `shaypal5/pr-agent-context@v4.0.16`
+- `shaypal5/pr-agent-context@v4.0.18`
+  - Refresh flow uses `include_outdated_review_threads: true` to keep managed PR context aligned
+    with both active and outdated review discussions.
 
 Chosen behavior:
 
 - initial PR runs publish a managed context comment
 - refresh runs are triggered on review activity and completed external checks
 - refresh runs suppress no-op all-clear comments
+- refresh runs include outdated review threads for richer PR context updates
 - coverage comes from the `coverage-xml` artifact produced by CI
 - the repository provides a custom prompt template at `.github/pr-agent-context-template.md`
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -91,8 +91,14 @@ Implemented fields:
     - `copy`
     - `symlink`
     - `pointer`
+  - Current runtime support:
+    - `none` for workspace-backed sources
+    - `copy` for workspace-backed and external local sources
+    - `pointer` for workspace-backed sources
+    - `symlink` remains unimplemented
 - `storage_path`
   - Optional path under `raw/sources/` when Splendor materializes an artifact.
+  - Pointer-backed sources use `raw/sources/<source_id>/pointer.json`.
 - `materialized_at`
   - Timestamp indicating when `storage_path` was created or last refreshed.
 - `source_commit`

--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -420,13 +420,14 @@ Exit criteria:
 
 Scope:
 
-- define pointer artifact format
-- add `storage_mode=pointer`
-- teach resolver to follow pointer artifacts
+- define pointer artifact format at `raw/sources/<source_id>/pointer.json`
+- add `storage_mode=pointer` for workspace-backed sources
+- teach resolver to validate pointer artifacts and follow them back to workspace files
 
 Exit criteria:
 
-- projects have a cross-platform materialization alternative that does not duplicate bytes
+- projects have a cross-platform materialization alternative for workspace sources that does not
+  duplicate bytes
 
 #### SR-8 — Optional symlink mode
 

--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -407,8 +407,8 @@ Planning note:
 
 Scope:
 
-- add config for excerpt strategy
-- default in-repo summaries to short excerpt or none
+- activate config-driven extract strategy during ingest
+- default in-repo summaries to short excerpts
 - preserve fuller extracts for external or transformed sources
 - update tests for deterministic page rendering
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -335,6 +335,8 @@ sources.
 - configuration for storage policy defaults
 - CLI overrides for source storage behavior
 - manifest migration path for older workspaces
+- config-driven source-summary rendering that defaults in-repo text sources to excerpts and
+  external/copied text sources to fuller extracts
 
 ### Exit criteria
 - in-repo docs and code stop being duplicated into `raw/sources/` by default

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -326,7 +326,8 @@ sources.
 ### Scope
 - split canonical source reference from storage realization
 - default in-repo files to workspace-backed registration
-- preserve copy, pointer, and symlink options where projects need stronger materialization
+- preserve copy and pointer options where projects need stronger materialization
+- keep `symlink` available in schema/config while deferring runtime support
 - reduce source-summary duplication for in-repo text sources
 
 ### Deliverables
@@ -341,6 +342,8 @@ sources.
 ### Exit criteria
 - in-repo docs and code stop being duplicated into `raw/sources/` by default
 - external sources still get durable materialization when appropriate
+- workspace-backed sources can optionally materialize deterministic pointer artifacts under
+  `raw/sources/<source_id>/pointer.json`
 - ingest reads through one resolver interface regardless of source origin
 - source-summary pages remain deterministic while becoming less noisy
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -357,8 +357,14 @@ Field meanings:
   - Expected initial values: `workspace_path`, `external_path`, `url`, `imported`, `stored_artifact`.
 - `storage_mode`
   - Expected initial values: `none`, `copy`, `symlink`, `pointer`.
+  - Current runtime support:
+    - `none` for workspace-backed sources
+    - `copy` for workspace-backed and external local sources
+    - `pointer` for workspace-backed sources via `raw/sources/<source_id>/pointer.json`
+    - `symlink` remains schema-visible but unimplemented
 - `storage_path`
   - Optional path to the materialized artifact under `raw/sources/` when one exists.
+  - Pointer-backed sources use `raw/sources/<source_id>/pointer.json`.
 - `source_commit`
   - Optional git commit SHA captured for clean tracked workspace files when the project wants
     stronger repo-native provenance.

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -607,6 +607,13 @@ Recommended default behavior:
 - reserve full extracted text for cases where the source is external, transformed, or otherwise not
   directly readable from the repository
 
+Current implementation:
+
+- workspace-backed in-repo text sources default to `excerpt`
+- copied or external text sources default to `full`
+- projects may set either class to `none`, `excerpt`, or `full` through `sources.*extracts_as`
+- when the mode is `none`, the `## Extract` section is omitted entirely
+
 Later optional support:
 - PDF
 - image-based sources

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -611,7 +611,8 @@ Current implementation:
 
 - workspace-backed in-repo text sources default to `excerpt`
 - copied or external text sources default to `full`
-- projects may set either class to `none`, `excerpt`, or `full` through `sources.*extracts_as`
+- projects may set either class to `none`, `excerpt`, or `full` through
+  `sources.summarize_in_repo_extracts_as` and `sources.summarize_external_extracts_as`
 - when the mode is `none`, the `## Extract` section is omitted entirely
 
 Later optional support:

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -81,7 +81,10 @@ def handle_add_source(args: argparse.Namespace) -> int:
     print(f"Source ref: {result.source_ref}")
     print(f"Storage mode: {result.storage_mode}")
     if result.stored_path is not None:
-        print(f"Stored copy: {result.stored_path}")
+        if result.storage_mode == "pointer":
+            print(f"Pointer artifact: {result.stored_path}")
+        else:
+            print(f"Stored copy: {result.stored_path}")
     return 0
 
 

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -335,7 +335,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
                     f"- Source ID: `{source.source_id}`",
                     f"- Source type: `{source.source_type}`",
                     f"- Registered path: `{registered_path}`",
-                    f"- Source file: `{registered_path}`",
+                    f"- Source file: `{resolved_source.resolved_ref}`",
                 ]
             ),
             summary=_build_summary(source),

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -10,6 +10,7 @@ from splendor import __version__
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord, SourceRecord
+from splendor.schemas.types import SummaryMode
 from splendor.state.runtime import (
     load_queue_item,
     load_run_record,
@@ -20,6 +21,7 @@ from splendor.state.runtime import (
 )
 from splendor.state.source_compat import (
     canonical_source_ref,
+    effective_source_ref_kind,
     effective_storage_mode,
     effective_stored_path,
 )
@@ -101,6 +103,23 @@ def _build_extract(text: str) -> str:
         char_count = projected_count
 
     return "\n".join(extract_lines).rstrip()
+
+
+def _summary_mode_for(config, source: SourceRecord) -> SummaryMode:
+    if (
+        effective_storage_mode(source) == "none"
+        and effective_source_ref_kind(source) == "workspace_path"
+    ):
+        return config.sources.summarize_in_repo_extracts_as
+    return config.sources.summarize_external_extracts_as
+
+
+def _rendered_extract(text: str, mode: SummaryMode) -> str | None:
+    if mode == "none":
+        return None
+    if mode == "excerpt":
+        return _build_extract(text)
+    return text
 
 
 def _build_summary(source: SourceRecord) -> str:
@@ -294,6 +313,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
         except UnicodeDecodeError as exc:
             msg = f"Source file is not valid UTF-8 text: {resolved_source.resolved_path}"
             raise ValueError(msg) from exc
+        extract_mode = _summary_mode_for(config, source)
 
         page_path = _page_path_for(layout.wiki_sources_dir, source_id)
         page_relpath = _relative_to_root(root, page_path)
@@ -315,6 +335,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
                     f"- Source ID: `{source.source_id}`",
                     f"- Source type: `{source.source_type}`",
                     f"- Registered path: `{registered_path}`",
+                    f"- Source file: `{registered_path}`",
                 ]
             ),
             summary=_build_summary(source),
@@ -326,7 +347,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
                 f"Added at: `{source.added_at}`",
                 f"Ingested at: `{now}`",
             ],
-            extract=_build_extract(source_text),
+            extract=_rendered_extract(source_text, extract_mode),
             provenance=[
                 f"Manifest: `{_relative_to_root(root, manifest_path)}`",
                 f"{resolved_source.content_origin_label}: `{resolved_source.resolved_ref}`",

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -107,7 +107,7 @@ def _build_extract(text: str) -> str:
 
 def _summary_mode_for(config, source: SourceRecord) -> SummaryMode:
     if (
-        effective_storage_mode(source) == "none"
+        effective_storage_mode(source) in {"none", "pointer"}
         and effective_source_ref_kind(source) == "workspace_path"
     ):
         return config.sources.summarize_in_repo_extracts_as

--- a/src/splendor/schemas/__init__.py
+++ b/src/splendor/schemas/__init__.py
@@ -8,6 +8,7 @@ from splendor.schemas.planning import (
 )
 from splendor.schemas.runtime import QueueItemRecord, RunRecord
 from splendor.schemas.source import SourceRecord
+from splendor.schemas.source_pointer import SourcePointerArtifact
 from splendor.schemas.types import SourceRefKind, StorageMode, SummaryMode
 from splendor.schemas.wiki import KnowledgePageFrontmatter
 
@@ -19,6 +20,7 @@ __all__ = [
     "QueueItemRecord",
     "RunRecord",
     "SourceRefKind",
+    "SourcePointerArtifact",
     "SourceRecord",
     "StorageMode",
     "SummaryMode",

--- a/src/splendor/schemas/source_pointer.py
+++ b/src/splendor/schemas/source_pointer.py
@@ -1,0 +1,19 @@
+"""Pointer artifact schema for workspace-backed sources."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from splendor.schemas.common import StrictRecord
+from splendor.schemas.types import SourceRefKind
+
+
+class SourcePointerArtifact(StrictRecord):
+    kind: Literal["source-pointer"] = "source-pointer"
+    source_id: str
+    source_ref: str
+    source_ref_kind: SourceRefKind
+    checksum: str = Field(min_length=64, max_length=64)
+    created_at: str

--- a/src/splendor/state/source_compat.py
+++ b/src/splendor/state/source_compat.py
@@ -24,6 +24,18 @@ def effective_stored_path(source: SourceRecord) -> str | None:
     return source.storage_path or source.path
 
 
+def effective_materialized_path(source: SourceRecord) -> str | None:
+    if effective_storage_mode(source) not in {"copy", "pointer"}:
+        return None
+    return source.storage_path or source.path
+
+
+def pointer_source_error_label(source: SourceRecord) -> str:
+    if is_legacy_copied_manifest(source):
+        return "Legacy stored source pointer"
+    return "Source pointer artifact"
+
+
 def is_legacy_copied_manifest(source: SourceRecord) -> bool:
     return source.storage_mode is None and source.source_ref is None
 

--- a/src/splendor/state/source_pointer.py
+++ b/src/splendor/state/source_pointer.py
@@ -1,0 +1,40 @@
+"""Pointer artifact persistence and validation helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from splendor.schemas import SourcePointerArtifact
+from splendor.utils.fs import write_text_atomic
+
+
+def pointer_artifact_relpath(source_id: str) -> str:
+    return f"raw/sources/{source_id}/pointer.json"
+
+
+def load_source_pointer(path: Path) -> SourcePointerArtifact:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        msg = f"Pointer artifact is missing: {path}"
+        raise ValueError(msg) from None
+
+    try:
+        return SourcePointerArtifact.model_validate_json(raw)
+    except ValidationError as exc:
+        if any(error["type"] == "json_invalid" for error in exc.errors()):
+            msg = f"Pointer artifact is not valid JSON: {path}"
+            raise ValueError(msg) from exc
+        msg = f"Pointer artifact is invalid: {path}"
+        raise ValueError(msg) from exc
+
+
+def write_source_pointer(path: Path, artifact: SourcePointerArtifact) -> Path:
+    write_text_atomic(
+        path,
+        json.dumps(artifact.model_dump(mode="json"), indent=2, sort_keys=True) + "\n",
+    )
+    return path

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -9,9 +9,10 @@ from pathlib import Path
 from splendor import __version__
 from splendor.config import load_config
 from splendor.layout import resolve_layout
-from splendor.schemas import SourceRecord
+from splendor.schemas import SourcePointerArtifact, SourceRecord
 from splendor.schemas.types import StorageMode
-from splendor.state.source_compat import canonical_source_ref
+from splendor.state.source_compat import canonical_source_ref, effective_materialized_path
+from splendor.state.source_pointer import pointer_artifact_relpath, write_source_pointer
 from splendor.utils.fs import copy_file_if_missing, ensure_directory, write_text_atomic
 from splendor.utils.git import captured_source_commit
 from splendor.utils.hashing import sha256_file
@@ -106,7 +107,7 @@ def _effective_storage_mode(
     configured_storage_mode: StorageMode,
 ) -> StorageMode:
     if source_ref_kind == "workspace_path":
-        if configured_storage_mode in {"none", "copy"}:
+        if configured_storage_mode in {"none", "copy", "pointer"}:
             return configured_storage_mode
         msg = (
             f"Storage mode {configured_storage_mode!r} is not implemented yet for workspace sources"
@@ -115,7 +116,12 @@ def _effective_storage_mode(
 
     if configured_storage_mode == "copy":
         return "copy"
-    if configured_storage_mode in {"pointer", "symlink"}:
+    if configured_storage_mode == "pointer":
+        msg = (
+            f"Storage mode {configured_storage_mode!r} is not implemented yet for external sources"
+        )
+        raise ValueError(msg)
+    if configured_storage_mode == "symlink":
         msg = (
             f"Storage mode {configured_storage_mode!r} is not implemented yet for external sources"
         )
@@ -161,6 +167,16 @@ def _stored_path_for(layout, source_id: str, candidate: Path) -> Path:
     return layout.raw_sources_dir / source_id / candidate.name
 
 
+def _materialized_path_for(
+    layout, source_id: str, candidate: Path, storage_mode: StorageMode
+) -> Path | None:
+    if storage_mode == "copy":
+        return _stored_path_for(layout, source_id, candidate)
+    if storage_mode == "pointer":
+        return layout.root / pointer_artifact_relpath(source_id)
+    return None
+
+
 def _validated_existing_registration(
     *,
     root: Path,
@@ -177,7 +193,12 @@ def _validated_existing_registration(
             f"for source {existing.source_id}: {exc}"
         )
         raise ValueError(msg) from exc
-    stored_path = resolved.resolved_path if resolved.storage_mode == "copy" else None
+    stored_path_value = effective_materialized_path(existing)
+    stored_path = (
+        resolve_manifest_storage_path(root, stored_path_value)
+        if stored_path_value is not None
+        else None
+    )
     source_ref = canonical_source_ref(existing)
     return stored_path, resolved.storage_mode, source_ref
 
@@ -222,9 +243,7 @@ def register_source(
         source_ref_kind=source_ref_kind,
         capture_source_commit_enabled=capture_commit_enabled,
     )
-    stored_path = (
-        _stored_path_for(layout, source_id, candidate) if selected_storage_mode == "copy" else None
-    )
+    stored_path = _materialized_path_for(layout, source_id, candidate, selected_storage_mode)
 
     if manifest_path.exists():
         existing = load_source_record(manifest_path)
@@ -253,8 +272,9 @@ def register_source(
             already_registered=True,
         )
 
+    added_at = utc_now_iso()
     copied = False
-    if stored_path is not None:
+    if selected_storage_mode == "copy" and stored_path is not None:
         copied = copy_file_if_missing(candidate, stored_path)
         stored_checksum = sha256_file(stored_path)
         if stored_checksum != checksum:
@@ -263,8 +283,18 @@ def register_source(
                 f"expected {checksum}, got {stored_checksum}"
             )
             raise ValueError(msg)
-
-    added_at = utc_now_iso()
+    elif selected_storage_mode == "pointer" and stored_path is not None:
+        ensure_directory(stored_path.parent)
+        write_source_pointer(
+            stored_path,
+            SourcePointerArtifact(
+                source_id=source_id,
+                source_ref=source_ref,
+                source_ref_kind=source_ref_kind,
+                checksum=checksum,
+                created_at=added_at,
+            ),
+        )
     record = SourceRecord(
         source_id=source_id,
         title=_title_for(candidate),

--- a/src/splendor/state/source_resolver.py
+++ b/src/splendor/state/source_resolver.py
@@ -9,10 +9,12 @@ from splendor.schemas import SourceRecord
 from splendor.state.source_compat import (
     canonical_source_ref,
     copied_source_error_label,
+    effective_materialized_path,
     effective_source_ref_kind,
     effective_storage_mode,
     effective_stored_path,
 )
+from splendor.state.source_pointer import load_source_pointer
 from splendor.state.source_registry import (
     resolve_manifest_storage_path,
     validate_stored_source_location,
@@ -30,6 +32,36 @@ class ResolvedSource:
     content_origin_label: str
 
 
+def _resolve_workspace_ref(root: Path, source_ref: str, *, context: str) -> Path:
+    source_ref_path = Path(source_ref)
+    if source_ref_path.is_absolute():
+        msg = f"{context} path must be repo-relative: {source_ref}"
+        raise ValueError(msg)
+    if ".." in source_ref_path.parts:
+        msg = f"{context} path escapes workspace root: {source_ref}"
+        raise ValueError(msg)
+
+    resolved_path = (root / source_ref_path).resolve()
+    workspace_root = root.resolve()
+    try:
+        resolved_path.relative_to(workspace_root)
+    except ValueError as exc:
+        msg = f"{context} path escapes workspace root: {source_ref}"
+        raise ValueError(msg) from exc
+    return resolved_path
+
+
+def _require_workspace_source_checksum(
+    resolved_path: Path, checksum: str, *, label: str, source_ref: str
+) -> None:
+    if not resolved_path.exists():
+        msg = f"{label} is missing: {source_ref}"
+        raise ValueError(msg)
+    if sha256_file(resolved_path) != checksum:
+        msg = f"{label} checksum mismatch for ingestion: {source_ref}"
+        raise ValueError(msg)
+
+
 def _resolve_workspace_source(root: Path, source: SourceRecord) -> ResolvedSource:
     if not source.source_ref:
         msg = "Workspace-backed source is missing source_ref"
@@ -41,21 +73,112 @@ def _resolve_workspace_source(root: Path, source: SourceRecord) -> ResolvedSourc
         )
         raise ValueError(msg)
 
-    source_ref_path = Path(source.source_ref)
-    if source_ref_path.is_absolute():
-        msg = f"Workspace source path must be repo-relative: {source.source_ref}"
+    resolved_path = _resolve_workspace_ref(root, source.source_ref, context="Workspace source")
+    _require_workspace_source_checksum(
+        resolved_path,
+        source.checksum,
+        label="Workspace source",
+        source_ref=source.source_ref,
+    )
+
+    return ResolvedSource(
+        canonical_ref=source.source_ref,
+        canonical_ref_kind="workspace_path",
+        storage_mode="none",
+        resolved_path=resolved_path,
+        resolved_ref=source.source_ref,
+        content_origin_label="Workspace source",
+    )
+
+
+def _validate_materialized_source_location(
+    resolved_path: Path,
+    raw_sources_dir: Path,
+    source_id: str,
+    stored_path_value: str,
+    *,
+    description: str,
+) -> None:
+    try:
+        validate_stored_source_location(
+            resolved_path,
+            raw_sources_dir,
+            source_id,
+            stored_path_value,
+        )
+    except ValueError as exc:
+        lowered = str(exc).replace("Stored source path", description)
+        raise ValueError(lowered) from exc
+
+
+def _resolve_pointer_source(
+    root: Path, source: SourceRecord, raw_sources_dir: Path
+) -> ResolvedSource:
+    if not source.source_ref:
+        msg = "Pointer-backed source is missing source_ref"
         raise ValueError(msg)
-    if ".." in source_ref_path.parts:
-        msg = f"Workspace source path escapes workspace root: {source.source_ref}"
+    if source.source_ref_kind != "workspace_path":
+        msg = (
+            "Pointer-backed source must use source_ref_kind=workspace_path; "
+            f"got {source.source_ref_kind!r}"
+        )
         raise ValueError(msg)
 
-    resolved_path = (root / source_ref_path).resolve()
-    workspace_root = root.resolve()
-    try:
-        resolved_path.relative_to(workspace_root)
-    except ValueError as exc:
-        msg = f"Workspace source path escapes workspace root: {source.source_ref}"
-        raise ValueError(msg) from exc
+    pointer_path_value = effective_materialized_path(source)
+    if pointer_path_value is None:
+        msg = f"Pointer-backed source is missing a pointer artifact path: {source.source_id}"
+        raise ValueError(msg)
+    pointer_path = resolve_manifest_storage_path(root, pointer_path_value)
+    _validate_materialized_source_location(
+        pointer_path,
+        raw_sources_dir,
+        source.source_id,
+        pointer_path_value,
+        description="Pointer artifact path",
+    )
+
+    pointer = load_source_pointer(pointer_path)
+    if pointer.source_id != source.source_id:
+        msg = (
+            "Pointer artifact source ID mismatch for "
+            f"{pointer_path}: expected {source.source_id}, got {pointer.source_id}"
+        )
+        raise ValueError(msg)
+    if pointer.source_ref_kind != "workspace_path":
+        msg = (
+            "Pointer artifact must use source_ref_kind=workspace_path; "
+            f"got {pointer.source_ref_kind!r}"
+        )
+        raise ValueError(msg)
+    if pointer.source_ref != source.source_ref:
+        msg = (
+            "Pointer artifact source_ref mismatch for "
+            f"{pointer_path}: expected {source.source_ref}, got {pointer.source_ref}"
+        )
+        raise ValueError(msg)
+    if pointer.checksum != source.checksum:
+        msg = (
+            "Pointer artifact checksum mismatch for "
+            f"{pointer_path}: expected {source.checksum}, got {pointer.checksum}"
+        )
+        raise ValueError(msg)
+
+    resolved_path = _resolve_workspace_ref(root, pointer.source_ref, context="Pointer target")
+    _require_workspace_source_checksum(
+        resolved_path,
+        source.checksum,
+        label="Workspace source",
+        source_ref=pointer.source_ref,
+    )
+
+    return ResolvedSource(
+        canonical_ref=source.source_ref,
+        canonical_ref_kind="workspace_path",
+        storage_mode="pointer",
+        resolved_path=resolved_path,
+        resolved_ref=source.source_ref,
+        content_origin_label="Workspace source",
+    )
 
     if not resolved_path.exists():
         msg = f"Workspace source is missing: {source.source_ref}"
@@ -82,11 +205,12 @@ def _resolve_copied_source(
         msg = f"Copied source is missing a stored path: {source.source_id}"
         raise ValueError(msg)
     resolved_path = resolve_manifest_storage_path(root, stored_path_value)
-    validate_stored_source_location(
+    _validate_materialized_source_location(
         resolved_path,
         raw_sources_dir,
         source.source_id,
         stored_path_value,
+        description="Stored source path",
     )
     source_label = copied_source_error_label(source)
     if not resolved_path.exists():
@@ -110,7 +234,9 @@ def resolve_source_content(
     root: Path, source: SourceRecord, raw_sources_dir: Path
 ) -> ResolvedSource:
     storage_mode = effective_storage_mode(source)
-    if storage_mode in {"symlink", "pointer"}:
+    if storage_mode == "pointer":
+        return _resolve_pointer_source(root, source, raw_sources_dir)
+    if storage_mode == "symlink":
         msg = f"Unsupported storage mode for ingestion: {storage_mode}"
         raise ValueError(msg)
 

--- a/src/splendor/utils/wiki.py
+++ b/src/splendor/utils/wiki.py
@@ -44,11 +44,14 @@ def render_source_summary_page(
     source_section: str,
     summary: str,
     key_facts: list[str],
-    extract: str,
+    extract: str | None,
     provenance: list[str],
 ) -> str:
     key_fact_lines = "\n".join(f"- {line}" for line in key_facts)
     provenance_lines = "\n".join(f"- {line}" for line in provenance)
+    extract_section = ""
+    if extract is not None:
+        extract_section = f"## Extract\n\n{_fenced_extract_block(extract)}\n\n"
     return (
         f"---\n{render_frontmatter(frontmatter)}\n---\n\n"
         f"# {frontmatter.title}\n\n"
@@ -58,8 +61,7 @@ def render_source_summary_page(
         f"{summary}\n\n"
         "## Key Facts\n\n"
         f"{key_fact_lines}\n\n"
-        "## Extract\n\n"
-        f"{_fenced_extract_block(extract)}\n\n"
+        f"{extract_section}"
         "## Provenance\n\n"
         f"{provenance_lines}\n"
     )

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -5,6 +5,7 @@ import pytest
 
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
+from splendor.state.source_pointer import load_source_pointer
 from splendor.state.source_registry import load_source_record, write_source_record
 
 
@@ -126,14 +127,55 @@ def test_add_source_rejects_external_none_storage_mode(tmp_path: Path) -> None:
         external_dir.rmdir()
 
 
-@pytest.mark.parametrize("storage_mode", ["pointer", "symlink"])
-def test_add_source_rejects_unimplemented_storage_modes(tmp_path: Path, storage_mode: str) -> None:
+def test_add_source_supports_pointer_for_workspace_sources(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+
+    result = add_source(tmp_path, source, storage_mode="pointer")
+
+    manifest = load_source_record(result.manifest_path)
+    assert result.storage_mode == "pointer"
+    assert result.stored_path is not None and result.stored_path.exists()
+    assert result.stored_path == tmp_path / "raw" / "sources" / result.source_id / "pointer.json"
+    assert manifest.path == f"raw/sources/{result.source_id}/pointer.json"
+    assert manifest.storage_path == manifest.path
+    assert manifest.source_ref == "note.md"
+    assert manifest.source_ref_kind == "workspace_path"
+    assert manifest.storage_mode == "pointer"
+    assert manifest.materialized_at is not None
+    assert not (tmp_path / "raw" / "sources" / result.source_id / "note.md").exists()
+
+    pointer = load_source_pointer(result.stored_path)
+    assert pointer.source_id == result.source_id
+    assert pointer.source_ref == "note.md"
+    assert pointer.source_ref_kind == "workspace_path"
+    assert pointer.checksum == manifest.checksum
+    assert pointer.created_at == manifest.materialized_at
+
+
+def test_add_source_rejects_pointer_for_external_sources(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    external_dir = tmp_path.parent / f"{tmp_path.name}-external"
+    external_dir.mkdir()
+    source = external_dir / "outside.md"
+    source.write_text("# outside\n", encoding="utf-8")
+
+    try:
+        with pytest.raises(ValueError, match="not implemented yet for external sources"):
+            add_source(tmp_path, source, storage_mode="pointer")
+    finally:
+        source.unlink(missing_ok=True)
+        external_dir.rmdir()
+
+
+def test_add_source_rejects_symlink_for_workspace_sources(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "note.md"
     source.write_text("# note\n", encoding="utf-8")
 
     with pytest.raises(ValueError, match="not implemented yet"):
-        add_source(tmp_path, source, storage_mode=storage_mode)
+        add_source(tmp_path, source, storage_mode="symlink")
 
 
 def test_add_source_is_deduplicated_by_checksum_for_workspace_backed_sources(
@@ -163,6 +205,22 @@ def test_add_source_is_deduplicated_by_checksum_for_copied_sources(tmp_path: Pat
     assert first.source_id == second.source_id
     assert second.already_registered is True
     assert second.storage_mode == "copy"
+    assert second.stored_path == first.stored_path
+
+
+def test_add_source_is_deduplicated_by_checksum_for_pointer_backed_sources(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "notes.txt"
+    source.write_text("same-content\n", encoding="utf-8")
+
+    first = add_source(tmp_path, source, storage_mode="pointer")
+    second = add_source(tmp_path, source, storage_mode="pointer")
+
+    assert first.source_id == second.source_id
+    assert second.already_registered is True
+    assert second.storage_mode == "pointer"
     assert second.stored_path == first.stored_path
 
 
@@ -307,10 +365,13 @@ def test_add_source_reuses_mixed_manifest_shapes_authoritatively(tmp_path: Path)
     workspace_source.write_text("# workspace\n", encoding="utf-8")
     copied_source = tmp_path / "copied.md"
     copied_source.write_text("# copied\n", encoding="utf-8")
+    pointer_source = tmp_path / "pointer.md"
+    pointer_source.write_text("# pointer\n", encoding="utf-8")
 
     legacy_added = add_source(tmp_path, legacy_source, storage_mode="copy")
     add_source(tmp_path, workspace_source)
     add_source(tmp_path, copied_source, storage_mode="copy")
+    add_source(tmp_path, pointer_source, storage_mode="pointer")
 
     legacy_manifest = load_source_record(legacy_added.manifest_path).model_copy(
         update={
@@ -327,6 +388,7 @@ def test_add_source_reuses_mixed_manifest_shapes_authoritatively(tmp_path: Path)
     legacy_repeat = add_source(tmp_path, legacy_source)
     workspace_repeat = add_source(tmp_path, workspace_source, storage_mode="copy")
     copied_repeat = add_source(tmp_path, copied_source)
+    pointer_repeat = add_source(tmp_path, pointer_source)
 
     assert legacy_repeat.already_registered is True
     assert legacy_repeat.source_ref == "legacy.md"
@@ -341,3 +403,8 @@ def test_add_source_reuses_mixed_manifest_shapes_authoritatively(tmp_path: Path)
     assert copied_repeat.source_ref == "copied.md"
     assert copied_repeat.storage_mode == "copy"
     assert copied_repeat.stored_path is not None
+
+    assert pointer_repeat.already_registered is True
+    assert pointer_repeat.source_ref == "pointer.md"
+    assert pointer_repeat.storage_mode == "pointer"
+    assert pointer_repeat.stored_path is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,6 +91,23 @@ def test_cli_add_source_supports_explicit_copy_for_workspace_files(tmp_path: Pat
     assert "Stored copy:" in captured.out
 
 
+def test_cli_add_source_supports_pointer_for_workspace_files(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+
+    exit_code = main(
+        ["--root", str(tmp_path), "add-source", "--storage-mode", "pointer", str(source)]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Source ref: brief.md" in captured.out
+    assert "Storage mode: pointer" in captured.out
+    assert "Pointer artifact:" in captured.out
+    assert "Stored copy:" not in captured.out
+
+
 def test_cli_add_source_reports_unsupported_mode_combinations(tmp_path: Path, capsys) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
@@ -107,6 +124,26 @@ def test_cli_add_source_reports_unsupported_mode_combinations(tmp_path: Path, ca
     assert exit_code == 1
     captured = capsys.readouterr()
     assert "not supported for external sources" in captured.out
+
+
+def test_cli_add_source_reports_pointer_as_unsupported_for_external_files(
+    tmp_path: Path, capsys
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    source = fake_home / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+
+    main(["--root", str(repo_root), "init"])
+    exit_code = main(
+        ["--root", str(repo_root), "add-source", "--storage-mode", "pointer", str(source)]
+    )
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "not implemented yet for external sources" in captured.out
 
 
 def test_cli_ingest_command(tmp_path: Path, capsys) -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -11,6 +11,7 @@ from splendor.config import load_config, write_config
 from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord
 from splendor.schemas.types import SummaryMode
 from splendor.state.runtime import load_queue_item, load_run_record
+from splendor.state.source_pointer import load_source_pointer, write_source_pointer
 from splendor.state.source_registry import load_source_record, write_source_record
 
 
@@ -34,6 +35,20 @@ def update_summary_modes(
     if external is not None:
         config.sources.summarize_external_extracts_as = external
     write_config(root, config)
+
+
+def rewrite_pointer(
+    root: Path,
+    source_id: str,
+    *,
+    source_ref: str = "brief.md",
+    checksum: str,
+) -> Path:
+    pointer_path = root / "raw" / "sources" / source_id / "pointer.json"
+    artifact = load_source_pointer(pointer_path)
+    updated = artifact.model_copy(update={"source_ref": source_ref, "checksum": checksum})
+    write_source_pointer(pointer_path, updated)
+    return pointer_path
 
 
 def test_ingest_source_happy_path(tmp_path: Path) -> None:
@@ -526,10 +541,13 @@ def test_ingest_source_supports_mixed_manifest_workspace(tmp_path: Path) -> None
     workspace_source.write_text("# Workspace\n\nnew world\n", encoding="utf-8")
     copied_source = tmp_path / "copied.md"
     copied_source.write_text("# Copied\n\nstored world\n", encoding="utf-8")
+    pointer_source = tmp_path / "pointer.md"
+    pointer_source.write_text("# Pointer\n\npointer world\n", encoding="utf-8")
 
     legacy_added = add_source(tmp_path, legacy_source, storage_mode="copy")
     workspace_added = add_source(tmp_path, workspace_source)
     copied_added = add_source(tmp_path, copied_source, storage_mode="copy")
+    pointer_added = add_source(tmp_path, pointer_source, storage_mode="pointer")
 
     legacy_manifest = load_source_record(legacy_added.manifest_path).model_copy(
         update={
@@ -546,6 +564,7 @@ def test_ingest_source_supports_mixed_manifest_workspace(tmp_path: Path) -> None
     legacy_result = ingest_source(tmp_path, legacy_added.source_id)
     workspace_result = ingest_source(tmp_path, workspace_added.source_id)
     copied_result = ingest_source(tmp_path, copied_added.source_id)
+    pointer_result = ingest_source(tmp_path, pointer_added.source_id)
 
     legacy_body = legacy_result.page_path.read_text(encoding="utf-8")
     assert "Stored source:" in legacy_body
@@ -573,6 +592,15 @@ def test_ingest_source_supports_mixed_manifest_workspace(tmp_path: Path) -> None
     assert copied_run.input_refs == [
         copied_added.manifest_path.relative_to(tmp_path).as_posix(),
         copied_manifest.storage_path,
+    ]
+
+    pointer_body = pointer_result.page_path.read_text(encoding="utf-8")
+    assert "Workspace source: `pointer.md`" in pointer_body
+    assert "registered from `pointer.md`" in pointer_body
+    pointer_run = load_run_record(pointer_result.run_path)
+    assert pointer_run.input_refs == [
+        pointer_added.manifest_path.relative_to(tmp_path).as_posix(),
+        "pointer.md",
     ]
 
 
@@ -634,8 +662,110 @@ def test_ingest_source_workspace_backed_manifest_checksum_drift(tmp_path: Path) 
     assert load_run_record(run_paths[0]).status == "failed"
 
 
-@pytest.mark.parametrize("mode", ["pointer", "symlink"])
-def test_ingest_source_rejects_unsupported_storage_mode(tmp_path: Path, mode: str) -> None:
+def test_ingest_source_pointer_backed_happy_path(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="pointer")
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "Workspace source: `brief.md`" in body
+    assert "Source file: `brief.md`" in body
+    run_record = load_run_record(result.run_path)
+    assert run_record.input_refs == [
+        added.manifest_path.relative_to(tmp_path).as_posix(),
+        "brief.md",
+    ]
+
+
+def test_ingest_source_pointer_backed_missing_artifact(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="pointer")
+    assert added.stored_path is not None
+    added.stored_path.unlink()
+
+    with pytest.raises(ValueError, match="Pointer artifact is missing"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+
+
+def test_ingest_source_pointer_backed_malformed_artifact(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="pointer")
+    assert added.stored_path is not None
+    added.stored_path.write_text("{not-json}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Pointer artifact is not valid JSON"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+
+
+def test_ingest_source_pointer_backed_mismatched_source_ref(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="pointer")
+    rewrite_pointer(
+        tmp_path,
+        added.source_id,
+        source_ref="other.md",
+        checksum=load_source_record(added.manifest_path).checksum,
+    )
+
+    with pytest.raises(ValueError, match="Pointer artifact source_ref mismatch"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+
+
+def test_ingest_source_pointer_backed_missing_workspace_target(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="pointer")
+    source.unlink()
+
+    with pytest.raises(ValueError, match="Workspace source is missing"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+
+
+def test_ingest_source_pointer_backed_checksum_drift(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="pointer")
+    source.write_text("# Brief\n\nchanged\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Workspace source checksum mismatch"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+
+
+def test_ingest_source_rejects_unsupported_symlink_storage_mode(
+    tmp_path: Path,
+) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
@@ -644,12 +774,12 @@ def test_ingest_source_rejects_unsupported_storage_mode(tmp_path: Path, mode: st
         update={
             "source_ref": "brief.md",
             "source_ref_kind": "workspace_path",
-            "storage_mode": mode,
+            "storage_mode": "symlink",
         }
     )
     write_source_record(added.manifest_path, source_record)
 
-    with pytest.raises(ValueError, match=f"Unsupported storage mode for ingestion: {mode}"):
+    with pytest.raises(ValueError, match="Unsupported storage mode for ingestion: symlink"):
         ingest_source(tmp_path, added.source_id)
 
     source_record = load_source_record(added.manifest_path)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -9,6 +9,7 @@ from splendor.commands.ingest import ingest_source
 from splendor.commands.init import initialize_workspace
 from splendor.config import load_config, write_config
 from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord
+from splendor.schemas.types import SummaryMode
 from splendor.state.runtime import load_queue_item, load_run_record
 from splendor.state.source_registry import load_source_record, write_source_record
 
@@ -22,7 +23,10 @@ def parse_frontmatter(page_path: Path) -> tuple[KnowledgePageFrontmatter, str]:
 
 
 def update_summary_modes(
-    root: Path, *, in_repo: str | None = None, external: str | None = None
+    root: Path,
+    *,
+    in_repo: SummaryMode | None = None,
+    external: SummaryMode | None = None,
 ) -> None:
     config = load_config(root)
     if in_repo is not None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -681,6 +681,24 @@ def test_ingest_source_pointer_backed_happy_path(tmp_path: Path) -> None:
     ]
 
 
+def test_ingest_source_pointer_backed_default_uses_excerpt(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text(
+        "# Brief\n\n" + "\n".join(f"line {i}" for i in range(120)),
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source, storage_mode="pointer")
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "## Extract" in body
+    assert "line 10" in body
+    assert "line 119" not in body
+
+
 def test_ingest_source_pointer_backed_missing_artifact(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -7,6 +7,7 @@ import yaml
 from splendor.commands.add_source import add_source
 from splendor.commands.ingest import ingest_source
 from splendor.commands.init import initialize_workspace
+from splendor.config import load_config, write_config
 from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord
 from splendor.state.runtime import load_queue_item, load_run_record
 from splendor.state.source_registry import load_source_record, write_source_record
@@ -18,6 +19,17 @@ def parse_frontmatter(page_path: Path) -> tuple[KnowledgePageFrontmatter, str]:
     frontmatter_text, body = raw.removeprefix("---\n").split("\n---\n", maxsplit=1)
     frontmatter = KnowledgePageFrontmatter.model_validate(yaml.safe_load(frontmatter_text))
     return frontmatter, body
+
+
+def update_summary_modes(
+    root: Path, *, in_repo: str | None = None, external: str | None = None
+) -> None:
+    config = load_config(root)
+    if in_repo is not None:
+        config.sources.summarize_in_repo_extracts_as = in_repo
+    if external is not None:
+        config.sources.summarize_external_extracts_as = external
+    write_config(root, config)
 
 
 def test_ingest_source_happy_path(tmp_path: Path) -> None:
@@ -339,6 +351,94 @@ def test_ingest_source_extract_uses_safe_fence_for_backticks(tmp_path: Path) -> 
     page_content = result.page_path.read_text(encoding="utf-8")
     assert "````text" in page_content
     assert "\n````\n\n## Provenance" in page_content
+
+
+def test_ingest_source_workspace_backed_default_uses_excerpt(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text(
+        "# Brief\n\n" + "\n".join(f"line {i}" for i in range(120)),
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "## Extract" in body
+    assert "line 10" in body
+    assert "line 119" not in body
+
+
+def test_ingest_source_workspace_backed_none_omits_extract_section(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    update_summary_modes(tmp_path, in_repo="none")
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "## Extract" not in body
+    assert "Workspace source: `brief.md`" in body
+    assert "Source file: `brief.md`" in body
+
+
+def test_ingest_source_workspace_backed_full_renders_full_text(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    update_summary_modes(tmp_path, in_repo="full")
+    source = tmp_path / "brief.md"
+    source.write_text(
+        "# Brief\n\n" + "\n".join(f"line {i}" for i in range(120)),
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "## Extract" in body
+    assert "line 119" in body
+
+
+def test_ingest_source_copied_default_renders_full_text(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text(
+        "# Brief\n\n" + "\n".join(f"line {i}" for i in range(120)),
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source, storage_mode="copy")
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "## Extract" in body
+    assert "line 119" in body
+
+
+def test_ingest_source_external_excerpt_override_uses_bounded_preview(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    update_summary_modes(tmp_path, external="excerpt")
+    source = tmp_path / "brief.md"
+    source.write_text(
+        "# Brief\n\n" + "\n".join(f"line {i}" for i in range(120)),
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source, storage_mode="copy")
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "## Extract" in body
+    assert "line 10" in body
+    assert "line 119" not in body
 
 
 def test_ingest_source_rolls_back_wiki_on_success_commit_failure(

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from splendor.schemas import SourceRecord
+from splendor.schemas import SourcePointerArtifact, SourceRecord
 
 
 def test_source_record_validation_accepts_valid_payload() -> None:
@@ -90,5 +90,51 @@ def test_source_record_validation_rejects_unknown_fields() -> None:
             checksum="a" * 64,
             added_at="2026-04-10T15:00:00+00:00",
             pipeline_version="0.1.0a0",
+            unexpected_field="nope",
+        )
+
+
+def test_source_pointer_artifact_accepts_valid_payload() -> None:
+    artifact = SourcePointerArtifact(
+        source_id="src-1234567890abcdef",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="a" * 64,
+        created_at="2026-04-10T15:00:00+00:00",
+    )
+
+    assert artifact.kind == "source-pointer"
+
+
+def test_source_pointer_artifact_rejects_bad_checksum() -> None:
+    with pytest.raises(ValidationError):
+        SourcePointerArtifact(
+            source_id="src-1234567890abcdef",
+            source_ref="docs/spec.md",
+            source_ref_kind="workspace_path",
+            checksum="short",
+            created_at="2026-04-10T15:00:00+00:00",
+        )
+
+
+def test_source_pointer_artifact_rejects_invalid_source_ref_kind() -> None:
+    with pytest.raises(ValidationError):
+        SourcePointerArtifact(
+            source_id="src-1234567890abcdef",
+            source_ref="docs/spec.md",
+            source_ref_kind="bogus",
+            checksum="a" * 64,
+            created_at="2026-04-10T15:00:00+00:00",
+        )
+
+
+def test_source_pointer_artifact_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        SourcePointerArtifact(
+            source_id="src-1234567890abcdef",
+            source_ref="docs/spec.md",
+            source_ref_kind="workspace_path",
+            checksum="a" * 64,
+            created_at="2026-04-10T15:00:00+00:00",
             unexpected_field="nope",
         )

--- a/tests/test_source_resolver.py
+++ b/tests/test_source_resolver.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 import pytest
 
-from splendor.schemas import SourceRecord
+from splendor.schemas import SourcePointerArtifact, SourceRecord
+from splendor.state.source_pointer import write_source_pointer
 from splendor.state.source_resolver import resolve_source_content
 
 
@@ -18,6 +19,29 @@ def make_source_record(**overrides: object) -> SourceRecord:
     }
     payload.update(overrides)
     return SourceRecord(**payload)
+
+
+def write_pointer(
+    root: Path,
+    *,
+    source_id: str = "src-1234567890abcdef",
+    source_ref: str = "docs/spec.md",
+    source_ref_kind: str = "workspace_path",
+    checksum: str = "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+) -> Path:
+    path = root / "raw" / "sources" / source_id / "pointer.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    write_source_pointer(
+        path,
+        SourcePointerArtifact(
+            source_id=source_id,
+            source_ref=source_ref,
+            source_ref_kind=source_ref_kind,
+            checksum=checksum,
+            created_at="2026-04-10T15:01:00+00:00",
+        ),
+    )
+    return path
 
 
 def test_resolve_source_content_legacy_manifest_uses_stored_copy(tmp_path: Path) -> None:
@@ -142,15 +166,128 @@ def test_resolve_source_content_workspace_source_rejects_checksum_mismatch(tmp_p
         resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
 
 
-@pytest.mark.parametrize("mode", ["pointer", "symlink"])
-def test_resolve_source_content_rejects_unsupported_storage_modes(
-    tmp_path: Path, mode: str
+def test_resolve_source_content_pointer_source_uses_workspace_target(tmp_path: Path) -> None:
+    source_file = tmp_path / "docs" / "spec.md"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("hello\n", encoding="utf-8")
+    write_pointer(tmp_path)
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/pointer.json",
+        storage_mode="pointer",
+        storage_path="raw/sources/src-1234567890abcdef/pointer.json",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+
+    resolved = resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+    assert resolved.canonical_ref == "docs/spec.md"
+    assert resolved.canonical_ref_kind == "workspace_path"
+    assert resolved.storage_mode == "pointer"
+    assert resolved.resolved_path == source_file.resolve()
+    assert resolved.resolved_ref == "docs/spec.md"
+    assert resolved.content_origin_label == "Workspace source"
+
+
+def test_resolve_source_content_pointer_source_rejects_missing_pointer_artifact(
+    tmp_path: Path,
 ) -> None:
     source = make_source_record(
-        storage_mode=mode,
+        path="raw/sources/src-1234567890abcdef/pointer.json",
+        storage_mode="pointer",
+        storage_path="raw/sources/src-1234567890abcdef/pointer.json",
         source_ref="docs/spec.md",
         source_ref_kind="workspace_path",
     )
 
-    with pytest.raises(ValueError, match=f"Unsupported storage mode for ingestion: {mode}"):
+    with pytest.raises(ValueError, match="Pointer artifact is missing"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_pointer_source_rejects_malformed_pointer_artifact(
+    tmp_path: Path,
+) -> None:
+    pointer_path = tmp_path / "raw" / "sources" / "src-1234567890abcdef" / "pointer.json"
+    pointer_path.parent.mkdir(parents=True)
+    pointer_path.write_text("{not-json}\n", encoding="utf-8")
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/pointer.json",
+        storage_mode="pointer",
+        storage_path="raw/sources/src-1234567890abcdef/pointer.json",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+    )
+
+    with pytest.raises(ValueError, match="Pointer artifact is not valid JSON"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_pointer_source_rejects_source_ref_mismatch(
+    tmp_path: Path,
+) -> None:
+    source_file = tmp_path / "docs" / "spec.md"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("hello\n", encoding="utf-8")
+    write_pointer(tmp_path, source_ref="docs/other.md")
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/pointer.json",
+        storage_mode="pointer",
+        storage_path="raw/sources/src-1234567890abcdef/pointer.json",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+
+    with pytest.raises(ValueError, match="Pointer artifact source_ref mismatch"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_pointer_source_rejects_missing_workspace_target(
+    tmp_path: Path,
+) -> None:
+    write_pointer(tmp_path)
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/pointer.json",
+        storage_mode="pointer",
+        storage_path="raw/sources/src-1234567890abcdef/pointer.json",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+
+    with pytest.raises(ValueError, match="Workspace source is missing"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_pointer_source_rejects_checksum_drift(
+    tmp_path: Path,
+) -> None:
+    source_file = tmp_path / "docs" / "spec.md"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("changed\n", encoding="utf-8")
+    write_pointer(tmp_path)
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/pointer.json",
+        storage_mode="pointer",
+        storage_path="raw/sources/src-1234567890abcdef/pointer.json",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+
+    with pytest.raises(ValueError, match="Workspace source checksum mismatch"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_rejects_unsupported_symlink_storage_mode(
+    tmp_path: Path,
+) -> None:
+    source = make_source_record(
+        storage_mode="symlink",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+    )
+
+    with pytest.raises(ValueError, match="Unsupported storage mode for ingestion: symlink"):
         resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")


### PR DESCRIPTION
## Summary
- implement pointer-backed registration for workspace sources using deterministic JSON artifacts under `raw/sources/<source_id>/pointer.json`
- teach the source resolver and ingest path to validate pointer artifacts and read bytes from the canonical workspace file
- add pointer-specific CLI reporting, docs updates, and mixed-manifest regression coverage

## Verification
- uv run ruff format --check .
- uv run ruff check src tests
- PYTHONPATH=src pytest tests/test_add_source.py tests/test_ingest.py tests/test_source_resolver.py tests/test_cli.py tests/test_config.py tests/test_schemas.py tests/test_init.py