### PR TITLE
Implement M3-P1 planning object CLI

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,7 +3,9 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Last action taken: `PR #15 Implement queue-first ingest draining` merged to `main`; `splendor ingest --pending` and queue-draining semantics are now landed.
+- Last action taken: `M3-P1` planning-object CLI slice landed locally; task/milestone create/list plus decision/question create commands now exist and roadmap PR IDs are assigned.
+- Active planned PR: `M3-P1`
+- Next planned PR: `M3-P2`
 - Current blockers: none
 
 ## Active Task Breakdown
@@ -13,8 +15,9 @@
 - [x] Create a dynamic state tracker that points back to the long-form plans
 - [x] Complete Milestone 2 follow-on work: implement `splendor ingest --pending`
 - [x] Define queue-draining semantics over file-based queue/run state
-- [ ] Scope the Milestone 3 CLI slice for query plus planning-object create/list commands
-- [ ] Expand maintenance tooling from the current narrow `health` command toward full Milestone 4 lint/health coverage
+- [x] Implement `M3-P1`: planning-object markdown storage plus create/list CLI support
+- [ ] Implement `M3-P2`: query CLI plus `query --json`
+- [ ] Implement `M4-P1`: lint/health command framework and report writing
 
 ## Context Pointers
 
@@ -23,3 +26,28 @@
 - Source-resolution sequence (completed through SR-9): `docs/source_resolution_refactor_plan.md`
 - Schema summary: `docs/schema_contracts.md`
 - CI and contributor automation: `docs/ci_and_repo_automation.md`
+
+## Planned PR Queue
+
+- `M3-P1` Planning-object create/list commands
+- `M3-P2` Query CLI plus `query --json`
+- `M3-P3` Optional filed-answer workflow
+- `M4-P1` Lint/health command framework and report writing
+- `M4-P2` Wiki/planning/source integrity checks
+- `M4-P3` Queue/run integrity checks and repair diagnostics
+- `M5-P1` MVP docs, quickstart, and example workspace
+- `M5-P2` MVP hardening: coverage, errors, packaging, polish
+- `M6-P1` Review-state and provenance model expansion
+- `M6-P2` Contradiction surfacing and review-task linkage
+- `M7-P1` Repo scan and code/doc source classification
+- `M7-P2` Repo refresh and architecture/topic linkage
+- `M8-P1` GitHub Actions lint/health integration
+- `M8-P2` Optional PR-centric generated-change workflows
+- `M9-P1` Local web UI browse/search shell
+- `M9-P2` Planning/runs UI views
+- `M10-P1` Queue inspect/retry/repair commands
+- `M10-P2` Backoff, dead-letter, and stale-lease recovery
+- `M11-P1` Rich-source dispatch and PDF path
+- `M11-P2` OCR/image ingest path
+- `M12-P1` Schema/docs/migration stabilization
+- `M12-P2` Extension/performance/release finalization

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ uv run pre-commit run --all-files
 
 ## What comes next
 
-The next milestone should move from deterministic ingestion into the first Milestone 3 CLI slice:
+The next milestone should move from deterministic ingestion to the first Milestone 3 CLI slice:
 query support plus planning-object create/list commands.
 
 ## Additional documentation

--- a/README.md
+++ b/README.md
@@ -101,9 +101,7 @@ uv run pre-commit run --all-files
 
 ## What comes next
 
-`M3-P1` is now implemented: planning-object create/list commands landed as the first Milestone 3
-slice. The next planned PR is `M3-P2`, which should add query CLI support plus `splendor query
---json`.
+`M3-P1` is now implemented: planning-object create/list commands landed as the first Milestone 3 slice. The next planned PR is `M3-P2`, which should add query CLI support plus `splendor query --json`.
 
 ## Additional documentation
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ planning objects inside version control instead of rebuilding context from scrat
 ## Status
 
 This repository is in the bootstrap phase. Milestone 0 is established and the earliest Milestone 1
-surface plus the first deterministic Milestone 2 ingest path are implemented:
+surface, the first deterministic Milestone 2 ingest path, and the first Milestone 3 planning slice
+are implemented:
 
 - Python package scaffold with `src/` layout and a minimal CLI
 - `splendor init` for repository layout creation
 - `splendor add-source <path>` for deterministic source registration
 - `splendor ingest <source-id>` for deterministic single-source ingestion into `wiki/sources/`
+- `splendor task create|list`, `splendor milestone create|list`, `splendor decision create`, and
+  `splendor question create` for structured planning objects under `planning/`
 - Pydantic schema foundations for source, wiki, planning, queue, and run records
 - unit tests, linting, coverage, pre-commit, and GitHub Actions automation
 
@@ -24,7 +27,6 @@ Not implemented yet:
 
 - OCR and derived extraction workflows
 - query engine
-- planning-object creation commands
 - web UI
 - advanced code-aware repository scanning
 
@@ -99,8 +101,9 @@ uv run pre-commit run --all-files
 
 ## What comes next
 
-The next milestone should move from deterministic ingestion to the first Milestone 3 CLI slice:
-query support plus planning-object create/list commands.
+`M3-P1` is now implemented: planning-object create/list commands landed as the first Milestone 3
+slice. The next planned PR is `M3-P2`, which should add query CLI support plus `splendor query
+--json`.
 
 ## Additional documentation
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ uv run pre-commit run --all-files
 
 ## What comes next
 
-The next milestone should move from deterministic ingestion to the first Milestone 3 CLI slice:
+The next milestone should move from deterministic ingestion into the first Milestone 3 CLI slice:
 query support plus planning-object create/list commands.
 
 ## Additional documentation

--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -16,7 +16,7 @@ checksum during ingest, and only materialize a snapshot when the project explici
 
 Status note:
 
-- this plan has been implemented through `SR-9`
+- this plan is fully implemented through `SR-9`
 - the last planned slice landed in `PR #15`, which completed queue-first ingest draining on top of
   the source-resolution rollout
 - treat the sections below as the completed implementation sequence and design record for this
@@ -299,15 +299,15 @@ Proposed default policy:
 
 This keeps `wiki/sources/` useful without turning it into a second docs tree.
 
-## 10. Detailed Implementation Plan
+## 10. Implemented PR Breakdown
 
