### PR TITLE
Validate queued ingest payload paths

### DIFF
--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -12,6 +12,7 @@ from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord, SourceRecord
 from splendor.schemas.types import SummaryMode
+from splendor.state.paths import resolve_workspace_path
 from splendor.state.runtime import (
     load_queue_item,
     load_run_record,
@@ -254,7 +255,7 @@ def _validate_workspace_files(layout) -> None:
 
 
 def _load_source_for_queue(root: Path, queue_item: QueueItemRecord) -> tuple[Path, SourceRecord]:
-    manifest_path = root / queue_item.payload_ref
+    manifest_path = resolve_workspace_path(root, queue_item.payload_ref, context="Queue payload")
     if not manifest_path.exists():
         msg = f"Queue payload is missing source manifest: {manifest_path}"
         raise FileNotFoundError(msg)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -319,6 +319,50 @@ def test_enqueue_ingest_job_refreshes_created_at_when_reenqueuing_terminal_item(
     assert reenqueued_queue.attempt_count == first_queue.attempt_count
 
 
+def test_run_ingest_job_rejects_absolute_queue_payload_ref(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = load_queue_item(queue_path).model_copy(
+        update={"payload_ref": "/tmp/outside-manifest.json"}
+    )
+    queue_path.write_text(queue_record.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Queue payload path must be repo-relative"):
+        run_ingest_job(tmp_path, queue_path)
+
+    updated_queue = load_queue_item(queue_path)
+    assert updated_queue.status == "failed"
+    assert (
+        updated_queue.last_error
+        == "Queue payload path must be repo-relative: /tmp/outside-manifest.json"
+    )
+
+
+def test_run_ingest_job_rejects_escaping_queue_payload_ref(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = load_queue_item(queue_path).model_copy(
+        update={"payload_ref": "../outside-manifest.json"}
+    )
+    queue_path.write_text(queue_record.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Queue payload path escapes workspace root"):
+        run_ingest_job(tmp_path, queue_path)
+
+    updated_queue = load_queue_item(queue_path)
+    assert updated_queue.status == "failed"
+    assert (
+        updated_queue.last_error
+        == "Queue payload path escapes workspace root: ../outside-manifest.json"
+    )
+
+
 def test_run_ingest_job_claims_once_and_clears_lease_on_success(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"


### PR DESCRIPTION
## Summary
- reject queue payload manifest paths that are absolute or escape the workspace root
- reuse the existing workspace-path resolver when loading queued source manifests
- add regression tests for absolute and parent-escaping payload refs and assert failed queue state

## Context
This recovers a small but worthwhile hardening fix that was left behind on an older local branch after the queue-first ingest work. Current `main` still joins `root / queue_item.payload_ref` directly when loading a queued manifest, which means a malformed queue record can point outside the workspace before validation happens.

## Problem
`payload_ref` is intended to be a repo-relative reference into Splendor state. Without explicit path validation in the queue loading path, an absolute path or a `../`-escaping relative path can bypass that assumption and cause the ingest runner to inspect files outside the workspace boundary.

## Solution
The ingest queue loader now resolves `payload_ref` through `resolve_workspace_path(..., context="Queue payload")` before reading the manifest. That gives us the same repo-relative and no-escape guarantees already used in other source resolution paths.

## Testing
- `/opt/homebrew/bin/uv run pytest -q tests/test_ingest.py`

## Notes
This is intentionally scoped as a small hardening PR rather than a larger queue refactor.