### PR TITLE
Implement M5-P2 hardening and upgrade pr-agent-context refresh fallback

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,9 +3,9 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Last action taken: `M5-P1` is implemented; the repository now has an MVP entrypoint README, a dedicated quickstart, companion-repo guidance, a committed example workspace, and smoke tests that keep the docs and sample artifacts aligned with the current CLI behavior.
-- Active planned PR: `M5-P2`
-- Next planned PR: `M6-P1`
+- Last action taken: `M5-P2` is implemented; the repository now hardens operational edge cases with broader regression coverage, consistent one-line CLI error output, a package-install smoke path, and updated MVP install/docs guidance.
+- Active planned PR: `M6-P1`
+- Next planned PR: `M6-P2`
 - Current blockers: none
 
 ## Active Task Breakdown
@@ -25,7 +25,8 @@
 - [x] Implement `M4-P3`: queue/run integrity checks and repair diagnostics
 - [x] Publish a non-draft GitHub PR for `M4-P3` with a detailed description, labels, and a milestone
 - [x] Implement `M5-P1`: MVP docs, quickstart, and example workspace
-- [ ] Implement `M5-P2`: MVP hardening: coverage, errors, packaging, polish
+- [x] Implement `M5-P2`: MVP hardening: coverage, errors, packaging, polish
+- [ ] Implement `M6-P1`: Review-state and provenance model expansion
 
 ## Context Pointers
 
@@ -37,7 +38,6 @@
 
 ## Planned PR Queue
 
-- `M5-P2` MVP hardening: coverage, errors, packaging, polish
 - `M6-P1` Review-state and provenance model expansion
 - `M6-P2` Contradiction surfacing and review-task linkage
 - `M7-P1` Repo scan and code/doc source classification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
       contents: read
       actions: read
       pull-requests: write
-    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4.0.18
+    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4.0.19
     with:
-      tool_ref: v4.0.18
+      tool_ref: v4.0.19
       include_patch_coverage: true
       patch_coverage_source_mode: coverage_xml_artifact
       coverage_report_artifact_name: coverage-xml

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -1,4 +1,25 @@
 name: pr-agent-context-refresh
+run-name: >-
+  ${{
+    github.event_name == 'workflow_dispatch' &&
+    format(
+      'scheduled refresh PR #{0} @ {1}',
+      github.event.inputs.pull_request_number,
+      github.event.inputs.pull_request_head_sha
+    ) ||
+    github.event_name == 'schedule' &&
+    'scheduled refresh fanout' ||
+    github.event_name == 'pull_request_review' &&
+    format('review refresh PR #{0}', github.event.pull_request.number) ||
+    github.event_name == 'pull_request_review_comment' &&
+    format('review-comment refresh PR #{0}', github.event.pull_request.number) ||
+    github.event_name == 'check_run' &&
+    format(
+      'check refresh {0}',
+      github.event.check_run.pull_requests[0].number || github.event.check_run.head_sha
+    ) ||
+    github.workflow
+  }}
 
 on:
   pull_request_review:
@@ -7,15 +28,54 @@ on:
     types: [created, edited, deleted]
   check_run:
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Pull request number to refresh explicitly.
+        required: true
+        type: string
+      pull_request_base_sha:
+        description: Base SHA for the explicit refresh target.
+        required: true
+        type: string
+      pull_request_head_sha:
+        description: Head SHA for the explicit refresh target.
+        required: true
+        type: string
+      trigger_event_name:
+        description: Synthetic trigger event name used in rendered metadata.
+        required: false
+        default: workflow_dispatch
+        type: string
+      trigger_event_action:
+        description: Synthetic trigger event action used in rendered metadata.
+        required: false
+        default: ""
+        type: string
+  schedule:
+    - cron: "*/15 * * * *"
 
 concurrency:
   group: >-
