### PR TITLE
M4-P1: add maintenance reporting commands

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,10 +3,10 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Last action taken: `M3-P3` landed locally; successful queries now persist `state/queries/last-query.json`, and `file-answer --from-last-query` files deterministic answer dossiers into `wiki/topics/` with optional question linkage.
-- Active planned PR: `M3-P3`
-- Next planned PR: `M4-P1`
-- Current blockers: none
+- Last action taken: `M4-P1` is implemented locally; `splendor lint` now checks workspace bootstrap/layout state, and both `lint` and `health` write timestamped JSON/Markdown reports under `reports/`.
+- Active planned PR: `M4-P1`
+- Next planned PR: `M4-P2`
+- Current blockers: publish the review-ready GitHub PR for `M4-P1` with intentional labels and a milestone before treating the slice as complete
 
 ## Active Task Breakdown
 
@@ -18,7 +18,9 @@
 - [x] Implement `M3-P1`: planning-object markdown storage plus create/list CLI support
 - [x] Implement `M3-P2`: query CLI plus `query --json`
 - [x] Implement `M3-P3`: optional file-answer workflow
-- [ ] Implement `M4-P1`: lint/health command framework and report writing
+- [x] Implement `M4-P1`: lint/health command framework and report writing
+- [ ] Publish a non-draft GitHub PR for `M4-P1` with a detailed description, labels, and a milestone
+- [ ] Implement `M4-P2`: wiki/planning/source integrity checks
 
 ## Context Pointers
 
@@ -32,7 +34,6 @@
 
 - `M3-P1` Planning-object create/list commands
 - `M3-P2` Query CLI plus `query --json`
-- `M4-P1` Lint/health command framework and report writing
 - `M4-P2` Wiki/planning/source integrity checks
 - `M4-P3` Queue/run integrity checks and repair diagnostics
 - `M5-P1` MVP docs, quickstart, and example workspace

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,10 +3,10 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Last action taken: `M4-P1` is implemented locally; `splendor lint` now checks workspace bootstrap/layout state, and both `lint` and `health` write timestamped JSON/Markdown reports under `reports/`.
+- Last action taken: `M4-P1` is implemented and published in PR `#21`; `splendor lint` now checks workspace bootstrap/layout state, and both `lint` and `health` write timestamped JSON/Markdown reports under `reports/`.
 - Active planned PR: `M4-P1`
 - Next planned PR: `M4-P2`
-- Current blockers: publish the review-ready GitHub PR for `M4-P1` with intentional labels and a milestone before treating the slice as complete
+- Current blockers: none
 
 ## Active Task Breakdown
 
@@ -19,7 +19,7 @@
 - [x] Implement `M3-P2`: query CLI plus `query --json`
 - [x] Implement `M3-P3`: optional file-answer workflow
 - [x] Implement `M4-P1`: lint/health command framework and report writing
-- [ ] Publish a non-draft GitHub PR for `M4-P1` with a detailed description, labels, and a milestone
+- [x] Publish a non-draft GitHub PR for `M4-P1` with a detailed description, labels, and a milestone
 - [ ] Implement `M4-P2`: wiki/planning/source integrity checks
 
 ## Context Pointers

--- a/.github/skills/feature-pr-finish/SKILL.md
+++ b/.github/skills/feature-pr-finish/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: "feature-pr-finish"
+description: "Treat feature work as complete only after a published, fully-metadata'd, non-draft PR exists on GitHub."
+---
+
+# Feature PR Finish
+
+Use this skill whenever a task produces a feature branch, bug-fix branch, or any other reviewable
+change set that should result in a pull request.
+
+## Completion rule
+
+Do not report the work as complete when code is only local. Completion requires all of the
+following:
+
+- the changes are committed on a descriptive branch
+- the branch is pushed to GitHub
+- a non-draft PR is open on GitHub
+- the PR body is detailed enough for handoff and review
+- the PR has intentional labels
+- the PR is assigned to a milestone
+
+## Required PR body sections
+
+- summary of the change
+- why the change was made
+- tests or checks run
+- follow-up notes or known limits when relevant
+
+## Required final verification
+
+Before reporting completion, verify:
+
+- the PR URL
+- the PR is open and not draft
+- the expected labels are present
+- the milestone is set
+
+If any of those are missing, the work is still in progress.

--- a/.github/skills/pr-publish-completion/SKILL.md
+++ b/.github/skills/pr-publish-completion/SKILL.md
@@ -18,6 +18,8 @@ Treat the work as incomplete until all of the following are true:
 - the pull request description is detailed and review-ready
 - the pull request has the appropriate labels
 - the pull request is assigned to a milestone
+- the PR URL and metadata have been verified after publication rather than assumed from a local
+  commit or push succeeding
 
 ## Publishing checklist
 
@@ -33,8 +35,10 @@ Treat the work as incomplete until all of the following are true:
 6. Apply or create the needed labels.
 7. Assign the PR to the correct milestone, creating one when the repository does not already have
    a suitable milestone.
+8. Verify the published PR URL, state, labels, and milestone before reporting completion.
 
 ## Notes
 
 - Do not stop at “code is written” or “commit exists”.
+- Do not stop at “tests pass locally” or “the branch is pushed”.
 - Do not leave a review-ready feature PR in draft unless the user explicitly asks for that state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,11 +23,14 @@
 - Cleanup or tooling branches may use `refactor/<topic>`.
 - Keep commits scoped to one logical change.
 - Do not rewrite history on shared branches unless explicitly requested.
