### PR TITLE
feat: support symlink-backed workspace sources

### DIFF
--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -95,10 +95,11 @@ Implemented fields:
     - `none` for workspace-backed sources
     - `copy` for workspace-backed and external local sources
     - `pointer` for workspace-backed sources
-    - `symlink` remains unimplemented
+    - `symlink` for workspace-backed sources
 - `storage_path`
   - Optional path under `raw/sources/` when Splendor materializes an artifact.
   - Pointer-backed sources use `raw/sources/<source_id>/pointer.json`.
+  - Symlink-backed sources use `raw/sources/<source_id>/<filename>`.
 - `materialized_at`
   - Timestamp indicating when `storage_path` was created or last refreshed.
 - `source_commit`

--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -433,13 +433,15 @@ Exit criteria:
 
 Scope:
 
-- add guarded `storage_mode=symlink`
-- validate platform constraints
+- add guarded `storage_mode=symlink` for workspace-backed sources
+- validate symlink artifacts and workspace-target safety
 - document operational caveats
 
 Exit criteria:
 
 - projects that prefer filesystem-level mirroring can opt in knowingly
+- symlink artifacts live under `raw/sources/<source_id>/<filename>`
+- external local files remain `copy`-only
 
 #### SR-9 — Materialization workflow polish
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -326,8 +326,7 @@ sources.
 ### Scope
 - split canonical source reference from storage realization
 - default in-repo files to workspace-backed registration
-- preserve copy and pointer options where projects need stronger materialization
-- keep `symlink` available in schema/config while deferring runtime support
+- preserve copy, pointer, and symlink options where projects need stronger materialization
 - reduce source-summary duplication for in-repo text sources
 
 ### Deliverables
@@ -344,6 +343,8 @@ sources.
 - external sources still get durable materialization when appropriate
 - workspace-backed sources can optionally materialize deterministic pointer artifacts under
   `raw/sources/<source_id>/pointer.json`
+- workspace-backed sources can optionally materialize symlink artifacts under
+  `raw/sources/<source_id>/<filename>`
 - ingest reads through one resolver interface regardless of source origin
 - source-summary pages remain deterministic while becoming less noisy
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -361,10 +361,11 @@ Field meanings:
     - `none` for workspace-backed sources
     - `copy` for workspace-backed and external local sources
     - `pointer` for workspace-backed sources via `raw/sources/<source_id>/pointer.json`
-    - `symlink` remains schema-visible but unimplemented
+    - `symlink` for workspace-backed sources via `raw/sources/<source_id>/<filename>`
 - `storage_path`
   - Optional path to the materialized artifact under `raw/sources/` when one exists.
   - Pointer-backed sources use `raw/sources/<source_id>/pointer.json`.
+  - Symlink-backed sources use `raw/sources/<source_id>/<filename>`.
 - `source_commit`
   - Optional git commit SHA captured for clean tracked workspace files when the project wants
     stronger repo-native provenance.

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -83,6 +83,8 @@ def handle_add_source(args: argparse.Namespace) -> int:
     if result.stored_path is not None:
         if result.storage_mode == "pointer":
             print(f"Pointer artifact: {result.stored_path}")
+        elif result.storage_mode == "symlink":
+            print(f"Symlink artifact: {result.stored_path}")
         else:
             print(f"Stored copy: {result.stored_path}")
     return 0

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -107,7 +107,7 @@ def _build_extract(text: str) -> str:
 
 def _summary_mode_for(config, source: SourceRecord) -> SummaryMode:
     if (
-        effective_storage_mode(source) in {"none", "pointer"}
+        effective_storage_mode(source) in {"none", "pointer", "symlink"}
         and effective_source_ref_kind(source) == "workspace_path"
     ):
         return config.sources.summarize_in_repo_extracts_as

--- a/src/splendor/state/source_compat.py
+++ b/src/splendor/state/source_compat.py
@@ -25,7 +25,7 @@ def effective_stored_path(source: SourceRecord) -> str | None:
 
 
 def effective_materialized_path(source: SourceRecord) -> str | None:
-    if effective_storage_mode(source) not in {"copy", "pointer"}:
+    if effective_storage_mode(source) not in {"copy", "pointer", "symlink"}:
         return None
     return source.storage_path or source.path
 
@@ -44,3 +44,9 @@ def copied_source_error_label(source: SourceRecord) -> str:
     if is_legacy_copied_manifest(source):
         return "Legacy stored source copy"
     return "Stored source copy"
+
+
+def symlink_source_error_label(source: SourceRecord) -> str:
+    if is_legacy_copied_manifest(source):
+        return "Legacy stored source symlink"
+    return "Source symlink artifact"

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -107,7 +108,7 @@ def _effective_storage_mode(
     configured_storage_mode: StorageMode,
 ) -> StorageMode:
     if source_ref_kind == "workspace_path":
