### PR TITLE
Add Claude Code automated PR review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,6 @@ jobs:
           fetch-depth: 0
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.PR_REVIEWS_ANTHROPIC_API_KEY }}
           model: "claude-sonnet-4-20250514"
           trigger_phrase: "@claude"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,6 @@
 name: Claude Code Review
 
 on:
-  pull_request:
   issue_comment:
     types: [created]
   workflow_run:
@@ -19,7 +18,8 @@ jobs:
     if: >
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'pull_request') ||
+       github.event.workflow_run.event == 'pull_request' &&
+       github.event.workflow_run.pull_requests[0].id) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude'))
@@ -32,3 +32,14 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.PR_REVIEWS_ANTHROPIC_API_KEY }}
           trigger_phrase: "@claude"
+          prompt: |
+            Review this pull request. Focus on:
+            - correctness bugs and regressions
+            - security issues
+            - missing or weak tests
+            - stale planning docs or schema contract drift
+            - violations of repo conventions in AGENTS.md
+
+            Prefer concise inline comments for concrete issues.
+            Do not comment on style-only issues unless they affect correctness.
+            Use a top-level summary only for overall context.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,29 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude-code-review:
+    if: >
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: "claude-sonnet-4-20250514"
+          trigger_phrase: "@claude"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,16 +4,22 @@ on:
   pull_request:
   issue_comment:
     types: [created]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   claude-code-review:
     if: >
-      (github.event_name == 'pull_request') ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'pull_request') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude'))
@@ -25,5 +31,4 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.PR_REVIEWS_ANTHROPIC_API_KEY }}
-          model: "claude-sonnet-4-20250514"
           trigger_phrase: "@claude"

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -141,9 +141,35 @@ Optional repository variables:
 
 - `OPENAI_MODEL`
 
+## `Claude Code Review`
+
+File: `.github/workflows/claude-code-review.yml`
+
+Runs on:
+
+- pull requests (automatic review)
+- issue comments containing `@claude` on pull requests (interactive follow-up)
+
+What it does:
+
+- runs an automated code review on every pull request using `anthropics/claude-code-action`
+- responds to `@claude` mentions in PR comments for interactive follow-up questions
+- uses `claude-sonnet-4-20250514` as the review model
+
+Permissions:
+
+- `contents: read`
+- `pull-requests: write`
+- `issues: write`
+
+Required secrets:
+
+- `ANTHROPIC_API_KEY`
+
 ## How the workflows fit together
 
 - `CI` is the primary quality gate.
+- `Claude Code Review` provides automated AI code review on every PR and interactive follow-up.
 - `pr-agent-context` turns CI, review, and failing-check state into a maintained PR handoff comment.
 - `pre-commit.ci autofix trigger` bridges bot PRs and `pre-commit.ci` label-based autofix behavior.
 - `weekly-repo-review` is scheduled maintenance, not a merge gate.

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -164,7 +164,7 @@ Permissions:
 
 Required secrets:
 
-- `ANTHROPIC_API_KEY`
+- `PR_REVIEWS_ANTHROPIC_API_KEY`
 
 ## How the workflows fit together
 

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -147,7 +147,7 @@ File: `.github/workflows/claude-code-review.yml`
 
 Runs on:
 
-- pull requests (automatic review)
+- after the CI workflow succeeds on a pull request (via `workflow_run`)
 - issue comments containing `@claude` on pull requests (interactive follow-up)
 
 What it does:


### PR DESCRIPTION
## Summary
- Add `anthropics/claude-code-action` workflow for automatic code review on every PR
- Support interactive `@claude` mentions in PR comments for follow-up questions
- Document the new workflow in `docs/ci_and_repo_automation.md`

## Setup required
Populate `secrets.ANTHROPIC_API_KEY` in the repository settings.

## Test plan
- [ ] Verify `ANTHROPIC_API_KEY` secret is configured in repo settings
- [ ] Open a test PR and confirm Claude posts an automated review
- [ ] Comment `@claude <question>` on a PR and confirm a response

🤖 Generated with [Claude Code](https://claude.com/claude-code)