-    ${{ github.workflow }}-${{
-      github.event.pull_request.number ||
-      github.event.check_run.head_sha ||
-      github.sha
+    ${{
+      github.event_name == 'workflow_dispatch' &&
+      format(
+        '{0}-{1}-{2}',
+        github.workflow,
+        github.event.inputs.pull_request_number,
+        github.event.inputs.pull_request_head_sha
+      ) ||
+      format(
+        '{0}-{1}',
+        github.workflow,
+        github.event.pull_request.number ||
+        github.event.check_run.pull_requests[0].number ||
+        github.event.check_run.head_sha ||
+        github.ref_name ||
+        github.sha
+      )
     }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 permissions:
   contents: read
@@ -23,21 +83,163 @@ permissions:
   pull-requests: write
 
 jobs:
+  dispatch-scheduled-refreshes:
+    name: Dispatch scheduled refreshes
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const sameRepoPulls = pulls.filter(
+              (pull) => pull.head?.repo?.full_name === `${owner}/${repo}`,
+            );
+
+            const markerPrefix = '<!-- pr-agent-context:managed-comment;';
+            let dispatchCount = 0;
+            let skipCount = 0;
+            let errorCount = 0;
+            const recentDispatchWindowMs = 60 * 60 * 1000;
+
+            const recentDispatchCutoff = Date.now() - recentDispatchWindowMs;
+            const { data: workflowRunsResponse } =
+              await github.rest.actions.listWorkflowRunsForWorkflow({
+                owner,
+                repo,
+                workflow_id: 'pr-agent-context-refresh.yml',
+                event: 'workflow_dispatch',
+                per_page: 100,
+              });
+            const workflowDispatchRuns = workflowRunsResponse.workflow_runs.filter((run) => {
+              const createdTimestamp = run.created_at ? Date.parse(run.created_at) : 0;
+              return createdTimestamp >= recentDispatchCutoff || run.status !== 'completed';
+            });
+
+            const hasCurrentRefreshComment = async (pull) => {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: pull.number,
+                per_page: 50,
+                sort: 'created',
+                direction: 'desc',
+              });
+
+              return comments.some(
+                (comment) =>
+                  comment.body?.startsWith(markerPrefix) &&
+                  comment.body.includes('execution_mode=refresh;') &&
+                  comment.body.includes(`head_sha=${pull.head.sha};`),
+              );
+            };
+
+            const hasRecentOrInFlightScheduledDispatchRun = (pull) => {
+              const expectedTitle = `scheduled refresh PR #${pull.number} @ ${pull.head.sha}`;
+              const now = Date.now();
+
+              return workflowDispatchRuns.some((run) => {
+                if (run.display_title !== expectedTitle) {
+                  return false;
+                }
+                if (run.status !== 'completed') {
+                  return true;
+                }
+                const completedTimestamp = run.updated_at
+                  ? new Date(run.updated_at).getTime()
+                  : run.created_at
+                    ? new Date(run.created_at).getTime()
+                    : 0;
+                return completedTimestamp > 0 && now - completedTimestamp <= recentDispatchWindowMs;
+              });
+            };
+
+            for (const pull of sameRepoPulls) {
+              try {
+                const refreshCommentExists = await hasCurrentRefreshComment(pull);
+                const hasRecentDispatchRun = hasRecentOrInFlightScheduledDispatchRun(pull);
+
+                if (refreshCommentExists) {
+                  core.notice(
+                    `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} already exists.`,
+                  );
+                  skipCount += 1;
+                  continue;
+                }
+                if (hasRecentDispatchRun) {
+                  core.notice(
+                    `Skipping PR #${pull.number}: recent or in-flight scheduled dispatch for head ${pull.head.sha} already exists.`,
+                  );
+                  skipCount += 1;
+                  continue;
+                }
+
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id: 'pr-agent-context-refresh.yml',
+                  ref: context.ref.replace('refs/heads/', ''),
+                  inputs: {
+                    pull_request_number: String(pull.number),
+                    pull_request_base_sha: pull.base.sha,
+                    pull_request_head_sha: pull.head.sha,
+                    trigger_event_name: 'schedule',
+                    trigger_event_action: '',
+                  },
+                });
+                dispatchCount += 1;
+              } catch (error) {
+                errorCount += 1;
+                core.warning(
+                  `Unable to evaluate or dispatch PR #${pull.number}: ${error instanceof Error ? error.message : String(error)}`,
+                );
+              }
+            }
+
+            core.notice(
+              `Scheduled refresh guard dispatched ${dispatchCount} run(s) and skipped ${skipCount}.`,
+            );
+            if (errorCount > 0) {
+              core.warning(`Scheduled refresh guard encountered ${errorCount} per-PR error(s).`);
+            }
+
   pr-agent-context:
     if: >-
-      (github.event_name == 'pull_request_review' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_review_comment' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'check_run' &&
-       github.event.action == 'completed' &&
-       github.event.check_run.app.slug != 'github-actions' &&
-       toJson(github.event.check_run.pull_requests) != '[]' &&
-       github.event.check_run.pull_requests[0].head.repo.full_name == github.repository)
-    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4.0.18
+      github.event_name != 'schedule' &&
+      (
+        (github.event_name == 'pull_request_review' &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'pull_request_review_comment' &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'check_run' &&
+         github.event.action == 'completed' &&
+         github.event.check_run.app.slug != 'github-actions' &&
+         toJson(github.event.check_run.pull_requests) != '[]' &&
+         github.event.check_run.pull_requests[0].head.repo.full_name == github.repository) ||
+        (github.event_name == 'workflow_dispatch' &&
+         github.event.inputs.pull_request_number != '' &&
+         github.event.inputs.pull_request_base_sha != '' &&
+         github.event.inputs.pull_request_head_sha != '')
+      )
+    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4.0.19
     with:
-      tool_ref: v4.0.18
+      tool_ref: v4.0.19
       execution_mode: refresh
+      trigger_event_name_override: ${{ github.event.inputs.trigger_event_name || '' }}
+      trigger_event_action_override: ${{ github.event.inputs.trigger_event_action || '' }}
+      pull_request_number_override: ${{ github.event.inputs.pull_request_number || '' }}
+      pull_request_base_sha_override: ${{ github.event.inputs.pull_request_base_sha || '' }}
+      pull_request_head_sha_override: ${{ github.event.inputs.pull_request_head_sha || '' }}
       publish_mode: append
       publish_all_clear_comments_in_refresh: false
       include_outdated_review_threads: true
@@ -45,6 +247,7 @@ jobs:
       patch_coverage_source_mode: coverage_xml_artifact
       coverage_report_artifact_name: coverage-xml
       coverage_report_filename: coverage.xml
+      enable_cross_run_coverage_lookup: true
       coverage_source_workflows: CI
       target_patch_coverage: "70"
       wait_for_reviews_to_settle: true

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Not implemented yet:
 
 ## What Comes Next
 
-`M5-P2` is implemented in this branch: the repository now pairs the MVP docs/example slice with
+`M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
 install validation.
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,28 @@ objects inside version control instead of rebuilding context from scratch on eve
 - Python 3.12+
 - [`uv`](https://docs.astral.sh/uv/)
 
-### Local setup
+### Contributor setup
 
 ```bash
 uv sync --dev
 uv run splendor --help
+```
+
+### Local package install
+
+Inside any Python 3.12 environment:
+
+```bash
+uv pip install .
+splendor --help
+```
+
+### Built wheel install
+
+```bash
+uv build
+uv pip install dist/splendor-*.whl
+splendor --help
 ```
 
 ## 5 Minute Quickstart
@@ -27,9 +44,9 @@ uv run splendor --help
 This is the primary MVP flow: one repository that contains both your project files and the
 Splendor workspace.
 
-Run the commands below from the Splendor checkout you set up in the install step, and point
-`--root` at the target repository. If you want to run the commands directly from an arbitrary repo
-instead, install Splendor into that repo's environment first and drop the explicit `--root`.
+If you are running from a contributor checkout, use `uv run splendor ...` and point `--root` at the
+target repository. If you installed Splendor into an environment, replace `uv run splendor` with
+`splendor`; if that environment lives inside the target repo, you can drop the explicit `--root`.
 
 ```bash
 mkdir /tmp/demo-repo
