### PR TITLE
Implement SR-9 materialization workflow polish

### DIFF
--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+import yaml
+
 from splendor.commands.add_source import add_source
 from splendor.commands.health import run_health
 from splendor.commands.ingest import ingest_source
@@ -116,7 +118,7 @@ def handle_ingest(args: argparse.Namespace) -> int:
 
     print(f"Ingested source {result.source_id}")
     print(f"Source ref: {result.canonical_ref}")
-    print(f"Canonical content: {result.canonical_ref_kind.replace('_', ' ')}")
+    print(f"Canonical content: {result.content_origin_kind.replace('_', ' ')}")
     print(f"Run: {result.run_id}")
     print(f"Page: {result.page_path}")
     print(f"Queue record: {result.queue_path}")
@@ -142,7 +144,11 @@ def handle_materialize_source(args: argparse.Namespace) -> int:
 
 def handle_health(args: argparse.Namespace) -> int:
     root = args.root.resolve()
-    result = run_health(root)
+    try:
+        result = run_health(root)
+    except (ValueError, RuntimeError, OSError, yaml.YAMLError) as exc:
+        print(f"Error: {exc}")
+        return 1
     print(f"Checked sources: {result.checked_sources}")
     if not result.issues:
         print("Health check passed")

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -6,8 +6,10 @@ import argparse
 from pathlib import Path
 
 from splendor.commands.add_source import add_source
+from splendor.commands.health import run_health
 from splendor.commands.ingest import ingest_source
 from splendor.commands.init import initialize_workspace
+from splendor.commands.materialize_source import materialize_source
 from splendor.schemas.types import STORAGE_MODES
 
 
@@ -50,6 +52,20 @@ def build_parser() -> argparse.ArgumentParser:
     ingest_parser = subparsers.add_parser("ingest", help="Ingest a registered source into the wiki")
     ingest_parser.add_argument("source_id", help="Registered source identifier to ingest")
     ingest_parser.set_defaults(handler=handle_ingest)
+
+    materialize_parser = subparsers.add_parser(
+        "materialize-source", help="Create or refresh a source storage artifact"
+    )
+    materialize_parser.add_argument("source_id", help="Registered source identifier to materialize")
+    materialize_parser.add_argument(
+        "--storage-mode",
+        choices=tuple(mode for mode in STORAGE_MODES if mode != "none"),
+        help="Override the target storage mode for this materialization.",
+    )
+    materialize_parser.set_defaults(handler=handle_materialize_source)
+
+    health_parser = subparsers.add_parser("health", help="Validate source storage state")
+    health_parser.set_defaults(handler=handle_health)
     return parser
 
 
@@ -81,12 +97,7 @@ def handle_add_source(args: argparse.Namespace) -> int:
     print(f"Source ref: {result.source_ref}")
     print(f"Storage mode: {result.storage_mode}")
     if result.stored_path is not None:
-        if result.storage_mode == "pointer":
-            print(f"Pointer artifact: {result.stored_path}")
-        elif result.storage_mode == "symlink":
-            print(f"Symlink artifact: {result.stored_path}")
-        else:
-            print(f"Stored copy: {result.stored_path}")
+        print(f"Storage artifact: {result.stored_path}")
     return 0
 
 
@@ -104,11 +115,43 @@ def handle_ingest(args: argparse.Namespace) -> int:
         return 0
 
     print(f"Ingested source {result.source_id}")
+    print(f"Source ref: {result.canonical_ref}")
+    print(f"Canonical content: {result.canonical_ref_kind.replace('_', ' ')}")
     print(f"Run: {result.run_id}")
     print(f"Page: {result.page_path}")
     print(f"Queue record: {result.queue_path}")
     print(f"Run record: {result.run_path}")
     return 0
