### PR TITLE
docs: update plan after queue-first ingest merge

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -2,7 +2,7 @@
 
 ## Current System State
 
-- Active branch: `codex/update-plan-after-pr15`
+- Active branch: `(set in active worktree)`
 - Last action taken: `PR #15 Implement queue-first ingest draining` merged to `main`; `splendor ingest --pending` and queue-draining semantics are now landed.
 - Current blockers: none
 

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -2,8 +2,8 @@
 
 ## Current System State
 
-- Active branch: `(set in active worktree)`
-- Last action taken: `SR-9 materialization workflow polish` merged to `main`; agent-context cleanup landed after that change.
+- Active branch: `codex/update-plan-after-pr15`
+- Last action taken: `PR #15 Implement queue-first ingest draining` merged to `main`; `splendor ingest --pending` and queue-draining semantics are now landed.
 - Current blockers: none
 
 ## Active Task Breakdown
@@ -11,8 +11,8 @@
 - [x] Replace the bloated static rulebook with a concise `AGENTS.md`
 - [x] Add `llms.txt` as a dense architecture/index file for agents
 - [x] Create a dynamic state tracker that points back to the long-form plans
-- [ ] Complete Milestone 2 follow-on work: implement `splendor ingest --pending`
-- [ ] Define queue-draining semantics over file-based queue/run state
+- [x] Complete Milestone 2 follow-on work: implement `splendor ingest --pending`
+- [x] Define queue-draining semantics over file-based queue/run state
 - [ ] Scope the Milestone 3 CLI slice for query plus planning-object create/list commands
 - [ ] Expand maintenance tooling from the current narrow `health` command toward full Milestone 4 lint/health coverage
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@
 - Cleanup or tooling branches may use `refactor/<topic>`.
 - Keep commits scoped to one logical change.
 - Do not rewrite history on shared branches unless explicitly requested.
+- When a PR implements work from a plan, update the versioned planning state in the same PR:
+  `.agent-plan.md`, `README.md`, and any affected human-facing planning document in `docs/`.
 
 ## Architecture Boundaries
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ uv run pre-commit run --all-files
 
 ## What comes next
 
-The next milestone should move from deterministic ingestion into the first Milestone 3 CLI slice:
+The next milestone should move from deterministic ingestion to the first Milestone 3 CLI slice:
 query support plus planning-object create/list commands.
 
 ## Additional documentation

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ uv run pre-commit run --all-files
 
 ## What comes next
 
-The next milestone should expand deterministic ingestion into pending-queue draining, then layer on
-query and planning-object CLI support.
+The next milestone should move from deterministic ingestion into the first Milestone 3 CLI slice:
+query support plus planning-object create/list commands.
 
 ## Additional documentation
 

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -129,3 +129,15 @@ Optional repository variables:
 - `pr-agent-context` turns CI, review, and failing-check state into a maintained PR handoff comment.
 - `pre-commit.ci autofix trigger` bridges bot PRs and `pre-commit.ci` label-based autofix behavior.
 - `weekly-repo-review` is scheduled maintenance, not a merge gate.
+
+## Planning update rule for PRs
+
+When a pull request is opened against work that came from a tracked plan, the PR should update the
+versioned planning documents as part of the same change. At minimum that means:
+
+- `.agent-plan.md` for the current machine-readable task state
+- `README.md` when its "what comes next" or milestone framing changes
+- any relevant human-facing planning document under `docs/` that the PR advances, supersedes, or completes
+
+This keeps the plan aligned with merged work and avoids stale roadmap or milestone guidance after a
+planned slice lands.

--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -14,6 +14,14 @@ already lives inside the tracked repository, Splendor should not duplicate it in
 by default. Instead, Splendor should register the repo file as the canonical source, verify it by
 checksum during ingest, and only materialize a snapshot when the project explicitly opts in.
 
+Status note:
+
+- this plan has been implemented through `SR-9`
+- the last planned slice landed in `PR #15`, which completed queue-first ingest draining on top of
+  the source-resolution rollout
+- treat the sections below as the completed implementation sequence and design record for this
+  refactor
+
 ## 2. Problem Statement
 
 The current MVP source contract assumes that registration means "copy the file into
@@ -477,7 +485,7 @@ Mitigation:
 Mitigation:
 
 - land the documentation PR first
-- treat this file as the implementation sequence until Phase 2 is complete
+- treat this file as the implementation sequence; Phase 2 is now complete through `SR-9`
 
 ## 12. Recommended Default Decisions
 


### PR DESCRIPTION
## Summary
- update the versioned agent plan to reflect that PR #15 landed
- mark the Milestone 2 pending-ingest follow-on items complete
- move the README "What comes next" note to the Milestone 3 query/planning CLI slice

## Context
PR #15 (`Implement queue-first ingest draining`) already landed `splendor ingest --pending` plus the queue-draining semantics, so the checked state and next-step language in `.agent-plan.md` and `README.md` had become stale.