@@ -118,9 +135,9 @@ Not implemented yet:
 
 ## What Comes Next
 
-`M5-P1` is implemented in this branch: the repository now has an MVP entrypoint README, a dedicated
-quickstart, companion-repo guidance, a committed example workspace, and smoke tests that keep the
-example materials aligned with the current CLI behavior.
+`M5-P2` is implemented in this branch: the repository now pairs the MVP docs/example slice with
+hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
+install validation.
 
-The next planned slice is `M5-P2`, which will focus on MVP hardening: broader coverage, error
-polish, packaging, and release-quality cleanup.
+The next planned slice is `M6-P1`, which will focus on review-state and provenance model
+expansion.

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -24,6 +24,8 @@ What it does:
 - uploads a `coverage-xml` artifact
 - uploads coverage to Codecov
 - publishes a `pr-agent-context` comment on pull requests
+  - pinned to `shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4.0.19`
+  - uses the `coverage-xml` artifact directly for patch coverage context
 
 Permissions:
 
@@ -45,19 +47,35 @@ Runs on:
 - pull request reviews
 - pull request review comments
 - completed external check runs
+- scheduled fallback fanout every 15 minutes
+- manual dispatch for explicit PR/SHA-targeted refreshes
 
 What it does:
 
 - refreshes the managed PR context comment after review or check state changes
+- dispatches repo-owned fallback refresh runs for same-repo PRs when approval-gated bot events
+  leave event-driven refresh stuck
+- passes explicit PR number, base SHA, and head SHA overrides into the reusable workflow for
+  fallback-triggered refreshes
 - reuses the `coverage-xml` artifact from the matching CI run when possible
 - suppresses no-op refresh comments
 - includes outdated review threads when refreshing managed PR context
+- dedupes scheduled fallback dispatches against both recent refresh comments and recent or in-flight
+  refresh `workflow_dispatch` runs for the same PR head SHA
 
 Permissions:
 
 - `contents: read`
 - `actions: read`
 - `pull-requests: write`
+
+Scheduled dispatcher details:
+
+- enumerates only open same-repo PRs
+- looks back over a bounded recent comment window
+- isolates dispatch failures per PR instead of failing the entire fanout job
+- uses the `actions/github-script` `github.rest.*` method names
+- uses SHA-aware concurrency keys for dispatched refresh runs
 
 ## `pre-commit.ci autofix trigger`
 

--- a/docs/github_automation_architecture.md
+++ b/docs/github_automation_architecture.md
@@ -10,7 +10,8 @@ turning GitHub into the product runtime.
 2. The same CI workflow uploads `coverage.xml`, sends coverage to Codecov, and invokes
    `pr-agent-context` to publish a managed PR context comment.
 3. Follow-up review and check events trigger `pr-agent-context-refresh` to keep that context
-   current as comments and external checks evolve.
+   current as comments and external checks evolve; a repo-owned scheduled dispatcher backstops
+   approval-gated refresh events for same-repo PRs.
 4. `pre-commit.ci autofix trigger` listens for bot PR events and late-arriving `pre-commit.ci`
    failures, then applies the `pre-commit.ci autofix` label when the reusable workflow decides the
    PR is eligible.
@@ -62,7 +63,7 @@ Caveats:
 
 Pinned reusable workflow:
 
-- `shaypal5/pr-agent-context@v4.0.18`
+- `shaypal5/pr-agent-context@v4.0.19`
   - Refresh flow uses `include_outdated_review_threads: true` to keep managed PR context aligned
     with both active and outdated review discussions.
 
@@ -70,17 +71,24 @@ Chosen behavior:
 
 - initial PR runs publish a managed context comment
 - refresh runs are triggered on review activity and completed external checks
+- scheduled fallback runs dispatch explicit refreshes for same-repo PRs when approval-gated bot
+  events do not execute the event-triggered refresh workflow
 - refresh runs suppress no-op all-clear comments
 - refresh runs include outdated review threads for richer PR context updates
 - coverage comes from the `coverage-xml` artifact produced by CI
 - the repository provides a custom prompt template at `.github/pr-agent-context-template.md`
+- scheduled/dispatch-triggered refresh runs pass explicit PR number, base SHA, and head SHA
+  overrides into the reusable workflow
 
 Refresh flow:
 
 1. `CI` completes and posts the initial managed comment.
 2. A review, review-comment, or external check completion event fires.
 3. `pr-agent-context-refresh` re-invokes the reusable workflow in refresh mode.
-4. The latest actionable managed comment is refreshed with up-to-date unresolved comments, failing
+4. If approval-gated bot activity prevents that event-driven refresh from running, the scheduled
+   dispatcher wakes as the repository, dedupes against recent refresh comments and recent/in-flight
+   scheduled dispatches for the same head SHA, then re-dispatches explicit refresh runs.
+5. The latest actionable managed comment is refreshed with up-to-date unresolved comments, failing
    checks, and patch-coverage context.
 
 ## `repo-review-automation`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,18 +3,35 @@
 This quickstart walks through the current MVP in the primary supported mode: one repository that
 contains both your normal project files and the Splendor workspace.
 
-## 1. Install the dev environment
+## 1. Install Splendor
 
-From the Splendor repository checkout:
+Choose one of these supported MVP install paths.
+
+### Contributor checkout
 
 ```bash
 uv sync --dev
 uv run splendor --help
 ```
 
-The rest of this guide assumes you keep running `uv run splendor ...` from that same checkout and
-use `--root` to target the repository you want Splendor to manage. If you install Splendor into a
-different repo's environment instead, you can run the same commands from there without `--root`.
+### Local package install
+
+```bash
+uv pip install .
+splendor --help
+```
+
+### Built wheel install
+
+```bash
+uv build
+uv pip install dist/splendor-*.whl
+splendor --help
+```
+
+The examples below use `uv run splendor ... --root ...` from a contributor checkout. If you
+installed Splendor into an environment instead, replace `uv run splendor` with `splendor`. If that
+environment lives inside the target repository, you can also drop `--root`.
 
 ## 2. Create a demo repository
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -313,12 +313,13 @@ Ship a first public MVP that is stable enough for real project use.
 
 ### Milestone 5 status
 
