### PR TITLE
Implement queue-first ingest draining

### DIFF
--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -121,7 +121,7 @@ def handle_ingest(args: argparse.Namespace) -> int:
             print(f"Error: {exc}")
             return 1
 
-        if not result.items:
+        if result.total == 0:
             print("No pending ingest jobs")
             return 0
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -9,7 +9,7 @@ import yaml
 
 from splendor.commands.add_source import add_source
 from splendor.commands.health import run_health
-from splendor.commands.ingest import ingest_source
+from splendor.commands.ingest import drain_pending_ingest_jobs, ingest_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.materialize_source import materialize_source
 from splendor.schemas.types import STORAGE_MODES
@@ -51,8 +51,17 @@ def build_parser() -> argparse.ArgumentParser:
     add_source_parser.set_defaults(capture_source_commit=None)
     add_source_parser.set_defaults(handler=handle_add_source)
 
-    ingest_parser = subparsers.add_parser("ingest", help="Ingest a registered source into the wiki")
-    ingest_parser.add_argument("source_id", help="Registered source identifier to ingest")
+    ingest_parser = subparsers.add_parser("ingest", help="Ingest registered sources into the wiki")
+    ingest_parser.add_argument(
+        "source_id",
+        nargs="?",
+        help="Registered source identifier to ingest",
+    )
+    ingest_parser.add_argument(
+        "--pending",
+        action="store_true",
+        help="Drain pending ingestion jobs from the queue.",
+    )
     ingest_parser.set_defaults(handler=handle_ingest)
 
     materialize_parser = subparsers.add_parser(
@@ -105,6 +114,28 @@ def handle_add_source(args: argparse.Namespace) -> int:
 
 def handle_ingest(args: argparse.Namespace) -> int:
     root = args.root.resolve()
+    if args.pending:
+        try:
+            result = drain_pending_ingest_jobs(root)
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            print(f"Error: {exc}")
+            return 1
+
+        if not result.items:
+            print("No pending ingest jobs")
+            return 0
+
+        for item in result.items:
+            print(f"{item.source_id}: {item.outcome} ({item.message})")
+        print(
+            "Drain summary: "
+            f"processed={result.processed} "
+            f"succeeded={result.succeeded} "
+            f"failed={result.failed} "
+            f"skipped={result.skipped}"
+        )
+        return 1 if result.failed else 0
+
     try:
         result = ingest_source(root, args.source_id)
     except (FileNotFoundError, RuntimeError, ValueError) as exc:
@@ -163,6 +194,8 @@ def handle_health(args: argparse.Namespace) -> int:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.command == "ingest" and bool(args.source_id) == bool(args.pending):
+        parser.error("ingest requires exactly one of <source_id> or --pending")
     return args.handler(args)
 
 

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -86,6 +86,7 @@ class DrainItemResult:
 
 @dataclass(frozen=True)
 class DrainResult:
+    total: int
     processed: int
     succeeded: int
     failed: int
@@ -206,6 +207,21 @@ def _is_queue_eligible(queue_item: QueueItemRecord, now: datetime) -> bool:
     if queue_item.status == "pending":
         return True
     return _lease_is_expired(queue_item, now)
+
+
+def _skip_message(queue_item: QueueItemRecord, now: datetime) -> str:
+    if queue_item.status == "failed":
+        return "status=failed"
+    if queue_item.status == "done":
+        return "status=done"
+    if queue_item.status == "leased":
+        expires_at = _parse_timestamp(queue_item.lease_expires_at)
+        if expires_at is None:
+            return "leased with no expiry"
+        if expires_at > now:
+            return f"lease active until {queue_item.lease_expires_at}"
+        return f"expired lease at {queue_item.lease_expires_at}"
+    return f"status={queue_item.status}"
 
 
 def _is_no_op(root: Path, layout, source: SourceRecord) -> bool:
@@ -354,15 +370,27 @@ def enqueue_ingest_job(root: Path, source_id: str) -> Path:
         msg = f"Source manifest ID does not match requested source: {source_id}"
         raise ValueError(msg)
 
-    now = utc_now_iso()
+    now = _utc_now()
     queue_path = queue_item_path_for(layout, _ingest_job_id(source_id))
     existing_queue = load_queue_item(queue_path) if queue_path.exists() else None
+    if (
+        existing_queue is not None
+        and existing_queue.status == "leased"
+        and not _lease_is_expired(existing_queue, now)
+    ):
+        msg = f"Queue item is already leased: {existing_queue.job_id}"
+        raise RuntimeError(msg)
+
+    created_at = now.isoformat()
+    if existing_queue is not None and existing_queue.status in {"pending", "leased"}:
+        created_at = existing_queue.created_at
+
     queue_item = QueueItemRecord(
         job_id=_ingest_job_id(source_id),
         job_type="ingest_source",
         status="pending",
-        created_at=now if existing_queue is None else existing_queue.created_at,
-        updated_at=now,
+        created_at=created_at,
+        updated_at=now.isoformat(),
         attempt_count=0 if existing_queue is None else existing_queue.attempt_count,
         max_attempts=3 if existing_queue is None else existing_queue.max_attempts,
         payload_ref=_relative_to_root(root, manifest_path),
@@ -603,6 +631,7 @@ def drain_pending_ingest_jobs(root: Path) -> DrainResult:
     now = _utc_now()
     ordered_items = sorted(queue_items, key=lambda item: (item[1].created_at, item[1].job_id))
 
+    total = len(ordered_items)
     processed = 0
     succeeded = 0
     failed = 0
@@ -613,6 +642,14 @@ def drain_pending_ingest_jobs(root: Path) -> DrainResult:
         source_id = _source_id_from_job_id(queue_item.job_id)
         if not _is_queue_eligible(queue_item, now):
             skipped += 1
+            item_results.append(
+                DrainItemResult(
+                    source_id=source_id,
+                    queue_path=queue_path,
+                    outcome="skipped",
+                    message=_skip_message(queue_item, now),
+                )
+            )
             continue
 
         try:
@@ -654,6 +691,7 @@ def drain_pending_ingest_jobs(root: Path) -> DrainResult:
         )
 
     return DrainResult(
+        total=total,
         processed=processed,
         succeeded=succeeded,
         failed=failed,

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from splendor import __version__
@@ -60,6 +61,7 @@ SUPPORTED_SOURCE_TYPES = {
     "hpp",
     "sh",
 }
+LEASE_TTL_SECONDS = 300
 
 
 @dataclass(frozen=True)
@@ -74,9 +76,44 @@ class IngestResult:
     content_origin_kind: str | None
 
 
+@dataclass(frozen=True)
+class DrainItemResult:
+    source_id: str
+    queue_path: Path
+    outcome: str
+    message: str
+
+
+@dataclass(frozen=True)
+class DrainResult:
+    processed: int
+    succeeded: int
+    failed: int
+    skipped: int
+    items: list[DrainItemResult]
+
+
 def _make_run_id(source_id: str) -> str:
     stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
     return f"run-{source_id}-{stamp}"
+
+
+def _ingest_job_id(source_id: str) -> str:
+    return f"ingest-{source_id}"
+
+
+def _source_id_from_job_id(job_id: str) -> str:
+    if job_id.startswith("ingest-"):
+        return job_id.removeprefix("ingest-")
+    return job_id
+
+
+def _lease_owner() -> str:
+    return f"local-cli:{os.getpid()}"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
 
 
 def _relative_to_root(root: Path, path: Path) -> str:
@@ -144,6 +181,33 @@ def _best_available_source_ref(source: SourceRecord) -> str:
     return effective_stored_path(source) or canonical_source_ref(source)
 
 
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.fromisoformat(value)
+
+
+def _lease_expires_at(now: datetime) -> str:
+    return (now + timedelta(seconds=LEASE_TTL_SECONDS)).isoformat()
+
+
+def _lease_is_expired(queue_item: QueueItemRecord, now: datetime) -> bool:
+    if queue_item.status != "leased":
+        return False
+    expires_at = _parse_timestamp(queue_item.lease_expires_at)
+    if expires_at is None:
+        return True
+    return expires_at <= now
+
+
+def _is_queue_eligible(queue_item: QueueItemRecord, now: datetime) -> bool:
+    if queue_item.job_type != "ingest_source":
+        return False
+    if queue_item.status == "pending":
+        return True
+    return _lease_is_expired(queue_item, now)
+
+
 def _is_no_op(root: Path, layout, source: SourceRecord) -> bool:
     if source.status != "ingested" or not source.last_run_id:
         return False
@@ -173,6 +237,39 @@ def _validate_workspace_files(layout) -> None:
         raise RuntimeError(msg)
 
 
+def _load_source_for_queue(root: Path, queue_item: QueueItemRecord) -> tuple[Path, SourceRecord]:
+    manifest_path = root / queue_item.payload_ref
+    if not manifest_path.exists():
+        msg = f"Queue payload is missing source manifest: {manifest_path}"
+        raise FileNotFoundError(msg)
+    source = load_source_record(manifest_path)
+    expected_source_id = _source_id_from_job_id(queue_item.job_id)
+    if source.source_id != expected_source_id:
+        msg = f"Queue payload source ID does not match queued job: {queue_item.job_id}"
+        raise ValueError(msg)
+    return manifest_path, source
+
+
+def _finalize_queue_record(
+    queue_path: Path,
+    queue_item: QueueItemRecord,
+    *,
+    status: str,
+    last_error: str | None = None,
+) -> QueueItemRecord:
+    finalized = queue_item.model_copy(
+        update={
+            "status": status,
+            "updated_at": utc_now_iso(),
+            "lease_owner": None,
+            "lease_expires_at": None,
+            "last_error": last_error,
+        }
+    )
+    write_queue_item(queue_path, finalized)
+    return finalized
+
+
 def _mark_attempt_failed(
     *,
     queue_path: Path,
@@ -192,17 +289,18 @@ def _mark_attempt_failed(
         }
     )
     write_run_record(run_path, failed_run)
-    failed_queue = queue_item.model_copy(
-        update={
-            "status": "failed",
-            "updated_at": utc_now_iso(),
-            "last_error": error_message,
-        }
-    )
-    write_queue_item(queue_path, failed_queue)
+    _finalize_queue_record(queue_path, queue_item, status="failed", last_error=error_message)
     if manifest_path is not None and source is not None and run_id is not None:
         failed_source = source.model_copy(update={"status": "failed", "last_run_id": run_id})
         write_source_record(manifest_path, failed_source)
+
+
+def _mark_queue_failed_without_run(
+    queue_path: Path,
+    queue_item: QueueItemRecord,
+    error_message: str,
+) -> None:
+    _finalize_queue_record(queue_path, queue_item, status="failed", last_error=error_message)
 
 
 def _commit_success(
@@ -242,7 +340,7 @@ def _commit_success(
         raise
 
 
-def ingest_source(root: Path, source_id: str) -> IngestResult:
+def enqueue_ingest_job(root: Path, source_id: str) -> Path:
     config = load_config(root)
     layout = resolve_layout(root, config)
     _validate_workspace_files(layout)
@@ -256,43 +354,87 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
         msg = f"Source manifest ID does not match requested source: {source_id}"
         raise ValueError(msg)
 
+    now = utc_now_iso()
+    queue_path = queue_item_path_for(layout, _ingest_job_id(source_id))
+    existing_queue = load_queue_item(queue_path) if queue_path.exists() else None
+    queue_item = QueueItemRecord(
+        job_id=_ingest_job_id(source_id),
+        job_type="ingest_source",
+        status="pending",
+        created_at=now if existing_queue is None else existing_queue.created_at,
+        updated_at=now,
+        attempt_count=0 if existing_queue is None else existing_queue.attempt_count,
+        max_attempts=3 if existing_queue is None else existing_queue.max_attempts,
+        payload_ref=_relative_to_root(root, manifest_path),
+        lease_owner=None,
+        lease_expires_at=None,
+        last_error=None,
+    )
+    write_queue_item(queue_path, queue_item)
+    return queue_path
+
+
+def _claim_ingest_job(queue_path: Path, queue_item: QueueItemRecord) -> QueueItemRecord:
+    now = _utc_now()
+    leased_queue = queue_item.model_copy(
+        update={
+            "status": "leased",
+            "updated_at": now.isoformat(),
+            "attempt_count": queue_item.attempt_count + 1,
+            "lease_owner": _lease_owner(),
+            "lease_expires_at": _lease_expires_at(now),
+            "last_error": None,
+        }
+    )
+    write_queue_item(queue_path, leased_queue)
+    return leased_queue
+
+
+def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    _validate_workspace_files(layout)
+    queue_item = load_queue_item(queue_path)
+    if queue_item.job_type != "ingest_source":
+        msg = f"Unsupported queue job type for ingest worker: {queue_item.job_type}"
+        raise ValueError(msg)
+
+    now = _utc_now()
+    if queue_item.status == "leased" and not _lease_is_expired(queue_item, now):
+        msg = f"Queue item is already leased: {queue_item.job_id}"
+        raise RuntimeError(msg)
+    if queue_item.status not in {"pending", "leased"}:
+        msg = f"Queue item is not runnable: {queue_item.job_id}"
+        raise RuntimeError(msg)
+
+    queue_item = _claim_ingest_job(queue_path, queue_item)
+
+    try:
+        manifest_path, source = _load_source_for_queue(root, queue_item)
+    except (FileNotFoundError, ValueError) as exc:
+        _mark_queue_failed_without_run(queue_path, queue_item, str(exc))
+        raise
+
     if _is_no_op(root, layout, source):
+        _finalize_queue_record(queue_path, queue_item, status="done", last_error=None)
         return IngestResult(
-            source_id=source_id,
+            source_id=source.source_id,
             run_id=None,
-            queue_path=None,
+            queue_path=queue_path,
             run_path=None,
-            page_path=layout.wiki_sources_dir / f"{source_id}.md",
+            page_path=_page_path_for(layout.wiki_sources_dir, source.source_id),
             no_op=True,
             canonical_ref=None,
             content_origin_kind=None,
         )
 
-    now = utc_now_iso()
-    job_id = f"ingest-{source_id}"
-    queue_path = queue_item_path_for(layout, job_id)
-    existing_queue = load_queue_item(queue_path) if queue_path.exists() else None
-    attempt_count = 1 if existing_queue is None else existing_queue.attempt_count + 1
-    queue_item = QueueItemRecord(
-        job_id=job_id,
-        job_type="ingest_source",
-        status="pending",
-        created_at=now if existing_queue is None else existing_queue.created_at,
-        updated_at=now,
-        attempt_count=attempt_count,
-        max_attempts=3,
-        payload_ref=_relative_to_root(root, manifest_path),
-        last_error=None,
-    )
-    write_queue_item(queue_path, queue_item)
-
-    run_id = _make_run_id(source_id)
+    run_id = _make_run_id(source.source_id)
     run_path = run_record_path_for(layout, run_id)
     run = RunRecord(
         run_id=run_id,
-        job_id=job_id,
+        job_id=queue_item.job_id,
         job_type="ingest_source",
-        started_at=now,
+        started_at=utc_now_iso(),
         status="running",
         input_refs=[
             _relative_to_root(root, manifest_path),
@@ -323,17 +465,17 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
         except UnicodeDecodeError as exc:
             msg = f"Source file is not valid UTF-8 text: {resolved_source.resolved_path}"
             raise ValueError(msg) from exc
-        extract_mode = _summary_mode_for(config, source)
 
-        page_path = _page_path_for(layout.wiki_sources_dir, source_id)
+        extract_mode = _summary_mode_for(config, source)
+        page_path = _page_path_for(layout.wiki_sources_dir, source.source_id)
         page_relpath = _relative_to_root(root, page_path)
         registered_path = canonical_source_ref(source)
         frontmatter = KnowledgePageFrontmatter(
             kind="source-summary",
             title=source.title,
-            page_id=source_id,
+            page_id=source.source_id,
             status="active",
-            source_refs=[source_id],
+            source_refs=[source.source_id],
             generated_by_run_ids=[run_id],
             confidence=1.0,
             tags=["source-summary", source.source_type],
@@ -355,7 +497,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
                 f"Checksum: `{source.checksum}`",
                 f"Source ref: `{canonical_source_ref(source)}`",
                 f"Added at: `{source.added_at}`",
-                f"Ingested at: `{now}`",
+                f"Ingested at: `{utc_now_iso()}`",
             ],
             extract=_rendered_extract(source_text, extract_mode),
             provenance=[
@@ -367,12 +509,13 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
         )
         index_content = update_index_content(
             layout.index_file.read_text(encoding="utf-8"),
-            source_id=source_id,
+            source_id=source.source_id,
             title=source.title,
             page_name=page_path.name,
         )
         log_entry = (
-            f"- {now} Ingested source `{source_id}` via run `{run_id}` into `{page_relpath}`."
+            f"- {utc_now_iso()} Ingested source `{source.source_id}` "
+            f"via run `{run_id}` into `{page_relpath}`."
         )
         log_content = append_log_entry(layout.log_file.read_text(encoding="utf-8"), log_entry)
         updated_source = source.model_copy(
@@ -393,7 +536,15 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
                 ],
             }
         )
-        queue_item = queue_item.model_copy(update={"status": "done", "updated_at": utc_now_iso()})
+        success_queue = queue_item.model_copy(
+            update={
+                "status": "done",
+                "updated_at": utc_now_iso(),
+                "lease_owner": None,
+                "lease_expires_at": None,
+                "last_error": None,
+            }
+        )
         _commit_success(
             layout=layout,
             manifest_path=manifest_path,
@@ -401,7 +552,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
             run_path=run_path,
             success_run=success_run,
             queue_path=queue_path,
-            success_queue=queue_item,
+            success_queue=success_queue,
             wiki_payload=WikiUpdatePayload(
                 page_path=page_path,
                 page_content=page_content,
@@ -410,7 +561,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
             ),
         )
         return IngestResult(
-            source_id=source_id,
+            source_id=source.source_id,
             run_id=run_id,
             queue_path=queue_path,
             run_path=run_path,
@@ -440,3 +591,102 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
             error_message=str(exc),
         )
         raise RuntimeError(f"Ingestion failed while committing outputs: {exc}") from exc
+
+
+def drain_pending_ingest_jobs(root: Path) -> DrainResult:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    queue_items: list[tuple[Path, QueueItemRecord]] = []
+    for queue_path in sorted(layout.queue_dir.glob("*.json")):
+        queue_items.append((queue_path, load_queue_item(queue_path)))
+
+    now = _utc_now()
+    ordered_items = sorted(queue_items, key=lambda item: (item[1].created_at, item[1].job_id))
+
+    processed = 0
+    succeeded = 0
+    failed = 0
+    skipped = 0
+    item_results: list[DrainItemResult] = []
+
+    for queue_path, queue_item in ordered_items:
+        source_id = _source_id_from_job_id(queue_item.job_id)
+        if not _is_queue_eligible(queue_item, now):
+            skipped += 1
+            continue
+
+        try:
+            result = run_ingest_job(root, queue_path)
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            processed += 1
+            failed += 1
+            item_results.append(
+                DrainItemResult(
+                    source_id=source_id,
+                    queue_path=queue_path,
+                    outcome="failed",
+                    message=str(exc),
+                )
+            )
+            continue
+
+        if result.no_op:
+            skipped += 1
+            item_results.append(
+                DrainItemResult(
+                    source_id=result.source_id,
+                    queue_path=queue_path,
+                    outcome="skipped",
+                    message="already ingested for the current pipeline version",
+                )
+            )
+            continue
+
+        processed += 1
+        succeeded += 1
+        item_results.append(
+            DrainItemResult(
+                source_id=result.source_id,
+                queue_path=queue_path,
+                outcome="succeeded",
+                message=f"run {result.run_id}",
+            )
+        )
+
+    return DrainResult(
+        processed=processed,
+        succeeded=succeeded,
+        failed=failed,
+        skipped=skipped,
+        items=item_results,
+    )
+
+
+def ingest_source(root: Path, source_id: str) -> IngestResult:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    _validate_workspace_files(layout)
+    manifest_path = manifest_path_for(root, source_id)
+    if not manifest_path.exists():
+        msg = f"Unknown source ID: {source_id}"
+        raise FileNotFoundError(msg)
+
+    source = load_source_record(manifest_path)
+    if source.source_id != source_id:
+        msg = f"Source manifest ID does not match requested source: {source_id}"
+        raise ValueError(msg)
+
+    if _is_no_op(root, layout, source):
+        return IngestResult(
+            source_id=source_id,
+            run_id=None,
+            queue_path=None,
+            run_path=None,
+            page_path=layout.wiki_sources_dir / f"{source_id}.md",
+            no_op=True,
+            canonical_ref=None,
+            content_origin_kind=None,
+        )
+
+    queue_path = enqueue_ingest_job(root, source_id)
+    return run_ingest_job(root, queue_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,10 @@
 import shutil
 from pathlib import Path
 
+import pytest
+
 from splendor.cli import build_parser, main
+from splendor.commands.ingest import enqueue_ingest_job
 
 
 def test_cli_init_command(tmp_path: Path, capsys) -> None:
@@ -241,6 +244,68 @@ def test_cli_ingest_command_reports_missing_source(tmp_path: Path, capsys) -> No
     assert exit_code == 1
     captured = capsys.readouterr()
     assert "Unknown source ID" in captured.out
+
+
+def test_cli_ingest_requires_exactly_one_target_mode() -> None:
+    with pytest.raises(SystemExit):
+        main(["ingest"])
+
+    with pytest.raises(SystemExit):
+        main(["ingest", "src-123", "--pending"])
+
+
+def test_cli_ingest_pending_reports_no_jobs(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "No pending ingest jobs" in captured.out
+
+
+def test_cli_ingest_pending_prints_summary(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+
+    manifest_paths = list((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source_id = manifest_paths[0].stem
+    enqueue_ingest_job(tmp_path, source_id)
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert f"{source_id}: succeeded" in captured.out
+    assert "Drain summary: processed=1 succeeded=1 failed=0 skipped=0" in captured.out
+
+
+def test_cli_ingest_pending_continues_after_failure(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+
+    ok_source = tmp_path / "brief.md"
+    ok_source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(ok_source)])
+    ok_manifest = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    ok_source_id = ok_manifest.stem
+    enqueue_ingest_job(tmp_path, ok_source_id)
+
+    bad_source = tmp_path / "broken.bin"
+    bad_source.write_bytes(b"\x00\x01\x02")
+    main(["--root", str(tmp_path), "add-source", str(bad_source)])
+    manifest_paths = sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    bad_source_id = next(path.stem for path in manifest_paths if path.stem != ok_source_id)
+    enqueue_ingest_job(tmp_path, bad_source_id)
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert f"{ok_source_id}: succeeded" in captured.out
+    assert f"{bad_source_id}: failed" in captured.out
+    assert "Drain summary: processed=2 succeeded=1 failed=1 skipped=0" in captured.out
 
 
 def test_cli_materialize_source_command(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import pytest
 
 from splendor.cli import build_parser, main
 from splendor.commands.ingest import enqueue_ingest_job
+from splendor.state.runtime import load_queue_item
 
 
 def test_cli_init_command(tmp_path: Path, capsys) -> None:
@@ -262,6 +263,33 @@ def test_cli_ingest_pending_reports_no_jobs(tmp_path: Path, capsys) -> None:
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "No pending ingest jobs" in captured.out
+
+
+def test_cli_ingest_pending_reports_skipped_items(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+
+    manifest_paths = list((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source_id = manifest_paths[0].stem
+    queue_path = enqueue_ingest_job(tmp_path, source_id)
+    queue_record = load_queue_item(queue_path).model_copy(
+        update={
+            "status": "leased",
+            "lease_owner": "local-cli:123",
+            "lease_expires_at": "2099-01-01T00:00:00+00:00",
+        }
+    )
+    queue_path.write_text(queue_record.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert f"{source_id}: skipped (lease active until 2099-01-01T00:00:00+00:00)" in captured.out
+    assert "Drain summary: processed=0 succeeded=0 failed=0 skipped=1" in captured.out
+    assert "No pending ingest jobs" not in captured.out
 
 
 def test_cli_ingest_pending_prints_summary(tmp_path: Path, capsys) -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,11 +1,17 @@
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 import yaml
 
 from splendor.commands.add_source import add_source
-from splendor.commands.ingest import ingest_source
+from splendor.commands.ingest import (
+    drain_pending_ingest_jobs,
+    enqueue_ingest_job,
+    ingest_source,
+    run_ingest_job,
+)
 from splendor.commands.init import initialize_workspace
 from splendor.config import load_config, write_config
 from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord
@@ -251,6 +257,119 @@ def test_ingest_source_missing_source_id_does_not_create_runtime_state(tmp_path:
 
     assert list((tmp_path / "state" / "queue").glob("*.json")) == []
     assert list((tmp_path / "state" / "runs").glob("*.json")) == []
+
+
+def test_enqueue_ingest_job_creates_pending_item_without_attempt_increment(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.status == "pending"
+    assert queue_record.attempt_count == 0
+    assert queue_record.lease_owner is None
+    assert queue_record.lease_expires_at is None
+
+
+def test_run_ingest_job_claims_once_and_clears_lease_on_success(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+
+    result = run_ingest_job(tmp_path, queue_path)
+
+    assert result.no_op is False
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.status == "done"
+    assert queue_record.attempt_count == 1
+    assert queue_record.lease_owner is None
+    assert queue_record.lease_expires_at is None
+
+
+def test_drain_pending_ingest_jobs_reclaims_expired_leases(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = load_queue_item(queue_path).model_copy(
+        update={
+            "status": "leased",
+            "attempt_count": 2,
+            "lease_owner": "local-cli:999",
+            "lease_expires_at": (datetime.now(UTC) - timedelta(minutes=1)).isoformat(),
+        }
+    )
+    queue_path.write_text(queue_record.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+    result = drain_pending_ingest_jobs(tmp_path)
+
+    assert result.processed == 1
+    assert result.succeeded == 1
+    assert result.failed == 0
+    assert result.skipped == 0
+    updated_queue = load_queue_item(queue_path)
+    assert updated_queue.status == "done"
+    assert updated_queue.attempt_count == 3
+
+
+def test_drain_pending_ingest_jobs_skips_nonexpired_and_failed_items(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    leased_queue = load_queue_item(queue_path).model_copy(
+        update={
+            "status": "leased",
+            "lease_owner": "local-cli:123",
+            "lease_expires_at": (datetime.now(UTC) + timedelta(minutes=5)).isoformat(),
+        }
+    )
+    queue_path.write_text(leased_queue.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+    failed_source = tmp_path / "failed.md"
+    failed_source.write_bytes(b"\xff\xfe\xfa")
+    failed_added = add_source(tmp_path, failed_source)
+    failed_queue_path = enqueue_ingest_job(tmp_path, failed_added.source_id)
+    failed_queue = load_queue_item(failed_queue_path).model_copy(update={"status": "failed"})
+    failed_queue_path.write_text(failed_queue.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+    result = drain_pending_ingest_jobs(tmp_path)
+
+    assert result.processed == 0
+    assert result.succeeded == 0
+    assert result.failed == 0
+    assert result.skipped == 2
+    assert result.items == []
+
+
+def test_drain_pending_ingest_jobs_continues_after_failure(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    ok_source = tmp_path / "brief.md"
+    ok_source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    ok_added = add_source(tmp_path, ok_source)
+    enqueue_ingest_job(tmp_path, ok_added.source_id)
+
+    bad_source = tmp_path / "broken.bin"
+    bad_source.write_bytes(b"\x00\x01\x02")
+    bad_added = add_source(tmp_path, bad_source)
+    enqueue_ingest_job(tmp_path, bad_added.source_id)
+
+    result = drain_pending_ingest_jobs(tmp_path)
+
+    assert result.processed == 2
+    assert result.succeeded == 1
+    assert result.failed == 1
+    assert result.skipped == 0
+    outcomes = {item.source_id: item.outcome for item in result.items}
+    assert outcomes[ok_added.source_id] == "succeeded"
+    assert outcomes[bad_added.source_id] == "failed"
 
 
 def test_ingest_source_validates_stored_copy_checksum(tmp_path: Path) -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -274,6 +274,51 @@ def test_enqueue_ingest_job_creates_pending_item_without_attempt_increment(tmp_p
     assert queue_record.lease_expires_at is None
 
 
+def test_enqueue_ingest_job_rejects_unexpired_leased_item(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    leased_queue = load_queue_item(queue_path).model_copy(
+        update={
+            "status": "leased",
+            "lease_owner": "local-cli:123",
+            "lease_expires_at": (datetime.now(UTC) + timedelta(minutes=5)).isoformat(),
+        }
+    )
+    queue_path.write_text(leased_queue.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="already leased"):
+        enqueue_ingest_job(tmp_path, added.source_id)
+
+    updated_queue = load_queue_item(queue_path)
+    assert updated_queue.status == "leased"
+    assert updated_queue.lease_owner == "local-cli:123"
+
+
+def test_enqueue_ingest_job_refreshes_created_at_when_reenqueuing_terminal_item(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    first_queue = load_queue_item(queue_path)
+    terminal_queue = first_queue.model_copy(
+        update={"status": "done", "created_at": "2000-01-01T00:00:00+00:00"}
+    )
+    queue_path.write_text(terminal_queue.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+
+    reenqueued_queue = load_queue_item(queue_path)
+    assert reenqueued_queue.status == "pending"
+    assert reenqueued_queue.created_at != terminal_queue.created_at
+    assert reenqueued_queue.attempt_count == first_queue.attempt_count
+
+
 def test_run_ingest_job_claims_once_and_clears_lease_on_success(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
@@ -346,7 +391,11 @@ def test_drain_pending_ingest_jobs_skips_nonexpired_and_failed_items(tmp_path: P
     assert result.succeeded == 0
     assert result.failed == 0
     assert result.skipped == 2
-    assert result.items == []
+    assert result.total == 2
+    assert len(result.items) == 2
+    messages = {item.source_id: item.message for item in result.items}
+    assert "lease active until" in messages[added.source_id]
+    assert messages[failed_added.source_id] == "status=failed"
 
 
 def test_drain_pending_ingest_jobs_continues_after_failure(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

This PR completes the Milestone 2 follow-on ingestion slice by making `splendor ingest` explicitly queue-driven while keeping the user-facing workflow local and synchronous.

The core change is that `splendor ingest <source-id>` now enqueues a durable ingestion job and immediately executes it through the same worker path that powers `splendor ingest --pending`. The new pending-drain mode walks eligible queue items in FIFO order, reclaims expired leases, continues after failures, and returns a summarized non-zero result when any item fails.

## What changed

### Queue-first ingest execution

- split ingestion orchestration into:
  - `enqueue_ingest_job(root, source_id)`
  - `run_ingest_job(root, queue_path)`
  - `drain_pending_ingest_jobs(root)`
- preserved one durable queue record per source at `state/queue/ingest-<source_id>.json`
- changed `attempt_count` semantics so attempts increment on claim/execution, not on enqueue
- added lease handling for active jobs:
  - `status="leased"` while processing
  - deterministic `lease_owner` of the form `local-cli:<pid>`
  - fixed TTL-based `lease_expires_at` for crash recovery
- cleared lease metadata on terminal queue states

### `--pending` drain behavior

- added `splendor ingest --pending`
- drains only eligible ingestion jobs:
  - `pending`
  - `leased` with an expired lease
- does not auto-retry `failed` jobs in this milestone
- processes queue items oldest-first by `created_at`, then `job_id`
- continues draining after individual failures
- prints one line per processed/skipped item and a final summary with:
  - processed
  - succeeded
  - failed
  - skipped
- exits non-zero if any drained job fails
- prints a clear message when no queued jobs are eligible

### Single-source ingest behavior

- preserved the existing no-op behavior for already-current sources
- kept deterministic wiki/index/log/run/source updates in the worker path
- preserved failed run and failed queue records when ingestion errors occur
- reused the current runtime schema without introducing retry/backoff or dead-letter changes

### CLI contract

- updated `splendor ingest` to accept exactly one of:
  - `splendor ingest <source-id>`
  - `splendor ingest --pending`
- added parser-level validation for invalid combinations and missing ingest target mode

## Tests

Added and updated coverage for:

- enqueue creates a `pending` queue item without incrementing `attempt_count`
- claiming a job increments attempts and clears lease metadata on success
- expired leased jobs are reclaimed by `--pending`
- non-expired leased jobs are skipped
- `failed` jobs are not auto-drained
- pending-drain continues after failures and records mixed outcomes correctly
- CLI parser rejects invalid ingest mode combinations
- CLI drain mode prints the expected summary and exit behavior

## Validation

Ran:

- `uv run pytest tests/test_ingest.py tests/test_cli.py`
- `uv run ruff format --check src/splendor/commands/ingest.py src/splendor/cli.py tests/test_ingest.py tests/test_cli.py`
- `uv run ruff check src/splendor/commands/ingest.py src/splendor/cli.py tests/test_ingest.py tests/test_cli.py`

## Scope notes

This intentionally stays within the narrow MVP version of the milestone.

Not included here:

- queue inspection commands
- manual retry commands
- retry backoff policies
- dead-letter handling
- config-surface expansion for lease TTL

Those remain follow-on queue-ops work rather than part of this ingestion slice.
