### PR TITLE
M6-P1: Add provenance schemas and codify PR completion gate

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -20,7 +20,7 @@
 - [ ] Surface the richer provenance in CLI output and query results.
 - [ ] Add lint and health coverage for broken source/page/run provenance links.
 - [ ] Update schema/docs/user-facing references required by the new contracts.
-- [ ] Publish a non-draft GitHub PR for `M6-P1` with labels, milestone, and a detailed description.
+- [x] Publish a non-draft GitHub PR for `M6-P1` with labels, milestone, and a detailed description.
 
 ## M6-P1 Scope Boundaries
 

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -8,6 +8,27 @@
 - Next planned PR: `M6-P2`
 - Current blockers: none
 
+## M6-P1 Implementation Checklist
+
+- [x] Expand schema contracts for stronger review-state and provenance modeling.
+- [ ] Add page-level `review_state` without overloading lifecycle `status`.
+- [ ] Enrich source manifests with clearer review/provenance timestamps and durable page/run linkage.
+- [ ] Extend run records with structured source/page provenance alongside existing generic refs.
+- [ ] Keep existing manifests, pages, and run records backward-compatible with defaulted fields.
+- [ ] Thread the new fields through `splendor ingest` so source-summary pages start as `machine-generated`.
+- [ ] Persist deterministic cross-links among source manifests, source-summary pages, and run records.
+- [ ] Surface the richer provenance in CLI output and query results.
+- [ ] Add lint and health coverage for broken source/page/run provenance links.
+- [ ] Update schema/docs/user-facing references required by the new contracts.
+- [ ] Publish a non-draft GitHub PR for `M6-P1` with labels, milestone, and a detailed description.
+
+## M6-P1 Scope Boundaries
+
+- `M6-P1` includes review-state and provenance model expansion only.
+- `M6-P1` should focus on currently generated source-summary pages first, not every future wiki page type.
+- `M6-P1` should preserve `input_refs` and `output_refs` for compatibility even if richer structured fields are added.
+- `M6-P2` owns contradiction surfacing, contested annotations driven by conflicts, and automatic review-task creation.
+
 ## Active Task Breakdown
 
 - [x] Replace the bloated static rulebook with a concise `AGENTS.md`
@@ -27,6 +48,10 @@
 - [x] Implement `M5-P1`: MVP docs, quickstart, and example workspace
 - [x] Implement `M5-P2`: MVP hardening: coverage, errors, packaging, polish
 - [ ] Implement `M6-P1`: Review-state and provenance model expansion
+  - [x] Expand page, source, and run schemas with backward-compatible review/provenance fields
+  - [ ] Update ingest and wiki rendering to write `machine-generated` review state and explicit provenance links
+  - [ ] Expose provenance in CLI/query output and validate it in lint/health checks
+  - [ ] Update tests, schema docs, README, and PR-planning state for the finalized contract
 
 ## Context Pointers
 

--- a/.codex/memory.md
+++ b/.codex/memory.md
@@ -1,0 +1,7 @@
+# Repository Memory
+
+- Feature work and PR work in this repository are incomplete until the branch is pushed and a
+  non-draft GitHub PR with a detailed description is open.
+- Published PRs must carry intentional labels and the appropriate milestone before handoff.
+- Prefer repo-specific GitHub MCP tooling for PR metadata and use `gh` only for unsupported GitHub
+  actions such as creating a missing label or milestone or opening the PR.

--- a/.codex/skills/ready-non-draft-pr/SKILL.md
+++ b/.codex/skills/ready-non-draft-pr/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: "ready-non-draft-pr"
+description: "Use when work in this repository should count as complete only after a properly labeled, non-draft GitHub PR with a detailed description is open and assigned to the right milestone."
+---
+
+# Ready Non-Draft PR
+
+Use this skill for feature work, bugfix work, or PR work in this repository whenever GitHub
+handoff is part of completion.
+
+## Completion gate
+
+Do not treat the work as complete until all of the following are true:
+
+1. The intended changes are committed on the correct branch.
+2. The branch is pushed to the remote.
+3. A GitHub PR is open and is not a draft.
+4. The PR body explains what changed, why it changed, validation performed, and any follow-up work
+   or limitations.
+5. The PR has focused labels that match the change.
+6. The PR is assigned to the appropriate milestone when one exists.
+
+## Tool routing
+
+- Prefer repo-specific GitHub MCP tools for PR metadata updates.
+- Use `gh` only for unsupported GitHub operations such as creating a missing label or milestone or
+  opening the PR itself.
+
+## Close-out rule
+
+- If the PR is still draft, missing labels, missing a milestone, or missing a real description, the
+  task is still in progress.
+- Final handoff should report the branch name, PR URL, validation run, and any remaining follow-up
+  items.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,13 @@
 - Feature or PR work is not complete at local commit time, after local tests pass, or after the
   branch is committed locally. It only ends once the branch is pushed and a non-draft GitHub PR
   with a detailed description is open.