-- Feature or PR work is not complete at local commit time. It only ends once the branch is pushed
-  and a non-draft GitHub PR with a detailed description is open.
+- Feature or PR work is not complete at local commit time, after local tests pass, or after the
+  branch is committed locally. It only ends once the branch is pushed and a non-draft GitHub PR
+  with a detailed description is open.
 - Published PRs should carry intentional GitHub metadata:
   apply the appropriate labels, assign the PR to a milestone, and avoid leaving review-ready work
   as draft unless the user explicitly asks for a draft.
+- When finishing feature or PR work, explicitly verify that the published PR exists on GitHub and
+  that its labels and milestone are set before treating the task as done.
 - When a PR implements work from a plan, update the versioned planning state in the same PR:
   `.agent-plan.md`, `README.md`, and any affected human-facing planning document in `docs/`.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ are implemented:
   maintained wiki and planning markdown
 - `splendor file-answer --from-last-query --title "..."` for filing the latest saved query result
   back into `wiki/topics/`
+- `splendor lint` and `splendor health --json` for deterministic maintenance checks with durable
+  timestamped reports under `reports/lint/` and `reports/health/`
 - Pydantic schema foundations for source, wiki, planning, queue, and run records
 - unit tests, linting, coverage, pre-commit, and GitHub Actions automation
 