-The work should proceed in two phases. Each phase may span multiple PRs.
+The work proceeded in two phases. Each phase spanned multiple PRs.
 
 ### 10.1 Phase 1 — Introduce the source-resolution model
 
 ### Goal
 
-Make the core source manifest and ingest path understand canonical references and storage modes.
+Made the core source manifest and ingest path understand canonical references and storage modes.
 
 ### Phase 1 outcomes
 
@@ -317,11 +317,12 @@ Make the core source manifest and ingest path understand canonical references an
 - ingest reads through a resolver abstraction
 - older manifests still work
 
-### Recommended PR breakdown
+### Implemented PR breakdown
 
 Planning note:
 
-- the rollout steps below use `SR-n` labels (`Source Resolution`) to distinguish plan items from GitHub PR numbers
+- the rollout steps below use `SR-n` labels (`Source Resolution`) to distinguish implementation
+  plan items from GitHub PR numbers
 
 #### SR-1 — Docs and contract alignment
 
@@ -397,7 +398,7 @@ Exit criteria:
 
 ### Goal
 
-Make the wiki output and storage options match the new source model ergonomically.
+Made the wiki output and storage options match the new source model ergonomically.
 
 ### Phase 2 outcomes
 
@@ -405,7 +406,7 @@ Make the wiki output and storage options match the new source model ergonomicall
 - optional pointer and symlink materialization paths exist
 - projects can opt into stronger snapshot behavior where they need it
 
-### Recommended PR breakdown
+### Implemented PR breakdown
 
 Planning note:
 
@@ -485,11 +486,13 @@ Mitigation:
 Mitigation:
 
 - land the documentation PR first
-- treat this file as the implementation sequence; Phase 2 is now complete through `SR-9`
+- treat this file as the implementation sequence and completed design record; Phase 2 is complete
+  through `SR-9`
 
 ## 12. Recommended Default Decisions
 
-These should be treated as the proposed baseline unless implementation uncovers a blocking issue:
+These should be treated as the adopted baseline unless a future refactor intentionally changes
+them:
 
 - default in-repo storage mode: `none`
 - default external local storage mode: `copy`
@@ -497,8 +500,7 @@ These should be treated as the proposed baseline unless implementation uncovers 
 - source-summary rendering for external or transformed text: `full`
 - capture git commit for clean tracked workspace files: `true`
 
-## 13. Merge and Follow-up
+## 13. Follow-up
 
-After this design PR is merged, implementation should proceed as the PR series described above. The
-first code PR should focus on schema and config scaffolding, not on UI polish or richer source
-types.
+The source-resolution refactor is complete. Future source-type expansion should continue to build on
+this source-ref plus storage-mode contract rather than bypassing it.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -216,7 +216,7 @@ This is the point where Splendor starts to feel distinct from a generic RAG wrap
 ### Planned PR slices
 - `M3-P1` Planning-object create/list commands
 - `M3-P2` Query CLI plus `query --json`
-- `M3-P3` Optional filed-answer workflow
+- `M3-P3` Optional file-answer workflow
 
 ---
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -213,6 +213,11 @@ This is the point where Splendor starts to feel distinct from a generic RAG wrap
 - planning objects are stored in git-friendly markdown with machine-readable frontmatter
 - planning objects can be listed and filtered at least minimally
 
+### Planned PR slices
+- `M3-P1` Planning-object create/list commands
+- `M3-P2` Query CLI plus `query --json`
+- `M3-P3` Optional filed-answer workflow
+
 ---
 
 ## Milestone 4 — MVP core: deterministic lint and health checks
@@ -247,6 +252,11 @@ Ship the first strong maintenance layer without overusing LLMs.
 - a user can run deterministic health checks locally
 - failures are actionable
 - linting can run in CI later with minimal extra work
+
+### Planned PR slices
+- `M4-P1` Lint/health command framework and report writing
+- `M4-P2` Wiki/planning/source integrity checks
+- `M4-P3` Queue/run integrity checks and repair diagnostics
 
 ---
 
@@ -283,6 +293,10 @@ Ship a first public MVP that is stable enough for real project use.
 - the MVP is reliable on at least one real project
 - the CLI surface is coherent and documented
 
+### Planned PR slices
+- `M5-P1` MVP docs, quickstart, and example workspace
+- `M5-P2` MVP hardening: coverage, errors, packaging, polish
+
 ---
 
 ## Milestone 6 — Post-MVP: stronger provenance and review state
@@ -314,6 +328,10 @@ This milestone is especially important for sensitive, policy-heavy, or research-
 - users can inspect why a page says what it says
 - contested knowledge is surfaced instead of silently merged
 - provenance is visible enough to support trust and debugging
+
+### Planned PR slices
+- `M6-P1` Review-state and provenance model expansion
+- `M6-P2` Contradiction surfacing and review-task linkage
 
 ---
 
@@ -348,6 +366,17 @@ sources.
 - ingest reads through one resolver interface regardless of source origin
 - source-summary pages remain deterministic while becoming less noisy
 
+### Historical implementation sequence
+- `SR-1` Docs and contract alignment
+- `SR-2` Schema and config scaffolding
+- `SR-3` Source resolver abstraction
+- `SR-4` `add-source` default behavior switch
+- `SR-5` Migration and polish
+- `SR-6` Source-summary rendering policy
+- `SR-7` Pointer storage mode
+- `SR-8` Optional symlink mode
+- `SR-9` Materialization workflow polish
+
 ---
 
 ## Milestone 7 — Post-MVP: code awareness
@@ -376,6 +405,10 @@ This milestone is a likely differentiator for Splendor versus more generic LLM w
 - Splendor can reason about the code repo itself
 - repo changes can drive meaningful wiki maintenance
 - architecture understanding is materially improved
+
+### Planned PR slices
+- `M7-P1` Repo scan and code/doc source classification
+- `M7-P2` Repo refresh and architecture/topic linkage
 
 ---
 
@@ -410,6 +443,10 @@ Add strong optional GitHub-powered features without making GitHub mandatory.
 - a GitHub-heavy user can adopt strong GitHub-native workflows
 - a non-GitHub user is not blocked by any of this
 
+### Planned PR slices
+- `M8-P1` GitHub Actions lint/health integration
+- `M8-P2` Optional PR-centric generated-change workflows
+
 ---
 
 ## Milestone 9 — Post-MVP: local web UI v0