+- Treat that publish step as a universal completion gate for feature work and PR work, not as an
+  optional final polish step.
 - Published PRs should carry intentional GitHub metadata:
   apply the appropriate labels, assign the PR to a milestone, and avoid leaving review-ready work
   as draft unless the user explicitly asks for a draft.
+- Prefer repo-specific GitHub MCP tooling for PR metadata and fall back to `gh` only where the MCP
+  surface is missing, such as creating a missing label or milestone or opening the PR itself.
 - When finishing feature or PR work, explicitly verify that the published PR exists on GitHub and
   that its labels and milestone are set before treating the task as done.
 - When a PR implements work from a plan, update the versioned planning state in the same PR:

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -163,13 +163,18 @@ planned slice lands.
 ## Agent completion rule for PR work
 
 For agent-driven feature or PR work in this repository, local implementation is not the terminal
-state. The work should be treated as complete only after:
+state. Treat GitHub publication as a mandatory completion gate, not as optional follow-up. The work
+should be treated as complete only after:
 
 - the branch is pushed
 - a non-draft pull request is open on GitHub
 - the pull request has a detailed description
 - the pull request has intentional labels
 - the pull request is assigned to the appropriate milestone
+
+Prefer repo-specific GitHub MCP tooling for PR metadata updates and use `gh` only for operations
+the MCP surface does not support cleanly, such as creating a missing label or milestone or opening
+the PR itself.
 
 If any of those publication steps are still missing, the work is still in progress even if the code
 changes are already committed locally.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -28,8 +28,11 @@ Current implementation fields:
 - `pipeline_version`
 - `derived_artifacts`
 - `linked_pages`
+- `generated_by_run_ids`
 - `last_run_id`
 - `review_state`
+- `reviewed_at`
+- `reviewed_by`
 - `origin_url`
 - `original_path`
 - `source_ref`
@@ -38,6 +41,7 @@ Current implementation fields:
 - `storage_path`
 - `materialized_at`
 - `source_commit`
+- `provenance_links`
 
 ### Current source-record shape
 
@@ -64,11 +68,15 @@ Implemented fields:
 - `pipeline_version`
 - `derived_artifacts`
 - `linked_pages`
+- `generated_by_run_ids`
 - `last_run_id`
 - `review_state`
+- `reviewed_at`
+- `reviewed_by`
 - `origin_url`
 - `original_path`
 - `materialized_at`
+- `provenance_links`
 
 ### Field semantics
 
@@ -143,12 +151,15 @@ Minimal frontmatter contract for wiki pages:
 - `title`
 - `page_id`
 - `status`
+- `review_state`
 - `source_refs`
 - `generated_by_run_ids`
+- `last_generated_at`
 - `last_reviewed_at`
 - `confidence`
 - `related_pages`
 - `tags`
+- `provenance_links`
 
 ## Planning objects
 
@@ -173,6 +184,15 @@ Current persisted locations:
 
 - `state/queue/<job_id>.json`
 - `state/runs/<run_id>.json`
+
+Run records now reserve explicit provenance fields beside the original generic refs so later
+pipeline steps can answer questions like "which page did this run generate?" without parsing
+free-form `output_refs` values:
+
+- `source_ids`
+- `page_ids`
+- `page_refs`
+- `provenance_links`
 
 ## Current storage decision
 

--- a/examples/companion-repo/AGENTS.md
+++ b/examples/companion-repo/AGENTS.md
@@ -23,3 +23,9 @@ repository. It is not the governing `AGENTS.md` for the Splendor project itself.
 - Use source IDs such as `src-...` when linking planning records back to registered sources.
 - Do not use raw external file paths as planning `source_refs`.
 - Expect external sources to materialize under `raw/sources/` by default in the current MVP.
+
+## Completion gate
+
+- Treat feature work and PR work as incomplete until the branch is pushed and a non-draft GitHub PR
+  with a detailed description is open.
+- Published PRs should carry intentional labels and the appropriate milestone when one exists.