+
+
+def handle_materialize_source(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = materialize_source(root, args.source_id, storage_mode=args.storage_mode)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    print(f"Materialized source {result.source_id}")
+    print(f"Manifest: {result.manifest_path}")
+    print(f"Source ref: {result.source_ref}")
+    print(f"Storage mode: {result.storage_mode}")
+    print(f"Storage artifact: {result.stored_path}")
+    return 0
+
+
+def handle_health(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    result = run_health(root)
+    print(f"Checked sources: {result.checked_sources}")
+    if not result.issues:
+        print("Health check passed")
+        return 0
+
+    print(f"Health check failed: {len(result.issues)} issue(s)")
+    for issue in result.issues:
+        print(f"- {issue.source_id}: {issue.message}")
+    return 1
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -49,6 +49,10 @@ def run_health(root: Path) -> HealthResult:
     issues: list[HealthIssue] = []
     checked_sources = 0
 
+    if not layout.source_records_dir.is_dir():
+        msg = f"Source manifest directory is missing or unreadable: {layout.source_records_dir}"
+        raise RuntimeError(msg)
+
     for manifest_path in sorted(layout.source_records_dir.glob("*.json")):
         checked_sources += 1
         source_id = manifest_path.stem

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from splendor.config import load_config
 from splendor.layout import resolve_layout
+from splendor.schemas import SourceRecord
 from splendor.state.source_compat import effective_storage_mode
 from splendor.state.source_registry import load_source_record
 from splendor.state.source_resolver import resolve_source_content
@@ -24,7 +25,7 @@ class HealthResult:
     issues: list[HealthIssue]
 
 
-def _validate_storage_policy(source) -> None:
+def _validate_storage_policy(source: SourceRecord) -> None:
     storage_mode = effective_storage_mode(source)
     if storage_mode == "none" and source.source_ref_kind != "workspace_path":
         msg = (

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -1,0 +1,61 @@
+"""Implementation for `splendor health`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.state.source_compat import effective_storage_mode
+from splendor.state.source_registry import load_source_record
+from splendor.state.source_resolver import resolve_source_content
+
+
+@dataclass(frozen=True)
+class HealthIssue:
+    source_id: str
+    message: str
+
+
+@dataclass(frozen=True)
+class HealthResult:
+    checked_sources: int
+    issues: list[HealthIssue]
+
+
+def _validate_storage_policy(source) -> None:
+    storage_mode = effective_storage_mode(source)
+    if storage_mode == "none" and source.source_ref_kind != "workspace_path":
+        msg = (
+            "Storage mode 'none' requires source_ref_kind=workspace_path; "
+            f"got {source.source_ref_kind!r}"
+        )
+        raise ValueError(msg)
+    if storage_mode in {"pointer", "symlink"} and source.source_ref_kind != "workspace_path":
+        msg = (
+            f"Storage mode {storage_mode!r} requires source_ref_kind=workspace_path; "
+            f"got {source.source_ref_kind!r}"
+        )
+        raise ValueError(msg)
+    if storage_mode == "copy" and not source.path:
+        raise ValueError("Copied source is missing path")
+
+
+def run_health(root: Path) -> HealthResult:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    issues: list[HealthIssue] = []
+    checked_sources = 0
+
+    for manifest_path in sorted(layout.source_records_dir.glob("*.json")):
+        checked_sources += 1
+        source_id = manifest_path.stem
+        try:
+            source = load_source_record(manifest_path)
+            _validate_storage_policy(source)
+            resolve_source_content(root, source, layout.raw_sources_dir)
+        except Exception as exc:
+            issues.append(HealthIssue(source_id=source_id, message=str(exc)))
+
+    return HealthResult(checked_sources=checked_sources, issues=issues)

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -70,6 +70,8 @@ class IngestResult:
     run_path: Path | None
     page_path: Path | None
     no_op: bool
+    canonical_ref_kind: str | None
+    canonical_ref: str | None
 
 
 def _make_run_id(source_id: str) -> str:
@@ -256,6 +258,8 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
             run_path=None,
             page_path=layout.wiki_sources_dir / f"{source_id}.md",
             no_op=True,
+            canonical_ref_kind=None,
+            canonical_ref=None,
         )
 
     now = utc_now_iso()
@@ -406,6 +410,8 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
             run_path=run_path,
             page_path=page_path,
             no_op=False,
+            canonical_ref_kind=resolved_source.canonical_ref_kind,
+            canonical_ref=resolved_source.canonical_ref,
         )
     except ValueError as exc:
         _mark_attempt_failed(

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -70,8 +70,8 @@ class IngestResult:
     run_path: Path | None
     page_path: Path | None
     no_op: bool
-    canonical_ref_kind: str | None
     canonical_ref: str | None
+    content_origin_kind: str | None
 
 
 def _make_run_id(source_id: str) -> str:
@@ -130,6 +130,12 @@ def _build_summary(source: SourceRecord) -> str:
         f"This page records deterministic ingestion output for source `{source.source_id}`, "
         f"a `{source.source_type}` file registered from `{path_fragment}`."
     )
+
+
+def _content_origin_kind(storage_mode: str) -> str:
+    if storage_mode == "copy":
+        return "stored_artifact"
+    return "workspace_path"
 
 
 def _best_available_source_ref(source: SourceRecord) -> str:
@@ -258,8 +264,8 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
             run_path=None,
             page_path=layout.wiki_sources_dir / f"{source_id}.md",
             no_op=True,
-            canonical_ref_kind=None,
             canonical_ref=None,
+            content_origin_kind=None,
         )
 
     now = utc_now_iso()
@@ -410,8 +416,8 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
             run_path=run_path,
             page_path=page_path,
             no_op=False,
-            canonical_ref_kind=resolved_source.canonical_ref_kind,
             canonical_ref=resolved_source.canonical_ref,
+            content_origin_kind=_content_origin_kind(resolved_source.storage_mode),
         )
     except ValueError as exc:
         _mark_attempt_failed(

--- a/src/splendor/commands/materialize_source.py
+++ b/src/splendor/commands/materialize_source.py
@@ -1,0 +1,34 @@
+"""Implementation for `splendor materialize-source`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from splendor.schemas.types import StorageMode
+from splendor.state.source_registry import materialize_registered_source
+
+
+@dataclass(frozen=True)
+class MaterializeSourceResult:
+    source_id: str
+    manifest_path: Path
+    stored_path: Path
+    storage_mode: StorageMode
+    source_ref: str
+
+
+def materialize_source(
+    root: Path,
+    source_id: str,
+    *,
+    storage_mode: StorageMode | None = None,
+) -> MaterializeSourceResult:
+    materialized = materialize_registered_source(root, source_id, storage_mode=storage_mode)
+    return MaterializeSourceResult(
+        source_id=materialized.record.source_id,
+        manifest_path=materialized.manifest_path,
+        stored_path=materialized.stored_path,
+        storage_mode=materialized.storage_mode,
+        source_ref=materialized.source_ref,
+    )

--- a/src/splendor/state/paths.py
+++ b/src/splendor/state/paths.py
@@ -1,0 +1,24 @@
+"""Shared path validation helpers for source state operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_workspace_path(root: Path, source_ref: str, *, context: str) -> Path:
+    source_ref_path = Path(source_ref)
+    if source_ref_path.is_absolute():
+        msg = f"{context} path must be repo-relative: {source_ref}"
+        raise ValueError(msg)
+    if ".." in source_ref_path.parts:
+        msg = f"{context} path escapes workspace root: {source_ref}"
+        raise ValueError(msg)
+
+    resolved_path = (root / source_ref_path).resolve()
+    workspace_root = root.resolve()
+    try:
+        resolved_path.relative_to(workspace_root)
+    except ValueError as exc:
+        msg = f"{context} path escapes workspace root: {source_ref}"
+        raise ValueError(msg) from exc
+    return resolved_path

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -12,9 +12,19 @@ from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import SourcePointerArtifact, SourceRecord
 from splendor.schemas.types import StorageMode
-from splendor.state.source_compat import canonical_source_ref, effective_materialized_path
+from splendor.state.paths import resolve_workspace_path
+from splendor.state.source_compat import (
+    canonical_source_ref,
+    effective_materialized_path,
+    is_legacy_copied_manifest,
+)
 from splendor.state.source_pointer import pointer_artifact_relpath, write_source_pointer
-from splendor.utils.fs import copy_file_if_missing, ensure_directory, write_text_atomic
+from splendor.utils.fs import (
+    copy_file_atomic,
+    copy_file_if_missing,
+    ensure_directory,
+    write_text_atomic,
+)
 from splendor.utils.git import captured_source_commit
 from splendor.utils.hashing import sha256_file
 from splendor.utils.ids import stable_source_id
@@ -222,10 +232,15 @@ def write_source_artifact(
     checksum: str,
     storage_mode: StorageMode,
     materialized_at: str,
+    refresh: bool = False,
 ) -> bool:
     copied = False
     if storage_mode == "copy":
-        copied = copy_file_if_missing(candidate, stored_path)
+        if refresh:
+            copy_file_atomic(candidate, stored_path)
+            copied = True
+        else:
+            copied = copy_file_if_missing(candidate, stored_path)
         stored_checksum = sha256_file(stored_path)
         if stored_checksum != checksum:
             msg = (
@@ -290,16 +305,16 @@ def materializing_storage_mode_for_source(
     *,
     storage_mode: StorageMode | None = None,
 ) -> StorageMode:
+    if is_legacy_copied_manifest(source):
+        msg = (
+            "Legacy stored-artifact manifests cannot be materialized with this workflow: "
+            f"{source.source_id}"
+        )
+        raise ValueError(msg)
     if source.source_ref is None or source.source_ref_kind != "workspace_path":
         msg = (
             "Only workspace-backed sources can be materialized; "
             f"source {source.source_id} is {source.source_ref_kind or 'legacy'}"
-        )
-        raise ValueError(msg)
-    if source.storage_mode is None and source.source_ref is None:
-        msg = (
-            "Legacy stored-artifact manifests cannot be materialized with this workflow: "
-            f"{source.source_id}"
         )
         raise ValueError(msg)
 
@@ -360,7 +375,7 @@ def materialize_registered_source(
     selected_storage_mode = materializing_storage_mode_for_source(
         root, source, storage_mode=storage_mode
     )
-    candidate = _resolve_workspace_ref(root, source.source_ref)
+    candidate = resolve_workspace_path(root, source.source_ref, context="Workspace source")
     _require_workspace_source(candidate, source.checksum, source.source_ref)
 
     stored_path = _materialized_path_for(layout, source_id, candidate, selected_storage_mode)
@@ -377,6 +392,7 @@ def materialize_registered_source(
         checksum=source.checksum,
         storage_mode=selected_storage_mode,
         materialized_at=materialized_at,
+        refresh=True,
     )
     updated_source = source.model_copy(
         update={
@@ -394,24 +410,6 @@ def materialize_registered_source(
         storage_mode=selected_storage_mode,
         source_ref=source.source_ref,
     )
-
-
-def _resolve_workspace_ref(root: Path, source_ref: str) -> Path:
-    source_ref_path = Path(source_ref)
-    if source_ref_path.is_absolute():
-        msg = f"Workspace source path must be repo-relative: {source_ref}"
-        raise ValueError(msg)
-    if ".." in source_ref_path.parts:
-        msg = f"Workspace source path escapes workspace root: {source_ref}"
-        raise ValueError(msg)
-    resolved_path = (root / source_ref_path).resolve()
-    workspace_root = root.resolve()
-    try:
-        resolved_path.relative_to(workspace_root)
-    except ValueError as exc:
-        msg = f"Workspace source path escapes workspace root: {source_ref}"
-        raise ValueError(msg) from exc
-    return resolved_path
 
 
 def _require_workspace_source(resolved_path: Path, checksum: str, source_ref: str) -> None:

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -32,6 +32,15 @@ class RegisteredSource:
     already_registered: bool
 
 
+@dataclass(frozen=True)
+class MaterializedSource:
+    record: SourceRecord
+    manifest_path: Path
+    stored_path: Path
+    storage_mode: StorageMode
+    source_ref: str
+
+
 def manifest_path_for(root: Path, source_id: str) -> Path:
     config = load_config(root)
     layout = resolve_layout(root, config)
@@ -203,6 +212,51 @@ def _write_workspace_symlink(stored_path: Path, candidate: Path) -> None:
         raise ValueError(msg)
 
 
+def write_source_artifact(
+    candidate: Path,
+    *,
+    stored_path: Path,
+    source_id: str,
+    source_ref: str,
+    source_ref_kind: str,
+    checksum: str,
+    storage_mode: StorageMode,
+    materialized_at: str,
+) -> bool:
+    copied = False
+    if storage_mode == "copy":
+        copied = copy_file_if_missing(candidate, stored_path)
+        stored_checksum = sha256_file(stored_path)
+        if stored_checksum != checksum:
+            msg = (
+                f"Stored source checksum mismatch for {stored_path}: "
+                f"expected {checksum}, got {stored_checksum}"
+            )
+            raise ValueError(msg)
+        return copied
+
+    if storage_mode == "pointer":
+        ensure_directory(stored_path.parent)
+        write_source_pointer(
+            stored_path,
+            SourcePointerArtifact(
+                source_id=source_id,
+                source_ref=source_ref,
+                source_ref_kind=source_ref_kind,
+                checksum=checksum,
+                created_at=materialized_at,
+            ),
+        )
+        return False
+
+    if storage_mode == "symlink":
+        _write_workspace_symlink(stored_path, candidate)
+        return False
+
+    msg = f"Storage mode {storage_mode!r} does not materialize a source artifact"
+    raise ValueError(msg)
+
+
 def _validated_existing_registration(
     *,
     root: Path,
@@ -228,6 +282,145 @@ def _validated_existing_registration(
         stored_path = resolve_manifest_storage_path(root, stored_path_value)
     source_ref = canonical_source_ref(existing)
     return stored_path, resolved.storage_mode, source_ref
+
+
+def materializing_storage_mode_for_source(
+    root: Path,
+    source: SourceRecord,
+    *,
+    storage_mode: StorageMode | None = None,
+) -> StorageMode:
+    if source.source_ref is None or source.source_ref_kind != "workspace_path":
+        msg = (
+            "Only workspace-backed sources can be materialized; "
+            f"source {source.source_id} is {source.source_ref_kind or 'legacy'}"
+        )
+        raise ValueError(msg)
+    if source.storage_mode is None and source.source_ref is None:
+        msg = (
+            "Legacy stored-artifact manifests cannot be materialized with this workflow: "
+            f"{source.source_id}"
+        )
+        raise ValueError(msg)
+
+    if storage_mode is not None:
+        selected_storage_mode = _effective_storage_mode(
+            source_ref_kind="workspace_path",
+            configured_storage_mode=storage_mode,
+        )
+    elif source.storage_mode in {"copy", "pointer", "symlink"}:
+        selected_storage_mode = source.storage_mode
+    else:
+        config = load_config(root)
+        configured_mode = config.sources.in_repo_storage_mode
+        if configured_mode in {"copy", "pointer", "symlink"}:
+            selected_storage_mode = configured_mode
+        else:
+            selected_storage_mode = "pointer"
+
+    if selected_storage_mode == "none":
+        msg = f"Storage mode {selected_storage_mode!r} does not materialize a source artifact"
+        raise ValueError(msg)
+    return selected_storage_mode
+
+
+def materialize_registered_source(
+    root: Path,
+    source_id: str,
+    *,
+    storage_mode: StorageMode | None = None,
+) -> MaterializedSource:
+    manifest_path = manifest_path_for(root, source_id)
+    if not manifest_path.exists():
+        msg = f"Unknown source ID: {source_id}"
+        raise FileNotFoundError(msg)
+
+    source = load_source_record(manifest_path)
+    if source.source_id != source_id:
+        msg = f"Source manifest ID does not match requested source: {source_id}"
+        raise ValueError(msg)
+    if source.storage_mode is None and source.source_ref is None:
+        msg = (
+            "Legacy stored-artifact manifests cannot be materialized with this workflow: "
+            f"{source_id}"
+        )
+        raise ValueError(msg)
+    if source.source_ref is None or source.source_ref_kind != "workspace_path":
+        msg = (
+            "Only workspace-backed sources can be materialized; "
+            f"source {source_id} is {source.source_ref_kind or 'legacy'}"
+        )
+        raise ValueError(msg)
+
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    ensure_directory(layout.source_records_dir)
+    ensure_directory(layout.raw_sources_dir)
+
+    selected_storage_mode = materializing_storage_mode_for_source(
+        root, source, storage_mode=storage_mode
+    )
+    candidate = _resolve_workspace_ref(root, source.source_ref)
+    _require_workspace_source(candidate, source.checksum, source.source_ref)
+
+    stored_path = _materialized_path_for(layout, source_id, candidate, selected_storage_mode)
+    if stored_path is None:
+        msg = f"Storage mode {selected_storage_mode!r} did not produce a storage path"
+        raise ValueError(msg)
+    materialized_at = utc_now_iso()
+    write_source_artifact(
+        candidate,
+        stored_path=stored_path,
+        source_id=source_id,
+        source_ref=source.source_ref,
+        source_ref_kind=source.source_ref_kind,
+        checksum=source.checksum,
+        storage_mode=selected_storage_mode,
+        materialized_at=materialized_at,
+    )
+    updated_source = source.model_copy(
+        update={
+            "storage_mode": selected_storage_mode,
+            "storage_path": stored_path.relative_to(root).as_posix(),
+            "path": stored_path.relative_to(root).as_posix(),
+            "materialized_at": materialized_at,
+        }
+    )
+    write_source_record(manifest_path, updated_source)
+    return MaterializedSource(
+        record=updated_source,
+        manifest_path=manifest_path,
+        stored_path=stored_path,
+        storage_mode=selected_storage_mode,
+        source_ref=source.source_ref,
+    )
+
+
+def _resolve_workspace_ref(root: Path, source_ref: str) -> Path:
+    source_ref_path = Path(source_ref)
+    if source_ref_path.is_absolute():
+        msg = f"Workspace source path must be repo-relative: {source_ref}"
+        raise ValueError(msg)
+    if ".." in source_ref_path.parts:
+        msg = f"Workspace source path escapes workspace root: {source_ref}"
+        raise ValueError(msg)
+    resolved_path = (root / source_ref_path).resolve()
+    workspace_root = root.resolve()
+    try:
+        resolved_path.relative_to(workspace_root)
+    except ValueError as exc:
+        msg = f"Workspace source path escapes workspace root: {source_ref}"
+        raise ValueError(msg) from exc
+    return resolved_path
+
+
+def _require_workspace_source(resolved_path: Path, checksum: str, source_ref: str) -> None:
+    if not resolved_path.exists():
+        msg = f"Workspace source is missing: {source_ref}"
+        raise ValueError(msg)
+    if sha256_file(resolved_path) != checksum:
+        msg = f"Workspace source checksum mismatch for materialization: {source_ref}"
+        raise ValueError(msg)
 
 
 def register_source(
@@ -301,29 +494,17 @@ def register_source(
 
     added_at = utc_now_iso()
     copied = False
-    if selected_storage_mode == "copy" and stored_path is not None:
-        copied = copy_file_if_missing(candidate, stored_path)
-        stored_checksum = sha256_file(stored_path)
-        if stored_checksum != checksum:
-            msg = (
-                f"Stored source checksum mismatch for {stored_path}: "
-                f"expected {checksum}, got {stored_checksum}"
-            )
-            raise ValueError(msg)
-    elif selected_storage_mode == "pointer" and stored_path is not None:
-        ensure_directory(stored_path.parent)
-        write_source_pointer(
-            stored_path,
-            SourcePointerArtifact(
-                source_id=source_id,
-                source_ref=source_ref,
-                source_ref_kind=source_ref_kind,
-                checksum=checksum,
-                created_at=added_at,
-            ),
+    if selected_storage_mode in {"copy", "pointer", "symlink"} and stored_path is not None:
+        copied = write_source_artifact(
+            candidate,
+            stored_path=stored_path,
+            source_id=source_id,
+            source_ref=source_ref,
+            source_ref_kind=source_ref_kind,
+            checksum=checksum,
+            storage_mode=selected_storage_mode,
+            materialized_at=added_at,
         )
-    elif selected_storage_mode == "symlink" and stored_path is not None:
-        _write_workspace_symlink(stored_path, candidate)
     record = SourceRecord(
         source_id=source_id,
         title=_title_for(candidate),

--- a/src/splendor/state/source_resolver.py
+++ b/src/splendor/state/source_resolver.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from splendor.schemas import SourceRecord
+from splendor.state.paths import resolve_workspace_path
 from splendor.state.source_compat import (
     canonical_source_ref,
     copied_source_error_label,
@@ -31,25 +32,6 @@ class ResolvedSource:
     resolved_path: Path
     resolved_ref: str
     content_origin_label: str
-
-
-def _resolve_workspace_ref(root: Path, source_ref: str, *, context: str) -> Path:
-    source_ref_path = Path(source_ref)
-    if source_ref_path.is_absolute():
-        msg = f"{context} path must be repo-relative: {source_ref}"
-        raise ValueError(msg)
-    if ".." in source_ref_path.parts:
-        msg = f"{context} path escapes workspace root: {source_ref}"
-        raise ValueError(msg)
-
-    resolved_path = (root / source_ref_path).resolve()
-    workspace_root = root.resolve()
-    try:
-        resolved_path.relative_to(workspace_root)
-    except ValueError as exc:
-        msg = f"{context} path escapes workspace root: {source_ref}"
-        raise ValueError(msg) from exc
-    return resolved_path
 
 
 def _resolve_artifact_ref(root: Path, artifact_ref: str, *, context: str) -> Path:
@@ -85,7 +67,7 @@ def _resolve_workspace_source(root: Path, source: SourceRecord) -> ResolvedSourc
         )
         raise ValueError(msg)
 
-    resolved_path = _resolve_workspace_ref(root, source.source_ref, context="Workspace source")
+    resolved_path = resolve_workspace_path(root, source.source_ref, context="Workspace source")
     _require_workspace_source_checksum(
         resolved_path,
         source.checksum,
@@ -175,7 +157,7 @@ def _resolve_pointer_source(
         )
         raise ValueError(msg)
 
-    resolved_path = _resolve_workspace_ref(root, pointer.source_ref, context="Pointer target")
+    resolved_path = resolve_workspace_path(root, pointer.source_ref, context="Pointer target")
     _require_workspace_source_checksum(
         resolved_path,
         source.checksum,
@@ -243,7 +225,7 @@ def _resolve_symlink_source(
         msg = f"{source_label} target escapes workspace root: {symlink_path}"
         raise ValueError(msg) from exc
 
-    expected_path = _resolve_workspace_ref(root, source.source_ref, context="Workspace source")
+    expected_path = resolve_workspace_path(root, source.source_ref, context="Workspace source")
     if resolved_path != expected_path:
         actual_ref = resolved_path.relative_to(workspace_root).as_posix()
         msg = (

--- a/src/splendor/utils/fs.py
+++ b/src/splendor/utils/fs.py
@@ -28,6 +28,18 @@ def copy_file_if_missing(source: Path, destination: Path) -> bool:
     return True
 
 
+def copy_file_atomic(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=destination.parent, delete=False) as handle:
+        temp_path = Path(handle.name)
+    try:
+        shutil.copy2(source, temp_path)
+        temp_path.replace(destination)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
 def write_text_atomic(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile(

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -12,6 +12,7 @@ from splendor.state.source_registry import (
     _replace_path,
     _write_workspace_symlink,
     load_source_record,
+    materializing_storage_mode_for_source,
     write_source_record,
 )
 
@@ -571,6 +572,20 @@ def test_materialize_source_supports_copy_mode(tmp_path: Path) -> None:
     assert manifest.storage_path == manifest.path
 
 
+def test_materialize_source_refreshes_stale_copy_artifact(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    registered = add_source(tmp_path, source, storage_mode="copy")
+    assert registered.stored_path is not None
+    registered.stored_path.write_text("stale\n", encoding="utf-8")
+
+    result = materialize_source(tmp_path, registered.source_id)
+
+    assert result.storage_mode == "copy"
+    assert result.stored_path.read_text(encoding="utf-8") == "# note\n"
+
+
 def test_materialize_source_supports_symlink_mode(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "note.md"
@@ -629,6 +644,19 @@ def test_materialize_source_rejects_legacy_manifests(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="Legacy stored-artifact manifests cannot be materialized"):
         materialize_source(tmp_path, registered.source_id)
+
+
+def test_materializing_storage_mode_rejects_legacy_manifest_shape(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    registered = add_source(tmp_path, source, storage_mode="copy")
+    legacy_manifest = load_source_record(registered.manifest_path).model_copy(
+        update={"source_ref": None, "source_ref_kind": None, "storage_mode": None}
+    )
+
+    with pytest.raises(ValueError, match="Legacy stored-artifact manifests cannot be materialized"):
+        materializing_storage_mode_for_source(tmp_path, legacy_manifest)
 
 
 def test_materialize_source_rejects_missing_workspace_source(tmp_path: Path) -> None:

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -5,6 +5,7 @@ import pytest
 
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
+from splendor.commands.materialize_source import materialize_source
 from splendor.state.source_pointer import load_source_pointer
 from splendor.state.source_registry import (
     _effective_storage_mode,
@@ -535,3 +536,118 @@ def test_add_source_reuses_mixed_manifest_shapes_authoritatively(tmp_path: Path)
     assert symlink_repeat.source_ref == "symlink.md"
     assert symlink_repeat.storage_mode == "symlink"
     assert symlink_repeat.stored_path is not None
+
+
+def test_materialize_source_defaults_workspace_none_to_pointer(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    registered = add_source(tmp_path, source)
+
+    result = materialize_source(tmp_path, registered.source_id)
+
+    manifest = load_source_record(result.manifest_path)
+    assert result.storage_mode == "pointer"
+    assert (
+        result.stored_path == tmp_path / "raw" / "sources" / registered.source_id / "pointer.json"
+    )
+    assert manifest.storage_mode == "pointer"
+    assert manifest.storage_path == manifest.path
+    assert manifest.materialized_at is not None
+
+
+def test_materialize_source_supports_copy_mode(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    registered = add_source(tmp_path, source)
+
+    result = materialize_source(tmp_path, registered.source_id, storage_mode="copy")
+
+    manifest = load_source_record(result.manifest_path)
+    assert result.storage_mode == "copy"
+    assert result.stored_path.exists()
+    assert manifest.storage_mode == "copy"
+    assert manifest.storage_path == manifest.path
+
+
+def test_materialize_source_supports_symlink_mode(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    registered = add_source(tmp_path, source)
+
+    result = materialize_source(tmp_path, registered.source_id, storage_mode="symlink")
+
+    manifest = load_source_record(result.manifest_path)
+    assert result.storage_mode == "symlink"
+    assert result.stored_path.is_symlink()
+    assert manifest.storage_mode == "symlink"
+    assert manifest.storage_path == manifest.path
+
+
+def test_materialize_source_is_idempotent_for_existing_materialized_mode(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    registered = add_source(tmp_path, source, storage_mode="pointer")
+    first_manifest = load_source_record(registered.manifest_path)
+
+    result = materialize_source(tmp_path, registered.source_id)
+
+    manifest = load_source_record(result.manifest_path)
+    assert result.storage_mode == "pointer"
+    assert manifest.storage_mode == "pointer"
+    assert manifest.materialized_at is not None
+    assert manifest.materialized_at >= first_manifest.materialized_at
+
+
+def test_materialize_source_rejects_external_sources(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    external_dir = tmp_path.parent / f"{tmp_path.name}-external"
+    external_dir.mkdir()
+    source = external_dir / "outside.md"
+    source.write_text("# outside\n", encoding="utf-8")
+    try:
+        registered = add_source(tmp_path, source)
+        with pytest.raises(ValueError, match="Only workspace-backed sources can be materialized"):
+            materialize_source(tmp_path, registered.source_id)
+    finally:
+        source.unlink(missing_ok=True)
+        external_dir.rmdir()
+
+
+def test_materialize_source_rejects_legacy_manifests(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    registered = add_source(tmp_path, source, storage_mode="copy")
+    legacy_manifest = load_source_record(registered.manifest_path).model_copy(
+        update={"source_ref": None, "source_ref_kind": None, "storage_mode": None}
+    )
+    write_source_record(registered.manifest_path, legacy_manifest)
+
+    with pytest.raises(ValueError, match="Legacy stored-artifact manifests cannot be materialized"):
+        materialize_source(tmp_path, registered.source_id)
+
+
+def test_materialize_source_rejects_missing_workspace_source(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    registered = add_source(tmp_path, source)
+    source.unlink()
+
+    with pytest.raises(ValueError, match="Workspace source is missing"):
+        materialize_source(tmp_path, registered.source_id)
+
+
+def test_materialize_source_rejects_checksum_drift(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+    registered = add_source(tmp_path, source)
+    source.write_text("# changed\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Workspace source checksum mismatch for materialization"):
+        materialize_source(tmp_path, registered.source_id)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,6 +198,24 @@ def test_cli_ingest_command(tmp_path: Path, capsys) -> None:
     assert "Canonical content: workspace path" in captured.out
 
 
+def test_cli_ingest_command_reports_stored_artifact_for_copied_workspace_source(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "--storage-mode", "copy", str(source)])
+
+    manifest_paths = list((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source_id = manifest_paths[0].stem
+    exit_code = main(["--root", str(tmp_path), "ingest", source_id])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Source ref: brief.md" in captured.out
+    assert "Canonical content: stored artifact" in captured.out
+
+
 def test_cli_ingest_command_no_op(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     source = tmp_path / "brief.md"
@@ -269,3 +287,13 @@ def test_cli_health_command_fails_for_invalid_sources(tmp_path: Path, capsys) ->
     assert exit_code == 1
     captured = capsys.readouterr()
     assert "Health check failed: 1 issue(s)" in captured.out
+
+
+def test_cli_health_command_reports_top_level_errors(tmp_path: Path, capsys) -> None:
+    (tmp_path / "splendor.yaml").write_text("sources: [\n", encoding="utf-8")
+
+    exit_code = main(["--root", str(tmp_path), "health"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert captured.out.startswith("Error: ")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 
 from splendor.cli import build_parser, main
@@ -297,3 +298,17 @@ def test_cli_health_command_reports_top_level_errors(tmp_path: Path, capsys) -> 
     assert exit_code == 1
     captured = capsys.readouterr()
     assert captured.out.startswith("Error: ")
+
+
+def test_cli_health_command_fails_when_source_manifest_dir_is_missing(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_records_dir = tmp_path / "state" / "manifests" / "sources"
+    shutil.rmtree(source_records_dir)
+
+    exit_code = main(["--root", str(tmp_path), "health"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Source manifest directory is missing or unreadable" in captured.out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,7 +38,7 @@ def test_cli_add_source_command_reports_workspace_backed_registration(
     assert "Registered source" in captured.out
     assert "Source ref: brief.md" in captured.out
     assert "Storage mode: none" in captured.out
-    assert "Stored copy:" not in captured.out
+    assert "Storage artifact:" not in captured.out
 
 
 def test_cli_add_source_resolves_relative_paths_against_root(tmp_path: Path, capsys) -> None:
@@ -74,7 +74,7 @@ def test_cli_add_source_expands_user_paths(tmp_path: Path, capsys, monkeypatch) 
     captured = capsys.readouterr()
     assert "Registered source" in captured.out
     assert "Storage mode: copy" in captured.out
-    assert "Stored copy:" in captured.out
+    assert "Storage artifact:" in captured.out
 
 
 def test_cli_add_source_supports_explicit_copy_for_workspace_files(tmp_path: Path, capsys) -> None:
@@ -88,7 +88,7 @@ def test_cli_add_source_supports_explicit_copy_for_workspace_files(tmp_path: Pat
     captured = capsys.readouterr()
     assert "Source ref: brief.md" in captured.out
     assert "Storage mode: copy" in captured.out
-    assert "Stored copy:" in captured.out
+    assert "Storage artifact:" in captured.out
 
 
 def test_cli_add_source_supports_pointer_for_workspace_files(tmp_path: Path, capsys) -> None:
@@ -104,8 +104,7 @@ def test_cli_add_source_supports_pointer_for_workspace_files(tmp_path: Path, cap
     captured = capsys.readouterr()
     assert "Source ref: brief.md" in captured.out
     assert "Storage mode: pointer" in captured.out
-    assert "Pointer artifact:" in captured.out
-    assert "Stored copy:" not in captured.out
+    assert "Storage artifact:" in captured.out
 
 
 def test_cli_add_source_supports_symlink_for_workspace_files(tmp_path: Path, capsys) -> None:
@@ -121,8 +120,7 @@ def test_cli_add_source_supports_symlink_for_workspace_files(tmp_path: Path, cap
     captured = capsys.readouterr()
     assert "Source ref: brief.md" in captured.out
     assert "Storage mode: symlink" in captured.out
-    assert "Symlink artifact:" in captured.out
-    assert "Stored copy:" not in captured.out
+    assert "Storage artifact:" in captured.out
 
 
 def test_cli_add_source_reports_unsupported_mode_combinations(tmp_path: Path, capsys) -> None:
@@ -196,6 +194,8 @@ def test_cli_ingest_command(tmp_path: Path, capsys) -> None:
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "Ingested source" in captured.out
+    assert "Source ref: brief.md" in captured.out
+    assert "Canonical content: workspace path" in captured.out
 
 
 def test_cli_ingest_command_no_op(tmp_path: Path, capsys) -> None:
@@ -222,3 +222,50 @@ def test_cli_ingest_command_reports_missing_source(tmp_path: Path, capsys) -> No
     assert exit_code == 1
     captured = capsys.readouterr()
     assert "Unknown source ID" in captured.out
+
+
+def test_cli_materialize_source_command(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    manifest_paths = list((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source_id = manifest_paths[0].stem
+
+    exit_code = main(["--root", str(tmp_path), "materialize-source", source_id])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Materialized source" in captured.out
+    assert "Source ref: brief.md" in captured.out
+    assert "Storage mode: pointer" in captured.out
+    assert "Storage artifact:" in captured.out
+
+
+def test_cli_health_command_passes_for_valid_sources(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "--storage-mode", "pointer", str(source)])
+
+    exit_code = main(["--root", str(tmp_path), "health"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Checked sources: 1" in captured.out
+    assert "Health check passed" in captured.out
+
+
+def test_cli_health_command_fails_for_invalid_sources(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "--storage-mode", "pointer", str(source)])
+    pointer = next((tmp_path / "raw" / "sources").glob("*/pointer.json"))
+    pointer.write_text("{not-json}\n", encoding="utf-8")
+
+    exit_code = main(["--root", str(tmp_path), "health"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Health check failed: 1 issue(s)" in captured.out


### PR DESCRIPTION
## Summary

This PR implements SR-9, `Materialization workflow polish`, as a focused follow-on to the source-resolution refactor.

The goal of this change is to make source materialization operationally understandable and repairable without changing the underlying schema contract or ingest architecture. Concretely, this PR:

- adds a new `splendor materialize-source <source-id>` command for workspace-backed sources
- adds a minimal `splendor health` command that validates current source-storage state
- improves CLI reporting so canonical source references and storage artifacts are reported consistently
- reuses the existing source resolver and manifest contract rather than introducing a parallel validation path

This stays intentionally narrow. It does not add general repo linting, report persistence, dematerialization, or legacy manifest migration.

## Why

The repo already supports multiple storage modes for registered sources:

- `none` for workspace-backed sources
- `copy` for stored file artifacts
- `pointer` for pointer artifacts under `raw/sources/<source_id>/pointer.json`
- `symlink` for symlink artifacts under `raw/sources/<source_id>/<filename>`

Before this PR, those modes were usable at registration time, and ingest could resolve them, but the operational workflow around them was incomplete:

- there was no explicit repair/refresh flow for a registered workspace-backed source
- CLI output used mode-specific artifact wording instead of a stable reporting model
- there was no narrow command to validate the current health of source manifests plus their materialized artifacts

SR-9 closes that gap.

## User-Facing Changes

### New command: `splendor materialize-source`

Added:

```bash
splendor materialize-source <source-id> [--storage-mode copy|pointer|symlink]
```

Behavior:

- loads the existing source manifest for `source-id`
- only supports workspace-backed manifests with `source_ref_kind=workspace_path`
- rejects external sources and legacy stored-artifact manifests with clear errors
- resolves and checksum-verifies the canonical workspace source before creating or refreshing an artifact
- creates or refreshes the artifact under `raw/sources/<source_id>/...`
- updates the manifest fields:
  - `storage_mode`
  - `storage_path`
  - `path` (kept aligned with `storage_path` for compatibility)
  - `materialized_at`
- preserves canonical provenance fields such as:
  - `source_ref`
  - `source_ref_kind`
  - `checksum`
  - `source_commit`

Default mode selection follows the SR-9 plan:

- if the manifest is already materialized as `copy`, `pointer`, or `symlink`, that mode is reused by default
- if the current manifest is `storage_mode=none`, the command uses `sources.in_repo_storage_mode` only when it is a materializing mode
- if the configured in-repo default is `none`, the command falls back to `pointer`

This means `materialize-source` is both a repair workflow and a conversion workflow for workspace-backed sources.

### New command: `splendor health`

Added:

```bash
splendor health
```

This is intentionally a narrow health command scoped to source storage validation only.

It checks:

- every source manifest parses and validates
- `storage_mode` is coherent with `source_ref_kind`
- workspace-backed `none` sources still resolve inside the workspace and match the registered checksum
- `copy` sources still point at a valid artifact under `raw/sources/` and that artifact checksum matches the manifest checksum
- `pointer` sources have a valid pointer artifact, with manifest/artifact agreement, a resolvable target, and checksum consistency
- `symlink` sources have a valid symlink artifact whose target stays inside the workspace, matches `source_ref`, and still matches checksum

Output is human-readable and exits non-zero on failure. This PR does not write report files.

### CLI output improvements

`add-source` now always reports:

- `Source ref: ...`
- `Storage mode: ...`
- `Storage artifact: ...` when an artifact exists

This replaces mode-specific wording like `Pointer artifact:` or `Symlink artifact:` with one stable field.

`ingest` now also reports:

- `Source ref: ...`
- `Canonical content: workspace path` or `Canonical content: stored artifact`

That makes it easier to understand whether ingest is reading directly from the registered workspace file or from a materialized artifact.

## Implementation Notes

### Shared artifact-writing path

The main internal change is in `src/splendor/state/source_registry.py`.

Artifact creation logic that previously lived only inside registration has been factored into shared helpers so both registration and rematerialization use the same behavior for:

- copy artifacts
- pointer artifacts
- symlink artifacts

This avoids drift between `add-source` and `materialize-source` and keeps validation semantics anchored in one place.

### Resolver remains the source of truth

This PR does not introduce a new validation system. It keeps `src/splendor/state/source_resolver.py` as the primary source of truth for deciding whether a manifest plus artifact state is valid and ingestable.

`health` uses the current resolver behavior directly, rather than reimplementing storage-mode checks independently.

### No schema changes

No schema or config model changes were required for SR-9.

The existing source manifest fields were already sufficient:

- `source_ref`
- `source_ref_kind`
- `storage_mode`
- `storage_path`
- `path`
- `materialized_at`
- `source_commit`

This PR stays within that contract.

## Edge Cases Covered

The implementation and tests explicitly cover:

- converting a workspace-backed `storage_mode=none` source into a `pointer` artifact by default
- materializing directly into `copy` or `symlink` via `--storage-mode`
- rematerializing an already materialized source without corrupting manifest state
- rejecting external sources for `materialize-source`
- rejecting legacy stored-artifact manifests for `materialize-source`
- failing clearly if the workspace source is missing
- failing clearly if the workspace source content has drifted from the registered checksum
- health failures for malformed pointer artifacts
- health failures for broken symlinks
- health failures for missing stored copies
- health failures for checksum mismatches
- health failures for invalid `storage_mode` / `source_ref_kind` combinations

## Tests

Verification run for this PR:

- `python -m compileall src tests`
- `PYTHONPATH=src pytest tests/test_add_source.py tests/test_cli.py tests/test_source_resolver.py tests/test_ingest.py`

Focused pytest result:

- `116 passed`

New and updated coverage includes:

- `materialize-source` defaulting `none` -> `pointer`
- `materialize-source --storage-mode copy`
- `materialize-source --storage-mode symlink`
- rematerialization idempotency for existing materialized sources
- rejection of external and legacy manifests
- workspace-missing and checksum-drift failures
- CLI output assertions for `add-source`, `materialize-source`, `ingest`, and `health`
- `health` success and failure reporting

## Out of Scope

This PR intentionally does not do the following:

- add a generic `splendor lint` implementation
- persist health reports under `reports/`
- add dematerialization or storage-mode rollback workflows
- migrate legacy manifests forward
- broaden external-source storage support beyond the current model
- change ingest architecture or wiki rendering policy

## Reviewer Notes

The highest-signal files for review are:

- `src/splendor/cli.py`
- `src/splendor/commands/materialize_source.py`
- `src/splendor/commands/health.py`
- `src/splendor/state/source_registry.py`
- `tests/test_add_source.py`
- `tests/test_cli.py`

If you want to review by behavior rather than file, the main review buckets are:

1. CLI surface and output contract
2. materialization-mode selection and manifest updates
3. health validation semantics
4. shared artifact-writing behavior
