### PR TITLE
M7-P2.1: add repo refresh and lifecycle planning state

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,11 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Last completed PR sub-slice: `M6-P2.1`
-- Last action taken: `M6-P2.1` is implemented; ingest now optionally runs contradiction review against existing source-summary pages, contested pages persist contradiction annotations plus linked review tasks, query surfaces contradiction metadata, and lint/health validate the new task/run/page links.
-- Active planned slice: `M7-P1`
-- Active planned PR sub-slice: `M7-P1.1`
-- Next planned slice: `M7-P2`
+- Previous completed PR sub-slice: `M7-P1.1`
+- Last action taken: `M7-P1.1` is implemented; repo scan now discovers supported in-repo code, documentation, and configuration sources, backfills classification metadata, and lint enforces synchronized planning-state fields.
+- Current planned slice: `M7-P2`
+- Current PR sub-slice: `M7-P2.1`
+- Current PR lifecycle: `branch=in-progress; main=merged`
+- Next planned slice: `M8-P1`
+- Next planned PR sub-slice: `M8-P1.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -16,6 +18,8 @@
 - Concrete PRs under a parent slice use dotted sub-slices such as `M6-P1.1`, `M6-P1.2`, and `M6-P2.1`.
 - Planning updates, PR titles, and PR descriptions should use the concrete sub-slice notation when
   the work is one PR within a larger parent slice.
+- `Current PR lifecycle: branch=in-progress; main=merged` means the current sub-slice is in
+  progress on feature branches and complete once the same commit is observed on `main`.
 
 ## M6-P1 Implementation Checklist
 
@@ -81,6 +85,12 @@
    - [x] Upsert linked review tasks with source/page/run refs
    - [x] Surface contradiction metadata in query output and snapshots
    - [x] Validate contradiction/task/run links in lint and health
+- [x] Implement `M7-P1.1`: repo scan and code/doc source classification
+- [x] Implement `M7-P2.1`: repo refresh and architecture/topic linkage
+  - [x] Add deterministic `splendor repo refresh`
+  - [x] Generate architecture and topic pages from repo-scan output
+  - [x] Replace stale-prone planning markers with branch-stable lifecycle notation
+  - [x] Validate planning lifecycle semantics in lint
 
 ## Context Pointers
 
@@ -107,4 +117,5 @@
 
 ## PR Sub-slice Queue
 
-- `M7-P1.1` Repo scan and code/doc source classification
+- `M7-P2.1` Repo refresh and architecture/topic linkage
+- `M8-P1.1` GitHub Actions lint/health integration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,10 +45,15 @@
   `.agent-plan.md`, `README.md`, and any affected human-facing planning document in `docs/`.
 - Keep the structured planning-state lines synchronized across `.agent-plan.md`, the `README.md`
   "What Comes Next" block, and `docs/splendor_mvp_to_v1_roadmap.md`:
-  - `Last completed PR sub-slice`
-  - `Active planned slice`
-  - `Active planned PR sub-slice`
+  - `Previous completed PR sub-slice`
+  - `Current planned slice`
+  - `Current PR sub-slice`
+  - `Current PR lifecycle`
   - `Next planned slice`
+  - `Next planned PR sub-slice`
+- Use `Current PR lifecycle: branch=in-progress; main=merged` for planned PR work. On a feature
+  branch, the current PR sub-slice is in progress; on `main`, the same committed state means that
+  sub-slice has merged.
 - Before publishing a roadmap-advancing PR, run `uv run splendor lint` or otherwise verify the
   planning-state drift check passes so merged work cannot leave those files stale.
 - PR titles, descriptions, and planning updates should use the concrete PR sub-slice notation when

--- a/README.md
+++ b/README.md
@@ -117,13 +117,14 @@ Implemented today:
 - `splendor file-answer --from-last-query --title "..."`
 - `splendor task|milestone|decision|question ...`
 - `splendor repo scan`
+- `splendor repo refresh`
 - `splendor lint` and `splendor health`
 
 Not implemented yet:
 
 - OCR and image extraction flows
 - local web UI
-- code-aware repo refresh commands
+- changed-files-driven refresh suggestions
 
 ## Documentation
 
@@ -136,22 +137,24 @@ Not implemented yet:
 
 ## What Comes Next
 
-- Last completed PR sub-slice: `M6-P2.1`
-- Active planned slice: `M7-P1`
-- Active planned PR sub-slice: `M7-P1.1`
-- Next planned slice: `M7-P2`
+- Previous completed PR sub-slice: `M7-P1.1`
+- Current planned slice: `M7-P2`
+- Current PR sub-slice: `M7-P2.1`
+- Current PR lifecycle: `branch=in-progress; main=merged`
+- Next planned slice: `M8-P1`
+- Next planned PR sub-slice: `M8-P1.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
 install validation.
 
