### PR TITLE
M7-P1.1: add repo scan and planning-state guardrails

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,6 +3,7 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
+- Last completed PR sub-slice: `M6-P2.1`
 - Last action taken: `M6-P2.1` is implemented; ingest now optionally runs contradiction review against existing source-summary pages, contested pages persist contradiction annotations plus linked review tasks, query surfaces contradiction metadata, and lint/health validate the new task/run/page links.
 - Active planned slice: `M7-P1`
 - Active planned PR sub-slice: `M7-P1.1`
@@ -49,7 +50,7 @@
 - [x] Surface contradiction counts and review task IDs in query CLI output and snapshots.
 - [x] Add lint and health coverage for broken contradiction/task/run links.
 - [x] Update tests, schema docs, README, and roadmap state for the finalized contract.
-- [ ] Publish a non-draft GitHub PR for `M6-P2.1` with labels, milestone, and a detailed description.
+- [x] Publish a non-draft GitHub PR for `M6-P2.1` with labels, milestone, and a detailed description.
 
 ## Active Task Breakdown
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,14 @@
   that its labels and milestone are set before treating the task as done.
 - When a PR implements work from a plan, update the versioned planning state in the same PR:
   `.agent-plan.md`, `README.md`, and any affected human-facing planning document in `docs/`.
+- Keep the structured planning-state lines synchronized across `.agent-plan.md`, the `README.md`
+  "What Comes Next" block, and `docs/splendor_mvp_to_v1_roadmap.md`:
+  - `Last completed PR sub-slice`
+  - `Active planned slice`
+  - `Active planned PR sub-slice`
+  - `Next planned slice`
+- Before publishing a roadmap-advancing PR, run `uv run splendor lint` or otherwise verify the
+  planning-state drift check passes so merged work cannot leave those files stale.
 - PR titles, descriptions, and planning updates should use the concrete PR sub-slice notation when
   one exists, while still naming the parent milestone slice that the PR advances.
 

--- a/README.md
+++ b/README.md
@@ -116,13 +116,14 @@ Implemented today:
 - `splendor query "<question>"` and `splendor query "<question>" --json`
 - `splendor file-answer --from-last-query --title "..."`
 - `splendor task|milestone|decision|question ...`
+- `splendor repo scan`
 - `splendor lint` and `splendor health`
 
 Not implemented yet:
 
 - OCR and image extraction flows
 - local web UI
-- code-aware repo scan and refresh commands
+- code-aware repo refresh commands
 
 ## Documentation
 
@@ -134,6 +135,11 @@ Not implemented yet:
 - [docs/ci_and_repo_automation.md](docs/ci_and_repo_automation.md)
 
 ## What Comes Next
+
+- Last completed PR sub-slice: `M6-P2.1`
+- Active planned slice: `M7-P1`
+- Active planned PR sub-slice: `M7-P1.1`
+- Next planned slice: `M7-P2`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -41,6 +41,9 @@ Current implementation fields:
 - `storage_path`
 - `materialized_at`
 - `source_commit`
+- `source_class`
+- `source_labels`
+- `discovered_by`
 - `provenance_links`
 
 ### Current source-record shape
@@ -76,6 +79,10 @@ Implemented fields:
 - `origin_url`
 - `original_path`
 - `materialized_at`
+- `source_commit`
+- `source_class`
+- `source_labels`
+- `discovered_by`
 - `provenance_links`
 
 ### Field semantics
@@ -112,6 +119,21 @@ Implemented fields:
   - Timestamp indicating when `storage_path` was created or last refreshed.
 - `source_commit`
   - Optional git commit SHA captured for clean tracked workspace files.
+- `source_class`
+  - Deterministic repo-scan classification.
+  - One of:
+    - `code`
+    - `documentation`
+    - `configuration`
+    - `other`
+- `source_labels`
+  - Deterministic path-role labels such as `test`, `example`, `automation`, and
+    `agent-instructions`.
+- `discovered_by`
+  - Optional registration origin marker.
+  - One of:
+    - `manual`
+    - `repo_scan`
 
 ### Recommended default policy
 
@@ -133,7 +155,7 @@ Splendor currently supports both:
 
 1. legacy manifests that only have `path` and are treated as copied-source records at read time
 2. new manifests that write `source_ref`, `source_ref_kind`, `storage_mode`, `storage_path`,
-   `materialized_at`, and `source_commit`
+   `materialized_at`, `source_commit`, and optional repo-scan classification fields
 
 In this release:
 
@@ -225,6 +247,17 @@ Current runtime behavior:
   created or touched during that run
 - failed runs retain only the source/input-side structured provenance that was actually known at
   failure time