@@ -442,6 +479,10 @@ Provide a modest but useful human UI without changing the system’s center of g
 - the UI is helpful but non-essential
 - agents can still operate entirely through CLI
 
+### Planned PR slices
+- `M9-P1` Local web UI browse/search shell
+- `M9-P2` Planning/runs UI views
+
 ---
 
 ## Milestone 10 — Post-MVP: queue robustness and repair workflows
@@ -468,6 +509,10 @@ Make Splendor resilient in the face of failed ingest/maintenance jobs.
 - users can recover from broken jobs without manual state surgery
 - queue state is transparent and trustworthy
 - repeated maintenance/ingest workflows are operationally sane
+
+### Planned PR slices
+- `M10-P1` Queue inspect/retry/repair commands
+- `M10-P2` Backoff, dead-letter, and stale-lease recovery
 
 ---
 
@@ -504,6 +549,10 @@ model as text-native sources.
 - extraction artifacts are stored cleanly and repairably
 - failures in OCR-heavy paths do not destabilize the core system
 
+### Planned PR slices
+- `M11-P1` Rich-source dispatch and PDF path
+- `M11-P2` OCR/image ingest path
+
 ---
 
 ## Milestone 12 — v1 stabilization and release
@@ -519,6 +568,10 @@ Publish a coherent, documented v1 that feels like a complete product.
 - extension points
 - performance polish
 - one or two real-world showcase repos
+
+### Planned PR slices
+- `M12-P1` Schema/docs/migration stabilization
+- `M12-P2` Extension/performance/release finalization
 
 ### Deliverables
 - v1 schema versions

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -12,6 +12,15 @@ from splendor.commands.health import run_health
 from splendor.commands.ingest import drain_pending_ingest_jobs, ingest_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.materialize_source import materialize_source
+from splendor.commands.planning import (
+    create_decision,
+    create_milestone,
+    create_question,
+    create_task,
+    list_milestones,
+    list_tasks,
+)
+from splendor.schemas import DecisionRecord, MilestoneRecord, QuestionRecord, TaskRecord
 from splendor.schemas.types import STORAGE_MODES
 
 
@@ -77,6 +86,142 @@ def build_parser() -> argparse.ArgumentParser:
 
     health_parser = subparsers.add_parser("health", help="Validate source storage state")
     health_parser.set_defaults(handler=handle_health)
+
+    task_parser = subparsers.add_parser("task", help="Create or inspect task records")
+    task_subparsers = task_parser.add_subparsers(dest="task_command", required=True)
+    task_create_parser = task_subparsers.add_parser("create", help="Create a task record")
+    task_create_parser.add_argument("title", nargs="+", help="Task title")
+    task_create_parser.add_argument("--id", dest="record_id", help="Explicit task identifier")
+    task_create_parser.add_argument(
+        "--status",
+        choices=TaskRecord.model_fields["status"].annotation.__args__,
+        default=TaskRecord.model_fields["status"].default,
+        help="Initial task status.",
+    )
+    task_create_parser.add_argument(
+        "--priority",
+        choices=TaskRecord.model_fields["priority"].annotation.__args__,
+        default=TaskRecord.model_fields["priority"].default,
+        help="Task priority.",
+    )
+    task_create_parser.add_argument("--owner", help="Task owner")
+    task_create_parser.add_argument(
+        "--milestone-ref", action="append", default=[], help="Linked milestone reference"
+    )
+    task_create_parser.add_argument(
+        "--decision-ref", action="append", default=[], help="Linked decision reference"
+    )
+    task_create_parser.add_argument(
+        "--question-ref", action="append", default=[], help="Linked question reference"
+    )
+    task_create_parser.add_argument(
+        "--depends-on", action="append", default=[], help="Task dependency reference"
+    )
+    task_create_parser.add_argument(
+        "--source-ref", action="append", default=[], help="Linked source reference"
+    )
+    task_create_parser.set_defaults(handler=handle_task_create)
+    task_list_parser = task_subparsers.add_parser("list", help="List task records")
+    task_list_parser.add_argument(
+        "--status",
+        choices=TaskRecord.model_fields["status"].annotation.__args__,
+        help="Filter by task status.",
+    )
+    task_list_parser.add_argument(
+        "--priority",
+        choices=TaskRecord.model_fields["priority"].annotation.__args__,
+        help="Filter by task priority.",
+    )
+    task_list_parser.add_argument("--milestone-ref", help="Filter by milestone reference")
+    task_list_parser.set_defaults(handler=handle_task_list)
+
+    milestone_parser = subparsers.add_parser(
+        "milestone", help="Create or inspect milestone records"
+    )
+    milestone_subparsers = milestone_parser.add_subparsers(dest="milestone_command", required=True)
+    milestone_create_parser = milestone_subparsers.add_parser(
+        "create", help="Create a milestone record"
+    )
+    milestone_create_parser.add_argument("title", nargs="+", help="Milestone title")
+    milestone_create_parser.add_argument(
+        "--id", dest="record_id", help="Explicit milestone identifier"
+    )
+    milestone_create_parser.add_argument(
+        "--status",
+        choices=MilestoneRecord.model_fields["status"].annotation.__args__,
+        default=MilestoneRecord.model_fields["status"].default,
+        help="Initial milestone status.",
+    )
+    milestone_create_parser.add_argument("--target-date", help="Milestone target date")
+    milestone_create_parser.add_argument(
+        "--task-ref", action="append", default=[], help="Linked task reference"
+    )
+    milestone_create_parser.add_argument(
+        "--decision-ref", action="append", default=[], help="Linked decision reference"
+    )
+    milestone_create_parser.add_argument(
+        "--question-ref", action="append", default=[], help="Linked question reference"
+    )
+    milestone_create_parser.set_defaults(handler=handle_milestone_create)
+    milestone_list_parser = milestone_subparsers.add_parser("list", help="List milestone records")
+    milestone_list_parser.add_argument(
+        "--status",
+        choices=MilestoneRecord.model_fields["status"].annotation.__args__,
+        help="Filter by milestone status.",
+    )
+    milestone_list_parser.set_defaults(handler=handle_milestone_list)
+
+    decision_parser = subparsers.add_parser("decision", help="Create decision records")
+    decision_subparsers = decision_parser.add_subparsers(dest="decision_command", required=True)
+    decision_create_parser = decision_subparsers.add_parser(
+        "create", help="Create a decision record"
+    )
+    decision_create_parser.add_argument("title", nargs="+", help="Decision title")
+    decision_create_parser.add_argument("--id", dest="record_id", help="Explicit decision ID")
+    decision_create_parser.add_argument(
+        "--status",
+        choices=DecisionRecord.model_fields["status"].annotation.__args__,
+        default=DecisionRecord.model_fields["status"].default,
+        help="Initial decision status.",
+    )
+    decision_create_parser.add_argument("--decided-at", help="Decision date")
+    decision_create_parser.add_argument(
+        "--supersedes", action="append", default=[], help="Superseded decision reference"
+    )
+    decision_create_parser.add_argument(
+        "--source-ref", action="append", default=[], help="Linked source reference"
+    )
+    decision_create_parser.add_argument(
+        "--related-task", action="append", default=[], help="Related task reference"
+    )
+    decision_create_parser.add_argument(
+        "--related-question", action="append", default=[], help="Related question reference"
+    )
+    decision_create_parser.set_defaults(handler=handle_decision_create)
+
+    question_parser = subparsers.add_parser("question", help="Create question records")
+    question_subparsers = question_parser.add_subparsers(dest="question_command", required=True)
+    question_create_parser = question_subparsers.add_parser(
+        "create", help="Create a question record"
+    )
+    question_create_parser.add_argument("title", nargs="+", help="Question title")
+    question_create_parser.add_argument("--id", dest="record_id", help="Explicit question ID")
+    question_create_parser.add_argument(
+        "--status",
+        choices=QuestionRecord.model_fields["status"].annotation.__args__,
+        default=QuestionRecord.model_fields["status"].default,
+        help="Initial question status.",
+    )
+    question_create_parser.add_argument(
+        "--source-ref", action="append", default=[], help="Linked source reference"
+    )
+    question_create_parser.add_argument(
+        "--related-task", action="append", default=[], help="Related task reference"
+    )
+    question_create_parser.add_argument(
+        "--related-decision", action="append", default=[], help="Related decision reference"
+    )
+    question_create_parser.set_defaults(handler=handle_question_create)
     return parser
 
 