-Planning notation now distinguishes parent slices such as `M6-P1` from concrete PR sub-slices such
-as `M6-P1.1`, `M6-P1.2`, and `M6-P2.1`.
+Planning notation now distinguishes parent slices such as `M7-P2` from concrete PR sub-slices such
+as `M7-P2.1`. `Current PR lifecycle: branch=in-progress; main=merged` means the current sub-slice
+is in progress on feature branches and is the latest merged work once observed on `main`.
 
-`M6-P2.1` is now implemented on top of the `M6-P1` provenance foundation: ingest can optionally
-run contradiction review for source-summary pages, contested pages persist contradiction
-annotations plus linked review tasks, query surfaces contradiction counts and task IDs, and
-lint/health validate the new page/task/run links.
+`M7-P1.1` is now implemented: repo scan discovers supported in-repo code, documentation, and
+configuration sources, backfills classification metadata, and lint enforces synchronized
+planning-state fields.
 
-The next planned PR sub-slice is `M7-P1.1`, under the parent slice `M7-P1`, which will focus on
-repo scan and code/doc source classification.
+The current PR sub-slice is `M7-P2.1`, under the parent slice `M7-P2`, which focuses on repo
+refresh and architecture/topic linkage.

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -169,6 +169,19 @@ When one planned slice takes multiple PRs, each PR should use the next dotted su
 title, body, and plan updates instead of pretending the parent slice maps one-to-one with a single
 PR.
 
+Structured planning-state blocks must use these synchronized labels:
+
+- `Previous completed PR sub-slice`
+- `Current planned slice`
+- `Current PR sub-slice`
+- `Current PR lifecycle`
+- `Next planned slice`
+- `Next planned PR sub-slice`
+
+Use `Current PR lifecycle: branch=in-progress; main=merged`. This lets one committed planning
+state read correctly while a branch is open and after it lands on `main`: the current PR sub-slice
+is in progress on feature branches and merged on `main`.
+
 ## Agent completion rule for PR work
 
 For agent-driven feature or PR work in this repository, local implementation is not the terminal

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -259,6 +259,17 @@ Current runtime behavior:
 - backfill deterministic classification metadata on already-registered workspace-backed sources
 - ignore Splendor-managed directories and transient cache/build directories
 
+## Repo refresh
+
+The CLI now includes `splendor repo refresh` for deterministic repo-aware wiki maintenance.
+
+Current runtime behavior:
+
+- run repo discovery using the existing repo-scan registration path
+- write machine-generated architecture and topic pages for repository structure and source linkage
+- link generated pages to discovered source IDs through frontmatter and provenance links
+- update the wiki index and log idempotently
+
 ## Review config
 
 The workspace config now reserves an optional `reviews.contradictions` section:

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,13 +334,16 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Last completed PR sub-slice: `M6-P2.1`
-- Active planned slice: `M7-P1`
-- Active planned PR sub-slice: `M7-P1.1`
-- Next planned slice: `M7-P2`
+- Previous completed PR sub-slice: `M7-P1.1`
+- Current planned slice: `M7-P2`
+- Current PR sub-slice: `M7-P2.1`
+- Current PR lifecycle: `branch=in-progress; main=merged`
+- Next planned slice: `M8-P1`
+- Next planned PR sub-slice: `M8-P1.1`
 
-The next planned PR sub-slice is `M7-P1.1`, under parent slice `M7-P1`, which moves the roadmap
-forward into repo scan and code/doc source classification.
+The current PR sub-slice is `M7-P2.1`, under parent slice `M7-P2`, which moves the roadmap forward
+into repo refresh and architecture/topic linkage. The lifecycle marker means `M7-P2.1` is in
+progress on feature branches and merged once the same committed state is observed on `main`.
 
 ---
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -28,6 +28,7 @@ from splendor.commands.planning import (
     update_question_answer,
 )
 from splendor.commands.query import run_query