+
+## Repo scan
+
+The CLI now includes `splendor repo scan` for deterministic repo-native discovery.
+
+Current runtime behavior:
+
+- scan supported in-repo text/code files without ingesting them
+- register newly discovered files through the existing source manifest workflow
+- backfill deterministic classification metadata on already-registered workspace-backed sources
+- ignore Splendor-managed directories and transient cache/build directories
 
 ## Review config
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,6 +334,11 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
+- Last completed PR sub-slice: `M6-P2.1`
+- Active planned slice: `M7-P1`
+- Active planned PR sub-slice: `M7-P1.1`
+- Next planned slice: `M7-P2`
+
 The next planned PR sub-slice is `M7-P1.1`, under parent slice `M7-P1`, which moves the roadmap
 forward into repo scan and code/doc source classification.
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -28,6 +28,7 @@ from splendor.commands.planning import (
     update_question_answer,
 )
 from splendor.commands.query import run_query
+from splendor.commands.repo_scan import render_repo_scan_json, scan_repo
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import (
@@ -296,6 +297,19 @@ def build_parser() -> argparse.ArgumentParser:
         "--related-decision", action="append", default=[], help="Related decision reference"
     )
     question_create_parser.set_defaults(handler=handle_question_create)
+
+    repo_parser = subparsers.add_parser("repo", help="Inspect repository-native sources")
+    repo_subparsers = repo_parser.add_subparsers(dest="repo_command", required=True)
+    repo_scan_parser = repo_subparsers.add_parser(
+        "scan", help="Scan the workspace and register supported in-repo sources"
+    )
+    repo_scan_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    repo_scan_parser.set_defaults(handler=handle_repo_scan)
     return parser
 
 
@@ -533,6 +547,40 @@ def handle_query(args: argparse.Namespace) -> int:
             print(f"   Contradictions: {match.contradiction_count}")
         if match.review_task_ids:
             print(f"   Review tasks: {', '.join(match.review_task_ids)}")
+    return 0
+
+
+def handle_repo_scan(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = scan_repo(root)
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_repo_scan_json(result))
+        return 0
+
+    print(
+        "Repo scan summary: "
+        f"scanned={result.scanned} "
+        f"registered={result.registered} "
+        f"already_registered={result.already_registered} "
+        f"unsupported={result.unsupported} "
+        f"ignored={result.ignored}"
+    )
+    print(
+        "Class counts: "
+        + " ".join(f"{name}={count}" for name, count in result.class_counts.items())
+    )
+    if result.touched_sources:
+        print("Touched sources:")
+        for item in result.touched_sources:
+            labels = ", ".join(item.source_labels) if item.source_labels else "-"
+            print(
+                f"- {item.path}: {item.status} "
+                f"(source_id={item.source_id} class={item.source_class} labels={labels})"
+            )
     return 0
 
 

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -24,6 +24,17 @@ from splendor.utils.planning import iter_planning_paths, parse_planning_document
 from splendor.utils.wiki import parse_wiki_markdown
 
 _MARKDOWN_LINK_PATTERN = re.compile(r"(?<!!)\[[^\]]+]\(([^)]+)\)")
+_PLANNING_STATE_LABELS = (
+    "Last completed PR sub-slice",
+    "Active planned slice",
+    "Active planned PR sub-slice",
+    "Next planned slice",
+)
+_PLANNING_STATE_PATTERN = re.compile(
+    r"^- (?P<label>Last completed PR sub-slice|Active planned slice|"
+    r"Active planned PR sub-slice|Next planned slice): (?P<value>`[^`]+`|.+)$",
+    re.MULTILINE,
+)
 _PLANNING_MODELS = {
     "task": TaskRecord,
     "milestone": MilestoneRecord,
@@ -391,7 +402,74 @@ def _run_reference_integrity_checks(
             )
         )
 
+    planning_state_checked_count, planning_state_issues = _planning_state_issues(root)
+    checked_count += planning_state_checked_count
+    issues.extend(planning_state_issues)
+
     return _LintCheckResult(checked_count=checked_count, issues=issues)
