### PR TITLE
M4-P2: add content integrity lint checks

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,9 +3,9 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Last action taken: `M4-P1` is implemented and published in PR `#21`; `splendor lint` now checks workspace bootstrap/layout state, and both `lint` and `health` write timestamped JSON/Markdown reports under `reports/`.
-- Active planned PR: `M4-P1`
-- Next planned PR: `M4-P2`
+- Last action taken: `M4-P2` is implemented locally on `codex/m4-p2-integrity-checks`; `splendor lint` now inventories wiki/planning/source records non-fatally, validates cross-record references, checks local markdown links, and reports duplicate identifiers through the shared maintenance reporting layer.
+- Active planned PR: `M4-P2`
+- Next planned PR: `M4-P3`
 - Current blockers: none
 
 ## Active Task Breakdown
@@ -20,7 +20,8 @@
 - [x] Implement `M3-P3`: optional file-answer workflow
 - [x] Implement `M4-P1`: lint/health command framework and report writing
 - [x] Publish a non-draft GitHub PR for `M4-P1` with a detailed description, labels, and a milestone
-- [ ] Implement `M4-P2`: wiki/planning/source integrity checks
+- [x] Implement `M4-P2`: wiki/planning/source integrity checks
+- [ ] Publish a non-draft GitHub PR for `M4-P2` with a detailed description, labels, and a milestone
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -123,12 +123,13 @@ uv run pre-commit run --all-files
 
 ## What comes next
 
-`M4-P1` is now implemented: `splendor lint` and `splendor health` share a deterministic maintenance
-framework, both commands can emit JSON to stdout, and every run files timestamped JSON/Markdown
-reports into `reports/lint/` or `reports/health/`.
+`M4-P2` is now implemented: `splendor lint` still performs workspace bootstrap checks, and now also
+loads wiki pages, planning records, and source manifests non-fatally, validates cross-record
+references, flags broken local markdown links, and reports duplicate identifiers through the shared
+maintenance reporting framework.
 
-The next planned slice is `M4-P2`, which will add the first wiki/planning/source integrity checks on
-top of that maintenance framework.
+The next planned slice is `M4-P3`, which will extend deterministic maintenance into queue/run
+integrity checks and repair diagnostics.
 
 ## Additional documentation
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -263,6 +263,11 @@ Ship the first strong maintenance layer without overusing LLMs.
 - `M4-P2` Wiki/planning/source integrity checks
 - `M4-P3` Queue/run integrity checks and repair diagnostics
 
+### Milestone 4 status
+
+`M4-P1` and `M4-P2` are implemented. The next planned Milestone 4 PR is `M4-P3`, which adds
+queue/run integrity checks and repair-oriented diagnostics on top of the current maintenance layer.
+
 ---
 
 ## Milestone 5 — MVP release hardening

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -30,6 +30,7 @@ _PLANNING_MODELS = {
     "decision": DecisionRecord,
     "question": QuestionRecord,
 }
+_WHITESPACE_PATTERN = re.compile(r"\s+")
 
 
 @dataclass(frozen=True)