-        if configured_storage_mode in {"none", "copy", "pointer"}:
+        if configured_storage_mode in {"none", "copy", "pointer", "symlink"}:
             return configured_storage_mode
         msg = (
             f"Storage mode {configured_storage_mode!r} is not implemented yet for workspace sources"
@@ -170,11 +171,36 @@ def _stored_path_for(layout, source_id: str, candidate: Path) -> Path:
 def _materialized_path_for(
     layout, source_id: str, candidate: Path, storage_mode: StorageMode
 ) -> Path | None:
-    if storage_mode == "copy":
+    if storage_mode in {"copy", "symlink"}:
         return _stored_path_for(layout, source_id, candidate)
     if storage_mode == "pointer":
         return layout.root / pointer_artifact_relpath(source_id)
     return None
+
+
+def _replace_path(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        msg = f"Cannot replace existing directory with source artifact: {path}"
+        raise ValueError(msg)
+    if path.exists() or path.is_symlink():
+        path.unlink()
+
+
+def _write_workspace_symlink(stored_path: Path, candidate: Path) -> None:
+    ensure_directory(stored_path.parent)
+    _replace_path(stored_path)
+    target = Path(os.path.relpath(candidate, start=stored_path.parent))
+    stored_path.symlink_to(target)
+    if not stored_path.is_symlink():
+        msg = f"Failed to create source symlink artifact: {stored_path}"
+        raise ValueError(msg)
+    resolved_target = stored_path.resolve(strict=True)
+    if resolved_target != candidate.resolve():
+        msg = (
+            "Source symlink artifact does not resolve to the canonical workspace source: "
+            f"{stored_path}"
+        )
+        raise ValueError(msg)
 
 
 def _validated_existing_registration(
@@ -194,11 +220,12 @@ def _validated_existing_registration(
         )
         raise ValueError(msg) from exc
     stored_path_value = effective_materialized_path(existing)
-    stored_path = (
-        resolve_manifest_storage_path(root, stored_path_value)
-        if stored_path_value is not None
-        else None
-    )
+    if stored_path_value is None:
+        stored_path = None
+    elif resolved.storage_mode == "symlink":
+        stored_path = root.resolve() / Path(stored_path_value)
+    else:
+        stored_path = resolve_manifest_storage_path(root, stored_path_value)
     source_ref = canonical_source_ref(existing)
     return stored_path, resolved.storage_mode, source_ref
 
@@ -295,6 +322,8 @@ def register_source(
                 created_at=added_at,
             ),
         )
+    elif selected_storage_mode == "symlink" and stored_path is not None:
+        _write_workspace_symlink(stored_path, candidate)
     record = SourceRecord(
         source_id=source_id,
         title=_title_for(candidate),

--- a/src/splendor/state/source_resolver.py
+++ b/src/splendor/state/source_resolver.py
@@ -13,6 +13,7 @@ from splendor.state.source_compat import (
     effective_source_ref_kind,
     effective_storage_mode,
     effective_stored_path,
+    symlink_source_error_label,
 )
 from splendor.state.source_pointer import load_source_pointer
 from splendor.state.source_registry import (
@@ -49,6 +50,17 @@ def _resolve_workspace_ref(root: Path, source_ref: str, *, context: str) -> Path
         msg = f"{context} path escapes workspace root: {source_ref}"
         raise ValueError(msg) from exc
     return resolved_path
+
+
+def _resolve_artifact_ref(root: Path, artifact_ref: str, *, context: str) -> Path:
+    artifact_ref_path = Path(artifact_ref)
+    if artifact_ref_path.is_absolute():
+        msg = f"{context} path must be repo-relative: {artifact_ref}"
+        raise ValueError(msg)
+    if ".." in artifact_ref_path.parts:
+        msg = f"{context} path escapes workspace root: {artifact_ref}"
+        raise ValueError(msg)
+    return root.resolve() / artifact_ref_path
 
 
 def _require_workspace_source_checksum(
@@ -180,17 +192,74 @@ def _resolve_pointer_source(
         content_origin_label="Workspace source",
     )
 
-    if not resolved_path.exists():
+
+def _resolve_symlink_source(
+    root: Path, source: SourceRecord, raw_sources_dir: Path
+) -> ResolvedSource:
+    if not source.source_ref:
+        msg = "Symlink-backed source is missing source_ref"
+        raise ValueError(msg)
+    if source.source_ref_kind != "workspace_path":
+        msg = (
+            "Symlink-backed source must use source_ref_kind=workspace_path; "
+            f"got {source.source_ref_kind!r}"
+        )
+        raise ValueError(msg)
+
+    symlink_path_value = effective_materialized_path(source)
+    if symlink_path_value is None:
+        msg = f"Symlink-backed source is missing a symlink artifact path: {source.source_id}"
+        raise ValueError(msg)
+    symlink_path = _resolve_artifact_ref(root, symlink_path_value, context="Symlink artifact")
+    _validate_materialized_source_location(
+        symlink_path,
+        raw_sources_dir,
+        source.source_id,
+        symlink_path_value,
+        description="Symlink artifact path",
+    )
+
+    source_label = symlink_source_error_label(source)
+    if not symlink_path.exists() and not symlink_path.is_symlink():
+        msg = f"{source_label} is missing: {symlink_path}"
+        raise ValueError(msg)
+    if not symlink_path.is_symlink():
+        msg = f"{source_label} is not a symlink: {symlink_path}"
+        raise ValueError(msg)
+
+    try:
+        resolved_path = symlink_path.resolve(strict=True)
+    except FileNotFoundError as exc:
         msg = f"Workspace source is missing: {source.source_ref}"
+        raise ValueError(msg) from exc
+
+    workspace_root = root.resolve()
+    try:
+        resolved_path.relative_to(workspace_root)
+    except ValueError as exc:
+        msg = f"{source_label} target escapes workspace root: {symlink_path}"
+        raise ValueError(msg) from exc
+
+    expected_path = _resolve_workspace_ref(root, source.source_ref, context="Workspace source")
+    if resolved_path != expected_path:
+        actual_ref = resolved_path.relative_to(workspace_root).as_posix()
+        msg = (
+            f"{source_label} target does not match manifest source_ref: "
+            f"expected {source.source_ref}, got {actual_ref}"
+        )
         raise ValueError(msg)
-    if sha256_file(resolved_path) != source.checksum:
-        msg = f"Workspace source checksum mismatch for ingestion: {source.source_ref}"
-        raise ValueError(msg)
+
+    _require_workspace_source_checksum(
+        resolved_path,
+        source.checksum,
+        label="Workspace source",
+        source_ref=source.source_ref,
+    )
 
     return ResolvedSource(
         canonical_ref=source.source_ref,
         canonical_ref_kind="workspace_path",
-        storage_mode="none",
+        storage_mode="symlink",
         resolved_path=resolved_path,
         resolved_ref=source.source_ref,
         content_origin_label="Workspace source",
@@ -237,8 +306,7 @@ def resolve_source_content(
     if storage_mode == "pointer":
         return _resolve_pointer_source(root, source, raw_sources_dir)
     if storage_mode == "symlink":
-        msg = f"Unsupported storage mode for ingestion: {storage_mode}"
-        raise ValueError(msg)
+        return _resolve_symlink_source(root, source, raw_sources_dir)
 
     if storage_mode == "none":
         return _resolve_workspace_source(root, source)

--- a/src/splendor/state/source_resolver.py
+++ b/src/splendor/state/source_resolver.py
@@ -232,6 +232,9 @@ def _resolve_symlink_source(
     except FileNotFoundError as exc:
         msg = f"Workspace source is missing: {source.source_ref}"
         raise ValueError(msg) from exc
+    except (OSError, RuntimeError) as exc:
+        msg = f"{source_label} could not be resolved: {symlink_path}"
+        raise ValueError(msg) from exc
 
     workspace_root = root.resolve()
     try:

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -169,13 +169,41 @@ def test_add_source_rejects_pointer_for_external_sources(tmp_path: Path) -> None
         external_dir.rmdir()
 
 
-def test_add_source_rejects_symlink_for_workspace_sources(tmp_path: Path) -> None:
+def test_add_source_supports_symlink_for_workspace_sources(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "note.md"
     source.write_text("# note\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="not implemented yet"):
-        add_source(tmp_path, source, storage_mode="symlink")
+    result = add_source(tmp_path, source, storage_mode="symlink")
+
+    manifest = load_source_record(result.manifest_path)
+    assert result.storage_mode == "symlink"
+    assert result.stored_path is not None and result.stored_path.exists()
+    assert result.stored_path == tmp_path / "raw" / "sources" / result.source_id / "note.md"
+    assert result.stored_path.is_symlink()
+    assert result.stored_path.resolve() == source.resolve()
+    assert manifest.path == f"raw/sources/{result.source_id}/note.md"
+    assert manifest.storage_path == manifest.path
+    assert manifest.source_ref == "note.md"
+    assert manifest.source_ref_kind == "workspace_path"
+    assert manifest.storage_mode == "symlink"
+    assert manifest.materialized_at is not None
+    assert result.stored_path.read_text(encoding="utf-8") == "# note\n"
+
+
+def test_add_source_rejects_symlink_for_external_sources(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    external_dir = tmp_path.parent / f"{tmp_path.name}-external"
+    external_dir.mkdir()
+    source = external_dir / "outside.md"
+    source.write_text("# outside\n", encoding="utf-8")
+
+    try:
+        with pytest.raises(ValueError, match="not implemented yet for external sources"):
+            add_source(tmp_path, source, storage_mode="symlink")
+    finally:
+        source.unlink(missing_ok=True)
+        external_dir.rmdir()
 
 
 def test_add_source_is_deduplicated_by_checksum_for_workspace_backed_sources(
@@ -221,6 +249,22 @@ def test_add_source_is_deduplicated_by_checksum_for_pointer_backed_sources(
     assert first.source_id == second.source_id
     assert second.already_registered is True
     assert second.storage_mode == "pointer"
+    assert second.stored_path == first.stored_path
+
+
+def test_add_source_is_deduplicated_by_checksum_for_symlink_backed_sources(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "notes.txt"
+    source.write_text("same-content\n", encoding="utf-8")
+
+    first = add_source(tmp_path, source, storage_mode="symlink")
+    second = add_source(tmp_path, source, storage_mode="symlink")
+
+    assert first.source_id == second.source_id
+    assert second.already_registered is True
+    assert second.storage_mode == "symlink"
     assert second.stored_path == first.stored_path
 
 
@@ -367,11 +411,14 @@ def test_add_source_reuses_mixed_manifest_shapes_authoritatively(tmp_path: Path)
     copied_source.write_text("# copied\n", encoding="utf-8")
     pointer_source = tmp_path / "pointer.md"
     pointer_source.write_text("# pointer\n", encoding="utf-8")
+    symlink_source = tmp_path / "symlink.md"
+    symlink_source.write_text("# symlink\n", encoding="utf-8")
 
     legacy_added = add_source(tmp_path, legacy_source, storage_mode="copy")
     add_source(tmp_path, workspace_source)
     add_source(tmp_path, copied_source, storage_mode="copy")
     add_source(tmp_path, pointer_source, storage_mode="pointer")
+    add_source(tmp_path, symlink_source, storage_mode="symlink")
 
     legacy_manifest = load_source_record(legacy_added.manifest_path).model_copy(
         update={
@@ -389,6 +436,7 @@ def test_add_source_reuses_mixed_manifest_shapes_authoritatively(tmp_path: Path)
     workspace_repeat = add_source(tmp_path, workspace_source, storage_mode="copy")
     copied_repeat = add_source(tmp_path, copied_source)
     pointer_repeat = add_source(tmp_path, pointer_source)
+    symlink_repeat = add_source(tmp_path, symlink_source)
 
     assert legacy_repeat.already_registered is True
     assert legacy_repeat.source_ref == "legacy.md"
@@ -408,3 +456,8 @@ def test_add_source_reuses_mixed_manifest_shapes_authoritatively(tmp_path: Path)
     assert pointer_repeat.source_ref == "pointer.md"
     assert pointer_repeat.storage_mode == "pointer"
     assert pointer_repeat.stored_path is not None
+
+    assert symlink_repeat.already_registered is True
+    assert symlink_repeat.source_ref == "symlink.md"
+    assert symlink_repeat.storage_mode == "symlink"
+    assert symlink_repeat.stored_path is not None

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -6,7 +6,13 @@ import pytest
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
 from splendor.state.source_pointer import load_source_pointer
-from splendor.state.source_registry import load_source_record, write_source_record
+from splendor.state.source_registry import (
+    _effective_storage_mode,
+    _replace_path,
+    _write_workspace_symlink,
+    load_source_record,
+    write_source_record,
+)
 
 
 def git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -191,6 +197,16 @@ def test_add_source_supports_symlink_for_workspace_sources(tmp_path: Path) -> No
     assert result.stored_path.read_text(encoding="utf-8") == "# note\n"
 
 
+def test_effective_storage_mode_accepts_workspace_symlink() -> None:
+    assert (
+        _effective_storage_mode(
+            source_ref_kind="workspace_path",
+            configured_storage_mode="symlink",
+        )
+        == "symlink"
+    )
+
+
 def test_add_source_rejects_symlink_for_external_sources(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     external_dir = tmp_path.parent / f"{tmp_path.name}-external"
@@ -204,6 +220,64 @@ def test_add_source_rejects_symlink_for_external_sources(tmp_path: Path) -> None
     finally:
         source.unlink(missing_ok=True)
         external_dir.rmdir()
+
+
+def test_replace_path_rejects_existing_directory(tmp_path: Path) -> None:
+    existing = tmp_path / "artifact"
+    existing.mkdir()
+
+    with pytest.raises(ValueError, match="Cannot replace existing directory"):
+        _replace_path(existing)
+
+
+def test_replace_path_unlinks_existing_file_and_symlink(tmp_path: Path) -> None:
+    file_path = tmp_path / "artifact.txt"
+    file_path.write_text("hello\n", encoding="utf-8")
+    _replace_path(file_path)
+    assert not file_path.exists()
+
+    target = tmp_path / "target.txt"
+    target.write_text("hello\n", encoding="utf-8")
+    symlink_path = tmp_path / "artifact-link"
+    symlink_path.symlink_to(target)
+    _replace_path(symlink_path)
+    assert not symlink_path.exists()
+
+
+def test_write_workspace_symlink_replaces_stale_artifact(tmp_path: Path) -> None:
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    stored_path = tmp_path / "raw" / "sources" / "src-1" / "note.md"
+    stored_path.parent.mkdir(parents=True, exist_ok=True)
+    stored_path.write_text("stale\n", encoding="utf-8")
+
+    _write_workspace_symlink(stored_path, source)
+
+    assert stored_path.is_symlink()
+    assert stored_path.resolve() == source.resolve()
+
+
+def test_write_workspace_symlink_rejects_mismatched_resolution(tmp_path: Path) -> None:
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    stored_path = tmp_path / "raw" / "sources" / "src-1" / "note.md"
+    stored_path.parent.mkdir(parents=True, exist_ok=True)
+    other = tmp_path / "other.md"
+    other.write_text("# other\n", encoding="utf-8")
+    stored_path.symlink_to(other)
+
+    original_symlink_to = Path.symlink_to
+
+    def fake_symlink_to(self: Path, target: Path, target_is_directory: bool = False) -> None:
+        original_symlink_to(self, other, target_is_directory=target_is_directory)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(Path, "symlink_to", fake_symlink_to)
+    try:
+        with pytest.raises(ValueError, match="does not resolve to the canonical workspace source"):
+            _write_workspace_symlink(stored_path, source)
+    finally:
+        monkeypatch.undo()
 
 
 def test_add_source_is_deduplicated_by_checksum_for_workspace_backed_sources(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,6 +108,23 @@ def test_cli_add_source_supports_pointer_for_workspace_files(tmp_path: Path, cap
     assert "Stored copy:" not in captured.out
 
 
+def test_cli_add_source_supports_symlink_for_workspace_files(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+
+    exit_code = main(
+        ["--root", str(tmp_path), "add-source", "--storage-mode", "symlink", str(source)]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Source ref: brief.md" in captured.out
+    assert "Storage mode: symlink" in captured.out
+    assert "Symlink artifact:" in captured.out
+    assert "Stored copy:" not in captured.out
+
+
 def test_cli_add_source_reports_unsupported_mode_combinations(tmp_path: Path, capsys) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
@@ -139,6 +156,26 @@ def test_cli_add_source_reports_pointer_as_unsupported_for_external_files(
     main(["--root", str(repo_root), "init"])
     exit_code = main(
         ["--root", str(repo_root), "add-source", "--storage-mode", "pointer", str(source)]
+    )
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "not implemented yet for external sources" in captured.out
+
+
+def test_cli_add_source_reports_symlink_as_unsupported_for_external_files(
+    tmp_path: Path, capsys
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    source = fake_home / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+
+    main(["--root", str(repo_root), "init"])
+    exit_code = main(
+        ["--root", str(repo_root), "add-source", "--storage-mode", "symlink", str(source)]
     )
 
     assert exit_code == 1

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -51,6 +51,15 @@ def rewrite_pointer(
     return pointer_path
 
 
+def rewrite_symlink(root: Path, source_id: str, target: Path) -> Path:
+    symlink_path = root / "raw" / "sources" / source_id / "brief.md"
+    if symlink_path.exists() or symlink_path.is_symlink():
+        symlink_path.unlink()
+    symlink_path.parent.mkdir(parents=True, exist_ok=True)
+    symlink_path.symlink_to(target)
+    return symlink_path
+
+
 def test_ingest_source_happy_path(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
@@ -543,11 +552,14 @@ def test_ingest_source_supports_mixed_manifest_workspace(tmp_path: Path) -> None
     copied_source.write_text("# Copied\n\nstored world\n", encoding="utf-8")
     pointer_source = tmp_path / "pointer.md"
     pointer_source.write_text("# Pointer\n\npointer world\n", encoding="utf-8")
+    symlink_source = tmp_path / "symlink.md"
+    symlink_source.write_text("# Symlink\n\nsymlink world\n", encoding="utf-8")
 
     legacy_added = add_source(tmp_path, legacy_source, storage_mode="copy")
     workspace_added = add_source(tmp_path, workspace_source)
     copied_added = add_source(tmp_path, copied_source, storage_mode="copy")
     pointer_added = add_source(tmp_path, pointer_source, storage_mode="pointer")
+    symlink_added = add_source(tmp_path, symlink_source, storage_mode="symlink")
 
     legacy_manifest = load_source_record(legacy_added.manifest_path).model_copy(
         update={
@@ -565,6 +577,7 @@ def test_ingest_source_supports_mixed_manifest_workspace(tmp_path: Path) -> None
     workspace_result = ingest_source(tmp_path, workspace_added.source_id)
     copied_result = ingest_source(tmp_path, copied_added.source_id)
     pointer_result = ingest_source(tmp_path, pointer_added.source_id)
+    symlink_result = ingest_source(tmp_path, symlink_added.source_id)
 
     legacy_body = legacy_result.page_path.read_text(encoding="utf-8")
     assert "Stored source:" in legacy_body
@@ -601,6 +614,15 @@ def test_ingest_source_supports_mixed_manifest_workspace(tmp_path: Path) -> None
     assert pointer_run.input_refs == [
         pointer_added.manifest_path.relative_to(tmp_path).as_posix(),
         "pointer.md",
+    ]
+
+    symlink_body = symlink_result.page_path.read_text(encoding="utf-8")
+    assert "Workspace source: `symlink.md`" in symlink_body
+    assert "registered from `symlink.md`" in symlink_body
+    symlink_run = load_run_record(symlink_result.run_path)
+    assert symlink_run.input_refs == [
+        symlink_added.manifest_path.relative_to(tmp_path).as_posix(),
+        "symlink.md",
     ]
 
 
@@ -781,23 +803,98 @@ def test_ingest_source_pointer_backed_checksum_drift(tmp_path: Path) -> None:
     assert source_record.last_run_id is not None
 
 
-def test_ingest_source_rejects_unsupported_symlink_storage_mode(
-    tmp_path: Path,
-) -> None:
+def test_ingest_source_symlink_backed_happy_path(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
-    added = add_source(tmp_path, source)
-    source_record = load_source_record(added.manifest_path).model_copy(
-        update={
-            "source_ref": "brief.md",
-            "source_ref_kind": "workspace_path",
-            "storage_mode": "symlink",
-        }
-    )
-    write_source_record(added.manifest_path, source_record)
+    added = add_source(tmp_path, source, storage_mode="symlink")
 
-    with pytest.raises(ValueError, match="Unsupported storage mode for ingestion: symlink"):
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert "Workspace source: `brief.md`" in body
+    assert "registered from `brief.md`" in body
+    run_record = load_run_record(result.run_path)
+    assert run_record.input_refs == [
+        added.manifest_path.relative_to(tmp_path).as_posix(),
+        "brief.md",
+    ]
+
+
+def test_ingest_source_symlink_backed_missing_artifact(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="symlink")
+    assert added.stored_path is not None
+    added.stored_path.unlink()
+
+    with pytest.raises(ValueError, match="Source symlink artifact is missing"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+
+
+def test_ingest_source_symlink_backed_regular_file_artifact(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="symlink")
+    assert added.stored_path is not None
+    added.stored_path.unlink()
+    added.stored_path.write_text("not-a-link\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Source symlink artifact is not a symlink"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+
+
+def test_ingest_source_symlink_backed_target_mismatch(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    other = tmp_path / "other.md"
+    other.write_text("# Other\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="symlink")
+    rewrite_symlink(tmp_path, added.source_id, Path("../../../other.md"))
+
+    with pytest.raises(ValueError, match="target does not match manifest source_ref"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+
+
+def test_ingest_source_symlink_backed_missing_workspace_target(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="symlink")
+    source.unlink()
+
+    with pytest.raises(ValueError, match="Workspace source is missing"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.last_run_id is not None
+
+
+def test_ingest_source_symlink_backed_checksum_drift(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="symlink")
+    source.write_text("# Brief\n\nchanged\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Workspace source checksum mismatch"):
         ingest_source(tmp_path, added.source_id)
 
     source_record = load_source_record(added.manifest_path)

--- a/tests/test_source_resolver.py
+++ b/tests/test_source_resolver.py
@@ -44,6 +44,15 @@ def write_pointer(
     return path
 
 
+def write_symlink_artifact(root: Path, *, source_id: str = "src-1234567890abcdef") -> Path:
+    source_file = root / "docs" / "spec.md"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    artifact = root / "raw" / "sources" / source_id / "spec.md"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.symlink_to(Path("../../../docs/spec.md"))
+    return artifact
+
+
 def test_resolve_source_content_legacy_manifest_uses_stored_copy(tmp_path: Path) -> None:
     stored_path = tmp_path / "raw" / "sources" / "src-1234567890abcdef" / "spec.md"
     stored_path.parent.mkdir(parents=True)
@@ -260,6 +269,146 @@ def test_resolve_source_content_pointer_source_rejects_missing_workspace_target(
         resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
 
 
+def test_resolve_source_content_symlink_source_uses_workspace_target(tmp_path: Path) -> None:
+    source_file = tmp_path / "docs" / "spec.md"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("hello\n", encoding="utf-8")
+    write_symlink_artifact(tmp_path)
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/spec.md",
+        storage_mode="symlink",
+        storage_path="raw/sources/src-1234567890abcdef/spec.md",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+
+    resolved = resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+    assert resolved.canonical_ref == "docs/spec.md"
+    assert resolved.canonical_ref_kind == "workspace_path"
+    assert resolved.storage_mode == "symlink"
+    assert resolved.resolved_path == source_file.resolve()
+    assert resolved.resolved_ref == "docs/spec.md"
+    assert resolved.content_origin_label == "Workspace source"
+
+
+def test_resolve_source_content_symlink_source_rejects_missing_artifact(
+    tmp_path: Path,
+) -> None:
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/spec.md",
+        storage_mode="symlink",
+        storage_path="raw/sources/src-1234567890abcdef/spec.md",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+    )
+
+    with pytest.raises(ValueError, match="Source symlink artifact is missing"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_symlink_source_rejects_regular_file_artifact(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "raw" / "sources" / "src-1234567890abcdef" / "spec.md"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("not-a-link\n", encoding="utf-8")
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/spec.md",
+        storage_mode="symlink",
+        storage_path="raw/sources/src-1234567890abcdef/spec.md",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+    )
+
+    with pytest.raises(ValueError, match="Source symlink artifact is not a symlink"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_symlink_source_rejects_target_outside_workspace(
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path.parent / "outside.md"
+    outside.write_text("outside\n", encoding="utf-8")
+    artifact = tmp_path / "raw" / "sources" / "src-1234567890abcdef" / "spec.md"
+    artifact.parent.mkdir(parents=True)
+    artifact.symlink_to(outside)
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/spec.md",
+        storage_mode="symlink",
+        storage_path="raw/sources/src-1234567890abcdef/spec.md",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+    )
+
+    with pytest.raises(ValueError, match="target escapes workspace root"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_symlink_source_rejects_target_mismatch(
+    tmp_path: Path,
+) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "spec.md").write_text("hello\n", encoding="utf-8")
+    other = docs / "other.md"
+    other.write_text("hello\n", encoding="utf-8")
+    artifact = tmp_path / "raw" / "sources" / "src-1234567890abcdef" / "spec.md"
+    artifact.parent.mkdir(parents=True)
+    artifact.symlink_to(Path("../../../docs/other.md"))
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/spec.md",
+        storage_mode="symlink",
+        storage_path="raw/sources/src-1234567890abcdef/spec.md",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+
+    with pytest.raises(ValueError, match="target does not match manifest source_ref"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_symlink_source_rejects_missing_workspace_target(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "raw" / "sources" / "src-1234567890abcdef" / "spec.md"
+    artifact.parent.mkdir(parents=True)
+    artifact.symlink_to(Path("../../../docs/spec.md"))
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/spec.md",
+        storage_mode="symlink",
+        storage_path="raw/sources/src-1234567890abcdef/spec.md",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+
+    with pytest.raises(ValueError, match="Workspace source is missing"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_symlink_source_rejects_checksum_drift(
+    tmp_path: Path,
+) -> None:
+    source_file = tmp_path / "docs" / "spec.md"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("changed\n", encoding="utf-8")
+    write_symlink_artifact(tmp_path)
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/spec.md",
+        storage_mode="symlink",
+        storage_path="raw/sources/src-1234567890abcdef/spec.md",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+
+    with pytest.raises(ValueError, match="Workspace source checksum mismatch"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
 def test_resolve_source_content_pointer_source_rejects_checksum_drift(
     tmp_path: Path,
 ) -> None:
@@ -277,17 +426,4 @@ def test_resolve_source_content_pointer_source_rejects_checksum_drift(
     )
 
     with pytest.raises(ValueError, match="Workspace source checksum mismatch"):
-        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
-
-
-def test_resolve_source_content_rejects_unsupported_symlink_storage_mode(
-    tmp_path: Path,
-) -> None:
-    source = make_source_record(
-        storage_mode="symlink",
-        source_ref="docs/spec.md",
-        source_ref_kind="workspace_path",
-    )
-
-    with pytest.raises(ValueError, match="Unsupported storage mode for ingestion: symlink"):
         resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")

--- a/tests/test_source_resolver.py
+++ b/tests/test_source_resolver.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from splendor.schemas import SourcePointerArtifact, SourceRecord
+from splendor.state.source_compat import symlink_source_error_label
 from splendor.state.source_pointer import write_source_pointer
 from splendor.state.source_resolver import resolve_source_content
 
@@ -308,6 +309,36 @@ def test_resolve_source_content_symlink_source_rejects_missing_artifact(
         resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
 
 
+def test_resolve_source_content_symlink_source_rejects_absolute_artifact_ref(
+    tmp_path: Path,
+) -> None:
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/spec.md",
+        storage_mode="symlink",
+        storage_path="/tmp/spec.md",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+    )
+
+    with pytest.raises(ValueError, match="Symlink artifact path must be repo-relative"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_symlink_source_rejects_escaping_artifact_ref(
+    tmp_path: Path,
+) -> None:
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/spec.md",
+        storage_mode="symlink",
+        storage_path="../spec.md",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+    )
+
+    with pytest.raises(ValueError, match="Symlink artifact path escapes workspace root"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
 def test_resolve_source_content_symlink_source_rejects_regular_file_artifact(
     tmp_path: Path,
 ) -> None:
@@ -323,6 +354,34 @@ def test_resolve_source_content_symlink_source_rejects_regular_file_artifact(
     )
 
     with pytest.raises(ValueError, match="Source symlink artifact is not a symlink"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_symlink_source_rejects_missing_source_ref(
+    tmp_path: Path,
+) -> None:
+    source = make_source_record(
+        storage_mode="symlink",
+        source_ref=None,
+        source_ref_kind="workspace_path",
+        storage_path="raw/sources/src-1234567890abcdef/spec.md",
+    )
+
+    with pytest.raises(ValueError, match="Symlink-backed source is missing source_ref"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_symlink_source_rejects_wrong_source_ref_kind(
+    tmp_path: Path,
+) -> None:
+    source = make_source_record(
+        storage_mode="symlink",
+        source_ref="docs/spec.md",
+        source_ref_kind="external_path",
+        storage_path="raw/sources/src-1234567890abcdef/spec.md",
+    )
+
+    with pytest.raises(ValueError, match="must use source_ref_kind=workspace_path"):
         resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
 
 
@@ -407,6 +466,40 @@ def test_resolve_source_content_symlink_source_rejects_checksum_drift(
 
     with pytest.raises(ValueError, match="Workspace source checksum mismatch"):
         resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_symlink_source_wraps_resolution_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_file = tmp_path / "docs" / "spec.md"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("hello\n", encoding="utf-8")
+    artifact = write_symlink_artifact(tmp_path)
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/spec.md",
+        storage_mode="symlink",
+        storage_path="raw/sources/src-1234567890abcdef/spec.md",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+    original_resolve = Path.resolve
+
+    def fake_resolve(self: Path, *args: object, **kwargs: object) -> Path:
+        if self == artifact:
+            raise RuntimeError("loop")
+        return original_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", fake_resolve)
+
+    with pytest.raises(ValueError, match="Source symlink artifact could not be resolved"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_symlink_source_error_label_covers_legacy_shape() -> None:
+    legacy = make_source_record(source_ref=None, storage_mode=None)
+
+    assert symlink_source_error_label(legacy) == "Legacy stored source symlink"
 
 
 def test_resolve_source_content_pointer_source_rejects_checksum_drift(


### PR DESCRIPTION
## SR-8: Symlink Storage Mode for Workspace Sources

This PR implements the `SR-8` step of the source-resolution refactor plan.

`storage_mode="symlink"` is now supported for **workspace-backed sources only**. The implementation follows the same high-level model as SR-7 pointer support: the manifest keeps the canonical workspace source, `raw/sources/` contains a deterministic realization artifact, and ingest still treats the source as a workspace source after validating the artifact.

## What Changed

### Registration and manifest behavior
- workspace files may now register with `--storage-mode symlink`
- external local files remain `copy`-only; external `--storage-mode symlink` is still rejected
- symlink-backed records now write:
  - `source_ref` as the canonical repo-relative workspace path
  - `source_ref_kind="workspace_path"`
  - `storage_mode="symlink"`
  - `storage_path` as `raw/sources/<source_id>/<filename>`
  - `path` mirroring `storage_path` for compatibility
  - `materialized_at` when the symlink artifact is created
- deduplication remains first-registration-wins and content-addressed
- re-registering an existing symlink-backed manifest validates the existing manifest through the shared resolver path instead of rewriting it

### Symlink artifact contract
- symlink artifacts live at `raw/sources/<source_id>/<original_filename>`
- registration creates a symlink that points back to the canonical workspace source
- the artifact path reuses the same copy-style layout shape as `storage_mode="copy"`

### Resolver and ingest behavior
- `resolve_source_content(...)` now supports `storage_mode="symlink"`
- symlink-backed ingestion validates that the artifact:
  - exists under `raw/sources/<source_id>/`
  - is actually a symlink
  - resolves to a target inside the workspace root
  - resolves to the manifest’s `source_ref`
  - points at a workspace file whose checksum still matches the manifest checksum
- after validation, ingest reads the **workspace file**, not bytes under `raw/sources/`
- resolved provenance remains workspace-centric:
  - `canonical_ref` is the workspace `source_ref`
  - `resolved_ref` is the canonical workspace ref
  - `content_origin_label` remains `Workspace source`

### CLI behavior
- CLI reporting is now fully mode-aware across all materialized modes:
  - `copy` => `Stored copy:`
  - `pointer` => `Pointer artifact:`
  - `symlink` => `Symlink artifact:`
- successful workspace symlink registration reports `Storage mode: symlink`
- unsupported external symlink registration returns a clear error

### Documentation
This PR updates the shipped docs to reflect the implemented SR-8 boundary:
- `symlink` is now implemented for workspace-backed sources
- external local files remain `copy`-only
- symlink artifacts live under `raw/sources/<source_id>/<filename>`
- ingest validates the symlink artifact and then reads the workspace file
- `pointer` remains the more portable cross-platform option, while `symlink` carries filesystem/platform portability caveats

## Files of Interest
- `src/splendor/state/source_registry.py`
- `src/splendor/state/source_resolver.py`
- `src/splendor/state/source_compat.py`
- `src/splendor/cli.py`
- `src/splendor/commands/ingest.py`
- `tests/test_add_source.py`
- `tests/test_source_resolver.py`
- `tests/test_ingest.py`
- `tests/test_cli.py`

## Test Coverage Added or Updated
- workspace symlink registration
- unsupported external symlink registration
- deduplication of symlink-backed sources
- authoritative reuse of symlink-backed manifests in mixed-manifest workspaces
- symlink resolver happy path
- symlink failure cases:
  - missing artifact
  - artifact exists but is not a symlink
  - target escapes the workspace
  - target does not match `source_ref`
  - missing workspace target
  - workspace checksum drift
- ingest happy path for symlink-backed sources
- mixed workspace compatibility across:
  - legacy copied
  - copied
  - workspace-backed (`none`)
  - pointer-backed
  - symlink-backed
- CLI output for successful symlink registration and unsupported external symlink registration

## Verification
- `uv run ruff format --check .`
- `uv run ruff check src tests`
- `PYTHONPATH=src pytest tests/test_add_source.py tests/test_ingest.py tests/test_source_resolver.py tests/test_cli.py tests/test_config.py tests/test_schemas.py tests/test_init.py`

Result: `115 passed`