+
+
+def _planning_state_issues(root: Path) -> tuple[int, list[MaintenanceIssue]]:
+    paths = {
+        "agent-plan": root / ".agent-plan.md",
+        "readme": root / "README.md",
+        "roadmap": root / "docs" / "splendor_mvp_to_v1_roadmap.md",
+    }
+    if not all(path.is_file() for path in paths.values()):
+        return 0, []
+
+    checked_count = len(_PLANNING_STATE_LABELS) * len(paths)
+    parsed = {
+        name: _parse_planning_state(path.read_text(encoding="utf-8"))
+        for name, path in paths.items()
+    }
+    issues: list[MaintenanceIssue] = []
+    for name, values in parsed.items():
+        path = workspace_relative_path(root, paths[name])
+        for label in _PLANNING_STATE_LABELS:
+            if label in values:
+                continue
+            issues.append(
+                MaintenanceIssue(
+                    code="missing-planning-state",
+                    message=f"Planning state line is missing: {label}",
+                    path=path,
+                    record_id=label,
+                    check_name="planning-state",
+                )
+            )
+
+    canonical = parsed["agent-plan"]
+    for name in ("readme", "roadmap"):
+        path = workspace_relative_path(root, paths[name])
+        for label in _PLANNING_STATE_LABELS:
+            if label not in canonical or label not in parsed[name]:
+                continue
+            if parsed[name][label] == canonical[label]:
+                continue
+            issues.append(
+                MaintenanceIssue(
+                    code="planning-state-drift",
+                    message=(
+                        f"{label} does not match .agent-plan.md: "
+                        f"expected {canonical[label]}, found {parsed[name][label]}"
+                    ),
+                    path=path,
+                    record_id=label,
+                    check_name="planning-state",
+                )
+            )
+    return checked_count, issues
+
+
+def _parse_planning_state(text: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for match in _PLANNING_STATE_PATTERN.finditer(text):
+        value = match.group("value").strip()
+        if value.startswith("`") and value.endswith("`"):
+            value = value[1:-1]
+        values[match.group("label")] = value
+    return values
 
 
 def _duplicate_id_issues(

--- a/src/splendor/commands/repo_scan.py
+++ b/src/splendor/commands/repo_scan.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -52,19 +53,28 @@ def scan_repo(root: Path) -> RepoScanResult:
     ignored = 0
     unsupported = 0
 
-    for path in sorted(
-        root.rglob("*"), key=lambda candidate: candidate.relative_to(root).as_posix()
-    ):
-        if not path.is_file():
-            continue
-        relative_path = path.relative_to(root).as_posix()
-        if _is_ignored_path(path, root, layout):
-            ignored += 1
-            continue
-        if path.suffix.lstrip(".") not in SUPPORTED_SOURCE_TYPES:
-            unsupported += 1
-            continue
-        supported_paths.append(path)
+    for dirpath, dirnames, filenames in os.walk(root, topdown=True):
+        current_dir = Path(dirpath)
+        dirnames[:] = [
+            dirname
+            for dirname in sorted(dirnames)
+            if not _is_ignored_dir(current_dir / dirname, root, layout)
+        ]
+        ignored += len(filenames) - len(
+            [
+                filename
+                for filename in filenames
+                if not _is_ignored_path(current_dir / filename, root, layout)
+            ]
+        )
+        for filename in sorted(filenames):
+            path = current_dir / filename
+            if _is_ignored_path(path, root, layout):
+                continue
+            if path.suffix.lstrip(".") not in SUPPORTED_SOURCE_TYPES:
+                unsupported += 1
+                continue
+            supported_paths.append(path)
 
     touched_sources: list[RepoScanItem] = []
     class_counts = {name: 0 for name in ("code", "documentation", "configuration", "other")}
@@ -137,6 +147,19 @@ def _is_ignored_path(path: Path, root: Path, layout) -> bool:
     if not relative.parts:
         return False
     first = relative.parts[0]
+    return first in _ignored_top_level_dirs(root, layout)
+
+
+def _is_ignored_dir(path: Path, root: Path, layout) -> bool:
+    relative = path.relative_to(root)
+    if not relative.parts:
+        return False
+    if len(relative.parts) == 1:
+        return relative.parts[0] in _ignored_top_level_dirs(root, layout)
+    return False
+
+
+def _ignored_top_level_dirs(root: Path, layout) -> set[str]:
     ignored_top_level_dirs = _IGNORED_TOP_LEVEL_DIRS | {
         layout.raw_dir.relative_to(root).parts[0],
         layout.derived_dir.relative_to(root).parts[0],
@@ -145,7 +168,7 @@ def _is_ignored_path(path: Path, root: Path, layout) -> bool:
         layout.wiki_dir.relative_to(root).parts[0],
         layout.planning_dir.relative_to(root).parts[0],
     }
-    return first in ignored_top_level_dirs
+    return ignored_top_level_dirs
 
 
 def _classify_path(path: Path, relative_path: str) -> SourceClass:

--- a/src/splendor/commands/repo_scan.py
+++ b/src/splendor/commands/repo_scan.py
@@ -1,0 +1,173 @@
+"""Implementation for `splendor repo scan`."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from splendor.commands.ingest import SUPPORTED_SOURCE_TYPES
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas.types import SourceClass
+from splendor.state.source_registry import register_source
+
+_CODE_EXTENSIONS = SUPPORTED_SOURCE_TYPES - {"json", "md", "txt", "yaml", "yml"}
+_CONFIG_EXTENSIONS = {"json", "yaml", "yml"}
+_IGNORED_TOP_LEVEL_DIRS = {
+    ".git",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+}
+
+
+@dataclass(frozen=True)
+class RepoScanItem:
+    path: str
+    source_id: str
+    source_class: SourceClass
+    source_labels: list[str]
+    status: str
+
+
+@dataclass(frozen=True)
+class RepoScanResult:
+    scanned: int
+    registered: int
+    already_registered: int
+    unsupported: int
+    ignored: int
+    class_counts: dict[str, int]
+    touched_sources: list[RepoScanItem]
+
+
+def scan_repo(root: Path) -> RepoScanResult:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    supported_paths: list[Path] = []
+    ignored = 0
+    unsupported = 0
+
+    for path in sorted(
+        root.rglob("*"), key=lambda candidate: candidate.relative_to(root).as_posix()
+    ):
+        if not path.is_file():
+            continue
+        relative_path = path.relative_to(root).as_posix()
+        if _is_ignored_path(path, root, layout):
+            ignored += 1
+            continue
+        if path.suffix.lstrip(".") not in SUPPORTED_SOURCE_TYPES:
+            unsupported += 1
+            continue
+        supported_paths.append(path)
+
+    touched_sources: list[RepoScanItem] = []
+    class_counts = {name: 0 for name in ("code", "documentation", "configuration", "other")}
+    registered = 0
+    already_registered = 0
+
+    for path in supported_paths:
+        relative_path = path.relative_to(root).as_posix()
+        source_class = _classify_path(path, relative_path)
+        source_labels = _labels_for(relative_path)
+        registered_source = register_source(
+            root,
+            path,
+            source_class=source_class,
+            source_labels=source_labels,
+            discovered_by="repo_scan",
+            refresh_existing_metadata=True,
+        )
+        status = "already_registered" if registered_source.already_registered else "registered"
+        if registered_source.already_registered:
+            already_registered += 1
+        else:
+            registered += 1
+        class_counts[source_class] += 1
+        touched_sources.append(
+            RepoScanItem(
+                path=relative_path,
+                source_id=registered_source.record.source_id,
+                source_class=source_class,
+                source_labels=source_labels,
+                status=status,
+            )
+        )
+
+    return RepoScanResult(
+        scanned=len(supported_paths),
+        registered=registered,
+        already_registered=already_registered,
+        unsupported=unsupported,
+        ignored=ignored,
+        class_counts=class_counts,
+        touched_sources=touched_sources,
+    )
+
+
+def render_repo_scan_json(result: RepoScanResult) -> str:
+    payload = {
+        "scanned": result.scanned,
+        "registered": result.registered,
+        "already_registered": result.already_registered,
+        "unsupported": result.unsupported,
+        "ignored": result.ignored,
+        "class_counts": result.class_counts,
+        "touched_sources": [
+            {
+                "path": item.path,
+                "source_id": item.source_id,
+                "source_class": item.source_class,
+                "source_labels": item.source_labels,
+                "status": item.status,
+            }
+            for item in result.touched_sources
+        ],
+    }
+    return json.dumps(payload, indent=2)
+
+
+def _is_ignored_path(path: Path, root: Path, layout) -> bool:
+    relative = path.relative_to(root)
+    if not relative.parts:
+        return False
+    first = relative.parts[0]
+    ignored_top_level_dirs = _IGNORED_TOP_LEVEL_DIRS | {
+        layout.raw_dir.relative_to(root).parts[0],
+        layout.derived_dir.relative_to(root).parts[0],
+        layout.state_dir.relative_to(root).parts[0],
+        layout.reports_dir.relative_to(root).parts[0],
+        layout.wiki_dir.relative_to(root).parts[0],
+        layout.planning_dir.relative_to(root).parts[0],
+    }
+    return first in ignored_top_level_dirs
+
+
+def _classify_path(path: Path, relative_path: str) -> SourceClass:
+    suffix = path.suffix.lstrip(".")
+    if suffix in {"md", "txt"}:
+        return "documentation"
+    if suffix in _CONFIG_EXTENSIONS or relative_path.startswith(".github/workflows/"):
+        return "configuration"
+    if suffix in _CODE_EXTENSIONS:
+        return "code"
+    return "other"
+
+
+def _labels_for(relative_path: str) -> list[str]:
+    labels: list[str] = []
+    name = Path(relative_path).name
+    if relative_path.startswith("tests/") or name.startswith("test_") or name.endswith("_test.py"):
+        labels.append("test")
+    if relative_path.startswith("examples/"):
+        labels.append("example")
+    if relative_path.startswith(".github/workflows/"):
+        labels.append("automation")
+    if relative_path in {"AGENTS.md", "llms.txt"}:
+        labels.append("agent-instructions")
+    return labels

--- a/src/splendor/schemas/__init__.py
+++ b/src/splendor/schemas/__init__.py
@@ -16,6 +16,8 @@ from splendor.schemas.source_pointer import SourcePointerArtifact
 from splendor.schemas.types import (
     PageReviewState,
     ProvenanceRole,
+    SourceClass,
+    SourceDiscoveryMode,
     SourceRefKind,
     SourceReviewState,
     StorageMode,
@@ -40,6 +42,8 @@ __all__ = [
     "QuestionRecord",
     "QueueItemRecord",
     "RunRecord",
+    "SourceClass",
+    "SourceDiscoveryMode",
     "SourceRefKind",
     "SourceReviewState",
     "SourcePointerArtifact",

--- a/src/splendor/schemas/source.py
+++ b/src/splendor/schemas/source.py
@@ -13,7 +13,13 @@ from pydantic import Field
 
 from splendor.schemas.common import StrictRecord
 from splendor.schemas.provenance import ProvenanceLink
-from splendor.schemas.types import SourceRefKind, SourceReviewState, StorageMode
+from splendor.schemas.types import (
+    SourceClass,
+    SourceDiscoveryMode,
+    SourceRefKind,
+    SourceReviewState,
+    StorageMode,
+)
 
 
 class SourceRecord(StrictRecord):
@@ -43,4 +49,7 @@ class SourceRecord(StrictRecord):
     storage_path: str | None = None
     materialized_at: str | None = None
     source_commit: str | None = None
+    source_class: SourceClass | None = None
+    source_labels: list[str] = Field(default_factory=list)
+    discovered_by: SourceDiscoveryMode | None = None
     provenance_links: list[ProvenanceLink] = Field(default_factory=list)

--- a/src/splendor/schemas/types.py
+++ b/src/splendor/schemas/types.py
@@ -7,6 +7,8 @@ from typing import Literal
 StorageMode = Literal["none", "copy", "symlink", "pointer"]
 SummaryMode = Literal["none", "excerpt", "full"]
 SourceRefKind = Literal["workspace_path", "external_path", "url", "imported", "stored_artifact"]
+SourceClass = Literal["code", "documentation", "configuration", "other"]
+SourceDiscoveryMode = Literal["manual", "repo_scan"]
 PageReviewState = Literal["draft", "machine-generated", "human-reviewed", "contested", "stale"]
 SourceReviewState = Literal[
     "unreviewed",

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -11,7 +11,7 @@ from splendor import __version__
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import SourcePointerArtifact, SourceRecord
-from splendor.schemas.types import StorageMode
+from splendor.schemas.types import SourceClass, SourceDiscoveryMode, StorageMode
 from splendor.state.paths import resolve_workspace_path
 from splendor.state.source_compat import (
     canonical_source_ref,
@@ -427,6 +427,10 @@ def register_source(
     *,
     storage_mode: StorageMode | None = None,
     capture_source_commit: bool | None = None,
+    source_class: SourceClass | None = None,
+    source_labels: list[str] | None = None,
+    discovered_by: SourceDiscoveryMode | None = None,
+    refresh_existing_metadata: bool = False,
 ) -> RegisteredSource:
     candidate = source_path.expanduser().resolve()
     if not candidate.exists():
@@ -480,6 +484,23 @@ def register_source(
         existing_stored_path, existing_storage_mode, existing_source_ref = (
             _validated_existing_registration(root=root, layout=layout, existing=existing)
         )
+        if refresh_existing_metadata and existing.source_ref_kind == "workspace_path":
+            updated = existing.model_copy(
+                update={
+                    "source_class": source_class
+                    if source_class is not None
+                    else existing.source_class,
+                    "source_labels": sorted(source_labels or existing.source_labels),
+                    "discovered_by": (
+                        existing.discovered_by
+                        if existing.discovered_by is not None
+                        else discovered_by
+                    ),
+                }
+            )
+            if updated != existing:
+                write_source_record(manifest_path, updated)
+                existing = updated
         return RegisteredSource(
             record=existing,
             manifest_path=manifest_path,
@@ -520,6 +541,9 @@ def register_source(
         ),
         materialized_at=(added_at if stored_path is not None else None),
         source_commit=source_commit,
+        source_class=source_class,
+        source_labels=sorted(source_labels or []),
+        discovered_by=discovered_by,
     )
     write_source_record(manifest_path, record)
     return RegisteredSource(

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -485,12 +485,15 @@ def register_source(
             _validated_existing_registration(root=root, layout=layout, existing=existing)
         )
         if refresh_existing_metadata and existing.source_ref_kind == "workspace_path":
-            updated = existing.model_copy(
-                update={
+            updated = SourceRecord.model_validate(
+                existing.model_dump(mode="json")
+                | {
                     "source_class": source_class
                     if source_class is not None
                     else existing.source_class,
-                    "source_labels": sorted(source_labels or existing.source_labels),
+                    "source_labels": sorted(
+                        source_labels if source_labels is not None else existing.source_labels
+                    ),
                     "discovered_by": (
                         existing.discovered_by
                         if existing.discovered_by is not None

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -61,6 +61,9 @@ def test_add_source_registers_workspace_file_without_copy_by_default(tmp_path: P
     assert manifest.storage_mode == "none"
     assert manifest.storage_path is None
     assert manifest.materialized_at is None
+    assert manifest.source_class is None
+    assert manifest.source_labels == []
+    assert manifest.discovered_by is None
     assert manifest.original_path == "note.md"
     assert not (tmp_path / "raw" / "sources" / result.source_id).exists()
 

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -13,6 +13,7 @@ from splendor.state.source_registry import (
     _write_workspace_symlink,
     load_source_record,
     materializing_storage_mode_for_source,
+    register_source,
     resolve_manifest_storage_path,
     validate_stored_source_location,
     write_source_record,
@@ -241,8 +242,48 @@ def test_add_source_supports_symlink_for_workspace_sources(tmp_path: Path) -> No
     assert manifest.source_ref == "note.md"
     assert manifest.source_ref_kind == "workspace_path"
     assert manifest.storage_mode == "symlink"
-    assert manifest.materialized_at is not None
-    assert result.stored_path.read_text(encoding="utf-8") == "# note\n"
+
+
+def test_add_source_refresh_existing_metadata_validates_updated_values(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+
+    add_source(tmp_path, source)
+
+    with pytest.raises(ValueError):
+        register_source(
+            tmp_path,
+            source,
+            source_class="bogus",  # type: ignore[arg-type]
+            refresh_existing_metadata=True,
+        )
+
+
+def test_add_source_refresh_existing_metadata_allows_clearing_labels(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+
+    added = register_source(
+        tmp_path,
+        source,
+        source_class="documentation",
+        source_labels=["agent-instructions"],
+        discovered_by="repo_scan",
+    )
+    cleared = register_source(
+        tmp_path,
+        source,
+        source_class="documentation",
+        source_labels=[],
+        discovered_by="repo_scan",
+        refresh_existing_metadata=True,
+    )
+
+    manifest = load_source_record(cleared.manifest_path)
+    assert manifest.source_id == added.record.source_id
+    assert manifest.source_labels == []
 
 
 def test_effective_storage_mode_accepts_workspace_symlink() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,6 +54,16 @@ def test_cli_add_source_capture_source_commit_flags_are_tri_state() -> None:
     assert no_capture_flag.capture_source_commit is False
 
 
+def test_cli_repo_scan_parser_accepts_json_flag() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["repo", "scan", "--json"])
+
+    assert args.command == "repo"
+    assert args.repo_command == "scan"
+    assert args.json_output is True
+
+
 def test_cli_add_source_command_reports_workspace_backed_registration(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -64,6 +64,87 @@ def test_run_lint_checks_returns_no_issues_for_initialized_workspace(tmp_path: P
     assert result.issues == []
 
 
+def test_run_lint_checks_skips_planning_state_guard_when_files_are_absent(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    result = _run_lint(tmp_path)
+
+    assert all(issue.check_name != "planning-state" for issue in result.issues)
+
+
+def test_run_lint_checks_reports_planning_state_drift(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n"
+        "## Current System State\n\n"
+        "- Last completed PR sub-slice: `M6-P2.1`\n"
+        "- Active planned slice: `M7-P1`\n"
+        "- Active planned PR sub-slice: `M7-P1.1`\n"
+        "- Next planned slice: `M7-P2`\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "## What Comes Next\n\n"
+        "- Last completed PR sub-slice: `M6-P2.1`\n"
+        "- Active planned slice: `M7-P1`\n"
+        "- Active planned PR sub-slice: `M7-P1.1`\n"
+        "- Next planned slice: `M8-P1`\n",
+        encoding="utf-8",
+    )
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "splendor_mvp_to_v1_roadmap.md").write_text(
+        "- Last completed PR sub-slice: `M6-P2.1`\n"
+        "- Active planned slice: `M7-P1`\n"
+        "- Active planned PR sub-slice: `M7-P1.1`\n"
+        "- Next planned slice: `M7-P2`\n",
+        encoding="utf-8",
+    )
+
+    result = _run_lint(tmp_path)
+
+    planning_issues = [issue for issue in result.issues if issue.check_name == "planning-state"]
+    assert len(planning_issues) == 1
+    assert planning_issues[0].code == "planning-state-drift"
+    assert planning_issues[0].path == "README.md"
+
+
+def test_run_lint_checks_reports_missing_planning_state_line(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n"
+        "## Current System State\n\n"
+        "- Last completed PR sub-slice: `M6-P2.1`\n"
+        "- Active planned slice: `M7-P1`\n"
+        "- Active planned PR sub-slice: `M7-P1.1`\n"
+        "- Next planned slice: `M7-P2`\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "## What Comes Next\n\n"
+        "- Last completed PR sub-slice: `M6-P2.1`\n"
+        "- Active planned slice: `M7-P1`\n"
+        "- Active planned PR sub-slice: `M7-P1.1`\n"
+        "- Next planned slice: `M7-P2`\n",
+        encoding="utf-8",
+    )
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "splendor_mvp_to_v1_roadmap.md").write_text(
+        "- Last completed PR sub-slice: `M6-P2.1`\n"
+        "- Active planned slice: `M7-P1`\n"
+        "- Next planned slice: `M7-P2`\n",
+        encoding="utf-8",
+    )
+
+    result = _run_lint(tmp_path)
+
+    planning_issues = [issue for issue in result.issues if issue.check_name == "planning-state"]
+    assert len(planning_issues) == 1
+    assert planning_issues[0].code == "missing-planning-state"
+    assert planning_issues[0].path == "docs/splendor_mvp_to_v1_roadmap.md"
+
+
 def test_run_lint_checks_reports_invalid_wiki_frontmatter_without_fatal_error(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_repo_scan.py
+++ b/tests/test_repo_scan.py
@@ -78,7 +78,7 @@ def test_repo_scan_ignores_managed_and_transient_directories(tmp_path: Path) -> 
 
     assert result.scanned == 1
     assert result.registered == 1
-    assert result.ignored >= 4
+    assert result.ignored == 0
     assert [item.path for item in result.touched_sources] == ["README.md"]
 
 

--- a/tests/test_repo_scan.py
+++ b/tests/test_repo_scan.py
@@ -1,0 +1,150 @@
+import json
+from pathlib import Path
+
+from splendor.commands.add_source import add_source
+from splendor.commands.init import initialize_workspace
+from splendor.commands.repo_scan import render_repo_scan_json, scan_repo
+from splendor.state.source_registry import load_source_record
+
+
+def _manifest_paths(root: Path) -> list[Path]:
+    return sorted((root / "state" / "manifests" / "sources").glob("*.json"))
+
+
+def _remove_workspace_config(root: Path) -> None:
+    (root / "splendor.yaml").unlink(missing_ok=True)
+
+
+def test_repo_scan_registers_and_classifies_supported_workspace_files(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("# Agents\n", encoding="utf-8")
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "main.py").write_text("print('hi')\n", encoding="utf-8")
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_main.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+    workflows_dir = tmp_path / ".github" / "workflows"
+    workflows_dir.mkdir(parents=True)
+    (workflows_dir / "ci.yml").write_text("name: CI\n", encoding="utf-8")
+
+    result = scan_repo(tmp_path)
+
+    assert result.scanned == 6
+    assert result.registered == 6
+    assert result.already_registered == 0
+    assert result.class_counts == {
+        "code": 2,
+        "documentation": 3,
+        "configuration": 1,
+        "other": 0,
+    }
+    touched = {item.path: item for item in result.touched_sources}
+    assert touched["AGENTS.md"].source_labels == ["agent-instructions"]
+    assert touched["README.md"].source_class == "documentation"
+    assert touched["docs/guide.md"].source_class == "documentation"
+    assert touched["src/main.py"].source_class == "code"
+    assert touched["tests/test_main.py"].source_labels == ["test"]
+    assert touched[".github/workflows/ci.yml"].source_class == "configuration"
+    assert touched[".github/workflows/ci.yml"].source_labels == ["automation"]
+
+    manifest_by_ref = {
+        load_source_record(path).source_ref: load_source_record(path)
+        for path in _manifest_paths(tmp_path)
+    }
+    assert manifest_by_ref["AGENTS.md"].discovered_by == "repo_scan"
+    assert manifest_by_ref["AGENTS.md"].source_class == "documentation"
+    assert manifest_by_ref["AGENTS.md"].source_labels == ["agent-instructions"]
+    assert manifest_by_ref["src/main.py"].source_class == "code"
+
+
+def test_repo_scan_ignores_managed_and_transient_directories(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+    (tmp_path / "wiki" / "sources" / "skip.md").write_text("# Skip\n", encoding="utf-8")
+    (tmp_path / "state" / "queue" / "skip.json").write_text("{}\n", encoding="utf-8")
+    (tmp_path / ".venv").mkdir()
+    (tmp_path / ".venv" / "ignored.py").write_text("print('ignored')\n", encoding="utf-8")
+    (tmp_path / "build").mkdir()
+    (tmp_path / "build" / "ignored.py").write_text("print('ignored')\n", encoding="utf-8")
+
+    result = scan_repo(tmp_path)
+
+    assert result.scanned == 1
+    assert result.registered == 1
+    assert result.ignored >= 4
+    assert [item.path for item in result.touched_sources] == ["README.md"]
+
+
+def test_repo_scan_reports_unsupported_files(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+
+    result = scan_repo(tmp_path)
+
+    assert result.scanned == 1
+    assert result.unsupported == 1
+
+
+def test_repo_scan_is_idempotent_and_backfills_existing_workspace_metadata(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    source = tmp_path / "README.md"
+    source.write_text("# Readme\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    original = load_source_record(added.manifest_path)
+    assert original.source_class is None
+    assert original.discovered_by is None
+
+    result = scan_repo(tmp_path)
+
+    touched = {item.path: item for item in result.touched_sources}
+    assert touched["README.md"].status == "already_registered"
+    updated = load_source_record(added.manifest_path)
+    assert updated.source_class == "documentation"
+    assert updated.discovered_by == "repo_scan"
+    assert updated.source_labels == []
+
+
+def test_repo_scan_registers_new_source_id_after_content_changes(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    source = tmp_path / "README.md"
+    source.write_text("# One\n", encoding="utf-8")
+
+    first = scan_repo(tmp_path)
+    first_id = {item.path: item for item in first.touched_sources}["README.md"].source_id
+
+    source.write_text("# Two\n", encoding="utf-8")
+    second = scan_repo(tmp_path)
+    second_id = {item.path: item for item in second.touched_sources}["README.md"].source_id
+
+    assert first_id != second_id
+    assert second.registered == 1
+
+
+def test_render_repo_scan_json_matches_expected_shape(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+
+    payload = json.loads(render_repo_scan_json(scan_repo(tmp_path)))
+
+    assert payload["scanned"] == 1
+    assert payload["registered"] == 1
+    assert payload["already_registered"] == 0
+    assert payload["unsupported"] == 0
+    assert payload["ignored"] >= 0
+    assert payload["class_counts"]["documentation"] == 1
+    assert payload["touched_sources"][0]["path"] == "README.md"
+    assert payload["touched_sources"][0]["source_class"] == "documentation"
+    assert payload["touched_sources"][0]["status"] == "registered"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -41,6 +41,9 @@ def test_source_record_validation_accepts_valid_expanded_payload() -> None:
         storage_path=None,
         materialized_at="2026-04-10T15:01:00+00:00",
         source_commit="abc123",
+        source_class="documentation",
+        source_labels=["agent-instructions"],
+        discovered_by="repo_scan",
         generated_by_run_ids=["run-src-123"],
         reviewed_at="2026-04-11T15:00:00+00:00",
         reviewed_by="reviewer@example.com",
@@ -56,6 +59,9 @@ def test_source_record_validation_accepts_valid_expanded_payload() -> None:
 
     assert record.source_ref == "docs/spec.md"
     assert record.storage_mode == "none"
+    assert record.source_class == "documentation"
+    assert record.source_labels == ["agent-instructions"]
+    assert record.discovered_by == "repo_scan"
     assert record.generated_by_run_ids == ["run-src-123"]
     assert record.reviewed_by == "reviewer@example.com"
 
@@ -217,6 +223,20 @@ def test_source_record_validation_rejects_invalid_storage_mode() -> None:
             added_at="2026-04-10T15:00:00+00:00",
             pipeline_version="0.1.0a0",
             storage_mode="bogus",
+        )
+
+
+def test_source_record_validation_rejects_invalid_source_class() -> None:
+    with pytest.raises(ValidationError):
+        SourceRecord(
+            source_id="src-1234567890abcdef",
+            title="Spec",
+            source_type="md",
+            path="raw/sources/src-123/spec.md",
+            checksum="a" * 64,
+            added_at="2026-04-10T15:00:00+00:00",
+            pipeline_version="0.1.0a0",
+            source_class="bogus",
         )
 
 


### PR DESCRIPTION
## Summary
- add `splendor repo scan` to discover supported in-repo files, register them as workspace-backed sources, and persist deterministic classification metadata
- add a lint-enforced planning-state drift check across `.agent-plan.md`, `README.md`, and `docs/splendor_mvp_to_v1_roadmap.md`
- update planning/docs state for the merged `M6-P2.1` baseline and add the missing tracked `state/queries/.gitkeep`

## Planning notation
- PR sub-slice: `M7-P1.1`
- Parent milestone slice: `M7-P1`
- Plan source: `.agent-plan.md`, `README.md`, and `docs/splendor_mvp_to_v1_roadmap.md`

## What changed
- added a new `repo` CLI group with `splendor repo scan` and `splendor repo scan --json`
- introduced optional `SourceRecord` metadata for `source_class`, `source_labels`, and `discovered_by`
- reused the existing source registry flow so repo scan backfills classification metadata on already-registered workspace sources without ingesting them
- added deterministic scan heuristics for supported files, ignored/generated directories, and path-based labels such as `test`, `example`, `automation`, and `agent-instructions`
- extended `splendor lint` with a text-structured planning-state consistency check
- updated repo docs and agent instructions so roadmap-advancing PRs must keep the state snapshot synchronized

## Validation
- `uv run ruff check .`
- `uv run pytest`
- `uv run splendor lint`

## Limitations
- `M7-P1.1` only covers discovery and classification; it does not ingest scanned files automatically
- repo refresh, changed-files maintenance, and wiki architecture/topic linkage remain future `M7` work