--- a/src/splendor/schemas/__init__.py
+++ b/src/splendor/schemas/__init__.py
@@ -7,11 +7,19 @@ from splendor.schemas.planning import (
     QuestionRecord,
     TaskRecord,
 )
+from splendor.schemas.provenance import ProvenanceLink
 from splendor.schemas.query import QueryMatchSnapshot, QuerySnapshot
 from splendor.schemas.runtime import QueueItemRecord, RunRecord
 from splendor.schemas.source import SourceRecord
 from splendor.schemas.source_pointer import SourcePointerArtifact
-from splendor.schemas.types import SourceRefKind, StorageMode, SummaryMode
+from splendor.schemas.types import (
+    PageReviewState,
+    ProvenanceRole,
+    SourceRefKind,
+    SourceReviewState,
+    StorageMode,
+    SummaryMode,
+)
 from splendor.schemas.wiki import KnowledgePageFrontmatter
 
 __all__ = [
@@ -21,12 +29,16 @@ __all__ = [
     "MaintenanceIssue",
     "MaintenanceReport",
     "MilestoneRecord",
+    "PageReviewState",
+    "ProvenanceLink",
+    "ProvenanceRole",
     "QueryMatchSnapshot",
     "QuerySnapshot",
     "QuestionRecord",
     "QueueItemRecord",
     "RunRecord",
     "SourceRefKind",
+    "SourceReviewState",
     "SourcePointerArtifact",
     "SourceRecord",
     "StorageMode",

--- a/src/splendor/schemas/provenance.py
+++ b/src/splendor/schemas/provenance.py
@@ -1,0 +1,25 @@
+"""Shared provenance schema fragments."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from splendor.schemas.types import ProvenanceRole
+
+
+class ProvenanceLink(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str | None = None
+    page_id: str | None = None
+    run_id: str | None = None
+    path_ref: str | None = None
+    role: ProvenanceRole | None = None
+    note: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_identity_fields(self) -> ProvenanceLink:
+        if self.source_id or self.page_id or self.run_id or self.path_ref:
+            return self
+        msg = "Provenance link must include at least one of source_id, page_id, run_id, or path_ref"
+        raise ValueError(msg)

--- a/src/splendor/schemas/runtime.py
+++ b/src/splendor/schemas/runtime.py
@@ -7,6 +7,7 @@ from typing import Literal
 from pydantic import Field
 
 from splendor.schemas.common import StrictRecord
+from splendor.schemas.provenance import ProvenanceLink
 
 
 class QueueItemRecord(StrictRecord):
@@ -37,3 +38,7 @@ class RunRecord(StrictRecord):
     warnings: list[str] = Field(default_factory=list)
     errors: list[str] = Field(default_factory=list)
     pipeline_version: str
+    source_ids: list[str] = Field(default_factory=list)
+    page_ids: list[str] = Field(default_factory=list)
+    page_refs: list[str] = Field(default_factory=list)
+    provenance_links: list[ProvenanceLink] = Field(default_factory=list)

--- a/src/splendor/schemas/source.py
+++ b/src/splendor/schemas/source.py
@@ -12,7 +12,8 @@ from typing import Literal
 from pydantic import Field
 
 from splendor.schemas.common import StrictRecord
-from splendor.schemas.types import SourceRefKind, StorageMode
+from splendor.schemas.provenance import ProvenanceLink
+from splendor.schemas.types import SourceRefKind, SourceReviewState, StorageMode
 
 
 class SourceRecord(StrictRecord):
@@ -29,8 +30,11 @@ class SourceRecord(StrictRecord):
     pipeline_version: str
     derived_artifacts: list[str] = Field(default_factory=list)
     linked_pages: list[str] = Field(default_factory=list)
+    generated_by_run_ids: list[str] = Field(default_factory=list)
     last_run_id: str | None = None
-    review_state: Literal["unreviewed", "human-reviewed", "stale"] = "unreviewed"
+    review_state: SourceReviewState = "unreviewed"
+    reviewed_at: str | None = None
+    reviewed_by: str | None = None
     origin_url: str | None = None
     original_path: str | None = None
     source_ref: str | None = None
@@ -39,3 +43,4 @@ class SourceRecord(StrictRecord):
     storage_path: str | None = None
     materialized_at: str | None = None
     source_commit: str | None = None
+    provenance_links: list[ProvenanceLink] = Field(default_factory=list)

--- a/src/splendor/schemas/types.py
+++ b/src/splendor/schemas/types.py
@@ -7,5 +7,15 @@ from typing import Literal
 StorageMode = Literal["none", "copy", "symlink", "pointer"]
 SummaryMode = Literal["none", "excerpt", "full"]
 SourceRefKind = Literal["workspace_path", "external_path", "url", "imported", "stored_artifact"]
+PageReviewState = Literal["draft", "machine-generated", "human-reviewed", "contested", "stale"]
+SourceReviewState = Literal[
+    "unreviewed",
+    "draft",
+    "machine-generated",
+    "human-reviewed",
+    "contested",
+    "stale",
+]
+ProvenanceRole = Literal["input", "output", "supports", "generated-from", "generated-page"]
 
 STORAGE_MODES = ("none", "copy", "symlink", "pointer")

--- a/src/splendor/schemas/wiki.py
+++ b/src/splendor/schemas/wiki.py
@@ -7,6 +7,8 @@ from typing import Literal
 from pydantic import Field
 
 from splendor.schemas.common import StrictRecord
+from splendor.schemas.provenance import ProvenanceLink
+from splendor.schemas.types import PageReviewState
 
 
 class KnowledgePageFrontmatter(StrictRecord):
@@ -14,9 +16,12 @@ class KnowledgePageFrontmatter(StrictRecord):
     title: str
     page_id: str
     status: Literal["draft", "active", "stale"] = "draft"
+    review_state: PageReviewState = "draft"
     source_refs: list[str] = Field(default_factory=list)
     generated_by_run_ids: list[str] = Field(default_factory=list)
+    last_generated_at: str | None = None
     last_reviewed_at: str | None = None
     confidence: float = Field(default=0.0, ge=0.0, le=1.0)
     related_pages: list[str] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
+    provenance_links: list[ProvenanceLink] = Field(default_factory=list)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,7 +1,13 @@
 import pytest
 from pydantic import ValidationError
 
-from splendor.schemas import SourcePointerArtifact, SourceRecord
+from splendor.schemas import (
+    KnowledgePageFrontmatter,
+    ProvenanceLink,
+    RunRecord,
+    SourcePointerArtifact,
+    SourceRecord,
+)
 
 
 def test_source_record_validation_accepts_valid_payload() -> None:
@@ -33,10 +39,95 @@ def test_source_record_validation_accepts_valid_expanded_payload() -> None:
         storage_path=None,
         materialized_at="2026-04-10T15:01:00+00:00",
         source_commit="abc123",
+        generated_by_run_ids=["run-src-123"],
+        reviewed_at="2026-04-11T15:00:00+00:00",
+        reviewed_by="reviewer@example.com",
+        provenance_links=[
+            ProvenanceLink(
+                source_id="src-1234567890abcdef",
+                run_id="run-src-123",
+                path_ref="wiki/sources/src-1234567890abcdef.md",
+                role="generated-page",
+            )
+        ],
     )
 
     assert record.source_ref == "docs/spec.md"
     assert record.storage_mode == "none"
+    assert record.generated_by_run_ids == ["run-src-123"]
+    assert record.reviewed_by == "reviewer@example.com"
+
+
+def test_knowledge_page_frontmatter_defaults_review_and_provenance_fields() -> None:
+    record = KnowledgePageFrontmatter(
+        kind="concept",
+        title="Overview",
+        page_id="concept-overview",
+    )
+
+    assert record.review_state == "draft"
+    assert record.last_generated_at is None
+    assert record.provenance_links == []
+
+
+def test_knowledge_page_frontmatter_accepts_expanded_provenance_payload() -> None:
+    record = KnowledgePageFrontmatter(
+        kind="source-summary",
+        title="Spec",
+        page_id="src-1234567890abcdef",
+        status="active",
+        review_state="machine-generated",
+        source_refs=["src-1234567890abcdef"],
+        generated_by_run_ids=["run-src-123"],
+        last_generated_at="2026-04-10T15:02:00+00:00",
+        provenance_links=[
+            ProvenanceLink(
+                source_id="src-1234567890abcdef",
+                run_id="run-src-123",
+                path_ref="state/manifests/sources/src-1234567890abcdef.json",
+                role="generated-from",
+            )
+        ],
+    )
+
+    assert record.review_state == "machine-generated"
+    assert record.provenance_links[0].role == "generated-from"
+
+
+def test_run_record_accepts_expanded_provenance_payload() -> None:
+    record = RunRecord(
+        run_id="run-src-123",
+        job_id="ingest-src-123",
+        job_type="ingest_source",
+        started_at="2026-04-10T15:00:00+00:00",
+        finished_at="2026-04-10T15:01:00+00:00",
+        status="succeeded",
+        input_refs=["state/manifests/sources/src-1234567890abcdef.json"],
+        output_refs=["wiki/sources/src-1234567890abcdef.md"],
+        warnings=[],
+        errors=[],
+        pipeline_version="0.1.0a0",
+        source_ids=["src-1234567890abcdef"],
+        page_ids=["src-1234567890abcdef"],
+        page_refs=["wiki/sources/src-1234567890abcdef.md"],
+        provenance_links=[
+            ProvenanceLink(
+                source_id="src-1234567890abcdef",
+                page_id="src-1234567890abcdef",
+                run_id="run-src-123",
+                path_ref="wiki/sources/src-1234567890abcdef.md",
+                role="output",
+            )
+        ],
+    )
+
+    assert record.source_ids == ["src-1234567890abcdef"]
+    assert record.page_refs == ["wiki/sources/src-1234567890abcdef.md"]
+
+
+def test_provenance_link_requires_an_identity_field() -> None:
+    with pytest.raises(ValidationError):
+        ProvenanceLink()
 
 
 def test_source_record_validation_rejects_bad_checksum() -> None:


### PR DESCRIPTION
## Summary

This PR lands the first implementation slice of `M6-P1`.

It does two things:

- expands Splendor's schema contracts so review state and provenance can be modeled explicitly across knowledge pages, source manifests, and run records
- codifies the repository rule that feature work and PR work are only complete once a properly labeled, non-draft PR with a detailed description is open on GitHub

## Planning notation

- Notation: `M6-P1`
- Parent milestone: `Milestone 6 — Post-MVP: stronger provenance and review state`
- Plan sources:
  - `.agent-plan.md`
  - `docs/splendor_mvp_to_v1_roadmap.md`

## What changed

### Schema groundwork for provenance and review state

- added shared review-state aliases in `src/splendor/schemas/types.py`
- added a reusable `ProvenanceLink` model in `src/splendor/schemas/provenance.py`
- expanded `KnowledgePageFrontmatter` with:
  - `review_state`
  - `last_generated_at`
  - `provenance_links`
- expanded `SourceRecord` with:
  - `generated_by_run_ids`
  - `reviewed_at`
  - `reviewed_by`
  - `provenance_links`
  - a broader review-state enum for post-MVP workflows
- expanded `RunRecord` with:
  - `source_ids`
  - `page_ids`
  - `page_refs`
  - `provenance_links`
- kept the changes backward-compatible by adding defaulted fields instead of rewriting existing record requirements

### Validation and documentation

- added schema validation coverage for the new fields and provenance link shape in `tests/test_schemas.py`
- updated `docs/schema_contracts.md` to document the new page/source/run fields
- updated `.agent-plan.md` to record the completed schema-contract subtask for `M6-P1`

### Agent completion policy codification

- strengthened `AGENTS.md` so PR publication is treated as a mandatory completion gate, not optional polish
- updated `examples/companion-repo/AGENTS.md` with the same non-draft-PR completion rule
- updated `docs/ci_and_repo_automation.md` to make the PR gate and GitHub MCP preference explicit
- added repo-local agent memory in `.codex/memory.md`
- added a repo-local skill in `.codex/skills/ready-non-draft-pr/SKILL.md`

## Why this change

`M6-P1` is about trust and auditability. The existing schema layer could record basic lifecycle state, but it could not yet express richer review status or structured provenance links that later ingest, query, lint, and health work can rely on. This PR establishes that contract first so later `M6-P1` work can populate and surface the data without inventing incompatible shapes.

The PR-completion policy changes make the repository's existing expectation explicit in the agent-facing files that control behavior. That avoids agents stopping at a local commit or test pass when the repository expects a published, reviewable PR with labels and a milestone.

## Validation

- `uv run ruff check src/splendor/schemas tests/test_schemas.py tests/test_query.py tests/test_examples.py`
- `uv run pytest tests/test_schemas.py tests/test_query.py tests/test_examples.py`

## Known limitations and follow-up

This PR intentionally stops at the schema-contract and policy layer. It does not yet:

- thread the new provenance fields through `splendor ingest`
- render the richer provenance in CLI output
- add lint/health enforcement for the new cross-links
- implement contradiction surfacing or automatic review-task creation

Those follow-on pieces remain in the next `M6-P1` steps and `M6-P2`.