-`M5-P1` is implemented. The repository now has an MVP entrypoint README, a dedicated quickstart,
-companion-repo setup guidance, a committed in-repo example workspace, and smoke tests that keep
-the docs and sample artifacts aligned with the current CLI behavior.
+`M5-P1` and `M5-P2` are implemented. The repository now has an MVP entrypoint README, a dedicated
+quickstart, companion-repo setup guidance, a committed in-repo example workspace, broader
+regression coverage for operational edge cases, consistent one-line CLI error output, and a
+package-install smoke path that validates the built CLI.
 
-The next planned PR is `M5-P2`, which focuses on broader hardening: coverage expansion, error
-polish, packaging, and release-quality cleanup.
+The next planned PR is `M6-P1`, which expands review-state and provenance modeling for stronger
+post-MVP trust and auditability.
 
 ---
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 from pathlib import Path
 
+from splendor import __version__
 from splendor.commands.add_source import add_source
 from splendor.commands.file_answer import (
     default_answer_page_id,
@@ -45,10 +46,15 @@ from splendor.utils.time import utc_now_iso
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="splendor", description="Splendor knowledge compiler CLI")
     parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    parser.add_argument(
         "--root",
         default=Path.cwd(),
         type=Path,
-        help="Repository root to operate on. Defaults to the current working directory.",
+        help="Workspace root to operate on. Defaults to the current working directory.",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -56,7 +62,11 @@ def build_parser() -> argparse.ArgumentParser:
     init_parser.set_defaults(handler=handle_init)
 
     add_source_parser = subparsers.add_parser("add-source", help="Register a new immutable source")
-    add_source_parser.add_argument("path", type=Path, help="Path to the source file to register")
+    add_source_parser.add_argument(
+        "path",
+        type=Path,
+        help="Path to the source file to register.",
+    )
     add_source_parser.add_argument(
         "--storage-mode",
         choices=STORAGE_MODES,
@@ -94,7 +104,10 @@ def build_parser() -> argparse.ArgumentParser:
     materialize_parser = subparsers.add_parser(
         "materialize-source", help="Create or refresh a source storage artifact"
     )
-    materialize_parser.add_argument("source_id", help="Registered source identifier to materialize")
+    materialize_parser.add_argument(
+        "source_id",
+        help="Registered source identifier to materialize.",
+    )
     materialize_parser.add_argument(
         "--storage-mode",
         choices=tuple(mode for mode in STORAGE_MODES if mode != "none"),
@@ -121,7 +134,7 @@ def build_parser() -> argparse.ArgumentParser:
     health_parser.set_defaults(handler=handle_health)
 
     query_parser = subparsers.add_parser("query", help="Query maintained wiki and planning records")
-    query_parser.add_argument("question", nargs="+", help="Question or search phrase")
+    query_parser.add_argument("question", nargs="+", help="Question or search phrase.")
     query_parser.add_argument(
         "--json",
         action="store_true",
@@ -141,10 +154,10 @@ def build_parser() -> argparse.ArgumentParser:
     file_answer_parser.add_argument(
         "--title",
         required=True,
-        help="Title for the filed answer page",
+        help="Title for the filed answer page.",
     )
-    file_answer_parser.add_argument("--page-id", help="Explicit page identifier override")
-    file_answer_parser.add_argument("--question-id", help="Explicit question to mark answered")
+    file_answer_parser.add_argument("--page-id", help="Explicit page identifier override.")
+    file_answer_parser.add_argument("--question-id", help="Explicit question to mark answered.")
     file_answer_parser.set_defaults(handler=handle_file_answer)
 
     task_parser = subparsers.add_parser("task", help="Create or inspect task records")
@@ -293,6 +306,16 @@ def handle_init(args: argparse.Namespace) -> int:
     return 0
 
 
+def _error_message(exc: Exception) -> str:
+    message = " ".join(str(exc).splitlines()).strip()
+    return message or exc.__class__.__name__
+
+
+def _print_error(exc: Exception) -> int:
+    print(f"Error: {_error_message(exc)}")
+    return 1
+
+
 def handle_add_source(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     candidate_path = args.path.expanduser()
@@ -305,8 +328,7 @@ def handle_add_source(args: argparse.Namespace) -> int:
             capture_source_commit=args.capture_source_commit,
         )
     except (FileNotFoundError, IsADirectoryError, ValueError) as exc:
-        print(f"Error: {exc}")
-        return 1
+        return _print_error(exc)
     action = "Already registered" if result.already_registered else "Registered"
     print(f"{action} source {result.source_id}")
     print(f"Manifest: {result.manifest_path}")
@@ -323,8 +345,7 @@ def handle_ingest(args: argparse.Namespace) -> int:
         try:
             result = drain_pending_ingest_jobs(root)
         except (FileNotFoundError, RuntimeError, ValueError) as exc:
-            print(f"Error: {exc}")
-            return 1
+            return _print_error(exc)
 
         if result.total == 0:
             print("No pending ingest jobs")
@@ -344,8 +365,7 @@ def handle_ingest(args: argparse.Namespace) -> int:
     try:
         result = ingest_source(root, args.source_id)
     except (FileNotFoundError, RuntimeError, ValueError) as exc:
-        print(f"Error: {exc}")
-        return 1
+        return _print_error(exc)
 
     if result.no_op:
         print(f"Source {result.source_id} is already ingested for the current pipeline version")
@@ -367,8 +387,7 @@ def handle_materialize_source(args: argparse.Namespace) -> int:
     try:
         result = materialize_source(root, args.source_id, storage_mode=args.storage_mode)
     except (FileNotFoundError, ValueError) as exc:
-        print(f"Error: {exc}")
-        return 1
+        return _print_error(exc)
 
     print(f"Materialized source {result.source_id}")
     print(f"Manifest: {result.manifest_path}")
@@ -384,7 +403,7 @@ def _print_maintenance_stdout(command: str, report, *, json_output: bool) -> Non
         return
 
     if report.status == "error":
-        print(f"Error: {report.fatal_error}")
+        print(f"Error: {_error_message(ValueError(report.fatal_error or 'unknown error'))}")
         return
 
     label = "records" if command == "health" else "items"
@@ -424,8 +443,7 @@ def handle_query(args: argparse.Namespace) -> int:
     try:
         result = run_query(root, " ".join(args.question))
     except ValueError as exc:
-        print(f"Error: {exc}")
-        return 1
+        return _print_error(exc)
 
     try:
         layout = resolve_layout(root, load_config(root))
@@ -454,8 +472,7 @@ def handle_query(args: argparse.Namespace) -> int:
         )
         write_query_snapshot(last_query_path_for(layout), snapshot)
     except OSError as exc:
-        print(f"Error: {exc}")
-        return 1
+        return _print_error(exc)
 
     if args.json_output:
         payload = {
@@ -498,8 +515,7 @@ def handle_query(args: argparse.Namespace) -> int:
 
 def handle_file_answer(args: argparse.Namespace) -> int:
     if not args.from_last_query:
-        print("Error: file-answer currently requires --from-last-query")
-        return 1
+        return _print_error(ValueError("file-answer currently requires --from-last-query"))
 
     root = args.root.resolve()
     question_update = None
@@ -513,8 +529,7 @@ def handle_file_answer(args: argparse.Namespace) -> int:
                 answer_title=args.title,
             )
         except ValueError as exc:
-            print(f"Error: {exc}")
-            return 1
+            return _print_error(exc)
 
     try:
         result = file_answer_from_last_query(
@@ -524,8 +539,7 @@ def handle_file_answer(args: argparse.Namespace) -> int:
             question_update=question_update,
         )
     except (OSError, ValueError) as exc:
-        print(f"Error: {exc}")
-        return 1
+        return _print_error(exc)
 
     print(f"Filed answer {result.page_id}")
     print(f"Page: {result.page_path}")
@@ -555,8 +569,7 @@ def handle_task_create(args: argparse.Namespace) -> int:
             source_refs=args.source_ref,
         )
     except ValueError as exc:
-        print(f"Error: {exc}")
-        return 1
+        return _print_error(exc)
 
     print(f"Created task {result.record_id}")
     print(f"Path: {result.path}")
@@ -572,8 +585,7 @@ def handle_task_list(args: argparse.Namespace) -> int:
             milestone_ref=args.milestone_ref,
         )
     except ValueError as exc:
-        print(f"Error: {exc}")
-        return 1
+        return _print_error(exc)
 
     for row in rows:
         print(f"{row.task_id}  {row.status}  {row.priority}  {row.title}")
@@ -593,8 +605,7 @@ def handle_milestone_create(args: argparse.Namespace) -> int:
             question_refs=args.question_ref,
         )
     except ValueError as exc:
-        print(f"Error: {exc}")
-        return 1
+        return _print_error(exc)
 
     print(f"Created milestone {result.record_id}")
     print(f"Path: {result.path}")
@@ -605,8 +616,7 @@ def handle_milestone_list(args: argparse.Namespace) -> int:
     try:
         rows = list_milestones(args.root.resolve(), status=args.status)
     except ValueError as exc:
-        print(f"Error: {exc}")
-        return 1
+        return _print_error(exc)
 
     for row in rows:
         target_date = row.target_date or "-"
@@ -628,8 +638,7 @@ def handle_decision_create(args: argparse.Namespace) -> int:
             related_questions=args.related_question,
         )
     except ValueError as exc:
-        print(f"Error: {exc}")
-        return 1
+        return _print_error(exc)
 
     print(f"Created decision {result.record_id}")
     print(f"Path: {result.path}")
@@ -648,8 +657,7 @@ def handle_question_create(args: argparse.Namespace) -> int:
             related_decisions=args.related_decision,
         )
     except ValueError as exc:
-        print(f"Error: {exc}")
-        return 1
+        return _print_error(exc)
 
     print(f"Created question {result.record_id}")
     print(f"Path: {result.path}")

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -13,6 +13,8 @@ from splendor.state.source_registry import (
     _write_workspace_symlink,
     load_source_record,
     materializing_storage_mode_for_source,
+    resolve_manifest_storage_path,
+    validate_stored_source_location,
     write_source_record,
 )
 