+from splendor.commands.repo_refresh import refresh_repo, render_repo_refresh_json
 from splendor.commands.repo_scan import render_repo_scan_json, scan_repo
 from splendor.config import load_config
 from splendor.layout import resolve_layout
@@ -310,6 +311,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     repo_scan_parser.set_defaults(handler=handle_repo_scan)
+    repo_refresh_parser = repo_subparsers.add_parser(
+        "refresh", help="Refresh deterministic repo-aware wiki pages"
+    )
+    repo_refresh_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    repo_refresh_parser.set_defaults(handler=handle_repo_refresh)
     return parser
 
 
@@ -581,6 +592,32 @@ def handle_repo_scan(args: argparse.Namespace) -> int:
                 f"- {item.path}: {item.status} "
                 f"(source_id={item.source_id} class={item.source_class} labels={labels})"
             )
+    return 0
+
+
+def handle_repo_refresh(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = refresh_repo(root)
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_repo_refresh_json(result))
+        return 0
+
+    print(
+        "Repo refresh summary: "
+        f"scanned={result.scan.scanned} "
+        f"registered={result.scan.registered} "
+        f"already_registered={result.scan.already_registered} "
+        f"unsupported={result.scan.unsupported} "
+        f"ignored={result.scan.ignored}"
+    )
+    print("Generated pages:")
+    for page_ref in result.generated_page_refs:
+        print(f"- {page_ref}")
+    print(f"Linked sources: {len(result.linked_source_ids)}")
     return 0
 
 

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlsplit
@@ -25,16 +26,21 @@ from splendor.utils.wiki import parse_wiki_markdown
 
 _MARKDOWN_LINK_PATTERN = re.compile(r"(?<!!)\[[^\]]+]\(([^)]+)\)")
 _PLANNING_STATE_LABELS = (
-    "Last completed PR sub-slice",
-    "Active planned slice",
-    "Active planned PR sub-slice",
+    "Previous completed PR sub-slice",
+    "Current planned slice",
+    "Current PR sub-slice",
+    "Current PR lifecycle",
     "Next planned slice",
+    "Next planned PR sub-slice",
 )
 _PLANNING_STATE_PATTERN = re.compile(
-    r"^- (?P<label>Last completed PR sub-slice|Active planned slice|"
-    r"Active planned PR sub-slice|Next planned slice): (?P<value>`[^`]+`|.+)$",
+    r"^- (?P<label>Previous completed PR sub-slice|Current planned slice|"
+    r"Current PR sub-slice|Current PR lifecycle|Next planned slice|"
+    r"Next planned PR sub-slice): (?P<value>`[^`]+`|.+)$",
     re.MULTILINE,
 )
+_PLANNING_LIFECYCLE_VALUE = "branch=in-progress; main=merged"
+_PLANNING_SLICE_PATTERN = re.compile(r"^(?P<slice>M\d+-P\d+(?:\.\d+)?)\b")
 _PLANNING_MODELS = {
     "task": TaskRecord,
     "milestone": MilestoneRecord,
@@ -459,6 +465,32 @@ def _planning_state_issues(root: Path) -> tuple[int, list[MaintenanceIssue]]:
                     check_name="planning-state",
                 )
             )
+    lifecycle = canonical.get("Current PR lifecycle")
+    if lifecycle is not None and lifecycle != _PLANNING_LIFECYCLE_VALUE:
+        issues.append(
+            MaintenanceIssue(
+                code="invalid-planning-lifecycle",
+                message=(f"Current PR lifecycle must be exactly {_PLANNING_LIFECYCLE_VALUE!r}"),
+                path=workspace_relative_path(root, paths["agent-plan"]),
+                record_id="Current PR lifecycle",
+                check_name="planning-state",
+            )
+        )
+    head_slice = _current_main_head_slice(root)
+    current_slice = canonical.get("Current PR sub-slice")
+    if head_slice is not None and current_slice is not None and head_slice != current_slice:
+        issues.append(
+            MaintenanceIssue(
+                code="stale-planning-state",
+                message=(
+                    "Current PR sub-slice does not match latest main commit: "
+                    f"expected {head_slice}, found {current_slice}"
+                ),
+                path=workspace_relative_path(root, paths["agent-plan"]),
+                record_id="Current PR sub-slice",
+                check_name="planning-state",
+            )
+        )
     return checked_count, issues
 
 