@@ -189,6 +334,127 @@ def handle_health(args: argparse.Namespace) -> int:
     for issue in result.issues:
         print(f"- {issue.source_id}: {issue.message}")
     return 1
+
+
+def _title_from_args(args: argparse.Namespace) -> str:
+    return " ".join(args.title)
+
+
+def handle_task_create(args: argparse.Namespace) -> int:
+    try:
+        result = create_task(
+            args.root.resolve(),
+            _title_from_args(args),
+            record_id=args.record_id,
+            status=args.status,
+            priority=args.priority,
+            owner=args.owner,
+            milestone_refs=args.milestone_ref,
+            decision_refs=args.decision_ref,
+            question_refs=args.question_ref,
+            depends_on=args.depends_on,
+            source_refs=args.source_ref,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    print(f"Created task {result.record_id}")
+    print(f"Path: {result.path}")
+    return 0
+
+
+def handle_task_list(args: argparse.Namespace) -> int:
+    try:
+        rows = list_tasks(
+            args.root.resolve(),
+            status=args.status,
+            priority=args.priority,
+            milestone_ref=args.milestone_ref,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    for row in rows:
+        print(f"{row.task_id}  {row.status}  {row.priority}  {row.title}")
+    return 0
+
+
+def handle_milestone_create(args: argparse.Namespace) -> int:
+    try:
+        result = create_milestone(
+            args.root.resolve(),
+            _title_from_args(args),
+            record_id=args.record_id,
+            status=args.status,
+            target_date=args.target_date,
+            task_refs=args.task_ref,
+            decision_refs=args.decision_ref,
+            question_refs=args.question_ref,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    print(f"Created milestone {result.record_id}")
+    print(f"Path: {result.path}")
+    return 0
+
+
+def handle_milestone_list(args: argparse.Namespace) -> int:
+    try:
+        rows = list_milestones(args.root.resolve(), status=args.status)
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    for row in rows:
+        target_date = row.target_date or "-"
+        print(f"{row.milestone_id}  {row.status}  {target_date}  {row.title}")
+    return 0
+
+
+def handle_decision_create(args: argparse.Namespace) -> int:
+    try:
+        result = create_decision(
+            args.root.resolve(),
+            _title_from_args(args),
+            record_id=args.record_id,
+            status=args.status,
+            decided_at=args.decided_at,
+            supersedes=args.supersedes,
+            source_refs=args.source_ref,
+            related_tasks=args.related_task,
+            related_questions=args.related_question,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    print(f"Created decision {result.record_id}")
+    print(f"Path: {result.path}")
+    return 0
+
+
+def handle_question_create(args: argparse.Namespace) -> int:
+    try:
+        result = create_question(
+            args.root.resolve(),
+            _title_from_args(args),
+            record_id=args.record_id,
+            status=args.status,
+            source_refs=args.source_ref,
+            related_tasks=args.related_task,
+            related_decisions=args.related_decision,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    print(f"Created question {result.record_id}")
+    print(f"Path: {result.path}")
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/splendor/commands/planning.py
+++ b/src/splendor/commands/planning.py
@@ -1,0 +1,234 @@
+"""Implementation for planning object commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import DecisionRecord, MilestoneRecord, QuestionRecord, TaskRecord
+from splendor.utils.planning import (
+    default_record_id,
+    iter_planning_paths,
+    parse_planning_markdown,
+    planning_directory,
+    planning_path,
+    record_id_field,
+    render_planning_markdown,
+    write_planning_markdown,
+)
+from splendor.utils.time import utc_now_iso
+
+_RECORD_MODELS = {
+    "task": TaskRecord,
+    "milestone": MilestoneRecord,
+    "decision": DecisionRecord,
+    "question": QuestionRecord,
+}
+
+
+@dataclass(frozen=True)
+class CreatePlanningResult:
+    kind: str
+    record_id: str
+    path: Path
+    title: str
+
+
+@dataclass(frozen=True)
+class TaskListRow:
+    task_id: str
+    status: str
+    priority: str
+    title: str
+
+
+@dataclass(frozen=True)
+class MilestoneListRow:
+    milestone_id: str
+    status: str
+    target_date: str | None
+    title: str
+
+
+def _model_for(kind: str):
+    try:
+        return _RECORD_MODELS[kind]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported planning kind: {kind}") from exc
+
+
+def create_task(
+    root: Path,
+    title: str,
+    *,
+    record_id: str | None,
+    status: str,
+    priority: str,
+    owner: str | None,
+    milestone_refs: list[str],
+    decision_refs: list[str],
+    question_refs: list[str],
+    depends_on: list[str],
+    source_refs: list[str],
+) -> CreatePlanningResult:
+    timestamp = utc_now_iso()
+    task_id = record_id or default_record_id("task", title)
+    record = TaskRecord(
+        task_id=task_id,
+        title=title,
+        status=status,
+        priority=priority,
+        milestone_refs=milestone_refs,
+        decision_refs=decision_refs,
+        question_refs=question_refs,
+        owner=owner,
+        created_at=timestamp,
+        updated_at=timestamp,
+        depends_on=depends_on,
+        source_refs=source_refs,
+    )
+    return _write_record(root, record, title=title)
+
+
+def create_milestone(
+    root: Path,
+    title: str,
+    *,
+    record_id: str | None,
+    status: str,
+    target_date: str | None,
+    task_refs: list[str],
+    decision_refs: list[str],
+    question_refs: list[str],
+) -> CreatePlanningResult:
+    timestamp = utc_now_iso()
+    milestone_id = record_id or default_record_id("milestone", title)
+    record = MilestoneRecord(
+        milestone_id=milestone_id,
+        title=title,
+        status=status,
+        target_date=target_date,
+        created_at=timestamp,
+        updated_at=timestamp,
+        task_refs=task_refs,
+        decision_refs=decision_refs,
+        question_refs=question_refs,
+    )
+    return _write_record(root, record, title=title)
+
+
+def create_decision(
+    root: Path,
+    title: str,
+    *,
+    record_id: str | None,
+    status: str,
+    decided_at: str | None,
+    supersedes: list[str],
+    source_refs: list[str],
+    related_tasks: list[str],
+    related_questions: list[str],
+) -> CreatePlanningResult:
+    decision_id = record_id or default_record_id("decision", title)
+    record = DecisionRecord(
+        decision_id=decision_id,
+        title=title,
+        status=status,
+        decided_at=decided_at,
+        supersedes=supersedes,
+        source_refs=source_refs,
+        related_tasks=related_tasks,
+        related_questions=related_questions,
+    )
+    return _write_record(root, record, title=title)
+
+
+def create_question(
+    root: Path,
+    title: str,
+    *,
+    record_id: str | None,
+    status: str,
+    source_refs: list[str],
+    related_tasks: list[str],
+    related_decisions: list[str],
+) -> CreatePlanningResult:
+    timestamp = utc_now_iso()
+    question_id = record_id or default_record_id("question", title)
+    record = QuestionRecord(
+        question_id=question_id,
+        title=title,
+        status=status,
+        created_at=timestamp,
+        updated_at=timestamp,
+        source_refs=source_refs,
+        related_tasks=related_tasks,
+        related_decisions=related_decisions,
+    )
+    return _write_record(root, record, title=title)
+
+
+def list_tasks(
+    root: Path,
+    *,
+    status: str | None,
+    priority: str | None,
+    milestone_ref: str | None,
+) -> list[TaskListRow]:
+    rows: list[TaskListRow] = []
+    for record in _load_records(root, "task"):
+        if status is not None and record.status != status:
+            continue
+        if priority is not None and record.priority != priority:
+            continue
+        if milestone_ref is not None and milestone_ref not in record.milestone_refs:
+            continue
+        rows.append(
+            TaskListRow(
+                task_id=record.task_id,
+                status=record.status,
+                priority=record.priority,
+                title=record.title,
+            )
+        )
+    return rows
+
+
+def list_milestones(root: Path, *, status: str | None) -> list[MilestoneListRow]:
+    rows: list[MilestoneListRow] = []
+    for record in _load_records(root, "milestone"):
+        if status is not None and record.status != status:
+            continue
+        rows.append(
+            MilestoneListRow(
+                milestone_id=record.milestone_id,
+                status=record.status,
+                target_date=record.target_date,
+                title=record.title,
+            )
+        )
+    return rows
+
+
+def _write_record(root: Path, record, *, title: str) -> CreatePlanningResult:
+    kind = record.kind
+    layout = resolve_layout(root, load_config(root))
+    record_id = getattr(record, record_id_field(kind))
+    path = planning_path(layout, kind, record_id)
+    if path.exists():
+        raise ValueError(f"{kind.capitalize()} ID already exists: {record_id}")
+    content = render_planning_markdown(record, title=title)
+    write_planning_markdown(path, content)
+    return CreatePlanningResult(kind=kind, record_id=record_id, path=path, title=title)
+
+
+def _load_records(root: Path, kind: str):
+    layout = resolve_layout(root, load_config(root))
+    model = _model_for(kind)
+    rows = []
+    for path in iter_planning_paths(planning_directory(layout, kind)):
+        rows.append(parse_planning_markdown(path, model))
+    rows.sort(key=lambda record: getattr(record, record_id_field(kind)))
+    return rows

--- a/src/splendor/utils/planning.py
+++ b/src/splendor/utils/planning.py
@@ -28,6 +28,8 @@ _KIND_TO_ID_FIELD = {
     "question": "question_id",
 }
 
+_RECORD_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
 
 def planning_directory(layout: ResolvedLayout, kind: str) -> Path:
     try:
@@ -38,6 +40,7 @@ def planning_directory(layout: ResolvedLayout, kind: str) -> Path:
 
 
 def planning_path(layout: ResolvedLayout, kind: str, record_id: str) -> Path:
+    validate_record_id(record_id)
     return planning_directory(layout, kind) / f"{record_id}.md"
 
 
@@ -51,7 +54,7 @@ def record_id_field(kind: str) -> str:
 def default_record_id(kind: str, title: str) -> str:
     slug = slugify(title)
     if not slug:
-        raise ValueError("Title must contain at least one letter or number")
+        raise ValueError("Title must contain at least one ASCII letter or number")
     return f"{kind}-{slug}"
 
 
@@ -59,6 +62,14 @@ def slugify(value: str) -> str:
     normalized = value.strip().lower()
     normalized = re.sub(r"[^a-z0-9]+", "-", normalized)
     return normalized.strip("-")
+
+
+def validate_record_id(record_id: str) -> str:
+    if not _RECORD_ID_PATTERN.fullmatch(record_id):
+        raise ValueError(
+            "Record ID must match ^[a-z0-9]+(?:-[a-z0-9]+)*$ and may not contain path separators"
+        )
+    return record_id
 
 
 def render_frontmatter(record: BaseModel) -> str:

--- a/src/splendor/utils/planning.py
+++ b/src/splendor/utils/planning.py
@@ -75,11 +75,12 @@ def write_planning_markdown(path: Path, content: str) -> None:
 
 def parse_planning_markdown(path: Path, model: type[PlanningRecord]) -> PlanningRecord:
     raw = path.read_text(encoding="utf-8")
-    if not raw.startswith("---\n"):
+    normalized = raw.replace("\r\n", "\n").replace("\r", "\n")
+    if not normalized.startswith("---\n"):
         raise ValueError(f"Planning record {path} is missing YAML frontmatter")
 
     try:
-        frontmatter_text, _body = raw.removeprefix("---\n").split("\n---\n", maxsplit=1)
+        frontmatter_text, _body = normalized.removeprefix("---\n").split("\n---\n", maxsplit=1)
     except ValueError as exc:
         raise ValueError(f"Planning record {path} has malformed YAML frontmatter") from exc
 

--- a/src/splendor/utils/planning.py
+++ b/src/splendor/utils/planning.py
@@ -1,0 +1,102 @@
+"""Deterministic planning object helpers."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TypeVar
+
+import yaml
+from pydantic import BaseModel, ValidationError
+
+from splendor.layout import ResolvedLayout
+from splendor.utils.fs import write_text_atomic
+
+PlanningRecord = TypeVar("PlanningRecord", bound=BaseModel)
+
+_KIND_TO_SUBDIR = {
+    "task": "tasks",
+    "milestone": "milestones",
+    "decision": "decisions",
+    "question": "questions",
+}
+
+_KIND_TO_ID_FIELD = {
+    "task": "task_id",
+    "milestone": "milestone_id",
+    "decision": "decision_id",
+    "question": "question_id",
+}
+
+
+def planning_directory(layout: ResolvedLayout, kind: str) -> Path:
+    try:
+        subdir = _KIND_TO_SUBDIR[kind]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported planning kind: {kind}") from exc
+    return layout.planning_dir / subdir
+
+
+def planning_path(layout: ResolvedLayout, kind: str, record_id: str) -> Path:
+    return planning_directory(layout, kind) / f"{record_id}.md"
+
+
+def record_id_field(kind: str) -> str:
+    try:
+        return _KIND_TO_ID_FIELD[kind]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported planning kind: {kind}") from exc
+
+
+def default_record_id(kind: str, title: str) -> str:
+    slug = slugify(title)
+    if not slug:
+        raise ValueError("Title must contain at least one letter or number")
+    return f"{kind}-{slug}"
+
+
+def slugify(value: str) -> str:
+    normalized = value.strip().lower()
+    normalized = re.sub(r"[^a-z0-9]+", "-", normalized)
+    return normalized.strip("-")
+
+
+def render_frontmatter(record: BaseModel) -> str:
+    return yaml.safe_dump(record.model_dump(mode="json"), sort_keys=False).strip()
+
+
+def render_planning_markdown(record: BaseModel, *, title: str) -> str:
+    return f"---\n{render_frontmatter(record)}\n---\n\n# {title}\n\n## Notes\n\n"
+
+
+def write_planning_markdown(path: Path, content: str) -> None:
+    write_text_atomic(path, content)
+
+
+def parse_planning_markdown(path: Path, model: type[PlanningRecord]) -> PlanningRecord:
+    raw = path.read_text(encoding="utf-8")
+    if not raw.startswith("---\n"):
+        raise ValueError(f"Planning record {path} is missing YAML frontmatter")
+
+    try:
+        frontmatter_text, _body = raw.removeprefix("---\n").split("\n---\n", maxsplit=1)
+    except ValueError as exc:
+        raise ValueError(f"Planning record {path} has malformed YAML frontmatter") from exc
+
+    try:
+        payload = yaml.safe_load(frontmatter_text)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Planning record {path} has invalid YAML frontmatter") from exc
+
+    try:
+        return model.model_validate(payload or {})
+    except ValidationError as exc:
+        raise ValueError(f"Planning record {path} failed schema validation: {exc}") from exc
+
+
+def iter_planning_paths(directory: Path) -> list[Path]:
+    if not directory.exists():
+        return []
+    return sorted(
+        path for path in directory.glob("*.md") if path.name != ".gitkeep" and path.is_file()
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -405,3 +405,166 @@ def test_cli_health_command_fails_when_source_manifest_dir_is_missing(
     assert exit_code == 1
     captured = capsys.readouterr()
     assert "Source manifest directory is missing or unreadable" in captured.out
+
+
+def test_cli_task_create_command(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "create",
+            "Write",
+            "CLI",
+            "docs",
+            "--priority",
+            "high",
+            "--owner",
+            "codex",
+            "--milestone-ref",
+            "milestone-m3-p1",
+            "--source-ref",
+            "src-123",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Created task task-write-cli-docs" in captured.out
+    assert "planning/tasks/task-write-cli-docs.md" in captured.out
+
+
+def test_cli_task_list_command_supports_filters(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "create",
+            "Write",
+            "CLI",
+            "docs",
+            "--priority",
+            "high",
+            "--milestone-ref",
+            "milestone-m3-p1",
+        ]
+    )
+    main(["--root", str(tmp_path), "task", "create", "Ship", "query", "--priority", "low"])
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "list",
+            "--priority",
+            "high",
+            "--milestone-ref",
+            "milestone-m3-p1",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    lines = [line for line in captured.out.splitlines() if line.startswith("task-")]
+    assert lines == ["task-write-cli-docs  todo  high  Write CLI docs"]
+
+
+def test_cli_milestone_create_and_list_commands(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "milestone",
+            "create",
+            "Milestone",
+            "3",
+            "Slice",
+            "--status",
+            "active",
+            "--target-date",
+            "2026-05-01",
+        ]
+    )
+
+    exit_code = main(["--root", str(tmp_path), "milestone", "list", "--status", "active"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    lines = [line for line in captured.out.splitlines() if line.startswith("milestone-")]
+    assert lines == ["milestone-milestone-3-slice  active  2026-05-01  Milestone 3 Slice"]
+
+
+def test_cli_decision_create_command(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "decision",
+            "create",
+            "Use",
+            "planning",
+            "markdown",
+            "--related-task",
+            "task-write-cli-docs",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Created decision decision-use-planning-markdown" in captured.out
+
+
+def test_cli_question_create_command(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "question",
+            "create",
+            "How",
+            "should",
+            "query",
+            "ranking",
+            "work",
+            "--related-decision",
+            "decision-use-planning-markdown",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Created question question-how-should-query-ranking-work" in captured.out
+
+
+def test_cli_task_create_command_rejects_duplicate_ids(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    main(["--root", str(tmp_path), "task", "create", "Write", "CLI", "docs"])
+
+    exit_code = main(["--root", str(tmp_path), "task", "create", "Write", "CLI", "docs"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Task ID already exists: task-write-cli-docs" in captured.out
+
+
+def test_cli_task_list_fails_for_invalid_frontmatter(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    capsys.readouterr()
+    task_path = tmp_path / "planning" / "tasks" / "task-invalid.md"
+    task_path.write_text("---\nkind: task\nbogus: true\n---\n", encoding="utf-8")
+
+    exit_code = main(["--root", str(tmp_path), "task", "list"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert captured.out.startswith("Error: Planning record")

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -207,3 +207,34 @@ def test_parse_planning_markdown_rejects_invalid_frontmatter(tmp_path: Path) -> 
         assert "failed schema validation" in str(exc)
     else:
         raise AssertionError("Expected planning frontmatter validation failure")
+
+
+def test_parse_planning_markdown_accepts_crlf_frontmatter(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    task_path = tmp_path / "planning" / "tasks" / "task-crlf.md"
+    task_path.write_text(
+        "---\r\n"
+        "schema_version: '1'\r\n"
+        "kind: task\r\n"
+        "task_id: task-crlf\r\n"
+        "title: CRLF task\r\n"
+        "status: todo\r\n"
+        "priority: medium\r\n"
+        "milestone_refs: []\r\n"
+        "decision_refs: []\r\n"
+        "question_refs: []\r\n"
+        "owner: null\r\n"
+        "created_at: '2026-04-17T00:00:00+00:00'\r\n"
+        "updated_at: '2026-04-17T00:00:00+00:00'\r\n"
+        "depends_on: []\r\n"
+        "source_refs: []\r\n"
+        "---\r\n\r\n"
+        "# CRLF task\r\n\r\n"
+        "## Notes\r\n",
+        encoding="utf-8",
+    )
+
+    record = parse_planning_markdown(task_path, TaskRecord)
+
+    assert record.task_id == "task-crlf"
+    assert record.title == "CRLF task"

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -238,3 +238,49 @@ def test_parse_planning_markdown_accepts_crlf_frontmatter(tmp_path: Path) -> Non
 
     assert record.task_id == "task-crlf"
     assert record.title == "CRLF task"
+
+
+def test_create_task_rejects_path_traversal_id(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    try:
+        create_task(
+            tmp_path,
+            "Write CLI docs",
+            record_id="../escape",
+            status="todo",
+            priority="medium",
+            owner=None,
+            milestone_refs=[],
+            decision_refs=[],
+            question_refs=[],
+            depends_on=[],
+            source_refs=[],
+        )
+    except ValueError as exc:
+        assert "Record ID must match" in str(exc)
+    else:
+        raise AssertionError("Expected invalid record ID failure")
+
+
+def test_default_record_id_error_mentions_ascii_constraint(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    try:
+        create_task(
+            tmp_path,
+            "שלום",
+            record_id=None,
+            status="todo",
+            priority="medium",
+            owner=None,
+            milestone_refs=[],
+            decision_refs=[],
+            question_refs=[],
+            depends_on=[],
+            source_refs=[],
+        )
+    except ValueError as exc:
+        assert "ASCII letter or number" in str(exc)
+    else:
+        raise AssertionError("Expected ASCII-only slug validation failure")

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -1,0 +1,209 @@
+from pathlib import Path
+
+import yaml
+
+from splendor.commands.init import initialize_workspace
+from splendor.commands.planning import (
+    MilestoneListRow,
+    TaskListRow,
+    create_decision,
+    create_milestone,
+    create_question,
+    create_task,
+    list_milestones,
+    list_tasks,
+)
+from splendor.schemas import DecisionRecord, MilestoneRecord, QuestionRecord, TaskRecord
+from splendor.utils.planning import parse_planning_markdown
+
+
+def parse_frontmatter(path: Path) -> dict:
+    raw = path.read_text(encoding="utf-8")
+    frontmatter_text, _body = raw.removeprefix("---\n").split("\n---\n", maxsplit=1)
+    return yaml.safe_load(frontmatter_text)
+
+
+def test_create_task_writes_markdown_with_frontmatter(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    result = create_task(
+        tmp_path,
+        "Write CLI docs",
+        record_id=None,
+        status="in_progress",
+        priority="high",
+        owner="codex",
+        milestone_refs=["milestone-m3-p1"],
+        decision_refs=["decision-markdown"],
+        question_refs=["question-query"],
+        depends_on=["task-roadmap"],
+        source_refs=["src-123"],
+    )
+
+    payload = parse_frontmatter(result.path)
+    assert payload["task_id"] == "task-write-cli-docs"
+    assert payload["status"] == "in_progress"
+    assert payload["priority"] == "high"
+    assert payload["owner"] == "codex"
+    assert payload["milestone_refs"] == ["milestone-m3-p1"]
+    assert payload["decision_refs"] == ["decision-markdown"]
+    assert payload["question_refs"] == ["question-query"]
+    assert payload["depends_on"] == ["task-roadmap"]
+    assert payload["source_refs"] == ["src-123"]
+    body = result.path.read_text(encoding="utf-8")
+    assert "# Write CLI docs" in body
+    assert "## Notes" in body
+
+
+def test_create_milestone_round_trips_with_schema(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    result = create_milestone(
+        tmp_path,
+        "Milestone 3 Slice",
+        record_id="milestone-m3-p1",
+        status="active",
+        target_date="2026-05-01",
+        task_refs=["task-write-cli-docs"],
+        decision_refs=["decision-markdown"],
+        question_refs=["question-query"],
+    )
+
+    record = parse_planning_markdown(result.path, MilestoneRecord)
+    assert record.milestone_id == "milestone-m3-p1"
+    assert record.status == "active"
+    assert record.target_date == "2026-05-01"
+    assert record.task_refs == ["task-write-cli-docs"]
+
+
+def test_create_decision_round_trips_with_schema(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    result = create_decision(
+        tmp_path,
+        "Use planning markdown",
+        record_id=None,
+        status="accepted",
+        decided_at="2026-04-17",
+        supersedes=["decision-old"],
+        source_refs=["src-123"],
+        related_tasks=["task-write-cli-docs"],
+        related_questions=["question-query"],
+    )
+
+    record = parse_planning_markdown(result.path, DecisionRecord)
+    assert record.decision_id == "decision-use-planning-markdown"
+    assert record.status == "accepted"
+    assert record.decided_at == "2026-04-17"
+    assert record.related_tasks == ["task-write-cli-docs"]
+
+
+def test_create_question_round_trips_with_schema(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    result = create_question(
+        tmp_path,
+        "How should query ranking work",
+        record_id=None,
+        status="open",
+        source_refs=["src-123"],
+        related_tasks=["task-write-cli-docs"],
+        related_decisions=["decision-use-planning-markdown"],
+    )
+
+    record = parse_planning_markdown(result.path, QuestionRecord)
+    assert record.question_id == "question-how-should-query-ranking-work"
+    assert record.status == "open"
+    assert record.related_decisions == ["decision-use-planning-markdown"]
+
+
+def test_list_tasks_is_sorted_and_filtered(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    create_task(
+        tmp_path,
+        "Write CLI docs",
+        record_id="task-b",
+        status="todo",
+        priority="high",
+        owner=None,
+        milestone_refs=["milestone-m3-p1"],
+        decision_refs=[],
+        question_refs=[],
+        depends_on=[],
+        source_refs=[],
+    )
+    create_task(
+        tmp_path,
+        "Ship query",
+        record_id="task-a",
+        status="done",
+        priority="low",
+        owner=None,
+        milestone_refs=[],
+        decision_refs=[],
+        question_refs=[],
+        depends_on=[],
+        source_refs=[],
+    )
+
+    rows = list_tasks(tmp_path, status="todo", priority="high", milestone_ref="milestone-m3-p1")
+
+    assert rows == [
+        TaskListRow(
+            task_id="task-b",
+            status="todo",
+            priority="high",
+            title="Write CLI docs",
+        )
+    ]
+
+
+def test_list_milestones_is_sorted_and_filtered(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    create_milestone(
+        tmp_path,
+        "Milestone 4",
+        record_id="milestone-b",
+        status="planned",
+        target_date=None,
+        task_refs=[],
+        decision_refs=[],
+        question_refs=[],
+    )
+    create_milestone(
+        tmp_path,
+        "Milestone 3",
+        record_id="milestone-a",
+        status="active",
+        target_date="2026-05-01",
+        task_refs=[],
+        decision_refs=[],
+        question_refs=[],
+    )
+
+    rows = list_milestones(tmp_path, status="active")
+
+    assert rows == [
+        MilestoneListRow(
+            milestone_id="milestone-a",
+            status="active",
+            target_date="2026-05-01",
+            title="Milestone 3",
+        )
+    ]
+
+
+def test_parse_planning_markdown_rejects_invalid_frontmatter(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    task_path = tmp_path / "planning" / "tasks" / "task-invalid.md"
+    task_path.write_text(
+        "---\nkind: task\ntask_id: task-invalid\ntitle: Broken\nbogus: true\n---\n",
+        encoding="utf-8",
+    )
+
+    try:
+        parse_planning_markdown(task_path, TaskRecord)
+    except ValueError as exc:
+        assert "failed schema validation" in str(exc)
+    else:
+        raise AssertionError("Expected planning frontmatter validation failure")


### PR DESCRIPTION
## Summary

This PR implements `M3-P1`, the first Milestone 3 slice for Splendor.

It adds deterministic planning-object CLI support backed by markdown files with strict YAML frontmatter, and it updates the repo planning documents to use milestone-scoped planned-PR IDs throughout the roadmap and agent plan.

## What changed

### Planning object CLI

- add `splendor task create` and `splendor task list`
- add `splendor milestone create` and `splendor milestone list`
- add `splendor decision create`
- add `splendor question create`
- keep the interface deterministic and non-interactive

### Planning object storage

- store planning records as markdown under `planning/tasks/`, `planning/milestones/`, `planning/decisions/`, and `planning/questions/`
- validate planning frontmatter against the existing Pydantic schemas
- render a minimal deterministic markdown body with a title and `## Notes` section
- generate default IDs from titles using kind-prefixed kebab-case slugs
- reject duplicate IDs with a clear CLI error

### List behavior

- make `task list` and `milestone list` read markdown frontmatter from the planning directories
- ignore `.gitkeep`
- sort output deterministically by record ID
- support minimal filtering for task status / priority / milestone ref and milestone status
- fail fast when a planning record has invalid frontmatter, matching the strict behavior used elsewhere in the CLI

### Planning docs

- update `.agent-plan.md` to mark `M3-P1` as the active implemented slice and `M3-P2` as next
- update `README.md` to reflect that planning-object CLI support is now implemented
- update `docs/splendor_mvp_to_v1_roadmap.md` so remaining planned work is labeled with unique milestone-scoped PR IDs
- update `docs/source_resolution_refactor_plan.md` so it reads as completed implementation history rather than future rollout guidance

## Implementation notes

- add a dedicated planning command module for create/list behavior
- add shared planning utilities for slug generation, markdown rendering, frontmatter parsing, and per-kind path resolution
- reuse the repo's existing YAML/frontmatter style so planning files match the rest of the workspace

## Verification

- `PYTHONPATH=src pytest -q`
- `uv run ruff check .`

## Follow-up

`M3-P2` should add the initial query CLI surface, including `splendor query` and `splendor query --json`.