@@ -61,6 +63,47 @@ def test_add_source_registers_workspace_file_without_copy_by_default(tmp_path: P
     assert manifest.materialized_at is None
     assert manifest.original_path == "note.md"
     assert not (tmp_path / "raw" / "sources" / result.source_id).exists()
+
+
+def test_resolve_manifest_storage_path_rejects_absolute_paths(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="escapes workspace root"):
+        resolve_manifest_storage_path(tmp_path, "/tmp/source.md")
+
+
+def test_resolve_manifest_storage_path_rejects_escaping_paths(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="escapes workspace root"):
+        resolve_manifest_storage_path(tmp_path, "../outside.md")
+
+
+def test_validate_stored_source_location_rejects_paths_outside_raw_sources(tmp_path: Path) -> None:
+    raw_sources_dir = tmp_path / "raw" / "sources"
+    raw_sources_dir.mkdir(parents=True)
+    outside = tmp_path / "elsewhere" / "source.md"
+    outside.parent.mkdir(parents=True)
+    outside.write_text("hello\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="outside the configured raw source storage area"):
+        validate_stored_source_location(
+            outside,
+            raw_sources_dir,
+            "src-123",
+            "elsewhere/source.md",
+        )
+
+
+def test_validate_stored_source_location_rejects_wrong_source_directory(tmp_path: Path) -> None:
+    raw_sources_dir = tmp_path / "raw" / "sources"
+    stored = raw_sources_dir / "src-other" / "source.md"
+    stored.parent.mkdir(parents=True)
+    stored.write_text("hello\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="outside the expected source directory"):
+        validate_stored_source_location(
+            stored,
+            raw_sources_dir,
+            "src-123",
+            "raw/sources/src-other/source.md",
+        )
 
 
 def test_add_source_stores_workspace_relative_source_ref_for_nested_sources(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import json
 import re
 import shutil
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -9,7 +10,7 @@ import yaml
 import splendor.cli as cli_module
 from splendor.cli import build_parser, main
 from splendor.commands.ingest import enqueue_ingest_job
-from splendor.schemas import KnowledgePageFrontmatter
+from splendor.schemas import KnowledgePageFrontmatter, MaintenanceIssue, MaintenanceReport
 from splendor.state.query_snapshot import load_query_snapshot
 from splendor.state.runtime import load_queue_item
 
@@ -30,6 +31,14 @@ def test_cli_init_command(tmp_path: Path, capsys) -> None:
     assert (tmp_path / "wiki" / "index.md").exists()
     captured = capsys.readouterr()
     assert "Initialized Splendor workspace" in captured.out
+
+
+def test_cli_version_flag_prints_package_version(capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--version"])
+
+    assert exc_info.value.code == 0
+    assert capsys.readouterr().out == "splendor 0.1.0a0\n"
 
 
 def test_cli_add_source_capture_source_commit_flags_are_tri_state() -> None:
@@ -351,6 +360,37 @@ def test_cli_ingest_pending_continues_after_failure(tmp_path: Path, capsys) -> N
     assert "Drain summary: processed=2 succeeded=1 failed=1 skipped=0" in captured.out
 
 
+def test_cli_ingest_pending_reports_failed_and_skipped_mix(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+
+    skipped_source = tmp_path / "skipped.md"
+    skipped_source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(skipped_source)])
+    skipped_source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    main(["--root", str(tmp_path), "ingest", skipped_source_id])
+    capsys.readouterr()
+    enqueue_ingest_job(tmp_path, skipped_source_id)
+
+    missing_source = tmp_path / "missing.md"
+    missing_source.write_text("missing file content\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(missing_source)])
+    manifest_paths = sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    failing_source_id = next(path.stem for path in manifest_paths if path.stem != skipped_source_id)
+    missing_source.unlink()
+    enqueue_ingest_job(tmp_path, failing_source_id)
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert (
+        f"{skipped_source_id}: skipped (already ingested for the current pipeline version)"
+        in captured.out
+    )
+    assert f"{failing_source_id}: failed (Workspace source is missing: missing.md)" in captured.out
+    assert "Drain summary: processed=1 succeeded=0 failed=1 skipped=1" in captured.out
+
+
 def test_cli_materialize_source_command(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     source = tmp_path / "brief.md"
@@ -467,6 +507,48 @@ def test_cli_health_command_supports_json_output(tmp_path: Path, capsys) -> None
     assert payload["command"] == "health"
     assert payload["status"] == "passed"
     assert payload["issue_count"] == 0
+
+
+def test_cli_health_command_uses_issue_code_when_no_subject_fields_exist(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    report = MaintenanceReport(
+        command="health",
+        created_at="2026-04-21T10:00:00+00:00",
+        status="failed",
+        checked_count=0,
+        issue_count=1,
+        issues=[MaintenanceIssue(code="fallback-code", message="fallback message")],
+    )
+
+    fake_result = SimpleNamespace(exit_code=1, report=report)
+
+    monkeypatch.setattr(
+        cli_module,
+        "execute_maintenance_command",
+        lambda *args, **kwargs: fake_result,
+    )
+
+    exit_code = main(["--root", str(tmp_path), "health"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "- fallback-code: fallback message" in captured.out
+
+
+def test_cli_query_command_collapses_multiline_errors(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        cli_module,
+        "run_query",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("first line\nsecond line")),
+    )
+
+    exit_code = main(["--root", str(tmp_path), "query", "test"])
+
+    assert exit_code == 1
+    assert capsys.readouterr().out == "Error: first line second line\n"
 
 
 def test_cli_lint_command_passes_for_initialized_workspace(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 import splendor.cli as cli_module
+from splendor import __version__
 from splendor.cli import build_parser, main
 from splendor.commands.ingest import enqueue_ingest_job
 from splendor.schemas import KnowledgePageFrontmatter, MaintenanceIssue, MaintenanceReport
@@ -38,7 +39,7 @@ def test_cli_version_flag_prints_package_version(capsys) -> None:
         main(["--version"])
 
     assert exc_info.value.code == 0
-    assert capsys.readouterr().out == "splendor 0.1.0a0\n"
+    assert capsys.readouterr().out == f"splendor {__version__}\n"
 
 
 def test_cli_add_source_capture_source_commit_flags_are_tri_state() -> None:

--- a/tests/test_file_answer.py
+++ b/tests/test_file_answer.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+
+import pytest
+
+from splendor.commands.file_answer import default_answer_page_id, file_answer_from_last_query
+from splendor.commands.init import initialize_workspace
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import KnowledgePageFrontmatter, QueryMatchSnapshot, QuerySnapshot
+from splendor.state.query_snapshot import last_query_path_for, write_query_snapshot
+from splendor.utils.wiki import render_frontmatter
+
+
+def _write_queryable_page(path: Path, *, title: str, page_id: str, body: str) -> None:
+    record = KnowledgePageFrontmatter(
+        kind="topic",
+        title=title,
+        page_id=page_id,
+        status="active",
+        confidence=1.0,
+        source_refs=[],
+        related_pages=[],
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\n{render_frontmatter(record)}\n---\n\n{body}", encoding="utf-8")
+
+
+def test_default_answer_page_id_rejects_degenerate_titles() -> None:
+    with pytest.raises(ValueError, match="ASCII letter or number"):
+        default_answer_page_id("!!!")
+
+
+def test_file_answer_from_last_query_requires_saved_snapshot(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    with pytest.raises(ValueError, match="No saved query snapshot found"):
+        file_answer_from_last_query(tmp_path, title="Answer", page_id=None)
+
+
+def test_file_answer_from_last_query_renders_empty_match_snapshots(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    write_query_snapshot(
+        last_query_path_for(layout),
+        QuerySnapshot(
+            query="nothing",
+            summary='No matches found for "nothing".',
+            match_count=0,
+            created_at="2026-04-21T10:00:00+00:00",
+            matches=[],
+        ),
+    )
+
+    result = file_answer_from_last_query(tmp_path, title="No Match Answer", page_id=None)
+
+    page = result.page_path.read_text(encoding="utf-8")
+    assert "- No matches were present in the saved query snapshot." in page
+    assert "## Provenance" in page
+    assert "Filed from saved query snapshot" in page
+
+
+def test_file_answer_from_last_query_dedupes_source_refs(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    write_query_snapshot(
+        last_query_path_for(layout),
+        QuerySnapshot(
+            query="ranking",
+            summary="Ranking summary",
+            match_count=2,
+            created_at="2026-04-21T10:00:00+00:00",
+            matches=[
+                QueryMatchSnapshot(
+                    rank=1,
+                    score=9,
+                    document_class="wiki",
+                    kind="topic",
+                    record_id="topic-ranking",
+                    title="Ranking",
+                    path="wiki/topics/ranking.md",
+                    status="active",
+                    snippet="Ranking evidence.",
+                    source_refs=["src-1", "src-2"],
+                    generated_by_run_ids=[],
+                    tags=[],
+                ),
+                QueryMatchSnapshot(
+                    rank=2,
+                    score=8,
+                    document_class="wiki",
+                    kind="topic",
+                    record_id="topic-ranking-2",
+                    title="Ranking Follow-up",
+                    path="wiki/topics/ranking-2.md",
+                    status="active",
+                    snippet="More ranking evidence.",
+                    source_refs=["src-2", "src-3"],
+                    generated_by_run_ids=[],
+                    tags=[],
+                ),
+            ],
+        ),
+    )
+
+    result = file_answer_from_last_query(tmp_path, title="Ranking Answer", page_id=None)
+
+    page = result.page_path.read_text(encoding="utf-8")
+    assert "source_refs:\n- src-1\n- src-2\n- src-3\n" in page

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -363,6 +363,41 @@ def test_run_ingest_job_rejects_escaping_queue_payload_ref(tmp_path: Path) -> No
     )
 
 
+def test_run_ingest_job_rejects_missing_queue_manifest(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    added.manifest_path.unlink()
+
+    with pytest.raises(FileNotFoundError, match="Queue payload is missing source manifest"):
+        run_ingest_job(tmp_path, queue_path)
+
+    updated_queue = load_queue_item(queue_path)
+    assert updated_queue.status == "failed"
+    assert "missing source manifest" in updated_queue.last_error
+
+
+def test_run_ingest_job_rejects_manifest_source_id_mismatch(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={"source_id": "src-other"}
+    )
+    write_source_record(added.manifest_path, source_record)
+
+    with pytest.raises(ValueError, match="does not match queued job"):
+        run_ingest_job(tmp_path, queue_path)
+
+    updated_queue = load_queue_item(queue_path)
+    assert updated_queue.status == "failed"
+    assert "does not match queued job" in updated_queue.last_error
+
+
 def test_run_ingest_job_claims_once_and_clears_lease_on_success(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,43 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_built_wheel_exposes_splendor_cli(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    env = {**os.environ, "PYTHONPATH": str(repo_root / "src")}
+    subprocess.run(
+        ["uv", "build", "--out-dir", str(tmp_path / "dist")],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    wheel_path = next((tmp_path / "dist").glob("*.whl"))
+
+    venv_dir = tmp_path / "venv"
+    subprocess.run(
+        ["uv", "venv", str(venv_dir), "--python", sys.executable],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    bin_dir = venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
+    subprocess.run(
+        ["uv", "pip", "install", "--python", str(bin_dir / "python"), str(wheel_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = subprocess.run(
+        [str(bin_dir / "splendor"), "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "Splendor knowledge compiler CLI" in result.stdout
+    assert "add-source" in result.stdout

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -25,15 +25,17 @@ def test_built_wheel_exposes_splendor_cli(tmp_path: Path) -> None:
         text=True,
     )
     bin_dir = venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
+    python_executable = bin_dir / ("python.exe" if sys.platform == "win32" else "python")
+    splendor_executable = bin_dir / ("splendor.exe" if sys.platform == "win32" else "splendor")
     subprocess.run(
-        ["uv", "pip", "install", "--python", str(bin_dir / "python"), str(wheel_path)],
+        ["uv", "pip", "install", "--python", str(python_executable), str(wheel_path)],
         check=True,
         capture_output=True,
         text=True,
     )
 
     result = subprocess.run(
-        [str(bin_dir / "splendor"), "--help"],
+        [str(splendor_executable), "--help"],
         check=True,
         capture_output=True,
         text=True,

--- a/tests/test_source_resolver.py
+++ b/tests/test_source_resolver.py
@@ -233,6 +233,21 @@ def test_resolve_source_content_pointer_source_rejects_malformed_pointer_artifac
         resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
 
 
+def test_resolve_source_content_pointer_source_rejects_escaping_pointer_path(
+    tmp_path: Path,
+) -> None:
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/pointer.json",
+        storage_mode="pointer",
+        storage_path="../outside/pointer.json",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+    )
+
+    with pytest.raises(ValueError, match="escapes workspace root"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
 def test_resolve_source_content_pointer_source_rejects_source_ref_mismatch(
     tmp_path: Path,
 ) -> None:
@@ -354,6 +369,28 @@ def test_resolve_source_content_symlink_source_rejects_regular_file_artifact(
     )
 
     with pytest.raises(ValueError, match="Source symlink artifact is not a symlink"):
+        resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
+
+
+def test_resolve_source_content_symlink_source_rejects_wrong_source_directory(
+    tmp_path: Path,
+) -> None:
+    source_file = tmp_path / "docs" / "spec.md"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("hello\n", encoding="utf-8")
+    artifact = tmp_path / "raw" / "sources" / "src-other" / "spec.md"
+    artifact.parent.mkdir(parents=True)
+    artifact.symlink_to(Path("../../../docs/spec.md"))
+    source = make_source_record(
+        path="raw/sources/src-1234567890abcdef/spec.md",
+        storage_mode="symlink",
+        storage_path="raw/sources/src-other/spec.md",
+        source_ref="docs/spec.md",
+        source_ref_kind="workspace_path",
+        checksum="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+    )
+
+    with pytest.raises(ValueError, match="outside the expected source directory"):
         resolve_source_content(tmp_path, source, tmp_path / "raw" / "sources")
 
 

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -1,4 +1,16 @@
-from splendor.utils.wiki import update_index_content
+import pytest
+
+from splendor.commands.init import initialize_workspace
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import KnowledgePageFrontmatter
+from splendor.utils.wiki import (
+    WikiUpdatePayload,
+    apply_wiki_updates,
+    parse_wiki_markdown,
+    render_frontmatter,
+    update_index_content,
+)
 
 
 def test_update_index_content_replaces_existing_source_entry_by_source_id() -> None:
@@ -16,3 +28,80 @@ def test_update_index_content_replaces_existing_source_entry_by_source_id() -> N
     assert "- [Old title](sources/old-page.md) (`src-123`)" not in updated
     assert "- [New title](sources/new-page.md) (`src-123`)" in updated
     assert updated.count("(`src-123`)") == 1
+
+
+def test_parse_wiki_markdown_rejects_invalid_yaml(tmp_path) -> None:
+    page = tmp_path / "bad.md"
+    page.write_text("---\nkind: [\n---\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid YAML frontmatter"):
+        parse_wiki_markdown(page)
+
+
+def test_parse_wiki_markdown_rejects_schema_failure(tmp_path) -> None:
+    page = tmp_path / "bad.md"
+    page.write_text("---\nkind: concept\ntitle: Missing page id\n---\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="failed schema validation"):
+        parse_wiki_markdown(page)
+
+
+def test_parse_wiki_markdown_accepts_valid_page(tmp_path) -> None:
+    record = KnowledgePageFrontmatter(
+        kind="concept",
+        title="Valid",
+        page_id="concept-valid",
+        status="active",
+        confidence=1.0,
+        source_refs=[],
+        related_pages=[],
+    )
+    page = tmp_path / "valid.md"
+    page.write_text(
+        f"---\n{render_frontmatter(record)}\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    parsed = parse_wiki_markdown(page)
+
+    assert parsed.frontmatter.page_id == "concept-valid"
+    assert "Body." in parsed.body
+
+
+def test_apply_wiki_updates_rolls_back_when_extra_write_fails(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    initialize_workspace(tmp_path)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    page_path = layout.wiki_dir / "topics" / "answer.md"
+    original_index = layout.index_file.read_text(encoding="utf-8")
+    original_log = layout.log_file.read_text(encoding="utf-8")
+    extra_path = tmp_path / "planning" / "questions" / "question.md"
+
+    import splendor.utils.wiki as wiki_module
+
+    original_write_text_atomic = wiki_module.write_text_atomic
+
+    def fail_on_extra(path, content):
+        if path == extra_path:
+            raise OSError("disk full")
+        return original_write_text_atomic(path, content)
+
+    monkeypatch.setattr(wiki_module, "write_text_atomic", fail_on_extra)
+
+    with pytest.raises(OSError, match="disk full"):
+        apply_wiki_updates(
+            layout,
+            WikiUpdatePayload(
+                page_path=page_path,
+                page_content="page content\n",
+                index_content=original_index + "\n- changed\n",
+                log_content=original_log + "- changed\n",
+                extra_writes=[(extra_path, "question content\n")],
+            ),
+        )
+
+    assert not page_path.exists()
+    assert layout.index_file.read_text(encoding="utf-8") == original_index
+    assert layout.log_file.read_text(encoding="utf-8") == original_log
+    assert not extra_path.exists()


### PR DESCRIPTION
## Summary
- harden the CLI with shared one-line error formatting, a `--version` flag, and clearer install/help wording
- add targeted regression coverage for source registration, ingest queue edge cases, file-answer behavior, wiki rollback handling, and resolver path validation
- upgrade this repo's `pr-agent-context` integration to `v4.0.19` and adopt the approval-gated refresh fallback pattern with scheduled same-repo dispatches and explicit PR SHA overrides

## Why
This branch started as the planned `M5-P2` MVP hardening slice. While it was open, the repository also needed its existing `pr-agent-context` integration updated to the current recommended refresh pattern so approval-gated bot review events do not leave refresh stuck until a maintainer manually approves or reruns the workflow.

## pr-agent-context integration changes
- bumped both reusable workflow calls from `v4.0.18` to `v4.0.19`
- preserved the repository's `coverage_xml_artifact` patch-coverage setup and `coverage-xml` artifact reuse
- kept the normal review/comment/check-triggered refresh behavior
- added the repo-owned `schedule` -> `workflow_dispatch` fallback for same-repo PRs
- passed explicit `pull_request_number`, `pull_request_base_sha`, and `pull_request_head_sha` overrides into refresh runs
- adopted the guarded scheduled dispatcher shape from the upstream recommended example:
  - bounded recent comment lookup
  - recent/in-flight dispatch dedupe
  - per-PR error isolation
  - correct `github.rest.*` Octokit calls in `actions/github-script`
  - SHA-aware concurrency grouping for dispatched refresh runs

## Validation
- `uv run python` YAML parse validation for `.github/workflows/ci.yml` and `.github/workflows/pr-agent-context-refresh.yml`
- `uv run pytest`
- earlier branch validation for the M5-P2 changes also kept passing:
  - `uv run ruff format --check .`
  - `uv run ruff check .`
  - `uv run pytest --cov=splendor --cov-report=term-missing --cov-report=xml`
  - coverage improved from 91% to 92%

## Follow-up / Notes
- this PR intentionally keeps the repo's existing conventions unless they conflicted with the upstream `v4.0.19` refresh recommendation
- the next planned product slice after the M5-P2 work remains `M6-P1`: review-state and provenance model expansion
