### PR TITLE
M4-P3: add queue and run health diagnostics

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,9 +3,9 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Last action taken: `M4-P2` is implemented locally on `codex/m4-p2-integrity-checks`; `splendor lint` now inventories wiki/planning/source records non-fatally, validates cross-record references, checks local markdown links, and reports duplicate identifiers through the shared maintenance reporting layer.
-- Active planned PR: `M4-P2`
-- Next planned PR: `M4-P3`
+- Last action taken: `M4-P3` is implemented; `splendor health` now validates source storage, inventories queue/run records non-fatally, flags malformed runtime state, expired leases, unfinished runs, payload mismatches, and source-to-last-run inconsistencies through the shared maintenance reporting layer.
+- Active planned PR: `M5-P1`
+- Next planned PR: `M5-P2`
 - Current blockers: none
 
 ## Active Task Breakdown
@@ -21,7 +21,10 @@
 - [x] Implement `M4-P1`: lint/health command framework and report writing
 - [x] Publish a non-draft GitHub PR for `M4-P1` with a detailed description, labels, and a milestone
 - [x] Implement `M4-P2`: wiki/planning/source integrity checks
-- [ ] Publish a non-draft GitHub PR for `M4-P2` with a detailed description, labels, and a milestone
+- [x] Publish a non-draft GitHub PR for `M4-P2` with a detailed description, labels, and a milestone
+- [x] Implement `M4-P3`: queue/run integrity checks and repair diagnostics
+- [x] Publish a non-draft GitHub PR for `M4-P3` with a detailed description, labels, and a milestone
+- [ ] Implement `M5-P1`: MVP docs, quickstart, and example workspace
 
 ## Context Pointers
 
@@ -33,10 +36,6 @@
 
 ## Planned PR Queue
 
-- `M3-P1` Planning-object create/list commands
-- `M3-P2` Query CLI plus `query --json`
-- `M4-P2` Wiki/planning/source integrity checks
-- `M4-P3` Queue/run integrity checks and repair diagnostics
 - `M5-P1` MVP docs, quickstart, and example workspace
 - `M5-P2` MVP hardening: coverage, errors, packaging, polish
 - `M6-P1` Review-state and provenance model expansion

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ are implemented:
   maintained wiki and planning markdown
 - `splendor file-answer --from-last-query --title "..."` for filing the latest saved query result
   back into `wiki/topics/`
-- `splendor lint` and `splendor health --json` for deterministic maintenance checks with durable
-  timestamped reports under `reports/lint/` and `reports/health/`
+- `splendor lint`, `splendor health`, and JSON report output for deterministic maintenance checks
+  across source, queue, and run state with durable timestamped reports under `reports/lint/` and
+  `reports/health/`
 - Pydantic schema foundations for source, wiki, planning, queue, and run records
 - unit tests, linting, coverage, pre-commit, and GitHub Actions automation
 
@@ -116,20 +117,21 @@ uv run pre-commit run --all-files
 - `src/splendor/commands/file_answer.py` files the latest saved query snapshot into `wiki/topics/`
   and can link an explicit question record
 - `src/splendor/commands/lint.py`, `src/splendor/commands/health.py`, and
-  `src/splendor/commands/maintenance.py` provide the first shared deterministic maintenance/reporting
-  layer and write timestamped JSON/Markdown reports under `reports/`
+  `src/splendor/commands/maintenance.py` provide the shared deterministic maintenance/reporting
+  layer for content integrity, source storage, and queue/run diagnostics, and write timestamped
+  JSON/Markdown reports under `reports/`
 - `src/splendor/schemas/` defines the initial schema contracts
 - `.github/workflows/` contains CI, PR context, autofix-trigger, and weekly repo-review workflows
 
 ## What comes next
 
-`M4-P2` is now implemented: `splendor lint` still performs workspace bootstrap checks, and now also
-loads wiki pages, planning records, and source manifests non-fatally, validates cross-record
-references, flags broken local markdown links, and reports duplicate identifiers through the shared
-maintenance reporting framework.
+`M4-P3` is now implemented: `splendor health` still validates source storage/materialization, and
+now also inventories queue items and run records non-fatally, flags malformed runtime records,
+expired leases, unfinished runs, queue payload mismatches, and source-to-last-run inconsistencies
+through the shared maintenance reporting framework.
 
-The next planned slice is `M4-P3`, which will extend deterministic maintenance into queue/run
-integrity checks and repair diagnostics.
+The next planned slice is `M5-P1`, which will focus on MVP docs, quickstart flow, and an example
+workspace.
 
 ## Additional documentation
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -265,8 +265,12 @@ Ship the first strong maintenance layer without overusing LLMs.
 
 ### Milestone 4 status
 
-`M4-P1` and `M4-P2` are implemented. The next planned Milestone 4 PR is `M4-P3`, which adds
-queue/run integrity checks and repair-oriented diagnostics on top of the current maintenance layer.
+`M4-P1`, `M4-P2`, and `M4-P3` are implemented. Milestone 4 now covers bootstrap linting,
+wiki/planning/source integrity checks, and queue/run repair diagnostics through the shared
+maintenance reporting layer.
+
+The next planned PR is `M5-P1`, which moves into MVP docs, quickstart flow, and an example
+workspace.
 
 ---
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -387,7 +387,7 @@ def _print_maintenance_stdout(command: str, report, *, json_output: bool) -> Non
         print(f"Error: {report.fatal_error}")
         return
 