@@ -158,7 +159,7 @@ def _inventory_content_records(root: Path, layout: ResolvedLayout) -> _LintCheck
             issues.append(
                 MaintenanceIssue(
                     code="invalid-wiki-frontmatter",
-                    message=str(exc),
+                    message=_normalize_issue_exception(root, path, exc),
                     path=workspace_relative_path(root, path),
                     check_name="wiki-schema",
                 )
@@ -179,7 +180,7 @@ def _inventory_content_records(root: Path, layout: ResolvedLayout) -> _LintCheck
                 issues.append(
                     MaintenanceIssue(
                         code="invalid-planning-frontmatter",
-                        message=str(exc),
+                        message=_normalize_issue_exception(root, path, exc),
                         path=workspace_relative_path(root, path),
                         check_name="planning-schema",
                     )
@@ -202,7 +203,7 @@ def _inventory_content_records(root: Path, layout: ResolvedLayout) -> _LintCheck
                 issues.append(
                     MaintenanceIssue(
                         code="invalid-source-manifest",
-                        message=str(exc),
+                        message=_normalize_issue_exception(root, path, exc),
                         path=workspace_relative_path(root, path),
                         check_name="source-manifest",
                     )
@@ -604,7 +605,8 @@ def _linked_page_issues(
                 )
             )
             continue
-        page = wiki_by_path.get(linked_page)
+        normalized_linked_page = workspace_relative_path(root, resolved)
+        page = wiki_by_path.get(normalized_linked_page)
         if page is None or page.frontmatter is None:
             continue
         if source.source_id in page.frontmatter.source_refs:
@@ -613,14 +615,37 @@ def _linked_page_issues(
             MaintenanceIssue(
                 code="linked-page-source-mismatch",
                 message=(
-                    f"Linked wiki page does not include the source ID in source_refs: {linked_page}"
+                    "Linked wiki page does not include the source ID in source_refs: "
+                    f"{normalized_linked_page}"
                 ),
-                path=linked_page,
+                path=normalized_linked_page,
                 record_id=source.source_id,
                 check_name="reference-integrity",
             )
         )
     return issues
+
+
+def _normalize_issue_exception(root: Path, path: Path, exc: Exception) -> str:
+    message = str(exc).strip()
+    if not message:
+        return exc.__class__.__name__
+
+    absolute_path = str(path)
+    workspace_path = workspace_relative_path(root, path)
+    patterns = [
+        f"Wiki page {absolute_path} ",
+        f"Planning record {absolute_path} ",
+        f"{absolute_path} ",
+        absolute_path,
+    ]
+    for pattern in patterns:
+        if message.startswith(pattern):
+            message = message.removeprefix(pattern)
+            break
+
+    message = message.replace(absolute_path, workspace_path)
+    return _WHITESPACE_PATTERN.sub(" ", message).strip()
 
 
 def _markdown_link_issues(

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -592,9 +592,18 @@ def _linked_page_issues(
     for linked_page in source.linked_pages:
         try:
             resolved = resolve_workspace_path(root, linked_page, context="Linked page")
-        except ValueError:
-            resolved = None
-        if resolved is None or not resolved.is_file():
+        except ValueError as exc:
+            issues.append(
+                MaintenanceIssue(
+                    code="invalid-linked-page-ref",
+                    message=str(exc),
+                    path=workspace_relative_path(root, source_manifest.manifest_path),
+                    record_id=source.source_id,
+                    check_name="reference-integrity",
+                )
+            )
+            continue
+        if not resolved.is_file():
             issues.append(
                 MaintenanceIssue(
                     code="missing-linked-page",
@@ -678,8 +687,6 @@ def _resolve_local_markdown_target(root: Path, path: Path, target: str) -> Path 
     parsed = urlsplit(target)
     if parsed.scheme or parsed.netloc:
         return None
-    if parsed.path.startswith("mailto:"):
-        return None
     candidate_text = parsed.path
     if not candidate_text.endswith(".md"):
         return None
@@ -691,7 +698,7 @@ def _resolve_local_markdown_target(root: Path, path: Path, target: str) -> Path 
         resolved = candidate.resolve()
         resolved.relative_to(root.resolve())
         return resolved
-    except ValueError:
+    except (OSError, RuntimeError, ValueError):
         return None
 
 

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -2,14 +2,115 @@
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from splendor.commands.maintenance import MaintenanceCheckResult, workspace_relative_path
 from splendor.layout import ResolvedLayout, required_directories
-from splendor.schemas import MaintenanceIssue
+from splendor.schemas import (
+    DecisionRecord,
+    KnowledgePageFrontmatter,
+    MaintenanceIssue,
+    MilestoneRecord,
+    QuestionRecord,
+    SourceRecord,
+    TaskRecord,
+)
+from splendor.state.paths import resolve_workspace_path
+from splendor.state.source_registry import load_source_record
+from splendor.utils.planning import iter_planning_paths, parse_planning_document, planning_directory
+from splendor.utils.wiki import parse_wiki_markdown
+
+_MARKDOWN_LINK_PATTERN = re.compile(r"(?<!!)\[[^\]]+]\(([^)]+)\)")
+_PLANNING_MODELS = {
+    "task": TaskRecord,
+    "milestone": MilestoneRecord,
+    "decision": DecisionRecord,
+    "question": QuestionRecord,
+}
+
+
+@dataclass(frozen=True)
+class _WikiPageInventory:
+    path: Path
+    body: str | None
+    frontmatter: KnowledgePageFrontmatter | None
+
+    @property
+    def page_id(self) -> str | None:
+        if self.frontmatter is None:
+            return None
+        return self.frontmatter.page_id
+
+
+@dataclass(frozen=True)
+class _PlanningInventory:
+    kind: str
+    path: Path
+    body: str | None
+    record: TaskRecord | MilestoneRecord | DecisionRecord | QuestionRecord | None
+
+    @property
+    def record_id(self) -> str | None:
+        if self.record is None:
+            return None
+        field = {
+            "task": "task_id",
+            "milestone": "milestone_id",
+            "decision": "decision_id",
+            "question": "question_id",
+        }[self.kind]
+        return str(getattr(self.record, field))
+
+
+@dataclass(frozen=True)
+class _SourceInventory:
+    manifest_path: Path
+    record: SourceRecord | None
+
+    @property
+    def source_id(self) -> str | None:
+        if self.record is None:
+            return None
+        return self.record.source_id
+
+
+@dataclass(frozen=True)
+class _LintInventory:
+    wiki_pages: list[_WikiPageInventory]
+    planning_records: list[_PlanningInventory]
+    source_manifests: list[_SourceInventory]
 
 
 def run_lint_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckResult:
+    workspace_result = _run_workspace_checks(root, layout)
+    inventory_result = _inventory_content_records(root, layout)
+    reference_result = _run_reference_integrity_checks(root, layout, inventory_result)
+    return MaintenanceCheckResult(
+        checked_count=(
+            workspace_result.checked_count
+            + inventory_result.checked_count
+            + reference_result.checked_count
+        ),
+        issues=[*workspace_result.issues, *inventory_result.issues, *reference_result.issues],
+    )
+
+
+@dataclass(frozen=True)
+class _LintCheckContext:
+    inventory: _LintInventory
+
+
+@dataclass(frozen=True)
+class _LintCheckResult:
+    checked_count: int
+    issues: list[MaintenanceIssue]
+    context: _LintCheckContext | None = None
+
+
+def _run_workspace_checks(root: Path, layout: ResolvedLayout) -> _LintCheckResult:
     issues: list[MaintenanceIssue] = []
     checked_count = 0
 
@@ -26,8 +127,7 @@ def run_lint_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckResul
             )
         )
 
-    required_files = [layout.index_file, layout.log_file]
-    for path in required_files:
+    for path in (layout.index_file, layout.log_file):
         checked_count += 1
         if path.is_file():
             continue
@@ -40,4 +140,547 @@ def run_lint_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckResul
             )
         )
 
-    return MaintenanceCheckResult(checked_count=checked_count, issues=issues)
+    return _LintCheckResult(checked_count=checked_count, issues=issues)
+
+
+def _inventory_content_records(root: Path, layout: ResolvedLayout) -> _LintCheckResult:
+    checked_count = 0
+    issues: list[MaintenanceIssue] = []
+
+    wiki_pages: list[_WikiPageInventory] = []
+    for path in sorted(layout.wiki_dir.rglob("*.md")):
+        if path.name == ".gitkeep" or path in {layout.index_file, layout.log_file}:
+            continue
+        checked_count += 1
+        try:
+            parsed = parse_wiki_markdown(path)
+        except Exception as exc:
+            issues.append(
+                MaintenanceIssue(
+                    code="invalid-wiki-frontmatter",
+                    message=str(exc),
+                    path=workspace_relative_path(root, path),
+                    check_name="wiki-schema",
+                )
+            )
+            wiki_pages.append(_WikiPageInventory(path=path, body=None, frontmatter=None))
+            continue
+        wiki_pages.append(
+            _WikiPageInventory(path=path, body=parsed.body, frontmatter=parsed.frontmatter)
+        )
+
+    planning_records: list[_PlanningInventory] = []
+    for kind, model in _PLANNING_MODELS.items():
+        for path in iter_planning_paths(planning_directory(layout, kind)):
+            checked_count += 1
+            try:
+                parsed = parse_planning_document(path, model)
+            except Exception as exc:
+                issues.append(
+                    MaintenanceIssue(
+                        code="invalid-planning-frontmatter",
+                        message=str(exc),
+                        path=workspace_relative_path(root, path),
+                        check_name="planning-schema",
+                    )
+                )
+                planning_records.append(
+                    _PlanningInventory(kind=kind, path=path, body=None, record=None)
+                )
+                continue
+            planning_records.append(
+                _PlanningInventory(kind=kind, path=path, body=parsed.body, record=parsed.record)
+            )
+
+    source_manifests: list[_SourceInventory] = []
+    if layout.source_records_dir.is_dir():
+        for path in sorted(layout.source_records_dir.glob("*.json")):
+            checked_count += 1
+            try:
+                record = load_source_record(path)
+            except Exception as exc:
+                issues.append(
+                    MaintenanceIssue(
+                        code="invalid-source-manifest",
+                        message=str(exc),
+                        path=workspace_relative_path(root, path),
+                        check_name="source-manifest",
+                    )
+                )
+                source_manifests.append(_SourceInventory(manifest_path=path, record=None))
+                continue
+            source_manifests.append(_SourceInventory(manifest_path=path, record=record))
+
+    return _LintCheckResult(
+        checked_count=checked_count,
+        issues=issues,
+        context=_LintCheckContext(
+            inventory=_LintInventory(
+                wiki_pages=wiki_pages,
+                planning_records=planning_records,
+                source_manifests=source_manifests,
+            )
+        ),
+    )
+
+
+def _run_reference_integrity_checks(
+    root: Path, layout: ResolvedLayout, inventory_result: _LintCheckResult
+) -> _LintCheckResult:
+    if inventory_result.context is None:
+        return _LintCheckResult(checked_count=0, issues=[])
+
+    checked_count = 0
+    issues: list[MaintenanceIssue] = []
+    inventory = inventory_result.context.inventory
+
+    wiki_by_id: dict[str, list[_WikiPageInventory]] = {}
+    wiki_by_path: dict[str, _WikiPageInventory] = {}
+    for page in inventory.wiki_pages:
+        if page.frontmatter is None:
+            continue
+        wiki_by_id.setdefault(page.frontmatter.page_id, []).append(page)
+        wiki_by_path[workspace_relative_path(root, page.path)] = page
+
+    planning_by_kind: dict[str, dict[str, list[_PlanningInventory]]] = {
+        kind: {} for kind in _PLANNING_MODELS
+    }
+    for record in inventory.planning_records:
+        if record.record is None or record.record_id is None:
+            continue
+        planning_by_kind[record.kind].setdefault(record.record_id, []).append(record)
+
+    source_by_id: dict[str, list[_SourceInventory]] = {}
+    for manifest in inventory.source_manifests:
+        if manifest.record is None:
+            continue
+        source_by_id.setdefault(manifest.record.source_id, []).append(manifest)
+
+    for code, values in (
+        ("duplicate-page-id", wiki_by_id),
+        ("duplicate-source-id", source_by_id),
+    ):
+        checked_count += len(values)
+        issues.extend(_duplicate_id_issues(root, code, values))
+
+    for values in planning_by_kind.values():
+        checked_count += len(values)
+        issues.extend(_duplicate_id_issues(root, "duplicate-record-id", values))
+
+    valid_page_ids = set(wiki_by_id)
+    valid_source_ids = set(source_by_id)
+    valid_planning_ids = {kind: set(values) for kind, values in planning_by_kind.items()}
+
+    for page in inventory.wiki_pages:
+        if page.frontmatter is None:
+            continue
+        checked_count += len(page.frontmatter.source_refs)
+        issues.extend(
+            _missing_ref_issues(
+                refs=page.frontmatter.source_refs,
+                valid_refs=valid_source_ids,
+                code="missing-source-ref",
+                message_prefix="Wiki page references unknown source",
+                path=workspace_relative_path(root, page.path),
+                record_id=page.frontmatter.page_id,
+            )
+        )
+        checked_count += len(page.frontmatter.related_pages)
+        issues.extend(
+            _missing_ref_issues(
+                refs=page.frontmatter.related_pages,
+                valid_refs=valid_page_ids,
+                code="missing-page-ref",
+                message_prefix="Wiki page references unknown related page",
+                path=workspace_relative_path(root, page.path),
+                record_id=page.frontmatter.page_id,
+            )
+        )
+        page_link_count, page_link_issues = _markdown_link_issues(
+            root,
+            page.path,
+            page.body or "",
+            check_name="wiki-links",
+            record_id=page.frontmatter.page_id,
+        )
+        checked_count += page_link_count
+        issues.extend(page_link_issues)
+
+    for record in inventory.planning_records:
+        if record.record is None or record.record_id is None:
+            continue
+        checked_count += _planning_ref_count(record.record)
+        issues.extend(
+            _planning_ref_issues(root, layout, record, valid_planning_ids, valid_source_ids)
+        )
+        link_count, link_issues = _markdown_link_issues(
+            root,
+            record.path,
+            record.body or "",
+            check_name="planning-links",
+            record_id=record.record_id,
+        )
+        checked_count += link_count
+        issues.extend(link_issues)
+
+    for manifest in inventory.source_manifests:
+        if manifest.record is None:
+            continue
+        checked_count += len(manifest.record.linked_pages)
+        issues.extend(_linked_page_issues(root, manifest, wiki_by_path))
+
+    return _LintCheckResult(checked_count=checked_count, issues=issues)
+
+
+def _duplicate_id_issues(
+    root: Path,
+    code: str,
+    values: dict[str, list[_WikiPageInventory] | list[_PlanningInventory] | list[_SourceInventory]],
+) -> list[MaintenanceIssue]:
+    issues: list[MaintenanceIssue] = []
+    for record_id, records in sorted(values.items()):
+        if len(records) < 2:
+            continue
+        paths = sorted(_inventory_issue_path(root, record) for record in records)
+        issues.append(
+            MaintenanceIssue(
+                code=code,
+                message=f"Duplicate identifier {record_id!r} appears in: {', '.join(paths)}",
+                path=paths[0],
+                record_id=record_id,
+                check_name="reference-integrity",
+            )
+        )
+    return issues
+
+
+def _inventory_issue_path(
+    root: Path, record: _WikiPageInventory | _PlanningInventory | _SourceInventory
+) -> str:
+    path = (
+        record.path
+        if isinstance(record, _WikiPageInventory | _PlanningInventory)
+        else record.manifest_path
+    )
+    return workspace_relative_path(root, path)
+
+
+def _missing_ref_issues(
+    *,
+    refs: list[str],
+    valid_refs: set[str],
+    code: str,
+    message_prefix: str,
+    path: str,
+    record_id: str,
+) -> list[MaintenanceIssue]:
+    issues: list[MaintenanceIssue] = []
+    for ref in refs:
+        if ref in valid_refs:
+            continue
+        issues.append(
+            MaintenanceIssue(
+                code=code,
+                message=f"{message_prefix}: {ref}",
+                path=path,
+                record_id=record_id,
+                check_name="reference-integrity",
+            )
+        )
+    return issues
+
+
+def _planning_ref_count(
+    record: TaskRecord | MilestoneRecord | DecisionRecord | QuestionRecord,
+) -> int:
+    if isinstance(record, TaskRecord):
+        return (
+            len(record.milestone_refs)
+            + len(record.decision_refs)
+            + len(record.question_refs)
+            + len(record.depends_on)
+            + len(record.source_refs)
+        )
+    if isinstance(record, MilestoneRecord):
+        return len(record.task_refs) + len(record.decision_refs) + len(record.question_refs)
+    if isinstance(record, DecisionRecord):
+        return (
+            len(record.supersedes)
+            + len(record.source_refs)
+            + len(record.related_tasks)
+            + len(record.related_questions)
+        )
+    return (
+        len(record.source_refs)
+        + len(record.related_tasks)
+        + len(record.related_decisions)
+        + (1 if record.answer_page_ref is not None else 0)
+    )
+
+
+def _planning_ref_issues(
+    root: Path,
+    layout: ResolvedLayout,
+    record: _PlanningInventory,
+    valid_planning_ids: dict[str, set[str]],
+    valid_source_ids: set[str],
+) -> list[MaintenanceIssue]:
+    assert record.record is not None
+    assert record.record_id is not None
+    path = workspace_relative_path(root, record.path)
+
+    if isinstance(record.record, TaskRecord):
+        return [
+            *_missing_ref_issues(
+                refs=record.record.milestone_refs,
+                valid_refs=valid_planning_ids["milestone"],
+                code="missing-milestone-ref",
+                message_prefix="Task references unknown milestone",
+                path=path,
+                record_id=record.record_id,
+            ),
+            *_missing_ref_issues(
+                refs=record.record.decision_refs,
+                valid_refs=valid_planning_ids["decision"],
+                code="missing-decision-ref",
+                message_prefix="Task references unknown decision",
+                path=path,
+                record_id=record.record_id,
+            ),
+            *_missing_ref_issues(
+                refs=record.record.question_refs,
+                valid_refs=valid_planning_ids["question"],
+                code="missing-question-ref",
+                message_prefix="Task references unknown question",
+                path=path,
+                record_id=record.record_id,
+            ),
+            *_missing_ref_issues(
+                refs=record.record.depends_on,
+                valid_refs=valid_planning_ids["task"],
+                code="missing-task-ref",
+                message_prefix="Task depends on unknown task",
+                path=path,
+                record_id=record.record_id,
+            ),
+            *_missing_ref_issues(
+                refs=record.record.source_refs,
+                valid_refs=valid_source_ids,
+                code="missing-source-ref",
+                message_prefix="Task references unknown source",
+                path=path,
+                record_id=record.record_id,
+            ),
+        ]
+
+    if isinstance(record.record, MilestoneRecord):
+        return [
+            *_missing_ref_issues(
+                refs=record.record.task_refs,
+                valid_refs=valid_planning_ids["task"],
+                code="missing-task-ref",
+                message_prefix="Milestone references unknown task",
+                path=path,
+                record_id=record.record_id,
+            ),
+            *_missing_ref_issues(
+                refs=record.record.decision_refs,
+                valid_refs=valid_planning_ids["decision"],
+                code="missing-decision-ref",
+                message_prefix="Milestone references unknown decision",
+                path=path,
+                record_id=record.record_id,
+            ),
+            *_missing_ref_issues(
+                refs=record.record.question_refs,
+                valid_refs=valid_planning_ids["question"],
+                code="missing-question-ref",
+                message_prefix="Milestone references unknown question",
+                path=path,
+                record_id=record.record_id,
+            ),
+        ]
+
+    if isinstance(record.record, DecisionRecord):
+        return [
+            *_missing_ref_issues(
+                refs=record.record.supersedes,
+                valid_refs=valid_planning_ids["decision"],
+                code="missing-decision-ref",
+                message_prefix="Decision supersedes unknown decision",
+                path=path,
+                record_id=record.record_id,
+            ),
+            *_missing_ref_issues(
+                refs=record.record.source_refs,
+                valid_refs=valid_source_ids,
+                code="missing-source-ref",
+                message_prefix="Decision references unknown source",
+                path=path,
+                record_id=record.record_id,
+            ),
+            *_missing_ref_issues(
+                refs=record.record.related_tasks,
+                valid_refs=valid_planning_ids["task"],
+                code="missing-task-ref",
+                message_prefix="Decision references unknown task",
+                path=path,
+                record_id=record.record_id,
+            ),
+            *_missing_ref_issues(
+                refs=record.record.related_questions,
+                valid_refs=valid_planning_ids["question"],
+                code="missing-question-ref",
+                message_prefix="Decision references unknown question",
+                path=path,
+                record_id=record.record_id,
+            ),
+        ]
+
+    assert isinstance(record.record, QuestionRecord)
+    issues = [
+        *_missing_ref_issues(
+            refs=record.record.source_refs,
+            valid_refs=valid_source_ids,
+            code="missing-source-ref",
+            message_prefix="Question references unknown source",
+            path=path,
+            record_id=record.record_id,
+        ),
+        *_missing_ref_issues(
+            refs=record.record.related_tasks,
+            valid_refs=valid_planning_ids["task"],
+            code="missing-task-ref",
+            message_prefix="Question references unknown task",
+            path=path,
+            record_id=record.record_id,
+        ),
+        *_missing_ref_issues(
+            refs=record.record.related_decisions,
+            valid_refs=valid_planning_ids["decision"],
+            code="missing-decision-ref",
+            message_prefix="Question references unknown decision",
+            path=path,
+            record_id=record.record_id,
+        ),
+    ]
+    if record.record.answer_page_ref is not None and not _is_existing_wiki_markdown_path(
+        root, layout, record.record.answer_page_ref
+    ):
+        issues.append(
+            MaintenanceIssue(
+                code="missing-answer-page",
+                message=(
+                    "Question answer page ref does not point to an existing wiki markdown file: "
+                    f"{record.record.answer_page_ref}"
+                ),
+                path=path,
+                record_id=record.record_id,
+                check_name="reference-integrity",
+            )
+        )
+    return issues
+
+
+def _linked_page_issues(
+    root: Path, source_manifest: _SourceInventory, wiki_by_path: dict[str, _WikiPageInventory]
+) -> list[MaintenanceIssue]:
+    assert source_manifest.record is not None
+    source = source_manifest.record
+    issues: list[MaintenanceIssue] = []
+    for linked_page in source.linked_pages:
+        try:
+            resolved = resolve_workspace_path(root, linked_page, context="Linked page")
+        except ValueError:
+            resolved = None
+        if resolved is None or not resolved.is_file():
+            issues.append(
+                MaintenanceIssue(
+                    code="missing-linked-page",
+                    message=f"Source manifest references missing linked page: {linked_page}",
+                    path=workspace_relative_path(root, source_manifest.manifest_path),
+                    record_id=source.source_id,
+                    check_name="reference-integrity",
+                )
+            )
+            continue
+        page = wiki_by_path.get(linked_page)
+        if page is None or page.frontmatter is None:
+            continue
+        if source.source_id in page.frontmatter.source_refs:
+            continue
+        issues.append(
+            MaintenanceIssue(
+                code="linked-page-source-mismatch",
+                message=(
+                    f"Linked wiki page does not include the source ID in source_refs: {linked_page}"
+                ),
+                path=linked_page,
+                record_id=source.source_id,
+                check_name="reference-integrity",
+            )
+        )
+    return issues
+
+
+def _markdown_link_issues(
+    root: Path, path: Path, body: str, *, check_name: str, record_id: str
+) -> tuple[int, list[MaintenanceIssue]]:
+    checked_count = 0
+    issues: list[MaintenanceIssue] = []
+    for target in _MARKDOWN_LINK_PATTERN.findall(body):
+        resolved = _resolve_local_markdown_target(root, path, target.strip())
+        if resolved is None:
+            continue
+        checked_count += 1
+        if resolved.is_file():
+            continue
+        issues.append(
+            MaintenanceIssue(
+                code="broken-markdown-link",
+                message=f"Markdown link target does not exist: {target}",
+                path=workspace_relative_path(root, path),
+                record_id=record_id,
+                check_name=check_name,
+            )
+        )
+    return checked_count, issues
+
+
+def _resolve_local_markdown_target(root: Path, path: Path, target: str) -> Path | None:
+    if not target or target.startswith("#"):
+        return None
+    parsed = urlsplit(target)
+    if parsed.scheme or parsed.netloc:
+        return None
+    if parsed.path.startswith("mailto:"):
+        return None
+    candidate_text = parsed.path
+    if not candidate_text.endswith(".md"):
+        return None
+    if candidate_text.startswith("/"):
+        candidate = root / candidate_text.lstrip("/")
+    else:
+        candidate = path.parent / candidate_text
+    try:
+        resolved = candidate.resolve()
+        resolved.relative_to(root.resolve())
+        return resolved
+    except ValueError:
+        return None
+
+
+def _is_existing_wiki_markdown_path(
+    root: Path, layout: ResolvedLayout, answer_page_ref: str
+) -> bool:
+    try:
+        path = resolve_workspace_path(root, answer_page_ref, context="Answer page")
+    except ValueError:
+        return False
+    if path.suffix != ".md" or not path.is_file():
+        return False
+    try:
+        path.relative_to(layout.wiki_dir.resolve())
+    except ValueError:
+        return False
+    return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -527,6 +527,27 @@ def test_cli_lint_command_supports_json_output(tmp_path: Path, capsys) -> None:
     assert payload["issue_count"] == 0
 
 
+def test_cli_lint_command_reports_dirty_workspace_issues_in_json_output(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    capsys.readouterr()
+    bad_page = tmp_path / "wiki" / "concepts" / "bad.md"
+    bad_page.write_text("---\nkind: concept\nbogus: true\n---\n", encoding="utf-8")
+
+    exit_code = main(["--root", str(tmp_path), "lint", "--json"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["command"] == "lint"
+    assert payload["status"] == "failed"
+    assert payload["issue_count"] == 1
+    assert payload["issues"][0]["code"] == "invalid-wiki-frontmatter"
+    json_report, markdown_report = latest_report_paths(tmp_path, "lint")
+    assert json.loads(json_report.read_text(encoding="utf-8"))["status"] == "failed"
+    assert "invalid-wiki-frontmatter" in markdown_report.read_text(encoding="utf-8")
+
+
 def write_queryable_wiki_page(path: Path, *, title: str, page_id: str, body: str) -> None:
     frontmatter = KnowledgePageFrontmatter(
         kind="concept",

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,0 +1,253 @@
+import json
+from pathlib import Path
+
+import yaml
+
+from splendor.commands.add_source import add_source
+from splendor.commands.init import initialize_workspace
+from splendor.commands.lint import run_lint_checks
+from splendor.commands.planning import create_task
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import KnowledgePageFrontmatter, QuestionRecord, TaskRecord
+from splendor.state.source_registry import load_source_record, write_source_record
+
+
+def _run_lint(root: Path):
+    layout = resolve_layout(root, load_config(root))
+    return run_lint_checks(root, layout)
+
+
+def _write_wiki_page(
+    path: Path,
+    *,
+    title: str,
+    page_id: str,
+    body: str = "",
+    source_refs: list[str] | None = None,
+    related_pages: list[str] | None = None,
+) -> None:
+    frontmatter = KnowledgePageFrontmatter(
+        kind="concept",
+        title=title,
+        page_id=page_id,
+        status="active",
+        confidence=0.8,
+        source_refs=source_refs or [],
+        related_pages=related_pages or [],
+    )
+    frontmatter_text = yaml.safe_dump(frontmatter.model_dump(mode="json"), sort_keys=False).strip()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\n{frontmatter_text}\n---\n\n{body}", encoding="utf-8")
+
+
+def _write_planning_record(path: Path, record: TaskRecord | QuestionRecord, body: str = "") -> None:
+    frontmatter_text = yaml.safe_dump(record.model_dump(mode="json"), sort_keys=False).strip()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\n{frontmatter_text}\n---\n\n{body}", encoding="utf-8")
+
+
+def test_run_lint_checks_returns_no_issues_for_initialized_workspace(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    result = _run_lint(tmp_path)
+
+    assert result.issues == []
+
+
+def test_run_lint_checks_reports_invalid_wiki_frontmatter_without_fatal_error(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    bad_page = tmp_path / "wiki" / "concepts" / "bad.md"
+    bad_page.write_text("---\nkind: concept\nbogus: true\n---\n", encoding="utf-8")
+
+    result = _run_lint(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["invalid-wiki-frontmatter"]
+
+
+def test_run_lint_checks_reports_invalid_planning_frontmatter_without_fatal_error(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    bad_task = tmp_path / "planning" / "tasks" / "task-bad.md"
+    bad_task.write_text("---\nkind: task\nbogus: true\n---\n", encoding="utf-8")
+
+    result = _run_lint(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["invalid-planning-frontmatter"]
+
+
+def test_run_lint_checks_reports_invalid_source_manifest(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    manifest_path = tmp_path / "state" / "manifests" / "sources" / "bad.json"
+    manifest_path.write_text("{bad json}\n", encoding="utf-8")
+
+    result = _run_lint(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["invalid-source-manifest"]
+
+
+def test_run_lint_checks_reports_missing_wiki_refs_and_related_pages(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _write_wiki_page(
+        tmp_path / "wiki" / "concepts" / "refs.md",
+        title="Missing refs",
+        page_id="concept-missing-refs",
+        source_refs=["src-missing"],
+        related_pages=["concept-nowhere"],
+    )
+
+    result = _run_lint(tmp_path)
+
+    assert {issue.code for issue in result.issues} == {"missing-page-ref", "missing-source-ref"}
+
+
+def test_run_lint_checks_reports_missing_planning_refs_and_answer_page(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    create_task(
+        tmp_path,
+        "Broken task",
+        record_id="task-broken",
+        status="todo",
+        priority="medium",
+        owner=None,
+        milestone_refs=["milestone-missing"],
+        decision_refs=["decision-missing"],
+        question_refs=["question-missing"],
+        depends_on=["task-missing"],
+        source_refs=["src-missing"],
+    )
+    question = QuestionRecord(
+        question_id="question-broken",
+        title="Broken question",
+        status="answered",
+        created_at="2026-04-19T00:00:00+00:00",
+        updated_at="2026-04-19T00:00:00+00:00",
+        answer_page_ref="wiki/topics/answer-missing.md",
+        source_refs=["src-missing"],
+        related_tasks=["task-missing"],
+        related_decisions=["decision-missing"],
+    )
+    _write_planning_record(
+        tmp_path / "planning" / "questions" / "question-broken.md",
+        question,
+        body="Broken refs.\n",
+    )
+
+    result = _run_lint(tmp_path)
+
+    assert {
+        issue.code
+        for issue in result.issues
+        if issue.record_id in {"task-broken", "question-broken"}
+    } == {
+        "missing-answer-page",
+        "missing-decision-ref",
+        "missing-milestone-ref",
+        "missing-question-ref",
+        "missing-source-ref",
+        "missing-task-ref",
+    }
+
+
+def test_run_lint_checks_reports_missing_linked_pages_and_source_ref_mismatch(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("hello\n", encoding="utf-8")
+    add_source(tmp_path, source_path)
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source_record = load_source_record(manifest_path)
+    linked_page = tmp_path / "wiki" / "sources" / f"{source_record.source_id}.md"
+    _write_wiki_page(
+        linked_page,
+        title="Source summary",
+        page_id=f"concept-{source_record.source_id}",
+        source_refs=[],
+    )
+    updated_record = source_record.model_copy(
+        update={
+            "linked_pages": [
+                linked_page.relative_to(tmp_path).as_posix(),
+                "wiki/sources/missing.md",
+            ]
+        }
+    )
+    write_source_record(manifest_path, updated_record)
+
+    result = _run_lint(tmp_path)
+
+    assert {issue.code for issue in result.issues} == {
+        "linked-page-source-mismatch",
+        "missing-linked-page",
+    }
+
+
+def test_run_lint_checks_reports_duplicate_ids_once_per_duplicate_value(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _write_wiki_page(
+        tmp_path / "wiki" / "concepts" / "one.md",
+        title="One",
+        page_id="concept-dup",
+    )
+    _write_wiki_page(
+        tmp_path / "wiki" / "topics" / "two.md",
+        title="Two",
+        page_id="concept-dup",
+    )
+    task_record = TaskRecord(
+        task_id="task-dup",
+        title="Duplicate task",
+        status="todo",
+        priority="medium",
+        milestone_refs=[],
+        decision_refs=[],
+        question_refs=[],
+        owner=None,
+        created_at="2026-04-19T00:00:00+00:00",
+        updated_at="2026-04-19T00:00:00+00:00",
+        depends_on=[],
+        source_refs=[],
+    )
+    _write_planning_record(tmp_path / "planning" / "tasks" / "task-dup-a.md", task_record)
+    _write_planning_record(tmp_path / "planning" / "tasks" / "task-dup-b.md", task_record)
+    source_path = tmp_path / "source.md"
+    source_path.write_text("source\n", encoding="utf-8")
+    add_source(tmp_path, source_path)
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source_record = load_source_record(manifest_path)
+    duplicate_manifest = tmp_path / "state" / "manifests" / "sources" / "duplicate.json"
+    duplicate_manifest.write_text(
+        json.dumps(source_record.model_dump(mode="json"), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_lint(tmp_path)
+
+    assert [issue.code for issue in result.issues].count("duplicate-page-id") == 1
+    assert [issue.code for issue in result.issues].count("duplicate-record-id") == 1
+    assert [issue.code for issue in result.issues].count("duplicate-source-id") == 1
+
+
+def test_run_lint_checks_reports_broken_markdown_links_and_ignores_external_links(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    _write_wiki_page(
+        tmp_path / "wiki" / "concepts" / "links.md",
+        title="Links",
+        page_id="concept-links",
+        body=(
+            "[broken](missing.md)\n"
+            "[external](https://example.com/x.md)\n"
+            "[fragment](#section)\n"
+            "[mail](mailto:test@example.com)\n"
+        ),
+    )
+
+    result = _run_lint(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["broken-markdown-link"]

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -65,6 +65,9 @@ def test_run_lint_checks_reports_invalid_wiki_frontmatter_without_fatal_error(
     result = _run_lint(tmp_path)
 
     assert [issue.code for issue in result.issues] == ["invalid-wiki-frontmatter"]
+    assert result.issues[0].path == "wiki/concepts/bad.md"
+    assert "\n" not in result.issues[0].message
+    assert str(tmp_path) not in result.issues[0].message
 
 
 def test_run_lint_checks_reports_invalid_planning_frontmatter_without_fatal_error(
@@ -77,6 +80,9 @@ def test_run_lint_checks_reports_invalid_planning_frontmatter_without_fatal_erro
     result = _run_lint(tmp_path)
 
     assert [issue.code for issue in result.issues] == ["invalid-planning-frontmatter"]
+    assert result.issues[0].path == "planning/tasks/task-bad.md"
+    assert "\n" not in result.issues[0].message
+    assert str(tmp_path) not in result.issues[0].message
 
 
 def test_run_lint_checks_reports_invalid_source_manifest(tmp_path: Path) -> None:
@@ -87,6 +93,8 @@ def test_run_lint_checks_reports_invalid_source_manifest(tmp_path: Path) -> None
     result = _run_lint(tmp_path)
 
     assert [issue.code for issue in result.issues] == ["invalid-source-manifest"]
+    assert "\n" not in result.issues[0].message
+    assert str(tmp_path) not in result.issues[0].message
 
 
 def test_run_lint_checks_reports_missing_wiki_refs_and_related_pages(tmp_path: Path) -> None:
@@ -171,7 +179,7 @@ def test_run_lint_checks_reports_missing_linked_pages_and_source_ref_mismatch(
     updated_record = source_record.model_copy(
         update={
             "linked_pages": [
-                linked_page.relative_to(tmp_path).as_posix(),
+                f"./{linked_page.relative_to(tmp_path).as_posix()}",
                 "wiki/sources/missing.md",
             ]
         }
@@ -184,6 +192,10 @@ def test_run_lint_checks_reports_missing_linked_pages_and_source_ref_mismatch(
         "linked-page-source-mismatch",
         "missing-linked-page",
     }
+    mismatch_issue = next(
+        issue for issue in result.issues if issue.code == "linked-page-source-mismatch"
+    )
+    assert mismatch_issue.path == linked_page.relative_to(tmp_path).as_posix()
 
 
 def test_run_lint_checks_reports_duplicate_ids_once_per_duplicate_value(tmp_path: Path) -> None:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import pytest
 import yaml
 
 from splendor.commands.add_source import add_source
@@ -196,6 +197,52 @@ def test_run_lint_checks_reports_missing_linked_pages_and_source_ref_mismatch(
         issue for issue in result.issues if issue.code == "linked-page-source-mismatch"
     )
     assert mismatch_issue.path == linked_page.relative_to(tmp_path).as_posix()
+
+
+def test_run_lint_checks_reports_invalid_linked_page_refs_separately(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("hello\n", encoding="utf-8")
+    add_source(tmp_path, source_path)
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source_record = load_source_record(manifest_path)
+    updated_record = source_record.model_copy(
+        update={"linked_pages": ["../outside.md", "/tmp/absolute.md"]}
+    )
+    write_source_record(manifest_path, updated_record)
+
+    result = _run_lint(tmp_path)
+
+    assert {issue.code for issue in result.issues} == {"invalid-linked-page-ref"}
+    assert len(result.issues) == 2
+    assert all(
+        issue.path == manifest_path.relative_to(tmp_path).as_posix() for issue in result.issues
+    )
+
+
+def test_run_lint_checks_ignores_markdown_target_resolution_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    initialize_workspace(tmp_path)
+    _write_wiki_page(
+        tmp_path / "wiki" / "concepts" / "links.md",
+        title="Links",
+        page_id="concept-links",
+        body="[loop](loop.md)\n",
+    )
+
+    original_resolve = Path.resolve
+
+    def bad_resolve(self: Path, *args, **kwargs):
+        if self.name == "loop.md":
+            raise RuntimeError("symlink loop")
+        return original_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", bad_resolve)
+
+    result = _run_lint(tmp_path)
+
+    assert result.issues == []
 
 
 def test_run_lint_checks_reports_duplicate_ids_once_per_duplicate_value(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- extend `splendor lint` from bootstrap/layout checks into a full content integrity pass
- inventory wiki pages, planning records, and source manifests non-fatally so invalid records become report issues instead of fatal command errors
- validate cross-record references, local markdown links, linked source pages, and duplicate identifiers

## Why
Milestone 4 called for the first deterministic wiki/planning/source integrity checks on top of the shared maintenance reporting framework introduced in `M4-P1`. This PR delivers that slice while keeping `splendor health` focused on source storage/materialization.

## Impact
- `splendor lint` now catches invalid wiki/planning/source records without aborting the whole run
- deterministic maintenance reports now include missing source/page/task/milestone/decision/question refs, broken local markdown links, linked-page/source mismatches, and duplicate IDs
- planning state and README/roadmap status are updated so the next slice is `M4-P3`

## Validation
- `.venv/bin/ruff check .`
- `.venv/bin/pytest`

## Follow-up
- `M4-P3` will add queue/run integrity checks and repair-oriented diagnostics