@@ -470,6 +502,35 @@ def _parse_planning_state(text: str) -> dict[str, str]:
             value = value[1:-1]
         values[match.group("label")] = value
     return values
+
+
+def _current_main_head_slice(root: Path) -> str | None:
+    branch = _git_output(root, "rev-parse", "--abbrev-ref", "HEAD")
+    if branch != "main":
+        return None
+    subject = _git_output(root, "log", "-1", "--pretty=%s")
+    if subject is None:
+        return None
+    match = _PLANNING_SLICE_PATTERN.match(subject)
+    if match is None:
+        return None
+    return match.group("slice")
+
+
+def _git_output(root: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
 
 
 def _duplicate_id_issues(

--- a/src/splendor/commands/repo_refresh.py
+++ b/src/splendor/commands/repo_refresh.py
@@ -1,0 +1,222 @@
+"""Implementation for `splendor repo refresh`."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from splendor.commands.repo_scan import RepoScanResult, scan_repo
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import KnowledgePageFrontmatter
+from splendor.utils.fs import write_text_atomic
+from splendor.utils.provenance import dedupe_provenance_links, make_provenance_link
+from splendor.utils.time import utc_now_iso
+from splendor.utils.wiki import render_frontmatter, upsert_index_section
+
+_ARCHITECTURE_PAGE_ID = "architecture-repository-structure"
+_TOPIC_PAGE_ID = "topic-repository-sources"
+
+
+@dataclass(frozen=True)
+class RepoRefreshResult:
+    scan: RepoScanResult
+    generated_page_refs: list[str]
+    linked_source_ids: list[str]
+
+
+def refresh_repo(root: Path) -> RepoRefreshResult:
+    scan = scan_repo(root)
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    generated_at = utc_now_iso()
+    linked_source_ids = sorted({item.source_id for item in scan.touched_sources})
+    source_refs = linked_source_ids
+    provenance_links = dedupe_provenance_links(
+        make_provenance_link(
+            source_id=item.source_id,
+            path_ref=item.path,
+            role="supports",
+        )
+        for item in scan.touched_sources
+    )
+
+    architecture_path = layout.wiki_dir / "architecture" / "repository-structure.md"
+    topic_path = layout.wiki_dir / "topics" / "repository-sources.md"
+    architecture_ref = architecture_path.relative_to(root).as_posix()
+    topic_ref = topic_path.relative_to(root).as_posix()
+
+    architecture_page = KnowledgePageFrontmatter(
+        kind="architecture",
+        title="Repository Structure",
+        page_id=_ARCHITECTURE_PAGE_ID,
+        status="active",
+        review_state="machine-generated",
+        source_refs=source_refs,
+        last_generated_at=generated_at,
+        confidence=1.0,
+        related_pages=[_TOPIC_PAGE_ID],
+        tags=["repo-refresh", "architecture"],
+        provenance_links=provenance_links,
+    )
+    topic_page = KnowledgePageFrontmatter(
+        kind="topic",
+        title="Repository Sources",
+        page_id=_TOPIC_PAGE_ID,
+        status="active",
+        review_state="machine-generated",
+        source_refs=source_refs,
+        last_generated_at=generated_at,
+        confidence=1.0,
+        related_pages=[_ARCHITECTURE_PAGE_ID],
+        tags=["repo-refresh", "sources"],
+        provenance_links=provenance_links,
+    )
+
+    write_text_atomic(
+        architecture_path,
+        _render_architecture_page(
+            architecture_page, scan=scan, topic_ref="../topics/repository-sources.md"
+        ),
+    )
+    write_text_atomic(
+        topic_path,
+        _render_sources_page(
+            topic_page, scan=scan, architecture_ref="../architecture/repository-structure.md"
+        ),
+    )
+    write_text_atomic(
+        layout.index_file,
+        _update_index(
+            layout.index_file.read_text(encoding="utf-8"),
+            architecture_page=architecture_page,
+            topic_page=topic_page,
+        ),
+    )
+    write_text_atomic(
+        layout.log_file,
+        _upsert_log_entry(
+            layout.log_file.read_text(encoding="utf-8"),
+            f"- Refreshed repo pages `{architecture_ref}` and `{topic_ref}`.",
+        ),
+    )
+
+    return RepoRefreshResult(
+        scan=scan,
+        generated_page_refs=[architecture_ref, topic_ref],
+        linked_source_ids=linked_source_ids,
+    )
+
+
+def render_repo_refresh_json(result: RepoRefreshResult) -> str:
+    payload = {
+        "scanned": result.scan.scanned,
+        "registered": result.scan.registered,
+        "already_registered": result.scan.already_registered,
+        "unsupported": result.scan.unsupported,
+        "ignored": result.scan.ignored,
+        "class_counts": result.scan.class_counts,
+        "generated_page_refs": result.generated_page_refs,
+        "linked_source_ids": result.linked_source_ids,
+    }
+    return json.dumps(payload, indent=2)
+
+
+def _render_architecture_page(
+    frontmatter: KnowledgePageFrontmatter, *, scan: RepoScanResult, topic_ref: str
+) -> str:
+    class_lines = "\n".join(
+        f"- {name}: {count}" for name, count in sorted(scan.class_counts.items())
+    )
+    grouped = _group_paths_by_class(scan)
+    group_sections = "\n\n".join(
+        [f"### {name.title()}\n\n{_path_bullets(paths)}" for name, paths in grouped.items()]
+    )
+    if not group_sections:
+        group_sections = "No repository sources were discovered."
+    return (
+        f"---\n{render_frontmatter(frontmatter)}\n---\n\n"
+        f"# {frontmatter.title}\n\n"
+        "## Summary\n\n"
+        "This page is a deterministic repo-refresh view of the workspace structure.\n\n"
+        "## Source Classes\n\n"
+        f"{class_lines}\n\n"
+        "## Discovered Structure\n\n"
+        f"{group_sections}\n\n"
+        "## Related Pages\n\n"
+        f"- [Repository Sources]({topic_ref}) (`{_TOPIC_PAGE_ID}`)\n"
+    )
+
+
+def _render_sources_page(
+    frontmatter: KnowledgePageFrontmatter, *, scan: RepoScanResult, architecture_ref: str
+) -> str:
+    rows = [
+        "| Path | Source ID | Class | Labels | Status |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for item in sorted(scan.touched_sources, key=lambda candidate: candidate.path):
+        labels = ", ".join(item.source_labels) if item.source_labels else "-"
+        row = (
+            f"| `{item.path}` | `{item.source_id}` | {item.source_class} | "
+            f"{labels} | {item.status} |"
+        )
+        rows.append(row)
+    if len(rows) == 2:
+        rows.append("| - | - | - | - | - |")
+    return (
+        f"---\n{render_frontmatter(frontmatter)}\n---\n\n"
+        f"# {frontmatter.title}\n\n"
+        "## Summary\n\n"
+        "This page lists repo-native sources discovered by `splendor repo refresh`.\n\n"
+        "## Sources\n\n" + "\n".join(rows) + "\n\n"
+        "## Related Pages\n\n"
+        f"- [Repository Structure]({architecture_ref}) (`{_ARCHITECTURE_PAGE_ID}`)\n"
+    )
+
+
+def _group_paths_by_class(scan: RepoScanResult) -> dict[str, list[str]]:
+    grouped: dict[str, list[str]] = {
+        "code": [],
+        "documentation": [],
+        "configuration": [],
+        "other": [],
+    }
+    for item in sorted(scan.touched_sources, key=lambda candidate: candidate.path):
+        grouped[item.source_class].append(item.path)
+    return {name: paths for name, paths in grouped.items() if paths}
+
+
+def _path_bullets(paths: list[str]) -> str:
+    return "\n".join(f"- `{path}`" for path in paths)
+
+
+def _update_index(
+    index_content: str,
+    *,
+    architecture_page: KnowledgePageFrontmatter,
+    topic_page: KnowledgePageFrontmatter,
+) -> str:
+    updated = upsert_index_section(
+        index_content,
+        section_header="## Architecture",
+        bullet=(
+            f"- [{architecture_page.title}](architecture/repository-structure.md) "
+            f"(`{architecture_page.page_id}`)"
+        ),
+        dedupe_predicate=lambda line: f"(`{architecture_page.page_id}`)" in line,
+    )
+    return upsert_index_section(
+        updated,
+        section_header="## Topics",
+        bullet=f"- [{topic_page.title}](topics/repository-sources.md) (`{topic_page.page_id}`)",
+        dedupe_predicate=lambda line: f"(`{topic_page.page_id}`)" in line,
+    )
+
+
+def _upsert_log_entry(log_content: str, entry: str) -> str:
+    lines = log_content.rstrip().splitlines()
+    lines = [line for line in lines if line != entry]
+    lines.append(entry)
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,6 +64,48 @@ def test_cli_repo_scan_parser_accepts_json_flag() -> None:
     assert args.json_output is True
 
 
+def test_cli_repo_refresh_parser_accepts_json_flag() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["repo", "refresh", "--json"])
+
+    assert args.command == "repo"
+    assert args.repo_command == "refresh"
+    assert args.json_output is True
+
+
+def test_cli_repo_refresh_command_generates_pages(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    (tmp_path / "splendor.yaml").unlink()
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+
+    exit_code = main(["--root", str(tmp_path), "repo", "refresh"])
+
+    assert exit_code == 0
+    assert (tmp_path / "wiki" / "architecture" / "repository-structure.md").exists()
+    assert (tmp_path / "wiki" / "topics" / "repository-sources.md").exists()
+    captured = capsys.readouterr()
+    assert "Repo refresh summary:" in captured.out
+    assert "wiki/architecture/repository-structure.md" in captured.out
+
+
+def test_cli_repo_refresh_json_command(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    (tmp_path / "splendor.yaml").unlink()
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "repo", "refresh", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["scanned"] == 1
+    assert payload["generated_page_refs"] == [
+        "wiki/architecture/repository-structure.md",
+        "wiki/topics/repository-sources.md",
+    ]
+
+
 def test_cli_add_source_command_reports_workspace_backed_registration(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -25,6 +26,41 @@ from splendor.utils.wiki import parse_wiki_markdown
 def _run_lint(root: Path):
     layout = resolve_layout(root, load_config(root))
     return run_lint_checks(root, layout)
+
+
+def _planning_state_text(*, current: str = "M7-P2.1", lifecycle: str | None = None) -> str:
+    lifecycle_value = lifecycle or "branch=in-progress; main=merged"
+    return (
+        "- Previous completed PR sub-slice: `M7-P1.1`\n"
+        "- Current planned slice: `M7-P2`\n"
+        f"- Current PR sub-slice: `{current}`\n"
+        f"- Current PR lifecycle: `{lifecycle_value}`\n"
+        "- Next planned slice: `M8-P1`\n"
+        "- Next planned PR sub-slice: `M8-P1.1`\n"
+    )
+
+
+def _write_planning_state_files(
+    tmp_path: Path,
+    *,
+    current: str = "M7-P2.1",
+    lifecycle: str | None = None,
+) -> None:
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n## Current System State\n\n"
+        + _planning_state_text(current=current, lifecycle=lifecycle),
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "## What Comes Next\n\n" + _planning_state_text(current=current, lifecycle=lifecycle),
+        encoding="utf-8",
+    )
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir(exist_ok=True)
+    (docs_dir / "splendor_mvp_to_v1_roadmap.md").write_text(
+        _planning_state_text(current=current, lifecycle=lifecycle),
+        encoding="utf-8",
+    )
 
 
 def _write_wiki_page(
@@ -74,30 +110,12 @@ def test_run_lint_checks_skips_planning_state_guard_when_files_are_absent(tmp_pa
 
 def test_run_lint_checks_reports_planning_state_drift(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
-    (tmp_path / ".agent-plan.md").write_text(
-        "# Agent Plan\n\n"
-        "## Current System State\n\n"
-        "- Last completed PR sub-slice: `M6-P2.1`\n"
-        "- Active planned slice: `M7-P1`\n"
-        "- Active planned PR sub-slice: `M7-P1.1`\n"
-        "- Next planned slice: `M7-P2`\n",
-        encoding="utf-8",
-    )
+    _write_planning_state_files(tmp_path)
     (tmp_path / "README.md").write_text(
         "## What Comes Next\n\n"
-        "- Last completed PR sub-slice: `M6-P2.1`\n"
-        "- Active planned slice: `M7-P1`\n"
-        "- Active planned PR sub-slice: `M7-P1.1`\n"
-        "- Next planned slice: `M8-P1`\n",
-        encoding="utf-8",
-    )
-    docs_dir = tmp_path / "docs"
-    docs_dir.mkdir()
-    (docs_dir / "splendor_mvp_to_v1_roadmap.md").write_text(
-        "- Last completed PR sub-slice: `M6-P2.1`\n"
-        "- Active planned slice: `M7-P1`\n"
-        "- Active planned PR sub-slice: `M7-P1.1`\n"
-        "- Next planned slice: `M7-P2`\n",
+        + _planning_state_text().replace(
+            "Next planned slice: `M8-P1`", "Next planned slice: `M9-P1`"
+        ),
         encoding="utf-8",
     )
 
@@ -111,29 +129,11 @@ def test_run_lint_checks_reports_planning_state_drift(tmp_path: Path) -> None:
 
 def test_run_lint_checks_reports_missing_planning_state_line(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
-    (tmp_path / ".agent-plan.md").write_text(
-        "# Agent Plan\n\n"
-        "## Current System State\n\n"
-        "- Last completed PR sub-slice: `M6-P2.1`\n"
-        "- Active planned slice: `M7-P1`\n"
-        "- Active planned PR sub-slice: `M7-P1.1`\n"
-        "- Next planned slice: `M7-P2`\n",
-        encoding="utf-8",
-    )
-    (tmp_path / "README.md").write_text(
-        "## What Comes Next\n\n"
-        "- Last completed PR sub-slice: `M6-P2.1`\n"
-        "- Active planned slice: `M7-P1`\n"
-        "- Active planned PR sub-slice: `M7-P1.1`\n"
-        "- Next planned slice: `M7-P2`\n",
-        encoding="utf-8",
-    )
-    docs_dir = tmp_path / "docs"
-    docs_dir.mkdir()
-    (docs_dir / "splendor_mvp_to_v1_roadmap.md").write_text(
-        "- Last completed PR sub-slice: `M6-P2.1`\n"
-        "- Active planned slice: `M7-P1`\n"
-        "- Next planned slice: `M7-P2`\n",
+    _write_planning_state_files(tmp_path)
+    (tmp_path / "docs" / "splendor_mvp_to_v1_roadmap.md").write_text(
+        _planning_state_text().replace(
+            "- Current PR lifecycle: `branch=in-progress; main=merged`\n", ""
+        ),
         encoding="utf-8",
     )
 
@@ -143,6 +143,50 @@ def test_run_lint_checks_reports_missing_planning_state_line(tmp_path: Path) -> 
     assert len(planning_issues) == 1
     assert planning_issues[0].code == "missing-planning-state"
     assert planning_issues[0].path == "docs/splendor_mvp_to_v1_roadmap.md"
+
+
+def test_run_lint_checks_reports_invalid_planning_lifecycle(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _write_planning_state_files(tmp_path, lifecycle="in-progress")
+
+    result = _run_lint(tmp_path)
+
+    planning_issues = [issue for issue in result.issues if issue.check_name == "planning-state"]
+    assert len(planning_issues) == 1
+    assert planning_issues[0].code == "invalid-planning-lifecycle"
+    assert planning_issues[0].record_id == "Current PR lifecycle"
+
+
+def test_run_lint_checks_reports_stale_planning_state_on_main(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _write_planning_state_files(tmp_path, current="M7-P1.1")
+    subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "M7-P2.1: repo refresh"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    result = _run_lint(tmp_path)
+
+    planning_issues = [issue for issue in result.issues if issue.check_name == "planning-state"]
+    assert len(planning_issues) == 1
+    assert planning_issues[0].code == "stale-planning-state"
+    assert planning_issues[0].record_id == "Current PR sub-slice"
 
 
 def test_run_lint_checks_reports_invalid_wiki_frontmatter_without_fatal_error(

--- a/tests/test_repo_refresh.py
+++ b/tests/test_repo_refresh.py
@@ -1,0 +1,88 @@
+import json
+from pathlib import Path
+
+from splendor.commands.init import initialize_workspace
+from splendor.commands.repo_refresh import refresh_repo, render_repo_refresh_json
+from splendor.utils.wiki import parse_wiki_markdown
+
+
+def _remove_workspace_config(root: Path) -> None:
+    (root / "splendor.yaml").unlink(missing_ok=True)
+
+
+def _write_repo_files(root: Path) -> None:
+    (root / "README.md").write_text("# Readme\n", encoding="utf-8")
+    (root / "AGENTS.md").write_text("# Agents\n", encoding="utf-8")
+    src_dir = root / "src"
+    src_dir.mkdir()
+    (src_dir / "main.py").write_text("print('hi')\n", encoding="utf-8")
+    tests_dir = root / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_main.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+    workflows_dir = root / ".github" / "workflows"
+    workflows_dir.mkdir(parents=True)
+    (workflows_dir / "ci.yml").write_text("name: CI\n", encoding="utf-8")
+
+
+def test_repo_refresh_creates_architecture_and_topic_pages(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    _write_repo_files(tmp_path)
+
+    result = refresh_repo(tmp_path)
+
+    assert result.scan.scanned == 5
+    assert result.generated_page_refs == [
+        "wiki/architecture/repository-structure.md",
+        "wiki/topics/repository-sources.md",
+    ]
+    assert len(result.linked_source_ids) == 5
+
+    architecture = parse_wiki_markdown(tmp_path / result.generated_page_refs[0])
+    topic = parse_wiki_markdown(tmp_path / result.generated_page_refs[1])
+    assert architecture.frontmatter.kind == "architecture"
+    assert architecture.frontmatter.page_id == "architecture-repository-structure"
+    assert architecture.frontmatter.review_state == "machine-generated"
+    assert architecture.frontmatter.related_pages == ["topic-repository-sources"]
+    assert topic.frontmatter.kind == "topic"
+    assert topic.frontmatter.page_id == "topic-repository-sources"
+    assert topic.frontmatter.related_pages == ["architecture-repository-structure"]
+    assert "src/main.py" in architecture.body
+    assert "| `README.md` |" in topic.body
+    assert architecture.frontmatter.source_refs == result.linked_source_ids
+    assert topic.frontmatter.source_refs == result.linked_source_ids
+
+
+def test_repo_refresh_is_repeatable_without_duplicate_index_or_log_entries(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    _write_repo_files(tmp_path)
+
+    refresh_repo(tmp_path)
+    refresh_repo(tmp_path)
+
+    index = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+    log = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
+    assert index.count("(`architecture-repository-structure`)") == 1
+    assert index.count("(`topic-repository-sources`)") == 1
+    assert log.count("Refreshed repo pages `wiki/architecture/repository-structure.md`") == 1
+
+
+def test_render_repo_refresh_json_matches_expected_shape(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    _write_repo_files(tmp_path)
+
+    payload = json.loads(render_repo_refresh_json(refresh_repo(tmp_path)))
+
+    assert payload["scanned"] == 5
+    assert payload["registered"] == 5
+    assert payload["already_registered"] == 0
+    assert payload["class_counts"]["code"] == 2
+    assert payload["generated_page_refs"] == [
+        "wiki/architecture/repository-structure.md",
+        "wiki/topics/repository-sources.md",
+    ]
+    assert len(payload["linked_source_ids"]) == 5


### PR DESCRIPTION
## Summary
- Add `splendor repo refresh` to run repo discovery and generate deterministic architecture/topic wiki pages.
- Add JSON and human CLI output for repo refresh, with source linkage and generated page refs.
- Replace stale-prone planning markers with branch-stable lifecycle notation and lint validation.

## Why
This advances parent slice `M7-P2` by turning repo-scan metadata into repo-aware wiki pages, while ensuring planning files remain accurate both while the PR is open and after it merges to `main`.

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest`
- `uv run splendor lint`

## Notes
- Repo refresh is deterministic and local-only: no OpenAI calls, SQLite, background workers, or web UI.
- `Current PR lifecycle: branch=in-progress; main=merged` means `Current PR sub-slice` is in progress on a feature branch and merged once the same committed state is on `main`.