-    label = "sources" if command == "health" else "items"
+    label = "records" if command == "health" else "items"
     print(f"Checked {label}: {report.checked_count}")
     if report.status == "passed":
         print(f"{command.title()} check passed")

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -60,17 +60,36 @@ def _append_issue(
 
 
 def _parse_timestamp(value: str, *, context: str) -> datetime:
+    normalized_value = f"{value[:-1]}+00:00" if value.endswith("Z") else value
     try:
-        return datetime.fromisoformat(value)
+        parsed = datetime.fromisoformat(normalized_value)
     except ValueError as exc:
         msg = f"{context} is not a valid ISO timestamp: {value!r}"
         raise ValueError(msg) from exc
+    if parsed.tzinfo is None:
+        msg = f"{context} must include a timezone offset: {value!r}"
+        raise ValueError(msg)
+    return parsed.astimezone(UTC)
 
 
-def _require_runtime_directory(path: Path, *, label: str) -> None:
+def _check_runtime_directory(
+    *,
+    root: Path,
+    path: Path,
+    label: str,
+    issues: list[MaintenanceIssue],
+    check_name: str,
+) -> bool:
     if not path.is_dir():
-        msg = f"{label} directory is missing or unreadable: {path}"
-        raise RuntimeError(msg)
+        _append_issue(
+            issues,
+            code="missing-directory",
+            message=f"{label} directory is missing or unreadable",
+            path=workspace_relative_path(root, path),
+            check_name=check_name,
+        )
+        return False
+    return True
 
 
 def _load_source_records(
@@ -78,8 +97,8 @@ def _load_source_records(
     *,
     root: Path,
     issues: list[MaintenanceIssue],
-) -> tuple[dict[str, SourceRecord], set[str], int]:
-    records: dict[str, SourceRecord] = {}
+) -> tuple[dict[str, tuple[Path, SourceRecord]], set[str], int]:
+    records: dict[str, tuple[Path, SourceRecord]] = {}
     invalid_ids: set[str] = set()
     checked_count = 0
 
@@ -102,7 +121,7 @@ def _load_source_records(
                 check_name="source-storage",
             )
             continue
-        records[source_id] = source
+        records[source_id] = (manifest_path, source)
 
     return records, invalid_ids, checked_count
 
@@ -176,7 +195,8 @@ def _validate_queue_record(
     root: Path,
     queue_path: Path,
     queue_record: QueueItemRecord,
-    source_records: dict[str, SourceRecord],
+    layout: ResolvedLayout,
+    source_records: dict[str, tuple[Path, SourceRecord]],
     invalid_source_ids: set[str],
     now: datetime,
     issues: list[MaintenanceIssue],
@@ -323,8 +343,8 @@ def _validate_queue_record(
     if expected_source_id in invalid_source_ids:
         return
 
-    source_record = source_records.get(expected_source_id)
-    if source_record is None:
+    source_entry = source_records.get(expected_source_id)
+    if source_entry is None:
         _append_issue(
             issues,
             code="missing-queue-source-record",
@@ -337,6 +357,7 @@ def _validate_queue_record(
             check_name="queue-payload",
         )
         return
+    canonical_manifest_path, _ = source_entry
 
     try:
         payload_source = load_source_record(manifest_path)
@@ -363,11 +384,9 @@ def _validate_queue_record(
             record_id=queue_record.job_id,
             check_name="queue-payload",
         )
-    if manifest_path.name != f"{source_record.source_id}.json":
-        canonical_manifest_relpath = workspace_relative_path(
-            root,
-            root / "state" / "manifests" / "sources" / f"{source_record.source_id}.json",
-        )
+    canonical_manifest_relpath = workspace_relative_path(root, canonical_manifest_path)
+    payload_manifest_relpath = workspace_relative_path(root, manifest_path)
+    if payload_manifest_relpath != canonical_manifest_relpath:
         _append_issue(
             issues,
             code="queue-payload-path-mismatch",
@@ -480,14 +499,15 @@ def _validate_run_record(
 
 def _validate_source_runtime_state(
     *,
-    root: Path,
-    source_records: dict[str, SourceRecord],
+    layout: ResolvedLayout,
+    source_records: dict[str, tuple[Path, SourceRecord]],
     run_records: dict[str, tuple[Path, RunRecord]],
     invalid_run_ids: set[str],
     issues: list[MaintenanceIssue],
 ) -> None:
-    for source_id, source_record in source_records.items():
-        manifest_relpath = f"state/manifests/sources/{source_id}.json"
+    for source_id, source_entry in source_records.items():
+        manifest_path, source_record = source_entry
+        manifest_relpath = workspace_relative_path(layout.root, manifest_path)
 
         if source_record.status == "registered":
             if source_record.last_run_id is not None:
@@ -589,32 +609,65 @@ def run_health_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckRes
     checked_count = 0
     now = datetime.now(UTC)
 
-    _require_runtime_directory(layout.source_records_dir, label="Source manifest")
-    _require_runtime_directory(layout.queue_dir, label="Queue")
-    _require_runtime_directory(layout.runs_dir, label="Run")
+    if _check_runtime_directory(
+        root=root,
+        path=layout.source_records_dir,
+        label="Source manifest",
+        issues=issues,
+        check_name="workspace-layout",
+    ):
+        source_records, invalid_source_ids, loaded_sources = _load_source_records(
+            layout,
+            root=root,
+            issues=issues,
+        )
+        checked_count += loaded_sources
+    else:
+        source_records = {}
+        invalid_source_ids = set()
+        checked_count += 1
 
-    source_records, invalid_source_ids, loaded_sources = _load_source_records(
-        layout,
+    if _check_runtime_directory(
         root=root,
+        path=layout.queue_dir,
+        label="Queue",
         issues=issues,
-    )
-    queue_records, _, loaded_queues = _load_queue_records(
-        layout,
+        check_name="workspace-layout",
+    ):
+        queue_records, _, loaded_queues = _load_queue_records(
+            layout,
+            root=root,
+            issues=issues,
+        )
+        checked_count += loaded_queues
+    else:
+        queue_records = {}
+        checked_count += 1
+
+    if _check_runtime_directory(
         root=root,
+        path=layout.runs_dir,
+        label="Run",
         issues=issues,
-    )
-    run_records, invalid_run_ids, loaded_runs = _load_run_records(
-        layout,
-        root=root,
-        issues=issues,
-    )
-    checked_count += loaded_sources + loaded_queues + loaded_runs
+        check_name="workspace-layout",
+    ):
+        run_records, invalid_run_ids, loaded_runs = _load_run_records(
+            layout,
+            root=root,
+            issues=issues,
+        )
+        checked_count += loaded_runs
+    else:
+        run_records = {}
+        invalid_run_ids = set()
+        checked_count += 1
 
     for queue_path, queue_record in queue_records.values():
         _validate_queue_record(
             root=root,
             queue_path=queue_path,
             queue_record=queue_record,
+            layout=layout,
             source_records=source_records,
             invalid_source_ids=invalid_source_ids,
             now=now,
@@ -630,7 +683,7 @@ def run_health_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckRes
         )
 
     _validate_source_runtime_state(
-        root=root,
+        layout=layout,
         source_records=source_records,
         run_records=run_records,
         invalid_run_ids=invalid_run_ids,

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -2,14 +2,23 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 from splendor.commands.maintenance import MaintenanceCheckResult, workspace_relative_path
 from splendor.layout import ResolvedLayout
-from splendor.schemas import MaintenanceIssue, SourceRecord
+from splendor.schemas import MaintenanceIssue, QueueItemRecord, RunRecord, SourceRecord
+from splendor.state.paths import resolve_workspace_path
+from splendor.state.runtime import load_queue_item, load_run_record
 from splendor.state.source_compat import effective_storage_mode
 from splendor.state.source_registry import load_source_record
 from splendor.state.source_resolver import resolve_source_content
+
+
+def _source_id_from_job_id(job_id: str) -> str:
+    if job_id.startswith("ingest-"):
+        return job_id.removeprefix("ingest-")
+    return job_id
 
 
 def _validate_storage_policy(source: SourceRecord) -> None:
@@ -30,30 +39,602 @@ def _validate_storage_policy(source: SourceRecord) -> None:
         raise ValueError("Copied source is missing path")
 
 
-def run_health_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckResult:
-    issues: list[MaintenanceIssue] = []
-    checked_sources = 0
+def _append_issue(
+    issues: list[MaintenanceIssue],
+    *,
+    code: str,
+    message: str,
+    path: str,
+    record_id: str | None = None,
+    check_name: str,
+) -> None:
+    issues.append(
+        MaintenanceIssue(
+            code=code,
+            message=message,
+            path=path,
+            record_id=record_id,
+            check_name=check_name,
+        )
+    )
 
-    if not layout.source_records_dir.is_dir():
-        msg = f"Source manifest directory is missing or unreadable: {layout.source_records_dir}"
+
+def _parse_timestamp(value: str, *, context: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:
+        msg = f"{context} is not a valid ISO timestamp: {value!r}"
+        raise ValueError(msg) from exc
+
+
+def _require_runtime_directory(path: Path, *, label: str) -> None:
+    if not path.is_dir():
+        msg = f"{label} directory is missing or unreadable: {path}"
         raise RuntimeError(msg)
 
+
+def _load_source_records(
+    layout: ResolvedLayout,
+    *,
+    root: Path,
+    issues: list[MaintenanceIssue],
+) -> tuple[dict[str, SourceRecord], set[str], int]:
+    records: dict[str, SourceRecord] = {}
+    invalid_ids: set[str] = set()
+    checked_count = 0
+
     for manifest_path in sorted(layout.source_records_dir.glob("*.json")):
-        checked_sources += 1
+        checked_count += 1
         source_id = manifest_path.stem
+        manifest_relpath = workspace_relative_path(root, manifest_path)
         try:
             source = load_source_record(manifest_path)
             _validate_storage_policy(source)
             resolve_source_content(root, source, layout.raw_sources_dir)
         except Exception as exc:
-            issues.append(
-                MaintenanceIssue(
-                    code="source-health-check-failed",
-                    message=str(exc),
-                    path=workspace_relative_path(layout.root, manifest_path),
-                    record_id=source_id,
-                    check_name="source-storage",
+            invalid_ids.add(source_id)
+            _append_issue(
+                issues,
+                code="source-health-check-failed",
+                message=str(exc),
+                path=manifest_relpath,
+                record_id=source_id,
+                check_name="source-storage",
+            )
+            continue
+        records[source_id] = source
+
+    return records, invalid_ids, checked_count
+
+
+def _load_queue_records(
+    layout: ResolvedLayout,
+    *,
+    root: Path,
+    issues: list[MaintenanceIssue],
+) -> tuple[dict[str, tuple[Path, QueueItemRecord]], set[str], int]:
+    records: dict[str, tuple[Path, QueueItemRecord]] = {}
+    invalid_ids: set[str] = set()
+    checked_count = 0
+
+    for queue_path in sorted(layout.queue_dir.glob("*.json")):
+        checked_count += 1
+        queue_id = queue_path.stem
+        queue_relpath = workspace_relative_path(root, queue_path)
+        try:
+            queue_record = load_queue_item(queue_path)
+        except Exception as exc:
+            invalid_ids.add(queue_id)
+            _append_issue(
+                issues,
+                code="invalid-queue-record",
+                message=str(exc),
+                path=queue_relpath,
+                record_id=queue_id,
+                check_name="queue-record",
+            )
+            continue
+        records[queue_id] = (queue_path, queue_record)
+
+    return records, invalid_ids, checked_count
+
+
+def _load_run_records(
+    layout: ResolvedLayout,
+    *,
+    root: Path,
+    issues: list[MaintenanceIssue],
+) -> tuple[dict[str, tuple[Path, RunRecord]], set[str], int]:
+    records: dict[str, tuple[Path, RunRecord]] = {}
+    invalid_ids: set[str] = set()
+    checked_count = 0
+
+    for run_path in sorted(layout.runs_dir.glob("*.json")):
+        checked_count += 1
+        run_id = run_path.stem
+        run_relpath = workspace_relative_path(root, run_path)
+        try:
+            run_record = load_run_record(run_path)
+        except Exception as exc:
+            invalid_ids.add(run_id)
+            _append_issue(
+                issues,
+                code="invalid-run-record",
+                message=str(exc),
+                path=run_relpath,
+                record_id=run_id,
+                check_name="run-record",
+            )
+            continue
+        records[run_id] = (run_path, run_record)
+
+    return records, invalid_ids, checked_count
+
+
+def _validate_queue_record(
+    *,
+    root: Path,
+    queue_path: Path,
+    queue_record: QueueItemRecord,
+    source_records: dict[str, SourceRecord],
+    invalid_source_ids: set[str],
+    now: datetime,
+    issues: list[MaintenanceIssue],
+) -> None:
+    queue_relpath = workspace_relative_path(root, queue_path)
+
+    if queue_record.job_id != queue_path.stem:
+        _append_issue(
+            issues,
+            code="queue-job-id-mismatch",
+            message=(
+                f"Queue filename expects job_id={queue_path.stem!r}, "
+                f"but record stores {queue_record.job_id!r}"
+            ),
+            path=queue_relpath,
+            record_id=queue_record.job_id,
+            check_name="queue-record",
+        )
+
+    if queue_record.job_type != "ingest_source":
+        _append_issue(
+            issues,
+            code="unsupported-queue-job-type",
+            message=f"Unsupported queue job type for current runtime: {queue_record.job_type!r}",
+            path=queue_relpath,
+            record_id=queue_record.job_id,
+            check_name="queue-record",
+        )
+        return
+
+    if queue_record.status == "leased":
+        if not queue_record.lease_owner or not queue_record.lease_expires_at:
+            _append_issue(
+                issues,
+                code="invalid-queue-lease-state",
+                message=(
+                    "Leased queue items must include both lease_owner and lease_expires_at so "
+                    "operators can decide whether to reclaim them."
+                ),
+                path=queue_relpath,
+                record_id=queue_record.job_id,
+                check_name="queue-state",
+            )
+        else:
+            try:
+                expires_at = _parse_timestamp(
+                    queue_record.lease_expires_at,
+                    context="Queue lease expiry",
                 )
+            except ValueError as exc:
+                _append_issue(
+                    issues,
+                    code="invalid-queue-lease-expiry",
+                    message=str(exc),
+                    path=queue_relpath,
+                    record_id=queue_record.job_id,
+                    check_name="queue-state",
+                )
+            else:
+                if expires_at <= now:
+                    _append_issue(
+                        issues,
+                        code="expired-queue-lease",
+                        message=(
+                            "Queue item still claims a lease past its expiry; repair by "
+                            "reclaiming or resetting the job."
+                        ),
+                        path=queue_relpath,
+                        record_id=queue_record.job_id,
+                        check_name="queue-state",
+                    )
+    elif queue_record.lease_owner is not None or queue_record.lease_expires_at is not None:
+        _append_issue(
+            issues,
+            code="invalid-queue-lease-state",
+            message="Only leased queue items may carry lease_owner or lease_expires_at values.",
+            path=queue_relpath,
+            record_id=queue_record.job_id,
+            check_name="queue-state",
+        )
+
+    if queue_record.status == "failed":
+        if not queue_record.last_error:
+            _append_issue(
+                issues,
+                code="invalid-queue-error-state",
+                message="Failed queue items should persist last_error for repair diagnostics.",
+                path=queue_relpath,
+                record_id=queue_record.job_id,
+                check_name="queue-state",
+            )
+    elif queue_record.last_error is not None:
+        _append_issue(
+            issues,
+            code="invalid-queue-error-state",
+            message="Only failed queue items should persist last_error details.",
+            path=queue_relpath,
+            record_id=queue_record.job_id,
+            check_name="queue-state",
+        )
+
+    if queue_record.attempt_count > queue_record.max_attempts:
+        _append_issue(
+            issues,
+            code="queue-attempt-count-exceeded",
+            message=(
+                f"attempt_count={queue_record.attempt_count} exceeds "
+                f"max_attempts={queue_record.max_attempts}"
+            ),
+            path=queue_relpath,
+            record_id=queue_record.job_id,
+            check_name="queue-state",
+        )
+
+    try:
+        manifest_path = resolve_workspace_path(
+            root,
+            queue_record.payload_ref,
+            context="Queue payload",
+        )
+    except ValueError as exc:
+        _append_issue(
+            issues,
+            code="invalid-queue-payload-ref",
+            message=str(exc),
+            path=queue_relpath,
+            record_id=queue_record.job_id,
+            check_name="queue-payload",
+        )
+        return
+
+    if not manifest_path.exists():
+        _append_issue(
+            issues,
+            code="missing-queue-payload",
+            message=f"Queue payload is missing source manifest: {queue_record.payload_ref}",
+            path=queue_relpath,
+            record_id=queue_record.job_id,
+            check_name="queue-payload",
+        )
+        return
+
+    expected_source_id = _source_id_from_job_id(queue_record.job_id)
+    if expected_source_id in invalid_source_ids:
+        return
+
+    source_record = source_records.get(expected_source_id)
+    if source_record is None:
+        _append_issue(
+            issues,
+            code="missing-queue-source-record",
+            message=(
+                f"Queue job expects source manifest for {expected_source_id!r}, "
+                "but no valid source record was loaded."
+            ),
+            path=queue_relpath,
+            record_id=queue_record.job_id,
+            check_name="queue-payload",
+        )
+        return
+
+    try:
+        payload_source = load_source_record(manifest_path)
+    except Exception as exc:
+        _append_issue(
+            issues,
+            code="invalid-queue-payload-manifest",
+            message=str(exc),
+            path=queue_relpath,
+            record_id=queue_record.job_id,
+            check_name="queue-payload",
+        )
+        return
+
+    if payload_source.source_id != expected_source_id:
+        _append_issue(
+            issues,
+            code="queue-payload-source-mismatch",
+            message=(
+                f"Queue payload resolves to source_id={payload_source.source_id!r}, "
+                f"but job_id expects {expected_source_id!r}"
+            ),
+            path=queue_relpath,
+            record_id=queue_record.job_id,
+            check_name="queue-payload",
+        )
+    if manifest_path.name != f"{source_record.source_id}.json":
+        canonical_manifest_relpath = workspace_relative_path(
+            root,
+            root / "state" / "manifests" / "sources" / f"{source_record.source_id}.json",
+        )
+        _append_issue(
+            issues,
+            code="queue-payload-path-mismatch",
+            message=(
+                f"Queue payload points to {queue_record.payload_ref!r}, but the canonical "
+                f"manifest path for this source is {canonical_manifest_relpath!r}"
+            ),
+            path=queue_relpath,
+            record_id=queue_record.job_id,
+            check_name="queue-payload",
+        )
+
+
+def _validate_run_record(
+    *,
+    root: Path,
+    run_path: Path,
+    run_record: RunRecord,
+    issues: list[MaintenanceIssue],
+) -> None:
+    run_relpath = workspace_relative_path(root, run_path)
+
+    if run_record.run_id != run_path.stem:
+        _append_issue(
+            issues,
+            code="run-id-mismatch",
+            message=(
+                f"Run filename expects run_id={run_path.stem!r}, "
+                f"but record stores {run_record.run_id!r}"
+            ),
+            path=run_relpath,
+            record_id=run_record.run_id,
+            check_name="run-record",
+        )
+
+    if run_record.job_type != "ingest_source":
+        _append_issue(
+            issues,
+            code="unsupported-run-job-type",
+            message=f"Unsupported run job type for current runtime: {run_record.job_type!r}",
+            path=run_relpath,
+            record_id=run_record.run_id,
+            check_name="run-record",
+        )
+        return
+
+    if run_record.status == "running":
+        if run_record.finished_at is not None:
+            _append_issue(
+                issues,
+                code="invalid-run-finish-state",
+                message="Running runs must not set finished_at before completion.",
+                path=run_relpath,
+                record_id=run_record.run_id,
+                check_name="run-state",
+            )
+        _append_issue(
+            issues,
+            code="unfinished-run",
+            message=(
+                "Run is still marked running; repair by confirming the worker finished and then "
+                "marking the run terminal or retrying the queue item."
+            ),
+            path=run_relpath,
+            record_id=run_record.run_id,
+            check_name="run-state",
+        )
+    elif run_record.finished_at is None:
+        _append_issue(
+            issues,
+            code="invalid-run-finish-state",
+            message="Terminal runs must set finished_at for auditability and repair decisions.",
+            path=run_relpath,
+            record_id=run_record.run_id,
+            check_name="run-state",
+        )
+
+    if run_record.status == "succeeded" and run_record.errors:
+        _append_issue(
+            issues,
+            code="invalid-run-error-state",
+            message="Succeeded runs must not retain errors.",
+            path=run_relpath,
+            record_id=run_record.run_id,
+            check_name="run-state",
+        )
+    if run_record.status == "failed" and not run_record.errors:
+        _append_issue(
+            issues,
+            code="invalid-run-error-state",
+            message="Failed runs should preserve at least one error for repair diagnostics.",
+            path=run_relpath,
+            record_id=run_record.run_id,
+            check_name="run-state",
+        )
+
+    for ref in [*run_record.input_refs, *run_record.output_refs]:
+        try:
+            resolve_workspace_path(root, ref, context="Run reference")
+        except ValueError as exc:
+            _append_issue(
+                issues,
+                code="invalid-run-reference",
+                message=str(exc),
+                path=run_relpath,
+                record_id=run_record.run_id,
+                check_name="run-state",
             )
 
-    return MaintenanceCheckResult(checked_count=checked_sources, issues=issues)
+
+def _validate_source_runtime_state(
+    *,
+    root: Path,
+    source_records: dict[str, SourceRecord],
+    run_records: dict[str, tuple[Path, RunRecord]],
+    invalid_run_ids: set[str],
+    issues: list[MaintenanceIssue],
+) -> None:
+    for source_id, source_record in source_records.items():
+        manifest_relpath = f"state/manifests/sources/{source_id}.json"
+
+        if source_record.status == "registered":
+            if source_record.last_run_id is not None:
+                _append_issue(
+                    issues,
+                    code="registered-source-has-last-run",
+                    message=(
+                        "Registered sources should not point at last_run_id before an ingest "
+                        "attempt has completed."
+                    ),
+                    path=manifest_relpath,
+                    record_id=source_id,
+                    check_name="source-runtime",
+                )
+            continue
+
+        if source_record.last_run_id is None:
+            _append_issue(
+                issues,
+                code="source-missing-last-run",
+                message=(
+                    f"Source status {source_record.status!r} requires last_run_id so the "
+                    "corresponding ingest attempt can be audited or repaired."
+                ),
+                path=manifest_relpath,
+                record_id=source_id,
+                check_name="source-runtime",
+            )
+            continue
+
+        if source_record.last_run_id in invalid_run_ids:
+            _append_issue(
+                issues,
+                code="source-last-run-invalid",
+                message=(
+                    f"Source last_run_id points to an unreadable run record: "
+                    f"{source_record.last_run_id}"
+                ),
+                path=manifest_relpath,
+                record_id=source_id,
+                check_name="source-runtime",
+            )
+            continue
+
+        run_entry = run_records.get(source_record.last_run_id)
+        if run_entry is None:
+            _append_issue(
+                issues,
+                code="missing-last-run-record",
+                message=f"Run record is missing for last_run_id={source_record.last_run_id!r}",
+                path=manifest_relpath,
+                record_id=source_id,
+                check_name="source-runtime",
+            )
+            continue
+
+        _, run_record = run_entry
+        expected_job_id = f"ingest-{source_id}"
+        if run_record.job_id != expected_job_id:
+            _append_issue(
+                issues,
+                code="source-last-run-job-mismatch",
+                message=(
+                    f"Source last_run_id points to job_id={run_record.job_id!r}, "
+                    f"but expected {expected_job_id!r}"
+                ),
+                path=manifest_relpath,
+                record_id=source_id,
+                check_name="source-runtime",
+            )
+        if source_record.status == "ingested" and run_record.status != "succeeded":
+            _append_issue(
+                issues,
+                code="source-last-run-status-mismatch",
+                message=(
+                    f"Source is marked ingested, but last_run_id resolved to a "
+                    f"{run_record.status!r} run."
+                ),
+                path=manifest_relpath,
+                record_id=source_id,
+                check_name="source-runtime",
+            )
+        if source_record.status == "failed" and run_record.status != "failed":
+            _append_issue(
+                issues,
+                code="source-last-run-status-mismatch",
+                message=(
+                    f"Source is marked failed, but last_run_id resolved to a "
+                    f"{run_record.status!r} run."
+                ),
+                path=manifest_relpath,
+                record_id=source_id,
+                check_name="source-runtime",
+            )
+
+
+def run_health_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckResult:
+    issues: list[MaintenanceIssue] = []
+    checked_count = 0
+    now = datetime.now(UTC)
+
+    _require_runtime_directory(layout.source_records_dir, label="Source manifest")
+    _require_runtime_directory(layout.queue_dir, label="Queue")
+    _require_runtime_directory(layout.runs_dir, label="Run")
+
+    source_records, invalid_source_ids, loaded_sources = _load_source_records(
+        layout,
+        root=root,
+        issues=issues,
+    )
+    queue_records, _, loaded_queues = _load_queue_records(
+        layout,
+        root=root,
+        issues=issues,
+    )
+    run_records, invalid_run_ids, loaded_runs = _load_run_records(
+        layout,
+        root=root,
+        issues=issues,
+    )
+    checked_count += loaded_sources + loaded_queues + loaded_runs
+
+    for queue_path, queue_record in queue_records.values():
+        _validate_queue_record(
+            root=root,
+            queue_path=queue_path,
+            queue_record=queue_record,
+            source_records=source_records,
+            invalid_source_ids=invalid_source_ids,
+            now=now,
+            issues=issues,
+        )
+
+    for run_path, run_record in run_records.values():
+        _validate_run_record(
+            root=root,
+            run_path=run_path,
+            run_record=run_record,
+            issues=issues,
+        )
+
+    _validate_source_runtime_state(
+        root=root,
+        source_records=source_records,
+        run_records=run_records,
+        invalid_run_ids=invalid_run_ids,
+        issues=issues,
+    )
+
+    return MaintenanceCheckResult(checked_count=checked_count, issues=issues)

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -131,9 +131,8 @@ def _load_queue_records(
     *,
     root: Path,
     issues: list[MaintenanceIssue],
-) -> tuple[dict[str, tuple[Path, QueueItemRecord]], set[str], int]:
+) -> tuple[dict[str, tuple[Path, QueueItemRecord]], int]:
     records: dict[str, tuple[Path, QueueItemRecord]] = {}
-    invalid_ids: set[str] = set()
     checked_count = 0
 
     for queue_path in sorted(layout.queue_dir.glob("*.json")):
@@ -143,7 +142,6 @@ def _load_queue_records(
         try:
             queue_record = load_queue_item(queue_path)
         except Exception as exc:
-            invalid_ids.add(queue_id)
             _append_issue(
                 issues,
                 code="invalid-queue-record",
@@ -155,7 +153,7 @@ def _load_queue_records(
             continue
         records[queue_id] = (queue_path, queue_record)
 
-    return records, invalid_ids, checked_count
+    return records, checked_count
 
 
 def _load_run_records(
@@ -195,7 +193,6 @@ def _validate_queue_record(
     root: Path,
     queue_path: Path,
     queue_record: QueueItemRecord,
-    layout: ResolvedLayout,
     source_records: dict[str, tuple[Path, SourceRecord]],
     invalid_source_ids: set[str],
     now: datetime,
@@ -634,7 +631,7 @@ def run_health_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckRes
         issues=issues,
         check_name="workspace-layout",
     ):
-        queue_records, _, loaded_queues = _load_queue_records(
+        queue_records, loaded_queues = _load_queue_records(
             layout,
             root=root,
             issues=issues,
@@ -667,7 +664,6 @@ def run_health_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckRes
             root=root,
             queue_path=queue_path,
             queue_record=queue_record,
-            layout=layout,
             source_records=source_records,
             invalid_source_ids=invalid_source_ids,
             now=now,

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -199,17 +199,18 @@ def _validate_queue_record(
     issues: list[MaintenanceIssue],
 ) -> None:
     queue_relpath = workspace_relative_path(root, queue_path)
+    canonical_job_id = queue_path.stem
 
-    if queue_record.job_id != queue_path.stem:
+    if queue_record.job_id != canonical_job_id:
         _append_issue(
             issues,
             code="queue-job-id-mismatch",
             message=(
-                f"Queue filename expects job_id={queue_path.stem!r}, "
+                f"Queue filename expects job_id={canonical_job_id!r}, "
                 f"but record stores {queue_record.job_id!r}"
             ),
             path=queue_relpath,
-            record_id=queue_record.job_id,
+            record_id=canonical_job_id,
             check_name="queue-record",
         )
 
@@ -219,7 +220,7 @@ def _validate_queue_record(
             code="unsupported-queue-job-type",
             message=f"Unsupported queue job type for current runtime: {queue_record.job_type!r}",
             path=queue_relpath,
-            record_id=queue_record.job_id,
+            record_id=canonical_job_id,
             check_name="queue-record",
         )
         return
@@ -234,7 +235,7 @@ def _validate_queue_record(
                     "operators can decide whether to reclaim them."
                 ),
                 path=queue_relpath,
-                record_id=queue_record.job_id,
+                record_id=canonical_job_id,
                 check_name="queue-state",
             )
         else:
@@ -249,7 +250,7 @@ def _validate_queue_record(
                     code="invalid-queue-lease-expiry",
                     message=str(exc),
                     path=queue_relpath,
-                    record_id=queue_record.job_id,
+                    record_id=canonical_job_id,
                     check_name="queue-state",
                 )
             else:
@@ -262,7 +263,7 @@ def _validate_queue_record(
                             "reclaiming or resetting the job."
                         ),
                         path=queue_relpath,
-                        record_id=queue_record.job_id,
+                        record_id=canonical_job_id,
                         check_name="queue-state",
                     )
     elif queue_record.lease_owner is not None or queue_record.lease_expires_at is not None:
@@ -271,7 +272,7 @@ def _validate_queue_record(
             code="invalid-queue-lease-state",
             message="Only leased queue items may carry lease_owner or lease_expires_at values.",
             path=queue_relpath,
-            record_id=queue_record.job_id,
+            record_id=canonical_job_id,
             check_name="queue-state",
         )
 
@@ -282,7 +283,7 @@ def _validate_queue_record(
                 code="invalid-queue-error-state",
                 message="Failed queue items should persist last_error for repair diagnostics.",
                 path=queue_relpath,
-                record_id=queue_record.job_id,
+                record_id=canonical_job_id,
                 check_name="queue-state",
             )
     elif queue_record.last_error is not None:
@@ -291,7 +292,7 @@ def _validate_queue_record(
             code="invalid-queue-error-state",
             message="Only failed queue items should persist last_error details.",
             path=queue_relpath,
-            record_id=queue_record.job_id,
+            record_id=canonical_job_id,
             check_name="queue-state",
         )
 
@@ -304,7 +305,7 @@ def _validate_queue_record(
                 f"max_attempts={queue_record.max_attempts}"
             ),
             path=queue_relpath,
-            record_id=queue_record.job_id,
+            record_id=canonical_job_id,
             check_name="queue-state",
         )
 
@@ -320,7 +321,7 @@ def _validate_queue_record(
             code="invalid-queue-payload-ref",
             message=str(exc),
             path=queue_relpath,
-            record_id=queue_record.job_id,
+            record_id=canonical_job_id,
             check_name="queue-payload",
         )
         return
@@ -331,12 +332,12 @@ def _validate_queue_record(
             code="missing-queue-payload",
             message=f"Queue payload is missing source manifest: {queue_record.payload_ref}",
             path=queue_relpath,
-            record_id=queue_record.job_id,
+            record_id=canonical_job_id,
             check_name="queue-payload",
         )
         return
 
-    expected_source_id = _source_id_from_job_id(queue_record.job_id)
+    expected_source_id = _source_id_from_job_id(canonical_job_id)
     if expected_source_id in invalid_source_ids:
         return
 
@@ -350,7 +351,7 @@ def _validate_queue_record(
                 "but no valid source record was loaded."
             ),
             path=queue_relpath,
-            record_id=queue_record.job_id,
+            record_id=canonical_job_id,
             check_name="queue-payload",
         )
         return
@@ -364,7 +365,7 @@ def _validate_queue_record(
             code="invalid-queue-payload-manifest",
             message=str(exc),
             path=queue_relpath,
-            record_id=queue_record.job_id,
+            record_id=canonical_job_id,
             check_name="queue-payload",
         )
         return
@@ -378,7 +379,7 @@ def _validate_queue_record(
                 f"but job_id expects {expected_source_id!r}"
             ),
             path=queue_relpath,
-            record_id=queue_record.job_id,
+            record_id=canonical_job_id,
             check_name="queue-payload",
         )
     canonical_manifest_relpath = workspace_relative_path(root, canonical_manifest_path)
@@ -392,7 +393,7 @@ def _validate_queue_record(
                 f"manifest path for this source is {canonical_manifest_relpath!r}"
             ),
             path=queue_relpath,
-            record_id=queue_record.job_id,
+            record_id=canonical_job_id,
             check_name="queue-payload",
         )
 
@@ -405,17 +406,18 @@ def _validate_run_record(
     issues: list[MaintenanceIssue],
 ) -> None:
     run_relpath = workspace_relative_path(root, run_path)
+    canonical_run_id = run_path.stem
 
-    if run_record.run_id != run_path.stem:
+    if run_record.run_id != canonical_run_id:
         _append_issue(
             issues,
             code="run-id-mismatch",
             message=(
-                f"Run filename expects run_id={run_path.stem!r}, "
+                f"Run filename expects run_id={canonical_run_id!r}, "
                 f"but record stores {run_record.run_id!r}"
             ),
             path=run_relpath,
-            record_id=run_record.run_id,
+            record_id=canonical_run_id,
             check_name="run-record",
         )
 
@@ -425,7 +427,7 @@ def _validate_run_record(
             code="unsupported-run-job-type",
             message=f"Unsupported run job type for current runtime: {run_record.job_type!r}",
             path=run_relpath,
-            record_id=run_record.run_id,
+            record_id=canonical_run_id,
             check_name="run-record",
         )
         return
@@ -437,7 +439,7 @@ def _validate_run_record(
                 code="invalid-run-finish-state",
                 message="Running runs must not set finished_at before completion.",
                 path=run_relpath,
-                record_id=run_record.run_id,
+                record_id=canonical_run_id,
                 check_name="run-state",
             )
         _append_issue(
@@ -448,7 +450,7 @@ def _validate_run_record(
                 "marking the run terminal or retrying the queue item."
             ),
             path=run_relpath,
-            record_id=run_record.run_id,
+            record_id=canonical_run_id,
             check_name="run-state",
         )
     elif run_record.finished_at is None:
@@ -457,7 +459,7 @@ def _validate_run_record(
             code="invalid-run-finish-state",
             message="Terminal runs must set finished_at for auditability and repair decisions.",
             path=run_relpath,
-            record_id=run_record.run_id,
+            record_id=canonical_run_id,
             check_name="run-state",
         )
 
@@ -467,7 +469,7 @@ def _validate_run_record(
             code="invalid-run-error-state",
             message="Succeeded runs must not retain errors.",
             path=run_relpath,
-            record_id=run_record.run_id,
+            record_id=canonical_run_id,
             check_name="run-state",
         )
     if run_record.status == "failed" and not run_record.errors:
@@ -476,7 +478,7 @@ def _validate_run_record(
             code="invalid-run-error-state",
             message="Failed runs should preserve at least one error for repair diagnostics.",
             path=run_relpath,
-            record_id=run_record.run_id,
+            record_id=canonical_run_id,
             check_name="run-state",
         )
 
@@ -489,7 +491,7 @@ def _validate_run_record(
                 code="invalid-run-reference",
                 message=str(exc),
                 path=run_relpath,
-                record_id=run_record.run_id,
+                record_id=canonical_run_id,
                 check_name="run-state",
             )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -379,7 +379,7 @@ def test_cli_health_command_passes_for_valid_sources(tmp_path: Path, capsys) -> 
 
     assert exit_code == 0
     captured = capsys.readouterr()
-    assert "Checked sources: 1" in captured.out
+    assert "Checked records: 1" in captured.out
     assert "Health check passed" in captured.out
     json_report, markdown_report = latest_report_paths(tmp_path, "health")
     assert json_report.stem == markdown_report.stem
@@ -446,7 +446,11 @@ def test_cli_health_command_fails_when_source_manifest_dir_is_missing(
 
     assert exit_code == 1
     captured = capsys.readouterr()
+    assert "Health check failed: 1 issue(s)" in captured.out
     assert "Source manifest directory is missing or unreadable" in captured.out
+    payload = json.loads(latest_report_paths(tmp_path, "health")[0].read_text(encoding="utf-8"))
+    assert payload["issues"][0]["code"] == "missing-directory"
+    assert payload["issues"][0]["path"] == "state/manifests/sources"
 
 
 def test_cli_health_command_supports_json_output(tmp_path: Path, capsys) -> None:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -271,6 +271,11 @@ def test_run_health_checks_reports_queue_and_run_shape_mismatches(tmp_path: Path
         "run-id-mismatch",
         "unsupported-run-job-type",
     }
+    issue_by_code = {issue.code: issue for issue in result.issues}
+    assert issue_by_code["queue-job-id-mismatch"].record_id == queue_path.stem
+    assert issue_by_code["unsupported-queue-job-type"].record_id == queue_path.stem
+    assert issue_by_code["run-id-mismatch"].record_id == run_path.stem
+    assert issue_by_code["unsupported-run-job-type"].record_id == run_path.stem
 
 
 def test_run_health_checks_reports_invalid_queue_runtime_details(tmp_path: Path) -> None:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -46,11 +46,16 @@ def test_run_health_checks_normalizes_z_timestamps_and_rejects_naive_timestamps(
     added = add_source(tmp_path, source)
     queue_path = enqueue_ingest_job(tmp_path, added.source_id)
     queue_record = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+    expired_lease_z = (
+        (datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=5))
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
     z_queue = queue_record.model_copy(
         update={
             "status": "leased",
             "lease_owner": "local-cli:123",
-            "lease_expires_at": "2026-04-20T09:00:00Z",
+            "lease_expires_at": expired_lease_z,
         }
     )
     write_queue_item(queue_path, z_queue)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,3 +1,4 @@
+import shutil
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -6,7 +7,7 @@ from splendor.commands.add_source import add_source
 from splendor.commands.health import run_health_checks
 from splendor.commands.ingest import enqueue_ingest_job
 from splendor.commands.init import initialize_workspace
-from splendor.config import load_config
+from splendor.config import default_config, load_config, write_config
 from splendor.layout import resolve_layout
 from splendor.schemas import QueueItemRecord, RunRecord
 from splendor.state.runtime import write_queue_item, write_run_record
@@ -34,6 +35,51 @@ def test_run_health_checks_reports_invalid_queue_and_run_records(tmp_path: Path)
     result = _run_health(tmp_path)
 
     assert {issue.code for issue in result.issues} == {"invalid-queue-record", "invalid-run-record"}
+
+
+def test_run_health_checks_normalizes_z_timestamps_and_rejects_naive_timestamps(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+    z_queue = queue_record.model_copy(
+        update={
+            "status": "leased",
+            "lease_owner": "local-cli:123",
+            "lease_expires_at": "2026-04-20T09:00:00Z",
+        }
+    )
+    write_queue_item(queue_path, z_queue)
+
+    second_source = tmp_path / "naive.md"
+    second_source.write_text("# Naive\n\nhello world\n", encoding="utf-8")
+    second_added = add_source(tmp_path, second_source)
+    second_queue_path = enqueue_ingest_job(tmp_path, second_added.source_id)
+    second_queue = QueueItemRecord.model_validate_json(
+        second_queue_path.read_text(encoding="utf-8")
+    )
+    naive_queue = second_queue.model_copy(
+        update={
+            "status": "leased",
+            "lease_owner": "local-cli:456",
+            "lease_expires_at": "2026-04-20T09:00:00",
+        }
+    )
+    write_queue_item(second_queue_path, naive_queue)
+
+    result = _run_health(tmp_path)
+
+    issue_codes = [issue.code for issue in result.issues]
+    assert "expired-queue-lease" in issue_codes
+    assert "invalid-queue-lease-expiry" in issue_codes
+    invalid_issue = next(
+        issue for issue in result.issues if issue.code == "invalid-queue-lease-expiry"
+    )
+    assert "must include a timezone offset" in invalid_issue.message
 
 
 def test_run_health_checks_reports_stale_queue_and_run_runtime_state(tmp_path: Path) -> None:
@@ -85,6 +131,30 @@ def test_run_health_checks_reports_stale_queue_and_run_runtime_state(tmp_path: P
         "queue-attempt-count-exceeded",
         "unfinished-run",
         "source-last-run-status-mismatch",
+    }
+
+
+def test_run_health_checks_reports_missing_runtime_directories_nonfatally(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    for path in (
+        tmp_path / "state" / "manifests" / "sources",
+        tmp_path / "state" / "queue",
+        tmp_path / "state" / "runs",
+    ):
+        shutil.rmtree(path)
+
+    result = _run_health(tmp_path)
+
+    assert result.checked_count == 3
+    assert [issue.code for issue in result.issues] == [
+        "missing-directory",
+        "missing-directory",
+        "missing-directory",
+    ]
+    assert {issue.path for issue in result.issues} == {
+        "state/manifests/sources",
+        "state/queue",
+        "state/runs",
     }
 
 
@@ -153,4 +223,304 @@ def test_run_health_checks_reports_invalid_failed_queue_and_run_shapes(tmp_path:
         "invalid-queue-error-state",
         "invalid-run-error-state",
         "invalid-run-finish-state",
+    }
+
+
+def test_run_health_checks_reports_queue_and_run_shape_mismatches(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+    mismatched_queue = queue_record.model_copy(
+        update={
+            "job_id": "other-job",
+            "job_type": "refresh_topic",
+        }
+    )
+    write_queue_item(queue_path, mismatched_queue)
+
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    run_path = layout.runs_dir / f"run-{added.source_id}-shape.json"
+    write_run_record(
+        run_path,
+        RunRecord(
+            run_id="other-run",
+            job_id=f"ingest-{added.source_id}",
+            job_type="refresh_topic",
+            started_at="2026-04-20T09:00:00+00:00",
+            finished_at="2026-04-20T09:05:00+00:00",
+            status="succeeded",
+            input_refs=[],
+            errors=[],
+            pipeline_version=__version__,
+        ),
+    )
+
+    result = _run_health(tmp_path)
+
+    assert {issue.code for issue in result.issues} == {
+        "queue-job-id-mismatch",
+        "unsupported-queue-job-type",
+        "run-id-mismatch",
+        "unsupported-run-job-type",
+    }
+
+
+def test_run_health_checks_reports_invalid_queue_runtime_details(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+    invalid_queue = queue_record.model_copy(
+        update={
+            "status": "pending",
+            "lease_owner": "local-cli:123",
+            "lease_expires_at": "not-a-timestamp",
+        }
+    )
+    write_queue_item(queue_path, invalid_queue)
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["invalid-queue-lease-state"]
+
+
+def test_run_health_checks_reports_invalid_leased_queue_shape(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+    invalid_queue = queue_record.model_copy(
+        update={
+            "status": "leased",
+            "lease_owner": None,
+            "lease_expires_at": None,
+        }
+    )
+    write_queue_item(queue_path, invalid_queue)
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["invalid-queue-lease-state"]
+
+
+def test_run_health_checks_reports_missing_and_invalid_queue_payloads(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+    missing_queue = queue_record.model_copy(
+        update={"payload_ref": "state/manifests/sources/missing.json"}
+    )
+    write_queue_item(queue_path, missing_queue)
+
+    second_source = tmp_path / "broken.md"
+    second_source.write_text("# Broken\n\nhello world\n", encoding="utf-8")
+    second_added = add_source(tmp_path, second_source)
+    enqueue_ingest_job(tmp_path, second_added.source_id)
+    manifest_path = second_added.manifest_path
+    manifest_path.write_text("{bad json}\n", encoding="utf-8")
+
+    result = _run_health(tmp_path)
+
+    assert {issue.code for issue in result.issues} == {
+        "missing-queue-payload",
+        "source-health-check-failed",
+    }
+
+
+def test_run_health_checks_reports_queue_payload_source_and_path_mismatches_for_custom_layout(
+    tmp_path: Path,
+) -> None:
+    config = default_config(project_name="custom")
+    config.layout.source_records_dir = "custom/manifests"
+    write_config(tmp_path, config)
+    initialize_workspace(tmp_path)
+    custom_layout = resolve_layout(tmp_path, load_config(tmp_path))
+    custom_layout.source_records_dir.mkdir(parents=True, exist_ok=True)
+
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+
+    wrong_manifest_dir = tmp_path / "state" / "manifests" / "sources"
+    wrong_manifest_dir.mkdir(parents=True, exist_ok=True)
+    wrong_manifest_path = wrong_manifest_dir / f"{added.source_id}.json"
+    wrong_manifest_path.write_text(
+        added.manifest_path.read_text(encoding="utf-8").replace(added.source_id, "src-other", 1),
+        encoding="utf-8",
+    )
+    wrong_queue = queue_record.model_copy(
+        update={"payload_ref": wrong_manifest_path.relative_to(tmp_path).as_posix()}
+    )
+    write_queue_item(queue_path, wrong_queue)
+
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={"status": "failed", "last_run_id": None}
+    )
+    write_source_record(added.manifest_path, source_record)
+
+    result = _run_health(tmp_path)
+
+    issue_codes = {issue.code for issue in result.issues}
+    assert "queue-payload-source-mismatch" in issue_codes
+    assert "queue-payload-path-mismatch" in issue_codes
+    missing_run_issue = next(
+        issue for issue in result.issues if issue.code == "source-missing-last-run"
+    )
+    assert missing_run_issue.path == "custom/manifests/" + added.manifest_path.name
+
+
+def test_run_health_checks_reports_invalid_payload_manifest_for_valid_source_record(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+
+    alternate_manifest = tmp_path / "scratch" / "alternate.json"
+    alternate_manifest.parent.mkdir(parents=True, exist_ok=True)
+    alternate_manifest.write_text("{bad json}\n", encoding="utf-8")
+    broken_queue = queue_record.model_copy(update={"payload_ref": "scratch/alternate.json"})
+    write_queue_item(queue_path, broken_queue)
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["invalid-queue-payload-manifest"]
+
+
+def test_run_health_checks_reports_run_state_and_reference_problems(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    run_path = layout.runs_dir / "run-shape.json"
+    write_run_record(
+        run_path,
+        RunRecord(
+            run_id="run-shape",
+            job_id=f"ingest-{added.source_id}",
+            job_type="ingest_source",
+            started_at="2026-04-20T09:00:00+00:00",
+            finished_at="2026-04-20T09:05:00+00:00",
+            status="running",
+            input_refs=["/tmp/absolute.txt"],
+            output_refs=["../outside.md"],
+            errors=["boom"],
+            pipeline_version=__version__,
+        ),
+    )
+
+    second_run_path = layout.runs_dir / "run-success.json"
+    write_run_record(
+        second_run_path,
+        RunRecord(
+            run_id="run-success",
+            job_id=f"ingest-{added.source_id}",
+            job_type="ingest_source",
+            started_at="2026-04-20T09:00:00+00:00",
+            finished_at="2026-04-20T09:05:00+00:00",
+            status="succeeded",
+            input_refs=[],
+            errors=["should not be here"],
+            pipeline_version=__version__,
+        ),
+    )
+
+    result = _run_health(tmp_path)
+
+    assert {issue.code for issue in result.issues} == {
+        "invalid-run-finish-state",
+        "unfinished-run",
+        "invalid-run-reference",
+        "invalid-run-error-state",
+    }
+
+
+def test_run_health_checks_reports_source_runtime_cross_reference_problems(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    registered_source = tmp_path / "registered.md"
+    registered_source.write_text("# Registered\n\nhello world\n", encoding="utf-8")
+    registered_added = add_source(tmp_path, registered_source)
+    registered_record = load_source_record(registered_added.manifest_path).model_copy(
+        update={"last_run_id": "run-stray"}
+    )
+    write_source_record(registered_added.manifest_path, registered_record)
+
+    invalid_run_source = tmp_path / "invalid-run.md"
+    invalid_run_source.write_text("# Invalid Run\n\nhello world\n", encoding="utf-8")
+    invalid_run_added = add_source(tmp_path, invalid_run_source)
+    invalid_record = load_source_record(invalid_run_added.manifest_path).model_copy(
+        update={"status": "failed", "last_run_id": "run-invalid"}
+    )
+    write_source_record(invalid_run_added.manifest_path, invalid_record)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    (layout.runs_dir / "run-invalid.json").write_text("{bad json}\n", encoding="utf-8")
+
+    mismatched_job_source = tmp_path / "job-mismatch.md"
+    mismatched_job_source.write_text("# Job Mismatch\n\nhello world\n", encoding="utf-8")
+    mismatched_job_added = add_source(tmp_path, mismatched_job_source)
+    mismatched_run_path = layout.runs_dir / "run-job-mismatch.json"
+    write_run_record(
+        mismatched_run_path,
+        RunRecord(
+            run_id="run-job-mismatch",
+            job_id="ingest-someone-else",
+            job_type="ingest_source",
+            started_at="2026-04-20T09:00:00+00:00",
+            finished_at="2026-04-20T09:05:00+00:00",
+            status="succeeded",
+            input_refs=[],
+            pipeline_version=__version__,
+        ),
+    )
+    mismatched_record = load_source_record(mismatched_job_added.manifest_path).model_copy(
+        update={"status": "ingested", "last_run_id": "run-job-mismatch"}
+    )
+    write_source_record(mismatched_job_added.manifest_path, mismatched_record)
+
+    failed_status_source = tmp_path / "failed-status.md"
+    failed_status_source.write_text("# Failed Status\n\nhello world\n", encoding="utf-8")
+    failed_status_added = add_source(tmp_path, failed_status_source)
+    failed_status_run_path = layout.runs_dir / "run-failed-status.json"
+    write_run_record(
+        failed_status_run_path,
+        RunRecord(
+            run_id="run-failed-status",
+            job_id=f"ingest-{failed_status_added.source_id}",
+            job_type="ingest_source",
+            started_at="2026-04-20T09:00:00+00:00",
+            finished_at="2026-04-20T09:05:00+00:00",
+            status="succeeded",
+            input_refs=[],
+            pipeline_version=__version__,
+        ),
+    )
+    failed_status_record = load_source_record(failed_status_added.manifest_path).model_copy(
+        update={"status": "failed", "last_run_id": "run-failed-status"}
+    )
+    write_source_record(failed_status_added.manifest_path, failed_status_record)
+
+    result = _run_health(tmp_path)
+
+    assert {issue.code for issue in result.issues} == {
+        "registered-source-has-last-run",
+        "invalid-run-record",
+        "source-last-run-invalid",
+        "source-last-run-job-mismatch",
+        "source-last-run-status-mismatch",
     }

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,156 @@
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from splendor import __version__
+from splendor.commands.add_source import add_source
+from splendor.commands.health import run_health_checks
+from splendor.commands.ingest import enqueue_ingest_job
+from splendor.commands.init import initialize_workspace
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import QueueItemRecord, RunRecord
+from splendor.state.runtime import write_queue_item, write_run_record
+from splendor.state.source_registry import load_source_record, write_source_record
+
+
+def _run_health(root: Path):
+    layout = resolve_layout(root, load_config(root))
+    return run_health_checks(root, layout)
+
+
+def test_run_health_checks_returns_no_issues_for_initialized_workspace(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    result = _run_health(tmp_path)
+
+    assert result.issues == []
+
+
+def test_run_health_checks_reports_invalid_queue_and_run_records(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / "state" / "queue" / "ingest-bad.json").write_text("{bad json}\n", encoding="utf-8")
+    (tmp_path / "state" / "runs" / "run-bad.json").write_text("{bad json}\n", encoding="utf-8")
+
+    result = _run_health(tmp_path)
+
+    assert {issue.code for issue in result.issues} == {"invalid-queue-record", "invalid-run-record"}
+
+
+def test_run_health_checks_reports_stale_queue_and_run_runtime_state(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+    expired_queue = queue_record.model_copy(
+        update={
+            "status": "leased",
+            "attempt_count": 4,
+            "lease_owner": "local-cli:123",
+            "lease_expires_at": (datetime.now(UTC) - timedelta(minutes=5)).isoformat(),
+        }
+    )
+    write_queue_item(queue_path, expired_queue)
+
+    run_id = f"run-{added.source_id}-stale"
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    run_path = layout.runs_dir / f"{run_id}.json"
+    write_run_record(
+        run_path,
+        RunRecord(
+            run_id=run_id,
+            job_id=f"ingest-{added.source_id}",
+            job_type="ingest_source",
+            started_at="2026-04-20T09:00:00+00:00",
+            status="running",
+            finished_at=None,
+            input_refs=[
+                added.manifest_path.relative_to(tmp_path).as_posix(),
+                "brief.md",
+            ],
+            pipeline_version=__version__,
+        ),
+    )
+
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={"status": "ingested", "last_run_id": run_id}
+    )
+    write_source_record(added.manifest_path, source_record)
+
+    result = _run_health(tmp_path)
+
+    assert {issue.code for issue in result.issues} == {
+        "expired-queue-lease",
+        "queue-attempt-count-exceeded",
+        "unfinished-run",
+        "source-last-run-status-mismatch",
+    }
+
+
+def test_run_health_checks_reports_queue_payload_and_last_run_mismatches(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+    broken_queue = queue_record.model_copy(
+        update={
+            "payload_ref": "../outside-manifest.json",
+            "last_error": "should not be here",
+        }
+    )
+    write_queue_item(queue_path, broken_queue)
+
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={"status": "failed", "last_run_id": "run-missing"}
+    )
+    write_source_record(added.manifest_path, source_record)
+
+    result = _run_health(tmp_path)
+
+    assert {issue.code for issue in result.issues} == {
+        "invalid-queue-error-state",
+        "invalid-queue-payload-ref",
+        "missing-last-run-record",
+    }
+
+
+def test_run_health_checks_reports_invalid_failed_queue_and_run_shapes(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+    invalid_queue = queue_record.model_copy(update={"status": "failed", "last_error": None})
+    write_queue_item(queue_path, invalid_queue)
+
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    run_id = f"run-{added.source_id}-failed"
+    write_run_record(
+        layout.runs_dir / f"{run_id}.json",
+        RunRecord(
+            run_id=run_id,
+            job_id=f"ingest-{added.source_id}",
+            job_type="ingest_source",
+            started_at="2026-04-20T09:00:00+00:00",
+            finished_at=None,
+            status="failed",
+            input_refs=[
+                added.manifest_path.relative_to(tmp_path).as_posix(),
+                "brief.md",
+            ],
+            errors=[],
+            pipeline_version=__version__,
+        ),
+    )
+
+    result = _run_health(tmp_path)
+
+    assert {issue.code for issue in result.issues} == {
+        "invalid-queue-error-state",
+        "invalid-run-error-state",
+        "invalid-run-finish-state",
+    }


### PR DESCRIPTION
## Summary
- extend `splendor health` from source storage validation into queue/run runtime diagnostics
- inventory queue items and run records non-fatally so malformed runtime files become actionable report issues instead of fatal command errors
- validate lease state, attempt counters, payload references, unfinished runs, and source `last_run_id` consistency, with repair-oriented issue messages
- update the roadmap, README, and `.agent-plan.md` so that once this PR lands, `main` advances to `M5-P1` instead of remaining stuck on the completed Milestone 4 slice

## Why
Milestone 4 called for deterministic queue integrity checks plus stale/unfinished runtime diagnostics on top of the maintenance/reporting framework built in `M4-P1` and the content integrity pass added in `M4-P2`. This PR completes that Milestone 4 scope and makes the operational ledger auditable without adding a mutating repair command yet.

## What Changed
### `splendor health`
- keep the existing source storage/materialization validation path
- add non-fatal inventory/loading for `state/queue/*.json` and `state/runs/*.json`
- report invalid queue/run JSON separately from source manifest problems
- validate queue invariants including:
  - filename/job id agreement
  - supported job type
  - lease shape and expired leases
  - terminal error-state consistency
  - attempt counters exceeding `max_attempts`
  - payload path validity and queue-to-source manifest mismatches
- validate run invariants including:
  - filename/run id agreement
  - supported job type
  - terminal vs running `finished_at` state
  - succeeded/failed error-list consistency
  - repo-relative runtime references
- cross-check source manifests against runtime state so `last_run_id` points at a readable, matching terminal run

### Tests
- add focused health-check coverage for:
  - invalid queue and run records
  - expired leased items and unfinished runs
  - queue payload mismatches
  - missing or inconsistent `last_run_id` runtime state
  - invalid failed queue/run terminal shapes
- keep existing CLI health coverage green
- full repo test suite passes with the new runtime diagnostics in place

### Docs / planning state
- update `README.md` to describe `splendor health` as covering source, queue, and run maintenance
- update `docs/splendor_mvp_to_v1_roadmap.md` so Milestone 4 is marked complete and `M5-P1` is next
- update `.agent-plan.md` as post-merge truth for `main`, including the completed `M4-P2`/`M4-P3` publication steps and the next planned slice

## Validation
- `./.venv/bin/ruff check src tests`
- `./.venv/bin/python -m pytest`

## Follow-up
- `M5-P1` will focus on MVP docs, quickstart flow, and an example workspace
- `M10-P1` remains the place for explicit queue inspect/retry/repair commands; this PR stays diagnostic-only