@@ -87,6 +89,9 @@ uv run splendor file-answer --from-last-query --title "Query ranking answer"
 ### Run checks
 
 ```bash
+uv run splendor lint
+uv run splendor health
+uv run splendor health --json
 uv run ruff format --check .
 uv run ruff check .
 uv run pytest --cov=splendor --cov-report=term-missing --cov-report=xml
@@ -110,14 +115,20 @@ uv run pre-commit run --all-files
 - `src/splendor/commands/query.py` provides deterministic retrieval across `wiki/` and `planning/`
 - `src/splendor/commands/file_answer.py` files the latest saved query snapshot into `wiki/topics/`
   and can link an explicit question record
+- `src/splendor/commands/lint.py`, `src/splendor/commands/health.py`, and
+  `src/splendor/commands/maintenance.py` provide the first shared deterministic maintenance/reporting
+  layer and write timestamped JSON/Markdown reports under `reports/`
 - `src/splendor/schemas/` defines the initial schema contracts
 - `.github/workflows/` contains CI, PR context, autofix-trigger, and weekly repo-review workflows
 
 ## What comes next
 
-`M3-P3` is now implemented: successful queries persist `state/queries/last-query.json`, and
-`splendor file-answer --from-last-query --title "..."` files that deterministic result back into
-`wiki/topics/`, optionally linking an explicit question record.
+`M4-P1` is now implemented: `splendor lint` and `splendor health` share a deterministic maintenance
+framework, both commands can emit JSON to stdout, and every run files timestamped JSON/Markdown
+reports into `reports/lint/` or `reports/health/`.
+
+The next planned slice is `M4-P2`, which will add the first wiki/planning/source integrity checks on
+top of that maintenance framework.
 
 ## Additional documentation
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -6,16 +6,16 @@ import argparse
 import json
 from pathlib import Path
 
-import yaml
-
 from splendor.commands.add_source import add_source
 from splendor.commands.file_answer import (
     default_answer_page_id,
     file_answer_from_last_query,
 )
-from splendor.commands.health import run_health
+from splendor.commands.health import run_health_checks
 from splendor.commands.ingest import drain_pending_ingest_jobs, ingest_source
 from splendor.commands.init import initialize_workspace
+from splendor.commands.lint import run_lint_checks
+from splendor.commands.maintenance import execute_maintenance_command, render_report_json
 from splendor.commands.materialize_source import materialize_source
 from splendor.commands.planning import (
     create_decision,
@@ -102,7 +102,22 @@ def build_parser() -> argparse.ArgumentParser:
     )
     materialize_parser.set_defaults(handler=handle_materialize_source)
 
+    lint_parser = subparsers.add_parser("lint", help="Run deterministic maintenance checks")
+    lint_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    lint_parser.set_defaults(handler=handle_lint)
+
     health_parser = subparsers.add_parser("health", help="Validate source storage state")
+    health_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
     health_parser.set_defaults(handler=handle_health)
 
     query_parser = subparsers.add_parser("query", help="Query maintained wiki and planning records")
@@ -363,22 +378,45 @@ def handle_materialize_source(args: argparse.Namespace) -> int:
     return 0
 
 
-def handle_health(args: argparse.Namespace) -> int:
-    root = args.root.resolve()
-    try:
-        result = run_health(root)
-    except (ValueError, RuntimeError, OSError, yaml.YAMLError) as exc:
-        print(f"Error: {exc}")
-        return 1
-    print(f"Checked sources: {result.checked_sources}")
-    if not result.issues:
-        print("Health check passed")
-        return 0
+def _print_maintenance_stdout(command: str, report, *, json_output: bool) -> None:
+    if json_output:
+        print(render_report_json(report), end="")
+        return
 
-    print(f"Health check failed: {len(result.issues)} issue(s)")
-    for issue in result.issues:
-        print(f"- {issue.source_id}: {issue.message}")
-    return 1
+    if report.status == "error":
+        print(f"Error: {report.fatal_error}")
+        return
+
+    label = "sources" if command == "health" else "items"
+    print(f"Checked {label}: {report.checked_count}")
+    if report.status == "passed":
+        print(f"{command.title()} check passed")
+        return
+
+    print(f"{command.title()} check failed: {report.issue_count} issue(s)")
+    for issue in report.issues:
+        subject = issue.record_id or issue.path or issue.check_name or issue.code
+        print(f"- {subject}: {issue.message}")
+
+
+def handle_lint(args: argparse.Namespace) -> int:
+    result = execute_maintenance_command(
+        args.root.resolve(),
+        command="lint",
+        run_checks=run_lint_checks,
+    )
+    _print_maintenance_stdout("lint", result.report, json_output=args.json_output)
+    return result.exit_code
+
+
+def handle_health(args: argparse.Namespace) -> int:
+    result = execute_maintenance_command(
+        args.root.resolve(),
+        command="health",
+        run_checks=run_health_checks,
+    )
+    _print_maintenance_stdout("health", result.report, json_output=args.json_output)
+    return result.exit_code
 
 
 def handle_query(args: argparse.Namespace) -> int:

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -2,27 +2,14 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 
-from splendor.config import load_config
-from splendor.layout import resolve_layout
-from splendor.schemas import SourceRecord
+from splendor.commands.maintenance import MaintenanceCheckResult
+from splendor.layout import ResolvedLayout
+from splendor.schemas import MaintenanceIssue, SourceRecord
 from splendor.state.source_compat import effective_storage_mode
 from splendor.state.source_registry import load_source_record
 from splendor.state.source_resolver import resolve_source_content
-
-
-@dataclass(frozen=True)
-class HealthIssue:
-    source_id: str
-    message: str
-
-
-@dataclass(frozen=True)
-class HealthResult:
-    checked_sources: int
-    issues: list[HealthIssue]
 
 
 def _validate_storage_policy(source: SourceRecord) -> None:
@@ -43,10 +30,8 @@ def _validate_storage_policy(source: SourceRecord) -> None:
         raise ValueError("Copied source is missing path")
 
 
-def run_health(root: Path) -> HealthResult:
-    config = load_config(root)
-    layout = resolve_layout(root, config)
-    issues: list[HealthIssue] = []
+def run_health_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckResult:
+    issues: list[MaintenanceIssue] = []
     checked_sources = 0
 
     if not layout.source_records_dir.is_dir():
@@ -61,6 +46,14 @@ def run_health(root: Path) -> HealthResult:
             _validate_storage_policy(source)
             resolve_source_content(root, source, layout.raw_sources_dir)
         except Exception as exc:
-            issues.append(HealthIssue(source_id=source_id, message=str(exc)))
+            issues.append(
+                MaintenanceIssue(
+                    code="source-health-check-failed",
+                    message=str(exc),
+                    path=str(manifest_path),
+                    record_id=source_id,
+                    check_name="source-storage",
+                )
+            )
 
-    return HealthResult(checked_sources=checked_sources, issues=issues)
+    return MaintenanceCheckResult(checked_count=checked_sources, issues=issues)

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from splendor.commands.maintenance import MaintenanceCheckResult
+from splendor.commands.maintenance import MaintenanceCheckResult, workspace_relative_path
 from splendor.layout import ResolvedLayout
 from splendor.schemas import MaintenanceIssue, SourceRecord
 from splendor.state.source_compat import effective_storage_mode
@@ -50,7 +50,7 @@ def run_health_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckRes
                 MaintenanceIssue(
                     code="source-health-check-failed",
                     message=str(exc),
-                    path=str(manifest_path),
+                    path=workspace_relative_path(layout.root, manifest_path),
                     record_id=source_id,
                     check_name="source-storage",
                 )

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -1,0 +1,43 @@
+"""Implementation for `splendor lint`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from splendor.commands.maintenance import MaintenanceCheckResult
+from splendor.layout import ResolvedLayout, required_directories
+from splendor.schemas import MaintenanceIssue
+
+
+def run_lint_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckResult:
+    issues: list[MaintenanceIssue] = []
+    checked_count = 0
+
+    for directory in required_directories(layout):
+        checked_count += 1
+        if directory.is_dir():
+            continue
+        issues.append(
+            MaintenanceIssue(
+                code="missing-directory",
+                message="Required workspace directory is missing",
+                path=str(directory),
+                check_name="workspace-layout",
+            )
+        )
+
+    required_files = [layout.index_file, layout.log_file]
+    for path in required_files:
+        checked_count += 1
+        if path.is_file():
+            continue
+        issues.append(
+            MaintenanceIssue(
+                code="missing-file",
+                message="Required bootstrap file is missing",
+                path=str(path),
+                check_name="workspace-bootstrap",
+            )
+        )
+
+    return MaintenanceCheckResult(checked_count=checked_count, issues=issues)

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from splendor.commands.maintenance import MaintenanceCheckResult
+from splendor.commands.maintenance import MaintenanceCheckResult, workspace_relative_path
 from splendor.layout import ResolvedLayout, required_directories
 from splendor.schemas import MaintenanceIssue
 
@@ -21,7 +21,7 @@ def run_lint_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckResul
             MaintenanceIssue(
                 code="missing-directory",
                 message="Required workspace directory is missing",
-                path=str(directory),
+                path=workspace_relative_path(layout.root, directory),
                 check_name="workspace-layout",
             )
         )
@@ -35,7 +35,7 @@ def run_lint_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckResul
             MaintenanceIssue(
                 code="missing-file",
                 message="Required bootstrap file is missing",
-                path=str(path),
+                path=workspace_relative_path(layout.root, path),
                 check_name="workspace-bootstrap",
             )
         )

--- a/src/splendor/commands/maintenance.py
+++ b/src/splendor/commands/maintenance.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from splendor.config import default_config, load_config
 from splendor.layout import ResolvedLayout, resolve_layout
-from splendor.schemas import MaintenanceIssue, MaintenanceReport
+from splendor.schemas import MaintenanceCommand, MaintenanceIssue, MaintenanceReport
 from splendor.utils.fs import ensure_directory
 from splendor.utils.time import utc_now_iso
 
@@ -117,7 +117,7 @@ def write_report_artifacts(layout: ResolvedLayout, report: MaintenanceReport) ->
 def execute_maintenance_command(
     root: Path,
     *,
-    command: str,
+    command: MaintenanceCommand,
     run_checks: MaintenanceChecks,
 ) -> MaintenanceCommandResult:
     created_at = utc_now_iso()
@@ -155,8 +155,8 @@ def execute_maintenance_command(
             created_at=created_at,
             status="error",
             checked_count=report.checked_count,
-            issue_count=report.issue_count,
-            issues=report.issues,
+            issue_count=0,
+            issues=[],
             fatal_error=f"Failed to write report artifacts: {exc}",
         )
         return MaintenanceCommandResult(

--- a/src/splendor/commands/maintenance.py
+++ b/src/splendor/commands/maintenance.py
@@ -3,17 +3,16 @@
 from __future__ import annotations
 
 import json
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-import yaml
-
 from splendor.config import default_config, load_config
 from splendor.layout import ResolvedLayout, resolve_layout
 from splendor.schemas import MaintenanceIssue, MaintenanceReport
-from splendor.utils.fs import ensure_directory, write_text_atomic
+from splendor.utils.fs import ensure_directory
 from splendor.utils.time import utc_now_iso
 
 
@@ -74,13 +73,44 @@ def _report_basename(report_dir: Path) -> str:
     return candidate
 
 
+def workspace_relative_path(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
 def write_report_artifacts(layout: ResolvedLayout, report: MaintenanceReport) -> tuple[Path, Path]:
     report_dir = ensure_directory(layout.reports_dir / report.command)
     basename = _report_basename(report_dir)
     json_path = report_dir / f"{basename}.json"
     markdown_path = report_dir / f"{basename}.md"
-    write_text_atomic(json_path, render_report_json(report))
-    write_text_atomic(markdown_path, render_report_markdown(report))
+    json_content = render_report_json(report)
+    markdown_content = render_report_markdown(report)
+
+    temp_paths: list[Path] = []
+    committed_paths: list[Path] = []
+    try:
+        for destination, content in (
+            (json_path, json_content),
+            (markdown_path, markdown_content),
+        ):
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=destination.parent,
+                delete=False,
+            ) as handle:
+                handle.write(content)
+                temp_paths.append(Path(handle.name))
+
+        for temp_path, destination in zip(temp_paths, (json_path, markdown_path), strict=True):
+            temp_path.replace(destination)
+            committed_paths.append(destination)
+    except Exception:
+        for path in temp_paths:
+            path.unlink(missing_ok=True)
+        for path in committed_paths:
+            path.unlink(missing_ok=True)
+        raise
+
     return json_path, markdown_path
 
 
@@ -104,7 +134,7 @@ def execute_maintenance_command(
             issue_count=len(check_result.issues),
             issues=check_result.issues,
         )
-    except (ValueError, RuntimeError, OSError, yaml.YAMLError) as exc:
+    except Exception as exc:
         if layout is None:
             layout = resolve_layout(root, default_config(project_name=root.name))
         report = MaintenanceReport(

--- a/src/splendor/commands/maintenance.py
+++ b/src/splendor/commands/maintenance.py
@@ -1,0 +1,144 @@
+"""Shared maintenance command/reporting helpers."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+from splendor.config import default_config, load_config
+from splendor.layout import ResolvedLayout, resolve_layout
+from splendor.schemas import MaintenanceIssue, MaintenanceReport
+from splendor.utils.fs import ensure_directory, write_text_atomic
+from splendor.utils.time import utc_now_iso
+
+
+@dataclass(frozen=True)
+class MaintenanceCheckResult:
+    checked_count: int
+    issues: list[MaintenanceIssue]
+
+
+@dataclass(frozen=True)
+class MaintenanceCommandResult:
+    report: MaintenanceReport
+    exit_code: int
+    json_path: Path | None
+    markdown_path: Path | None
+
+
+MaintenanceChecks = Callable[[Path, ResolvedLayout], MaintenanceCheckResult]
+
+
+def render_report_json(report: MaintenanceReport) -> str:
+    return json.dumps(report.model_dump(mode="json"), indent=2, sort_keys=True) + "\n"
+
+
+def render_report_markdown(report: MaintenanceReport) -> str:
+    title = f"Splendor {report.command.title()} Report"
+    lines = [
+        f"# {title}",
+        "",
+        f"- Generated: `{report.created_at}`",
+        f"- Status: `{report.status}`",
+        f"- Checked: `{report.checked_count}`",
+        f"- Issues: `{report.issue_count}`",
+    ]
+    if report.fatal_error is not None:
+        lines.extend(["", "## Fatal Error", "", report.fatal_error])
+    if report.issues:
+        lines.extend(["", "## Issues", ""])
+        for issue in report.issues:
+            detail_parts = [f"[{issue.code}] {issue.message}"]
+            if issue.record_id:
+                detail_parts.append(f"record: `{issue.record_id}`")
+            if issue.path:
+                detail_parts.append(f"path: `{issue.path}`")
+            if issue.check_name:
+                detail_parts.append(f"check: `{issue.check_name}`")
+            lines.append(f"- {'; '.join(detail_parts)}")
+    return "\n".join(lines) + "\n"
+
+
+def _report_basename(report_dir: Path) -> str:
+    base = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    candidate = base
+    suffix = 1
+    while (report_dir / f"{candidate}.json").exists() or (report_dir / f"{candidate}.md").exists():
+        candidate = f"{base}-{suffix}"
+        suffix += 1
+    return candidate
+
+
+def write_report_artifacts(layout: ResolvedLayout, report: MaintenanceReport) -> tuple[Path, Path]:
+    report_dir = ensure_directory(layout.reports_dir / report.command)
+    basename = _report_basename(report_dir)
+    json_path = report_dir / f"{basename}.json"
+    markdown_path = report_dir / f"{basename}.md"
+    write_text_atomic(json_path, render_report_json(report))
+    write_text_atomic(markdown_path, render_report_markdown(report))
+    return json_path, markdown_path
+
+
+def execute_maintenance_command(
+    root: Path,
+    *,
+    command: str,
+    run_checks: MaintenanceChecks,
+) -> MaintenanceCommandResult:
+    created_at = utc_now_iso()
+    layout: ResolvedLayout | None = None
+    try:
+        config = load_config(root)
+        layout = resolve_layout(root, config)
+        check_result = run_checks(root, layout)
+        report = MaintenanceReport(
+            command=command,
+            created_at=created_at,
+            status="passed" if not check_result.issues else "failed",
+            checked_count=check_result.checked_count,
+            issue_count=len(check_result.issues),
+            issues=check_result.issues,
+        )
+    except (ValueError, RuntimeError, OSError, yaml.YAMLError) as exc:
+        if layout is None:
+            layout = resolve_layout(root, default_config(project_name=root.name))
+        report = MaintenanceReport(
+            command=command,
+            created_at=created_at,
+            status="error",
+            checked_count=0,
+            issue_count=0,
+            issues=[],
+            fatal_error=str(exc),
+        )
+
+    try:
+        json_path, markdown_path = write_report_artifacts(layout, report)
+    except OSError as exc:
+        report = MaintenanceReport(
+            command=command,
+            created_at=created_at,
+            status="error",
+            checked_count=report.checked_count,
+            issue_count=report.issue_count,
+            issues=report.issues,
+            fatal_error=f"Failed to write report artifacts: {exc}",
+        )
+        return MaintenanceCommandResult(
+            report=report,
+            exit_code=1,
+            json_path=None,
+            markdown_path=None,
+        )
+
+    return MaintenanceCommandResult(
+        report=report,
+        exit_code=0 if report.status == "passed" else 1,
+        json_path=json_path,
+        markdown_path=markdown_path,
+    )

--- a/src/splendor/schemas/__init__.py
+++ b/src/splendor/schemas/__init__.py
@@ -1,6 +1,6 @@
 """Schema exports."""
 
-from splendor.schemas.maintenance import MaintenanceIssue, MaintenanceReport
+from splendor.schemas.maintenance import MaintenanceCommand, MaintenanceIssue, MaintenanceReport
 from splendor.schemas.planning import (
     DecisionRecord,
     MilestoneRecord,
@@ -17,6 +17,7 @@ from splendor.schemas.wiki import KnowledgePageFrontmatter
 __all__ = [
     "DecisionRecord",
     "KnowledgePageFrontmatter",
+    "MaintenanceCommand",
     "MaintenanceIssue",
     "MaintenanceReport",
     "MilestoneRecord",

--- a/src/splendor/schemas/__init__.py
+++ b/src/splendor/schemas/__init__.py
@@ -1,5 +1,6 @@
 """Schema exports."""
 
+from splendor.schemas.maintenance import MaintenanceIssue, MaintenanceReport
 from splendor.schemas.planning import (
     DecisionRecord,
     MilestoneRecord,
@@ -16,6 +17,8 @@ from splendor.schemas.wiki import KnowledgePageFrontmatter
 __all__ = [
     "DecisionRecord",
     "KnowledgePageFrontmatter",
+    "MaintenanceIssue",
+    "MaintenanceReport",
     "MilestoneRecord",
     "QueryMatchSnapshot",
     "QuerySnapshot",

--- a/src/splendor/schemas/maintenance.py
+++ b/src/splendor/schemas/maintenance.py
@@ -1,0 +1,38 @@
+"""Schemas for deterministic maintenance reports."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from splendor.schemas.common import StrictRecord
+
+
+class MaintenanceIssue(StrictRecord):
+    kind: Literal["maintenance_issue"] = "maintenance_issue"
+    code: str
+    message: str
+    path: str | None = None
+    record_id: str | None = None
+    check_name: str | None = None
+
+
+class MaintenanceReport(StrictRecord):
+    kind: Literal["maintenance_report"] = "maintenance_report"
+    command: Literal["lint", "health"]
+    created_at: str
+    status: Literal["passed", "failed", "error"]
+    checked_count: int = Field(ge=0)
+    issue_count: int = Field(ge=0)
+    issues: list[MaintenanceIssue] = Field(default_factory=list)
+    fatal_error: str | None = None
+
+    @model_validator(mode="after")
+    def validate_counts(self) -> MaintenanceReport:
+        if self.issue_count != len(self.issues):
+            raise ValueError(
+                f"issue_count must equal the number of issues; got {self.issue_count} "
+                f"for {len(self.issues)} issues"
+            )
+        return self

--- a/src/splendor/schemas/maintenance.py
+++ b/src/splendor/schemas/maintenance.py
@@ -8,6 +8,8 @@ from pydantic import Field, model_validator
 
 from splendor.schemas.common import StrictRecord
 
+type MaintenanceCommand = Literal["lint", "health"]
+
 
 class MaintenanceIssue(StrictRecord):
     kind: Literal["maintenance_issue"] = "maintenance_issue"
@@ -20,7 +22,7 @@ class MaintenanceIssue(StrictRecord):
 
 class MaintenanceReport(StrictRecord):
     kind: Literal["maintenance_report"] = "maintenance_report"
-    command: Literal["lint", "health"]
+    command: MaintenanceCommand
     created_at: str
     status: Literal["passed", "failed", "error"]
     checked_count: int = Field(ge=0)

--- a/src/splendor/schemas/maintenance.py
+++ b/src/splendor/schemas/maintenance.py
@@ -35,4 +35,19 @@ class MaintenanceReport(StrictRecord):
                 f"issue_count must equal the number of issues; got {self.issue_count} "
                 f"for {len(self.issues)} issues"
             )
+        if self.status == "passed":
+            if self.issues or self.issue_count != 0:
+                raise ValueError("passed reports must not contain issues")
+            if self.fatal_error is not None:
+                raise ValueError("passed reports must not contain fatal_error")
+        elif self.status == "failed":
+            if not self.issues or self.issue_count == 0:
+                raise ValueError("failed reports must contain at least one issue")
+            if self.fatal_error is not None:
+                raise ValueError("failed reports must not contain fatal_error")
+        elif self.status == "error":
+            if self.fatal_error is None:
+                raise ValueError("error reports must contain fatal_error")
+            if self.issues or self.issue_count != 0:
+                raise ValueError("error reports must not contain issues")
         return self

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+import re
 import shutil
 from pathlib import Path
 
@@ -11,6 +12,15 @@ from splendor.commands.ingest import enqueue_ingest_job
 from splendor.schemas import KnowledgePageFrontmatter
 from splendor.state.query_snapshot import load_query_snapshot
 from splendor.state.runtime import load_queue_item
+
+
+def latest_report_paths(root: Path, command: str) -> tuple[Path, Path]:
+    report_dir = root / "reports" / command
+    json_reports = sorted(report_dir.glob("*.json"))
+    markdown_reports = sorted(report_dir.glob("*.md"))
+    assert json_reports, f"expected JSON reports in {report_dir}"
+    assert markdown_reports, f"expected Markdown reports in {report_dir}"
+    return json_reports[-1], markdown_reports[-1]
 
 
 def test_cli_init_command(tmp_path: Path, capsys) -> None:
@@ -371,6 +381,18 @@ def test_cli_health_command_passes_for_valid_sources(tmp_path: Path, capsys) -> 
     captured = capsys.readouterr()
     assert "Checked sources: 1" in captured.out
     assert "Health check passed" in captured.out
+    json_report, markdown_report = latest_report_paths(tmp_path, "health")
+    assert json_report.stem == markdown_report.stem
+    assert re.fullmatch(r"\d{8}T\d{6}Z(?:-\d+)?", json_report.stem)
+    payload = json.loads(json_report.read_text(encoding="utf-8"))
+    assert payload["command"] == "health"
+    assert payload["status"] == "passed"
+    assert payload["checked_count"] == 1
+    assert payload["issue_count"] == 0
+    markdown = markdown_report.read_text(encoding="utf-8")
+    assert "# Splendor Health Report" in markdown
+    assert "- Status: `passed`" in markdown
+    assert "- Issues: `0`" in markdown
 
 
 def test_cli_health_command_fails_for_invalid_sources(tmp_path: Path, capsys) -> None:
@@ -386,6 +408,15 @@ def test_cli_health_command_fails_for_invalid_sources(tmp_path: Path, capsys) ->
     assert exit_code == 1
     captured = capsys.readouterr()
     assert "Health check failed: 1 issue(s)" in captured.out
+    json_report, markdown_report = latest_report_paths(tmp_path, "health")
+    payload = json.loads(json_report.read_text(encoding="utf-8"))
+    assert payload["status"] == "failed"
+    assert payload["issue_count"] == 1
+    assert payload["issues"][0]["record_id"]
+    assert payload["issues"][0]["code"] == "source-health-check-failed"
+    markdown = markdown_report.read_text(encoding="utf-8")
+    assert "## Issues" in markdown
+    assert "[source-health-check-failed]" in markdown
 
 
 def test_cli_health_command_reports_top_level_errors(tmp_path: Path, capsys) -> None:
@@ -396,6 +427,11 @@ def test_cli_health_command_reports_top_level_errors(tmp_path: Path, capsys) -> 
     assert exit_code == 1
     captured = capsys.readouterr()
     assert captured.out.startswith("Error: ")
+    json_report, markdown_report = latest_report_paths(tmp_path, "health")
+    payload = json.loads(json_report.read_text(encoding="utf-8"))
+    assert payload["status"] == "error"
+    assert payload["fatal_error"]
+    assert "# Splendor Health Report" in markdown_report.read_text(encoding="utf-8")
 
 
 def test_cli_health_command_fails_when_source_manifest_dir_is_missing(
@@ -410,6 +446,82 @@ def test_cli_health_command_fails_when_source_manifest_dir_is_missing(
     assert exit_code == 1
     captured = capsys.readouterr()
     assert "Source manifest directory is missing or unreadable" in captured.out
+
+
+def test_cli_health_command_supports_json_output(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "health", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["command"] == "health"
+    assert payload["status"] == "passed"
+    assert payload["issue_count"] == 0
+
+
+def test_cli_lint_command_passes_for_initialized_workspace(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+
+    exit_code = main(["--root", str(tmp_path), "lint"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Checked items:" in captured.out
+    assert "Lint check passed" in captured.out
+    json_report, markdown_report = latest_report_paths(tmp_path, "lint")
+    payload = json.loads(json_report.read_text(encoding="utf-8"))
+    assert payload["command"] == "lint"
+    assert payload["status"] == "passed"
+    assert payload["issue_count"] == 0
+    assert "# Splendor Lint Report" in markdown_report.read_text(encoding="utf-8")
+
+
+def test_cli_lint_command_fails_when_required_directory_is_missing(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    shutil.rmtree(tmp_path / "planning" / "tasks")
+
+    exit_code = main(["--root", str(tmp_path), "lint"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Lint check failed: 1 issue(s)" in captured.out
+    assert "Required workspace directory is missing" in captured.out
+    payload = json.loads(latest_report_paths(tmp_path, "lint")[0].read_text(encoding="utf-8"))
+    assert payload["status"] == "failed"
+    assert payload["issues"][0]["code"] == "missing-directory"
+
+
+def test_cli_lint_command_fails_when_required_bootstrap_file_is_missing(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    (tmp_path / "wiki" / "index.md").unlink()
+
+    exit_code = main(["--root", str(tmp_path), "lint"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Required bootstrap file is missing" in captured.out
+    payload = json.loads(latest_report_paths(tmp_path, "lint")[0].read_text(encoding="utf-8"))
+    assert payload["issues"][0]["code"] == "missing-file"
+
+
+def test_cli_lint_command_supports_json_output(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "lint", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["command"] == "lint"
+    assert payload["status"] == "passed"
+    assert payload["issue_count"] == 0
 
 
 def write_queryable_wiki_page(path: Path, *, title: str, page_id: str, body: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -414,6 +414,7 @@ def test_cli_health_command_fails_for_invalid_sources(tmp_path: Path, capsys) ->
     assert payload["issue_count"] == 1
     assert payload["issues"][0]["record_id"]
     assert payload["issues"][0]["code"] == "source-health-check-failed"
+    assert payload["issues"][0]["path"].startswith("state/manifests/sources/")
     markdown = markdown_report.read_text(encoding="utf-8")
     assert "## Issues" in markdown
     assert "[source-health-check-failed]" in markdown
@@ -494,6 +495,7 @@ def test_cli_lint_command_fails_when_required_directory_is_missing(tmp_path: Pat
     payload = json.loads(latest_report_paths(tmp_path, "lint")[0].read_text(encoding="utf-8"))
     assert payload["status"] == "failed"
     assert payload["issues"][0]["code"] == "missing-directory"
+    assert payload["issues"][0]["path"] == "planning/tasks"
 
 
 def test_cli_lint_command_fails_when_required_bootstrap_file_is_missing(
@@ -509,6 +511,7 @@ def test_cli_lint_command_fails_when_required_bootstrap_file_is_missing(
     assert "Required bootstrap file is missing" in captured.out
     payload = json.loads(latest_report_paths(tmp_path, "lint")[0].read_text(encoding="utf-8"))
     assert payload["issues"][0]["code"] == "missing-file"
+    assert payload["issues"][0]["path"] == "wiki/index.md"
 
 
 def test_cli_lint_command_supports_json_output(tmp_path: Path, capsys) -> None:

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -72,6 +72,49 @@ def test_execute_maintenance_command_normalizes_unexpected_exceptions(tmp_path: 
     assert "unexpected crash" in payload["fatal_error"]
 
 
+def test_execute_maintenance_command_clears_issues_when_report_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    layout = resolve_layout(tmp_path, default_config(project_name=tmp_path.name))
+    for directory in (
+        layout.reports_dir,
+        layout.reports_dir / "lint",
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    def failing_checks(root: Path, resolved_layout) -> MaintenanceCheckResult:
+        return MaintenanceCheckResult(
+            checked_count=2,
+            issues=[
+                MaintenanceIssue(
+                    code="missing-directory",
+                    message="Required workspace directory is missing",
+                    path="planning/tasks",
+                )
+            ],
+        )
+
+    def boom(*args, **kwargs):
+        raise OSError("write failed")
+
+    monkeypatch.setattr("splendor.commands.maintenance.write_report_artifacts", boom)
+
+    result = execute_maintenance_command(
+        tmp_path,
+        command="lint",
+        run_checks=failing_checks,
+    )
+
+    assert result.exit_code == 1
+    assert result.report.status == "error"
+    assert result.report.checked_count == 2
+    assert result.report.issue_count == 0
+    assert result.report.issues == []
+    assert result.report.fatal_error == "Failed to write report artifacts: write failed"
+    assert result.json_path is None
+    assert result.markdown_path is None
+
+
 def test_maintenance_report_rejects_passed_report_with_issues() -> None:
     with pytest.raises(ValueError, match="passed reports must not contain issues"):
         MaintenanceReport(

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,113 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from splendor.commands.maintenance import (
+    MaintenanceCheckResult,
+    execute_maintenance_command,
+    write_report_artifacts,
+)
+from splendor.config import default_config
+from splendor.layout import resolve_layout
+from splendor.schemas import MaintenanceIssue, MaintenanceReport
+
+
+def test_write_report_artifacts_does_not_leave_dangling_json_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    layout = resolve_layout(tmp_path, default_config(project_name=tmp_path.name))
+    report_dir = layout.reports_dir / "lint"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report = MaintenanceReport(
+        command="lint",
+        created_at="2026-04-19T08:00:00+00:00",
+        status="passed",
+        checked_count=1,
+        issue_count=0,
+        issues=[],
+    )
+
+    original_replace = Path.replace
+    replace_calls = {"count": 0}
+
+    def flaky_replace(self: Path, target: Path) -> Path:
+        replace_calls["count"] += 1
+        if replace_calls["count"] == 2:
+            raise OSError("simulated markdown replace failure")
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", flaky_replace)
+
+    with pytest.raises(OSError, match="simulated markdown replace failure"):
+        write_report_artifacts(layout, report)
+
+    assert list(report_dir.glob("*.json")) == []
+    assert list(report_dir.glob("*.md")) == []
+
+
+def test_execute_maintenance_command_normalizes_unexpected_exceptions(tmp_path: Path) -> None:
+    layout = resolve_layout(tmp_path, default_config(project_name=tmp_path.name))
+    for directory in (
+        layout.reports_dir,
+        layout.reports_dir / "lint",
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    def boom(root: Path, resolved_layout) -> MaintenanceCheckResult:
+        raise KeyError("unexpected crash")
+
+    result = execute_maintenance_command(
+        tmp_path,
+        command="lint",
+        run_checks=boom,
+    )
+
+    assert result.exit_code == 1
+    assert result.report.status == "error"
+    assert "unexpected crash" in result.report.fatal_error
+    assert result.json_path is not None
+    payload = json.loads(result.json_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "error"
+    assert "unexpected crash" in payload["fatal_error"]
+
+
+def test_maintenance_report_rejects_passed_report_with_issues() -> None:
+    with pytest.raises(ValueError, match="passed reports must not contain issues"):
+        MaintenanceReport(
+            command="lint",
+            created_at="2026-04-19T08:00:00+00:00",
+            status="passed",
+            checked_count=1,
+            issue_count=1,
+            issues=[
+                MaintenanceIssue(
+                    code="bad",
+                    message="bad",
+                )
+            ],
+        )
+
+
+def test_maintenance_report_rejects_error_report_without_fatal_error() -> None:
+    with pytest.raises(ValueError, match="error reports must contain fatal_error"):
+        MaintenanceReport(
+            command="health",
+            created_at="2026-04-19T08:00:00+00:00",
+            status="error",
+            checked_count=0,
+            issue_count=0,
+            issues=[],
+        )
+
+
+def test_maintenance_report_rejects_failed_report_without_issues() -> None:
+    with pytest.raises(ValueError, match="failed reports must contain at least one issue"):
+        MaintenanceReport(
+            command="health",
+            created_at="2026-04-19T08:00:00+00:00",
+            status="failed",
+            checked_count=1,
+            issue_count=0,
+            issues=[],
+        )


### PR DESCRIPTION
## Summary

This PR implements `M4-P1`, the first Milestone 4 slice for Splendor.

It adds a shared deterministic maintenance/reporting framework, introduces `splendor lint`, refactors `splendor health` onto the same execution path, and writes timestamped JSON plus Markdown report artifacts under `reports/` for every run.

It also updates the repo’s agent instruction surface so feature or PR work is only considered complete after a properly published GitHub PR exists with a detailed description, labels, and a milestone.

## What Changed

### Shared maintenance/reporting framework

- add `MaintenanceIssue` and `MaintenanceReport` schemas for a stable internal report shape
- add `src/splendor/commands/maintenance.py` as the shared maintenance runner and report writer
- normalize successful runs, failing runs, and fatal pre-check errors into one report model
- write both machine-readable JSON and human-readable Markdown artifacts atomically per run
- store reports under:
  - `reports/lint/<timestamp>.json`
  - `reports/lint/<timestamp>.md`
  - `reports/health/<timestamp>.json`
  - `reports/health/<timestamp>.md`

### New `splendor lint` command

- add `splendor lint`
- add `splendor lint --json`
- keep this slice intentionally framework/bootstrap-focused rather than expanding into later integrity rules
- check only the baseline deterministic workspace state needed for Milestone 4 scaffolding:
  - required layout directories exist
  - required bootstrap files exist (`wiki/index.md` and `wiki/log.md`)
  - report directories already defined by the workspace layout are present

### Refactored `splendor health`

- keep the current source-storage validation logic for registered source manifests
- move `health` onto the new shared maintenance/reporting execution path
- add `splendor health --json`
- preserve existing exit-code semantics while making report artifacts durable and structured

### CLI output behavior

- human-readable stdout remains concise and deterministic by default
- `--json` now emits the machine-readable maintenance report to stdout
- fatal command setup errors still return exit code `1`, but now also produce an error-status report artifact when the report directory can be resolved

### Agent completion rules

This PR also updates the repo’s agent-facing instruction surface so “feature done” explicitly means “published PR done”, not just local implementation done.

Concretely:

- strengthen `AGENTS.md` to say feature work is incomplete until the branch is pushed and a non-draft PR with a detailed description, labels, and milestone is open on GitHub
- update `.agent-plan.md` to reflect that `M4-P1` remains incomplete until its PR is published, and to record the publication step explicitly
- strengthen `.github/skills/pr-publish-completion/SKILL.md`
- add `.github/skills/feature-pr-finish/SKILL.md` as a dedicated reusable skill for the publish-completion rule

### Docs / plan updates

- update `README.md` to document the new maintenance commands and timestamped report output
- move the “what comes next” note forward so `M4-P2` is explicitly next after this slice

## Tests and Validation

Added or extended coverage for:

- `splendor lint` succeeding on an initialized workspace
- `splendor lint` failing when required directories are missing
- `splendor lint` failing when required bootstrap files are missing
- `splendor health` continuing to pass for valid source state
- `splendor health` failing cleanly for invalid pointer/stored-source state
- timestamped report artifact creation for both commands
- JSON stdout mode for both maintenance commands
- report JSON and Markdown contents for passed, failed, and fatal-error runs

Validation run locally in the repo environment:

- `PYTHONPATH=src /Users/shaypalachy/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest`

Result:

- `205 passed`

## Scope Notes

This PR intentionally does **not** add the broader integrity checks reserved for later Milestone 4 slices.

Specifically, it does **not** yet implement:

- wiki internal-link validation
- planning/source reference integrity scans
- duplicate ID detection beyond current strict record parsing
- queue/run integrity and repair diagnostics

Those remain follow-on work for `M4-P2` and `M4-P3`.

## Follow-on

The next planned slice is `M4-P2`: wiki/planning/source integrity checks built on top of the shared maintenance framework added here.
