### PR TITLE
M9-P1.1: Add local web UI browse/search shell

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M8-P1.1`
-- Last action taken: `M8-P1.1` is implemented; GitHub Actions now run Splendor lint on pull requests and pushes to `main`, run Splendor health nightly, and publish generated maintenance reports as artifacts.
-- Current planned slice: `M8-P2`
-- Current PR sub-slice: `M8-P2.1`
+- Previous completed PR sub-slice: `M8-P2.1`
+- Last action taken: `M8-P2.1` is implemented; generated-change automation can propose deterministic repo-refresh output through a reviewable PR workflow.
+- Current planned slice: `M9-P1`
+- Current PR sub-slice: `M9-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M9-P1`
-- Next planned PR sub-slice: `M9-P1.1`
+- Next planned slice: `M9-P2`
+- Next planned PR sub-slice: `M9-P2.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -101,6 +101,11 @@
   - [x] Run deterministic `splendor repo refresh` before proposing changes
   - [x] Run `splendor lint` and upload lint reports from the generating workflow
   - [x] Open or update a reviewable PR for generated wiki/source-registry changes
+- [x] Implement `M9-P1.1`: Local web UI browse/search shell
+  - [x] Add `splendor serve` as a foreground FastAPI server
+  - [x] Render read-only wiki and planning markdown detail pages
+  - [x] Provide browse and deterministic search pages
+  - [x] Keep mutating UI actions and runs views deferred to later slices
 
 ## Context Pointers
 
@@ -127,5 +132,5 @@
 
 ## PR Sub-slice Queue
 
-- `M8-P2.1` Optional PR-centric generated-change workflows
 - `M9-P1.1` Local web UI browse/search shell
+- `M9-P2.1` Planning/runs UI views

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The companion-repo guidance and sample agent instructions live in
 ## What Splendor Is Not
 
 - A hosted service
-- A web UI product in the current MVP
+- A full web UI product beyond the local read-only browse/search shell
 - An OCR or rich-media ingestion pipeline in the current MVP
 - A mandatory GitHub-only workflow
 
@@ -118,12 +118,14 @@ Implemented today:
 - `splendor task|milestone|decision|question ...`
 - `splendor repo scan`
 - `splendor repo refresh`
+- `splendor serve` for a read-only local browse/search UI
 - `splendor lint` and `splendor health`
 
 Not implemented yet:
 
 - OCR and image extraction flows
-- local web UI
+- mutating web UI actions such as add-source forms
+- planning/runs UI views
 - changed-files-driven refresh suggestions
 
 ## Documentation
@@ -137,12 +139,12 @@ Not implemented yet:
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M8-P1.1`
-- Current planned slice: `M8-P2`
-- Current PR sub-slice: `M8-P2.1`
+- Previous completed PR sub-slice: `M8-P2.1`
+- Current planned slice: `M9-P1`
+- Current PR sub-slice: `M9-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M9-P1`
-- Next planned PR sub-slice: `M9-P1.1`
+- Next planned slice: `M9-P2`
+- Next planned PR sub-slice: `M9-P2.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -152,8 +154,10 @@ Planning notation now distinguishes parent slices such as `M7-P2` from concrete 
 as `M7-P2.1`. `Current PR lifecycle: branch=in-progress; main=merged` means the current sub-slice
 is in progress on feature branches and is the latest merged work once observed on `main`.
 
-`M8-P1.1` is now implemented: GitHub Actions run Splendor lint on pull requests and pushes to
-`main`, run Splendor health nightly, and publish generated maintenance reports as artifacts.
+`M8-P1.1` is implemented: GitHub Actions run Splendor lint on pull requests and pushes to `main`,
+run Splendor health nightly, and publish generated maintenance reports as artifacts. `M8-P2.1` is
+implemented: generated-change automation can propose deterministic repo-refresh output through a
+reviewable PR workflow.
 
-The current PR sub-slice is `M8-P2.1`, under the parent slice `M8-P2`, which adds an optional
-PR-centric generated-change workflow for deterministic repo-refresh output.
+The current PR sub-slice is `M9-P1.1`, under the parent slice `M9-P1`, which adds the first
+read-only local web UI shell for browsing and searching wiki/planning markdown.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,15 +334,15 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M8-P1.1`
-- Current planned slice: `M8-P2`
-- Current PR sub-slice: `M8-P2.1`
+- Previous completed PR sub-slice: `M8-P2.1`
+- Current planned slice: `M9-P1`
+- Current PR sub-slice: `M9-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M9-P1`
-- Next planned PR sub-slice: `M9-P1.1`
+- Next planned slice: `M9-P2`
+- Next planned PR sub-slice: `M9-P2.1`
 
-The current PR sub-slice is `M8-P2.1`, under parent slice `M8-P2`, which moves the roadmap forward
-into optional PR-centric generated-change workflows. The lifecycle marker means `M8-P2.1` is in
+The current PR sub-slice is `M9-P1.1`, under parent slice `M9-P1`, which moves the roadmap forward
+into the first local web UI browse/search shell. The lifecycle marker means `M9-P1.1` is in
 progress on feature branches and merged once the same committed state is observed on `main`.
 
 ---
@@ -543,6 +543,16 @@ Provide a modest but useful human UI without changing the system’s center of g
 ### Planned PR slices
 - `M9-P1` Local web UI browse/search shell
 - `M9-P2` Planning/runs UI views
+
+### Current PR sub-slices
+- `M9-P1.1` Read-only `splendor serve` browse/search shell
+
+### Milestone 9 status
+
+`M9-P1.1` implements the first local web UI shell: a foreground FastAPI-backed `splendor serve`
+command with read-only browsing, markdown detail rendering, and deterministic search over existing
+wiki and planning records. Mutating web actions, add-source forms, and planning/runs views remain
+deferred to later `M9` slices.
 
 ---
 

--- a/planning/tasks/task-harden-contradiction-review-boilerplate.md
+++ b/planning/tasks/task-harden-contradiction-review-boilerplate.md
@@ -1,0 +1,37 @@
+---
+schema_version: '1'
+kind: task
+task_id: task-harden-contradiction-review-boilerplate
+title: Harden contradiction review against source-summary boilerplate false positives
+status: todo
+priority: medium
+milestone_refs: []
+decision_refs: []
+question_refs: []
+owner: null
+created_at: '2026-04-30T05:22:00+00:00'
+updated_at: '2026-04-30T05:22:00+00:00'
+depends_on: []
+source_refs:
+- src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac
+- src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a
+- src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41
+- src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd
+page_refs:
+- wiki/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md
+- wiki/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md
+- wiki/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md
+- wiki/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.md
+run_refs: []
+---
+
+## Context
+
+Dogfooding Splendor's ingest path on several related LLM Wiki source notes created false-positive
+contradiction review tasks. The compared source-summary pages used similar deterministic boilerplate
+whose only meaningful difference was the source path.
+
+## Follow-up
+
+Future contradiction review should ignore or down-rank boilerplate source-summary prose and compare
+claims extracted from source content instead of generic ingestion scaffolding.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,17 @@ authors = [
   { name = "Splendor contributors" },
 ]
 dependencies = [
+  "fastapi>=0.115,<1.0",
+  "markdown>=3.7,<4.0",
   "pydantic>=2.8,<3.0",
   "pyyaml>=6.0.2,<7.0.0",
+  "uvicorn>=0.34,<1.0",
 ]
 
 [dependency-groups]
 dev = [
   "coverage[toml]>=7.6,<8.0",
+  "httpx>=0.27,<1.0",
   "pre-commit>=4.0,<5.0",
   "pytest>=8.3,<9.0",
   "pytest-cov>=6.0,<7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
   { name = "Splendor contributors" },
 ]
 dependencies = [
+  "bleach>=6.1,<7.0",
   "fastapi>=0.115,<1.0",
   "markdown>=3.7,<4.0",
   "pydantic>=2.8,<3.0",

--- a/raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md
+++ b/raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md
@@ -1,0 +1,39 @@
+# Karpathy LLM Wiki Pattern
+
+Source URL: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+
+Related announcement URL: https://x.com/karpathy/status/2039805659525644595
+
+## Source Note
+
+Andrej Karpathy's LLM Wiki note describes a pattern for using LLM agents to maintain a persistent
+personal knowledge base. The central contrast is with ordinary RAG-style document interaction:
+retrieval at answer time can find fragments, but it does not accumulate synthesis across sessions.
+
+The proposed alternative is a maintained wiki layer between raw sources and user questions. New
+sources are not only indexed; they are read, summarized, linked into existing pages, and used to
+revise prior synthesis when they strengthen, challenge, or contradict it.
+
+## Core Claims
+
+- The wiki is a persistent, compounding artifact rather than a transient answer.
+- Raw sources stay immutable and remain the source of truth.
+- The generated wiki consists of markdown pages such as summaries, entities, concepts,
+  comparisons, overview pages, and synthesis pages.
+- The LLM is responsible for repetitive maintenance work: summarization, cross-references,
+  consistency, contradiction surfacing, filing answers, and updating index/log files.
+- The human remains responsible for source selection, supervision, questions, and judgment.
+- `index.md` and `log.md` are special navigation files: one content-oriented and one chronological.
+- Query outputs can be filed back into the wiki so research work compounds instead of disappearing
+  into chat history.
+- Periodic linting should look for contradictions, stale claims, orphan pages, missing
+  cross-references, and gaps that need new sources.
+
+## Design Implications for Splendor
+
+Splendor already mirrors this architecture with `raw/`, `wiki/`, `planning/`, `state/`, lint,
+health, query snapshots, provenance, and a CLI-first workflow. The strongest alignment is that
+Splendor treats the filesystem as durable state and aims to make source-to-page provenance explicit.
+
+The next useful step for Splendor is to make the local wiki browsable enough that humans and agents
+can inspect accumulated synthesis without going straight back to raw source manifests.

--- a/raw/imports/llm-knowledge-work/karpathy-x-llm-knowledge-bases.md
+++ b/raw/imports/llm-knowledge-work/karpathy-x-llm-knowledge-bases.md
@@ -1,0 +1,29 @@
+# Karpathy X Post: LLM Knowledge Bases
+
+Source URL: https://x.com/karpathy/status/2039805659525644595
+
+Follow-up idea file: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+
+## Source Note
+
+The X post is the initial public reference for Karpathy's "LLM Knowledge Bases" idea. The post
+itself is not reliably accessible from unauthenticated fetches, but it is linked by the public gist
+and by open-source implementations as the announcement or originating thread.
+
+For Splendor's purposes, this source is tracked as the social-origin pointer. The durable technical
+content should be grounded primarily in the follow-up gist, which expands the pattern into a
+copyable idea file for LLM agents.
+
+## Interpretation
+
+The important product signal from the X post is not a particular implementation detail. It is the
+shift in framing: LLMs can compile a growing body of raw materials into an inspectable knowledge
+base, not merely answer isolated questions over uploaded files.
+
+That framing supports Splendor's design bias toward:
+
+- durable markdown pages,
+- explicit source registration,
+- provenance and review state,
+- query results that can become filed knowledge,
+- lint/health passes that keep the knowledge base maintainable.

--- a/raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md
+++ b/raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md
@@ -1,0 +1,37 @@
+# LLM Research and Knowledge Work Notes
+
+Source URLs:
+
+- https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+- https://github.com/lucasastorian/llmwiki
+- https://x.com/karpathy/status/2039805659525644595
+
+## Source Note
+
+This note distills design implications for Splendor from the LLM Wiki pattern and its first
+open-source implementation. It is intentionally a local synthesis note, not a verbatim mirror of any
+external source.
+
+## LLM Knowledge Work Loop
+
+LLM-assisted research becomes more useful when the agent is allowed to leave durable artifacts:
+
+1. Select or register a source.
+2. Extract key claims and relevant context.
+3. Integrate those claims into existing pages.
+4. Record provenance back to the source and run.
+5. Surface contradictions or stale assumptions.
+6. File useful answers back into the wiki.
+7. Periodically lint the knowledge base for health.
+
+This loop differs from ordinary chat because the user and agent are improving the workspace itself,
+not only producing a one-time answer.
+
+## Splendor Relevance
+
+Splendor can treat research as versioned knowledge compilation. The CLI, schemas, manifests, query
+snapshots, lint reports, and now the local web UI are all supporting machinery around that loop.
+
+The most important product test is whether a new agent can enter the repository, browse the current
+wiki, understand what has already been learned, and continue the work without relying on chat
+history.

--- a/raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md
+++ b/raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md
@@ -1,0 +1,35 @@
+# Lucas Astorian LLM Wiki Implementation
+
+Source URL: https://github.com/lucasastorian/llmwiki
+
+## Source Note
+
+`lucasastorian/llmwiki` is an open-source implementation of Karpathy's LLM Wiki pattern. Its README
+frames the system as a way to point at a research folder, run a local app, connect Claude through
+MCP, and let the agent write and maintain wiki pages with links and citations.
+
+## Implementation Pattern
+
+The project keeps source files in place, creates a `wiki/` directory for generated pages, and keeps
+a hidden local index/cache that can be rebuilt. Its architecture combines a web frontend, a FastAPI
+backend, a local SQLite index, an MCP server, and filesystem-backed source material.
+
+Claude-facing tools include guide, search, read, write, and delete operations. The system positions
+the filesystem as the source of truth while using SQLite as derived search/index infrastructure.
+
+## Useful Contrasts with Splendor
+
+- LLM Wiki emphasizes MCP tool access for Claude; Splendor currently emphasizes deterministic CLI
+  commands that agents and humans can both run.
+- LLM Wiki uses SQLite as a local derived index; Splendor currently avoids hidden caches and keeps
+  machine-readable state in tracked files.
+- LLM Wiki includes a fuller web app; Splendor's first web UI is intentionally read-only and
+  non-essential.
+- Both systems share the same core premise: raw sources should remain stable while the wiki evolves
+  as a maintained synthesis layer.
+
+## Product Lessons
+
+The implementation validates that a local web UI is useful even when the canonical state is a
+filesystem of markdown and JSON records. It also shows that agent-facing tools need clear operating
+conventions, not only storage primitives.

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -146,6 +146,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
     query_parser.set_defaults(handler=handle_query)
 
+    serve_parser = subparsers.add_parser("serve", help="Run the read-only local web UI")
+    serve_parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host interface to bind. Defaults to 127.0.0.1.",
+    )
+    serve_parser.add_argument(
+        "--port",
+        default=8000,
+        type=int,
+        help="Port to bind. Defaults to 8000.",
+    )
+    serve_parser.set_defaults(handler=handle_serve)
+
     file_answer_parser = subparsers.add_parser(
         "file-answer", help="File a saved query result back into the wiki"
     )
@@ -558,6 +572,18 @@ def handle_query(args: argparse.Namespace) -> int:
             print(f"   Contradictions: {match.contradiction_count}")
         if match.review_task_ids:
             print(f"   Review tasks: {', '.join(match.review_task_ids)}")
+    return 0
+
+
+def handle_serve(args: argparse.Namespace) -> int:
+    import uvicorn
+
+    from splendor.web import create_app
+
+    root = args.root.resolve()
+    app = create_app(root)
+    print(f"Serving Splendor at http://{args.host}:{args.port}")
+    uvicorn.run(app, host=args.host, port=args.port)
     return 0
 
 

--- a/src/splendor/commands/planning.py
+++ b/src/splendor/commands/planning.py
@@ -63,11 +63,15 @@ class UpdateQuestionAnswerResult:
     content: str
 
 
-def _model_for(kind: str):
+def model_for_planning_kind(kind: str):
     try:
         return _RECORD_MODELS[kind]
     except KeyError as exc:
         raise ValueError(f"Unsupported planning kind: {kind}") from exc
+
+
+def _model_for(kind: str):
+    return model_for_planning_kind(kind)
 
 
 def create_task(

--- a/src/splendor/commands/query.py
+++ b/src/splendor/commands/query.py
@@ -184,11 +184,11 @@ def _iter_wiki_documents(root: Path, layout: ResolvedLayout) -> list[_QueryDocum
 
 
 def _iter_planning_documents(root: Path, layout: ResolvedLayout) -> list[_QueryDocument]:
-    from splendor.commands.planning import _model_for  # imported lazily to avoid duplication
+    from splendor.commands.planning import model_for_planning_kind
 
     documents: list[_QueryDocument] = []
     for kind in _PLANNING_KINDS:
-        model = _model_for(kind)
+        model = model_for_planning_kind(kind)
         for path in iter_planning_paths(planning_directory(layout, kind)):
             parsed = parse_planning_document(path, model)
             record = parsed.record

--- a/src/splendor/commands/query.py
+++ b/src/splendor/commands/query.py
@@ -22,6 +22,10 @@ _TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
 _WHITESPACE_PATTERN = re.compile(r"\s+")
 
 
+class QueryValidationError(ValueError):
+    """Raised when the query text itself is invalid."""
+
+
 @dataclass(frozen=True)
 class QueryMatch:
     rank: int
@@ -88,7 +92,7 @@ def run_query(root: Path, question: str) -> QueryResult:
     normalized_query = question.strip()
     query_tokens = _query_tokens(normalized_query)
     if not query_tokens:
-        raise ValueError("Query must contain at least one ASCII letter or number")
+        raise QueryValidationError("Query must contain at least one ASCII letter or number")
 
     layout = resolve_layout(root, load_config(root))
     documents = [*_iter_wiki_documents(root, layout), *_iter_planning_documents(root, layout)]

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -14,7 +14,7 @@ import markdown as markdown_lib
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse
 
-from splendor.commands.planning import _model_for
+from splendor.commands.planning import model_for_planning_kind
 from splendor.commands.query import QueryMatch, QueryValidationError, run_query
 from splendor.config import load_config
 from splendor.layout import ResolvedLayout, resolve_layout
@@ -72,13 +72,25 @@ class _DocumentDetail:
     body: str
 
 
+class WebLayoutError(ValueError):
+    """Raised when configured web document roots are unsafe to serve."""
+
+
 def create_app(root: Path) -> FastAPI:
     """Create the read-only Splendor web application for a workspace root."""
     workspace_root = root.resolve()
     app = FastAPI(title="Splendor", docs_url=None, redoc_url=None)
 
-    @app.exception_handler(ValueError)
-    def workspace_value_error(_, __: ValueError) -> HTMLResponse:
+    @app.exception_handler(HTTPException)
+    def http_error(_, exc: HTTPException) -> HTMLResponse:
+        title = "Not Found" if exc.status_code == 404 else "Request Error"
+        if exc.status_code >= 500:
+            title = "Workspace Error"
+        detail = html.escape(str(exc.detail))
+        return _page(title, f'<p class="empty">{detail}</p>', status_code=exc.status_code)
+
+    @app.exception_handler(WebLayoutError)
+    def workspace_layout_error(_, __: WebLayoutError) -> HTMLResponse:
         _LOGGER.exception("Workspace configuration error.")
         return _page(
             "Workspace Error",
@@ -193,15 +205,15 @@ def _layout_for(root: Path) -> ResolvedLayout:
 def _validate_layout_root(root: Path, value: str, *, label: str) -> None:
     path = Path(value)
     if "\\" in value or path.is_absolute() or not path.parts or ".." in path.parts:
-        raise ValueError(f"Configured {label} must be a workspace-relative directory: {value}")
+        raise WebLayoutError(f"Configured {label} must be a workspace-relative directory: {value}")
     resolved = (root / path).resolve()
     workspace_root = root.resolve()
     if resolved == workspace_root:
-        raise ValueError(f"Configured {label} must not be the workspace root: {value}")
+        raise WebLayoutError(f"Configured {label} must not be the workspace root: {value}")
     try:
         resolved.relative_to(workspace_root)
     except ValueError as exc:
-        raise ValueError(
+        raise WebLayoutError(
             f"Configured {label} must resolve inside the workspace root: {value}"
         ) from exc
 
@@ -270,7 +282,7 @@ def _document_detail(root: Path, layout: ResolvedLayout, path: Path) -> _Documen
             body=body,
         )
     try:
-        parsed = parse_planning_document(path, _model_for(planning_kind))
+        parsed = parse_planning_document(path, model_for_planning_kind(planning_kind))
     except ValueError:
         body = path.read_text(encoding="utf-8")
         return _DocumentDetail(

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -1,0 +1,329 @@
+"""Read-only local web UI for Splendor workspaces."""
+
+from __future__ import annotations
+
+import html
+import json
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from urllib.parse import quote
+
+import markdown as markdown_lib
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.responses import HTMLResponse
+
+from splendor.commands.planning import _model_for
+from splendor.commands.query import QueryMatch, run_query
+from splendor.config import load_config
+from splendor.layout import ResolvedLayout, resolve_layout
+from splendor.utils.planning import parse_planning_document
+from splendor.utils.wiki import parse_wiki_markdown
+
+
+@dataclass(frozen=True)
+class _DocumentSummary:
+    path: str
+    title: str
+    document_class: str
+    kind: str | None
+    status: str | None
+
+
+@dataclass(frozen=True)
+class _DocumentDetail:
+    path: str
+    title: str
+    document_class: str
+    kind: str | None
+    status: str | None
+    metadata: dict[str, object]
+    body: str
+
+
+def create_app(root: Path) -> FastAPI:
+    """Create the read-only Splendor web application for a workspace root."""
+    workspace_root = root.resolve()
+    app = FastAPI(title="Splendor", docs_url=None, redoc_url=None)
+
+    @app.get("/", response_class=HTMLResponse)
+    def home() -> HTMLResponse:
+        layout = _layout_for(workspace_root)
+        documents = _iter_documents(workspace_root, layout)
+        wiki_count = sum(1 for item in documents if item.document_class == "wiki")
+        planning_count = sum(1 for item in documents if item.document_class == "planning")
+        body = (
+            '<section class="toolbar">'
+            '<form action="/search" method="get">'
+            '<input type="search" name="q" placeholder="Search wiki and planning" />'
+            '<button type="submit">Search</button>'
+            "</form>"
+            '<a class="button" href="/browse">Browse documents</a>'
+            "</section>"
+            '<section class="stats">'
+            f"<div><strong>{len(documents)}</strong><span>Documents</span></div>"
+            f"<div><strong>{wiki_count}</strong><span>Wiki pages</span></div>"
+            f"<div><strong>{planning_count}</strong><span>Planning records</span></div>"
+            "</section>"
+        )
+        return _page("Splendor", body)
+
+    @app.get("/browse", response_class=HTMLResponse)
+    def browse() -> HTMLResponse:
+        layout = _layout_for(workspace_root)
+        documents = _iter_documents(workspace_root, layout)
+        rows = "\n".join(_document_row(item) for item in documents)
+        body = (
+            '<section class="toolbar">'
+            '<form action="/search" method="get">'
+            '<input type="search" name="q" placeholder="Search wiki and planning" />'
+            '<button type="submit">Search</button>'
+            "</form>"
+            "</section>"
+            f"<table><thead><tr><th>Title</th><th>Kind</th><th>Status</th><th>Path</th></tr></thead>"
+            f"<tbody>{rows}</tbody></table>"
+        )
+        return _page("Browse", body)
+
+    @app.get("/documents/{document_path:path}", response_class=HTMLResponse)
+    def document(document_path: str) -> HTMLResponse:
+        layout = _layout_for(workspace_root)
+        path = _safe_document_path(workspace_root, layout, document_path)
+        detail = _document_detail(workspace_root, layout, path)
+        metadata = html.escape(json.dumps(detail.metadata, indent=2, sort_keys=True))
+        body_html = _render_markdown(detail.body)
+        body = (
+            '<p class="breadcrumbs"><a href="/browse">Browse</a> / '
+            f"{html.escape(detail.path)}</p>"
+            '<section class="metadata">'
+            f"<div><strong>Class</strong><span>{html.escape(detail.document_class)}</span></div>"
+            f"<div><strong>Kind</strong><span>{html.escape(detail.kind or '-')}</span></div>"
+            f"<div><strong>Status</strong><span>{html.escape(detail.status or '-')}</span></div>"
+            f"<pre>{metadata}</pre>"
+            "</section>"
+            f'<article class="markdown">{body_html}</article>'
+        )
+        return _page(detail.title, body)
+
+    @app.get("/search", response_class=HTMLResponse)
+    def search(q: str = Query(default="")) -> HTMLResponse:
+        query = q.strip()
+        form = (
+            '<section class="toolbar">'
+            '<form action="/search" method="get">'
+            f'<input type="search" name="q" value="{html.escape(query)}" '
+            'placeholder="Search wiki and planning" />'
+            '<button type="submit">Search</button>'
+            "</form>"
+            "</section>"
+        )
+        if not query:
+            return _page("Search", form)
+        try:
+            result = run_query(workspace_root, query)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        rows = "\n".join(_search_row(match) for match in result.matches)
+        if not rows:
+            rows = '<p class="empty">No matches found.</p>'
+        body = f"{form}<p>{html.escape(result.summary)}</p><section>{rows}</section>"
+        return _page("Search", body)
+
+    return app
+
+
+def _layout_for(root: Path) -> ResolvedLayout:
+    return resolve_layout(root, load_config(root))
+
+
+def _iter_documents(root: Path, layout: ResolvedLayout) -> list[_DocumentSummary]:
+    documents: list[_DocumentSummary] = []
+    for path in sorted(layout.wiki_dir.rglob("*.md")):
+        if path.name == ".gitkeep" or not path.is_file():
+            continue
+        documents.append(_document_summary(root, layout, path))
+    for path in sorted(layout.planning_dir.rglob("*.md")):
+        if path.name == ".gitkeep" or not path.is_file():
+            continue
+        documents.append(_document_summary(root, layout, path))
+    return sorted(documents, key=lambda item: (item.document_class, item.kind or "", item.title))
+
+
+def _document_summary(root: Path, layout: ResolvedLayout, path: Path) -> _DocumentSummary:
+    detail = _document_detail(root, layout, path)
+    return _DocumentSummary(
+        path=detail.path,
+        title=detail.title,
+        document_class=detail.document_class,
+        kind=detail.kind,
+        status=detail.status,
+    )
+
+
+def _document_detail(root: Path, layout: ResolvedLayout, path: Path) -> _DocumentDetail:
+    relative_path = path.relative_to(root).as_posix()
+    if path.is_relative_to(layout.wiki_dir):
+        try:
+            parsed = parse_wiki_markdown(path)
+        except ValueError:
+            body = path.read_text(encoding="utf-8")
+            return _DocumentDetail(
+                path=relative_path,
+                title=_title_from_markdown(body, relative_path),
+                document_class="wiki",
+                kind=None,
+                status=None,
+                metadata={},
+                body=body,
+            )
+        frontmatter = parsed.frontmatter
+        return _DocumentDetail(
+            path=relative_path,
+            title=frontmatter.title,
+            document_class="wiki",
+            kind=frontmatter.kind,
+            status=frontmatter.status,
+            metadata=frontmatter.model_dump(mode="json"),
+            body=parsed.body,
+        )
+
+    planning_kind = _planning_kind(layout, path)
+    if planning_kind is None:
+        body = path.read_text(encoding="utf-8")
+        return _DocumentDetail(
+            path=relative_path,
+            title=_title_from_markdown(body, relative_path),
+            document_class="planning",
+            kind=None,
+            status=None,
+            metadata={},
+            body=body,
+        )
+    parsed = parse_planning_document(path, _model_for(planning_kind))
+    record = parsed.record
+    metadata = record.model_dump(mode="json")
+    status = metadata.get("status")
+    return _DocumentDetail(
+        path=relative_path,
+        title=record.title,
+        document_class="planning",
+        kind=planning_kind,
+        status=status if isinstance(status, str) else None,
+        metadata=metadata,
+        body=parsed.body,
+    )
+
+
+def _planning_kind(layout: ResolvedLayout, path: Path) -> str | None:
+    relative_parts = path.relative_to(layout.planning_dir).parts
+    if not relative_parts:
+        return None
+    return {
+        "tasks": "task",
+        "milestones": "milestone",
+        "decisions": "decision",
+        "questions": "question",
+    }.get(relative_parts[0])
+
+
+def _safe_document_path(root: Path, layout: ResolvedLayout, document_path: str) -> Path:
+    pure_path = PurePosixPath(document_path)
+    if pure_path.is_absolute() or ".." in pure_path.parts or pure_path.suffix != ".md":
+        raise HTTPException(status_code=404, detail="Document not found")
+    if not pure_path.parts:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    path = (root / Path(*pure_path.parts)).resolve()
+    allowed_roots = (layout.wiki_dir.resolve(), layout.planning_dir.resolve())
+    if not any(path.is_relative_to(allowed_root) for allowed_root in allowed_roots):
+        raise HTTPException(status_code=404, detail="Document not found")
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="Document not found")
+    return path
+
+
+def _render_markdown(markdown_text: str) -> str:
+    escaped_markdown = html.escape(markdown_text, quote=False)
+    return markdown_lib.markdown(
+        escaped_markdown,
+        extensions=["extra", "sane_lists"],
+        output_format="html5",
+    )
+
+
+def _title_from_markdown(markdown_text: str, fallback: str) -> str:
+    for line in markdown_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped.removeprefix("# ").strip() or fallback
+    return fallback
+
+
+def _document_row(document: _DocumentSummary) -> str:
+    href = f"/documents/{quote(document.path, safe='/')}"
+    return (
+        "<tr>"
+        f'<td><a href="{href}">{html.escape(document.title)}</a></td>'
+        f"<td>{html.escape(document.kind or '-')}</td>"
+        f"<td>{html.escape(document.status or '-')}</td>"
+        f"<td><code>{html.escape(document.path)}</code></td>"
+        "</tr>"
+    )
+
+
+def _search_row(match: QueryMatch) -> str:
+    href = f"/documents/{quote(match.path, safe='/')}"
+    status = f" · {html.escape(match.status)}" if match.status else ""
+    return (
+        '<article class="result">'
+        f'<h2><a href="{href}">{html.escape(match.title)}</a></h2>'
+        f"<p><code>{html.escape(match.path)}</code> · {html.escape(match.kind)}{status}</p>"
+        f"<p>{html.escape(match.snippet)}</p>"
+        "</article>"
+    )
+
+
+def _page(title: str, body: str) -> HTMLResponse:
+    escaped_title = html.escape(title)
+    return HTMLResponse(
+        "<!doctype html>"
+        '<html lang="en">'
+        "<head>"
+        '<meta charset="utf-8" />'
+        '<meta name="viewport" content="width=device-width, initial-scale=1" />'
+        f"<title>{escaped_title} · Splendor</title>"
+        "<style>"
+        ":root{color-scheme:light;--border:#d8dee8;--text:#1f2937;--muted:#5f6b7a;"
+        "--surface:#f8fafc;--accent:#0f766e}"
+        "body{margin:0;font:15px/1.5 system-ui,-apple-system,BlinkMacSystemFont,"
+        "'Segoe UI',sans-serif;"
+        "color:var(--text);background:white}"
+        "header{border-bottom:1px solid var(--border);padding:18px 28px;background:var(--surface)}"
+        "main{max-width:1060px;margin:0 auto;padding:28px}"
+        "h1{font-size:28px;margin:0}h2{font-size:18px;margin:0 0 6px}"
+        "a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}"
+        ".toolbar{display:flex;gap:14px;align-items:center;margin-bottom:22px;flex-wrap:wrap}"
+        "form{display:flex;gap:8px;align-items:center;flex:1;min-width:260px}"
+        "input{border:1px solid var(--border);border-radius:6px;padding:9px 10px;"
+        "font:inherit;flex:1}"
+        "button,.button{border:1px solid var(--accent);border-radius:6px;background:var(--accent);"
+        "color:white;padding:9px 12px;font:inherit;cursor:pointer}"
+        ".stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px}"
+        ".stats div,.metadata,.result{border:1px solid var(--border);border-radius:8px;"
+        "padding:14px}"
+        ".stats strong{display:block;font-size:26px}.stats span,.breadcrumbs{color:var(--muted)}"
+        "table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--border);"
+        "padding:10px;text-align:left;vertical-align:top}th{background:var(--surface)}"
+        "code,pre{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}"
+        "pre{overflow:auto;background:var(--surface);border-radius:6px;padding:12px}"
+        ".metadata{display:grid;gap:10px;margin-bottom:24px;background:var(--surface)}"
+        ".metadata div{display:flex;gap:10px}.metadata strong{width:70px}"
+        ".markdown{max-width:820px}.markdown img{max-width:100%}.result{margin:0 0 12px}"
+        ".empty{color:var(--muted)}"
+        "</style>"
+        "</head>"
+        "<body>"
+        f"<header><h1>{escaped_title}</h1></header>"
+        f"<main>{body}</main>"
+        "</body></html>"
+    )

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -4,20 +4,52 @@ from __future__ import annotations
 
 import html
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from urllib.parse import quote
 
+import bleach
 import markdown as markdown_lib
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse
 
 from splendor.commands.planning import _model_for
-from splendor.commands.query import QueryMatch, run_query
+from splendor.commands.query import QueryMatch, QueryValidationError, run_query
 from splendor.config import load_config
 from splendor.layout import ResolvedLayout, resolve_layout
+from splendor.state.paths import resolve_workspace_path
 from splendor.utils.planning import parse_planning_document
 from splendor.utils.wiki import parse_wiki_markdown
+
+_LOGGER = logging.getLogger(__name__)
+_ALLOWED_MARKDOWN_TAGS = set(bleach.sanitizer.ALLOWED_TAGS) | {
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "p",
+    "pre",
+    "span",
+    "img",
+    "hr",
+    "br",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+}
+_ALLOWED_MARKDOWN_ATTRIBUTES = {
+    **bleach.sanitizer.ALLOWED_ATTRIBUTES,
+    "a": [*bleach.sanitizer.ALLOWED_ATTRIBUTES.get("a", []), "href", "title"],
+    "img": ["src", "alt", "title"],
+    "code": ["class"],
+    "span": ["class"],
+}
 
 
 @dataclass(frozen=True)
@@ -44,6 +76,15 @@ def create_app(root: Path) -> FastAPI:
     """Create the read-only Splendor web application for a workspace root."""
     workspace_root = root.resolve()
     app = FastAPI(title="Splendor", docs_url=None, redoc_url=None)
+
+    @app.exception_handler(ValueError)
+    def workspace_value_error(_, __: ValueError) -> HTMLResponse:
+        _LOGGER.exception("Workspace configuration error.")
+        return _page(
+            "Workspace Error",
+            '<p class="empty">Workspace configuration is invalid.</p>',
+            status_code=500,
+        )
 
     @app.get("/", response_class=HTMLResponse)
     def home() -> HTMLResponse:
@@ -120,8 +161,18 @@ def create_app(root: Path) -> FastAPI:
             return _page("Search", form)
         try:
             result = run_query(workspace_root, query)
-        except ValueError as exc:
+        except QueryValidationError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except ValueError:
+            _LOGGER.exception("Search failed while parsing workspace records.")
+            return _page(
+                "Search Error",
+                f"{form}"
+                '<p class="empty">'
+                "Search failed because the workspace contains invalid records."
+                "</p>",
+                status_code=500,
+            )
 
         rows = "\n".join(_search_row(match) for match in result.matches)
         if not rows:
@@ -133,7 +184,26 @@ def create_app(root: Path) -> FastAPI:
 
 
 def _layout_for(root: Path) -> ResolvedLayout:
-    return resolve_layout(root, load_config(root))
+    config = load_config(root)
+    _validate_layout_root(root, config.layout.wiki_dir, label="wiki_dir")
+    _validate_layout_root(root, config.layout.planning_dir, label="planning_dir")
+    return resolve_layout(root, config)
+
+
+def _validate_layout_root(root: Path, value: str, *, label: str) -> None:
+    path = Path(value)
+    if "\\" in value or path.is_absolute() or not path.parts or ".." in path.parts:
+        raise ValueError(f"Configured {label} must be a workspace-relative directory: {value}")
+    resolved = (root / path).resolve()
+    workspace_root = root.resolve()
+    if resolved == workspace_root:
+        raise ValueError(f"Configured {label} must not be the workspace root: {value}")
+    try:
+        resolved.relative_to(workspace_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"Configured {label} must resolve inside the workspace root: {value}"
+        ) from exc
 
 
 def _iter_documents(root: Path, layout: ResolvedLayout) -> list[_DocumentSummary]:
@@ -199,7 +269,19 @@ def _document_detail(root: Path, layout: ResolvedLayout, path: Path) -> _Documen
             metadata={},
             body=body,
         )
-    parsed = parse_planning_document(path, _model_for(planning_kind))
+    try:
+        parsed = parse_planning_document(path, _model_for(planning_kind))
+    except ValueError:
+        body = path.read_text(encoding="utf-8")
+        return _DocumentDetail(
+            path=relative_path,
+            title=_title_from_markdown(body, relative_path),
+            document_class="planning",
+            kind=planning_kind,
+            status=None,
+            metadata={},
+            body=body,
+        )
     record = parsed.record
     metadata = record.model_dump(mode="json")
     status = metadata.get("status")
@@ -228,12 +310,17 @@ def _planning_kind(layout: ResolvedLayout, path: Path) -> str | None:
 
 def _safe_document_path(root: Path, layout: ResolvedLayout, document_path: str) -> Path:
     pure_path = PurePosixPath(document_path)
+    if "\\" in document_path:
+        raise HTTPException(status_code=404, detail="Document not found")
     if pure_path.is_absolute() or ".." in pure_path.parts or pure_path.suffix != ".md":
         raise HTTPException(status_code=404, detail="Document not found")
     if not pure_path.parts:
         raise HTTPException(status_code=404, detail="Document not found")
 
-    path = (root / Path(*pure_path.parts)).resolve()
+    try:
+        path = resolve_workspace_path(root, document_path, context="Document")
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="Document not found") from exc
     allowed_roots = (layout.wiki_dir.resolve(), layout.planning_dir.resolve())
     if not any(path.is_relative_to(allowed_root) for allowed_root in allowed_roots):
         raise HTTPException(status_code=404, detail="Document not found")
@@ -243,11 +330,15 @@ def _safe_document_path(root: Path, layout: ResolvedLayout, document_path: str) 
 
 
 def _render_markdown(markdown_text: str) -> str:
-    escaped_markdown = html.escape(markdown_text, quote=False)
-    return markdown_lib.markdown(
-        escaped_markdown,
+    rendered = markdown_lib.markdown(
+        markdown_text,
         extensions=["extra", "sane_lists"],
         output_format="html5",
+    )
+    return bleach.clean(
+        rendered,
+        tags=_ALLOWED_MARKDOWN_TAGS,
+        attributes=_ALLOWED_MARKDOWN_ATTRIBUTES,
     )
 
 
@@ -283,7 +374,7 @@ def _search_row(match: QueryMatch) -> str:
     )
 
 
-def _page(title: str, body: str) -> HTMLResponse:
+def _page(title: str, body: str, *, status_code: int = 200) -> HTMLResponse:
     escaped_title = html.escape(title)
     return HTMLResponse(
         "<!doctype html>"
@@ -325,5 +416,6 @@ def _page(title: str, body: str) -> HTMLResponse:
         "<body>"
         f"<header><h1>{escaped_title}</h1></header>"
         f"<main>{body}</main>"
-        "</body></html>"
+        "</body></html>",
+        status_code=status_code,
     )

--- a/state/manifests/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.json
+++ b/state/manifests/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.json
@@ -1,0 +1,52 @@
+{
+  "added_at": "2026-04-30T05:11:05+00:00",
+  "checksum": "3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a",
+  "derived_artifacts": [],
+  "discovered_by": null,
+  "generated_by_run_ids": [
+    "run-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a-20260430T051115233135Z"
+  ],
+  "kind": "source",
+  "last_run_id": "run-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a-20260430T051115233135Z",
+  "linked_pages": [
+    "wiki/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md"
+  ],
+  "materialized_at": null,
+  "origin_url": null,
+  "original_path": "raw/imports/llm-knowledge-work/karpathy-x-llm-knowledge-bases.md",
+  "path": "raw/imports/llm-knowledge-work/karpathy-x-llm-knowledge-bases.md",
+  "pipeline_version": "0.1.0a0",
+  "provenance_links": [
+    {
+      "note": null,
+      "page_id": "src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a",
+      "path_ref": "wiki/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md",
+      "role": "generated-page",
+      "run_id": null,
+      "source_id": null
+    },
+    {
+      "note": null,
+      "page_id": null,
+      "path_ref": null,
+      "role": "output",
+      "run_id": "run-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a-20260430T051115233135Z",
+      "source_id": "src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a"
+    }
+  ],
+  "review_state": "unreviewed",
+  "reviewed_at": null,
+  "reviewed_by": null,
+  "schema_version": "1",
+  "source_class": null,
+  "source_commit": null,
+  "source_id": "src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a",
+  "source_labels": [],
+  "source_ref": "raw/imports/llm-knowledge-work/karpathy-x-llm-knowledge-bases.md",
+  "source_ref_kind": "workspace_path",
+  "source_type": "md",
+  "status": "ingested",
+  "storage_mode": "none",
+  "storage_path": null,
+  "title": "karpathy x llm knowledge bases"
+}

--- a/state/manifests/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.json
+++ b/state/manifests/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.json
@@ -1,0 +1,52 @@
+{
+  "added_at": "2026-04-30T05:11:04+00:00",
+  "checksum": "51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac",
+  "derived_artifacts": [],
+  "discovered_by": null,
+  "generated_by_run_ids": [
+    "run-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac-20260430T051115103716Z"
+  ],
+  "kind": "source",
+  "last_run_id": "run-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac-20260430T051115103716Z",
+  "linked_pages": [
+    "wiki/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md"
+  ],
+  "materialized_at": null,
+  "origin_url": null,
+  "original_path": "raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md",
+  "path": "raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md",
+  "pipeline_version": "0.1.0a0",
+  "provenance_links": [
+    {
+      "note": null,
+      "page_id": "src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac",
+      "path_ref": "wiki/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md",
+      "role": "generated-page",
+      "run_id": null,
+      "source_id": null
+    },
+    {
+      "note": null,
+      "page_id": null,
+      "path_ref": null,
+      "role": "output",
+      "run_id": "run-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac-20260430T051115103716Z",
+      "source_id": "src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac"
+    }
+  ],
+  "review_state": "unreviewed",
+  "reviewed_at": null,
+  "reviewed_by": null,
+  "schema_version": "1",
+  "source_class": null,
+  "source_commit": null,
+  "source_id": "src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac",
+  "source_labels": [],
+  "source_ref": "raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md",
+  "source_ref_kind": "workspace_path",
+  "source_type": "md",
+  "status": "ingested",
+  "storage_mode": "none",
+  "storage_path": null,
+  "title": "karpathy llm wiki pattern"
+}

--- a/state/manifests/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.json
+++ b/state/manifests/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.json
@@ -1,0 +1,52 @@
+{
+  "added_at": "2026-04-30T05:11:05+00:00",
+  "checksum": "9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41",
+  "derived_artifacts": [],
+  "discovered_by": null,
+  "generated_by_run_ids": [
+    "run-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41-20260430T051119086596Z"
+  ],
+  "kind": "source",
+  "last_run_id": "run-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41-20260430T051119086596Z",
+  "linked_pages": [
+    "wiki/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md"
+  ],
+  "materialized_at": null,
+  "origin_url": null,
+  "original_path": "raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md",
+  "path": "raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md",
+  "pipeline_version": "0.1.0a0",
+  "provenance_links": [
+    {
+      "note": null,
+      "page_id": "src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41",
+      "path_ref": "wiki/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md",
+      "role": "generated-page",
+      "run_id": null,
+      "source_id": null
+    },
+    {
+      "note": null,
+      "page_id": null,
+      "path_ref": null,
+      "role": "output",
+      "run_id": "run-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41-20260430T051119086596Z",
+      "source_id": "src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41"
+    }
+  ],
+  "review_state": "unreviewed",
+  "reviewed_at": null,
+  "reviewed_by": null,
+  "schema_version": "1",
+  "source_class": null,
+  "source_commit": null,
+  "source_id": "src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41",
+  "source_labels": [],
+  "source_ref": "raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md",
+  "source_ref_kind": "workspace_path",
+  "source_type": "md",
+  "status": "ingested",
+  "storage_mode": "none",
+  "storage_path": null,
+  "title": "llm research knowledge work notes"
+}

--- a/state/manifests/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.json
+++ b/state/manifests/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.json
@@ -1,0 +1,52 @@
+{
+  "added_at": "2026-04-30T05:11:05+00:00",
+  "checksum": "e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd",
+  "derived_artifacts": [],
+  "discovered_by": null,
+  "generated_by_run_ids": [
+    "run-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd-20260430T051120687562Z"
+  ],
+  "kind": "source",
+  "last_run_id": "run-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd-20260430T051120687562Z",
+  "linked_pages": [
+    "wiki/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.md"
+  ],
+  "materialized_at": null,
+  "origin_url": null,
+  "original_path": "raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md",
+  "path": "raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md",
+  "pipeline_version": "0.1.0a0",
+  "provenance_links": [
+    {
+      "note": null,
+      "page_id": "src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd",
+      "path_ref": "wiki/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.md",
+      "role": "generated-page",
+      "run_id": null,
+      "source_id": null
+    },
+    {
+      "note": null,
+      "page_id": null,
+      "path_ref": null,
+      "role": "output",
+      "run_id": "run-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd-20260430T051120687562Z",
+      "source_id": "src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd"
+    }
+  ],
+  "review_state": "unreviewed",
+  "reviewed_at": null,
+  "reviewed_by": null,
+  "schema_version": "1",
+  "source_class": null,
+  "source_commit": null,
+  "source_id": "src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd",
+  "source_labels": [],
+  "source_ref": "raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md",
+  "source_ref_kind": "workspace_path",
+  "source_type": "md",
+  "status": "ingested",
+  "storage_mode": "none",
+  "storage_path": null,
+  "title": "lucas astorian llmwiki implementation"
+}

--- a/state/queue/ingest-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.json
+++ b/state/queue/ingest-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.json
@@ -1,0 +1,15 @@
+{
+  "attempt_count": 1,
+  "created_at": "2026-04-30T05:11:15+00:00",
+  "job_id": "ingest-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a",
+  "job_type": "ingest_source",
+  "kind": "queue_item",
+  "last_error": null,
+  "lease_expires_at": null,
+  "lease_owner": null,
+  "max_attempts": 3,
+  "payload_ref": "state/manifests/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.json",
+  "schema_version": "1",
+  "status": "done",
+  "updated_at": "2026-04-30T05:11:18+00:00"
+}

--- a/state/queue/ingest-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.json
+++ b/state/queue/ingest-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.json
@@ -1,0 +1,15 @@
+{
+  "attempt_count": 1,
+  "created_at": "2026-04-30T05:11:15+00:00",
+  "job_id": "ingest-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac",
+  "job_type": "ingest_source",
+  "kind": "queue_item",
+  "last_error": null,
+  "lease_expires_at": null,
+  "lease_owner": null,
+  "max_attempts": 3,
+  "payload_ref": "state/manifests/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.json",
+  "schema_version": "1",
+  "status": "done",
+  "updated_at": "2026-04-30T05:11:15+00:00"
+}

--- a/state/queue/ingest-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.json
+++ b/state/queue/ingest-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.json
@@ -1,0 +1,15 @@
+{
+  "attempt_count": 1,
+  "created_at": "2026-04-30T05:11:19+00:00",
+  "job_id": "ingest-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41",
+  "job_type": "ingest_source",
+  "kind": "queue_item",
+  "last_error": null,
+  "lease_expires_at": null,
+  "lease_owner": null,
+  "max_attempts": 3,
+  "payload_ref": "state/manifests/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.json",
+  "schema_version": "1",
+  "status": "done",
+  "updated_at": "2026-04-30T05:11:20+00:00"
+}

--- a/state/queue/ingest-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.json
+++ b/state/queue/ingest-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.json
@@ -1,0 +1,15 @@
+{
+  "attempt_count": 1,
+  "created_at": "2026-04-30T05:11:20+00:00",
+  "job_id": "ingest-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd",
+  "job_type": "ingest_source",
+  "kind": "queue_item",
+  "last_error": null,
+  "lease_expires_at": null,
+  "lease_owner": null,
+  "max_attempts": 3,
+  "payload_ref": "state/manifests/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.json",
+  "schema_version": "1",
+  "status": "done",
+  "updated_at": "2026-04-30T05:11:33+00:00"
+}

--- a/state/runs/run-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a-20260430T051115233135Z.json
+++ b/state/runs/run-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a-20260430T051115233135Z.json
@@ -1,0 +1,69 @@
+{
+  "contradiction_ids": [],
+  "errors": [],
+  "finished_at": "2026-04-30T05:11:15+00:00",
+  "input_refs": [
+    "state/manifests/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.json",
+    "raw/imports/llm-knowledge-work/karpathy-x-llm-knowledge-bases.md"
+  ],
+  "job_id": "ingest-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a",
+  "job_type": "ingest_source",
+  "kind": "run",
+  "output_refs": [
+    "wiki/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md",
+    "wiki/index.md",
+    "wiki/log.md",
+    "wiki/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md",
+    "planning/tasks/task-review-src-3e2ae8bad7-src-51e62cdae9-2fafa4671f.md"
+  ],
+  "page_ids": [
+    "src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a"
+  ],
+  "page_refs": [
+    "wiki/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md"
+  ],
+  "pipeline_version": "0.1.0a0",
+  "provenance_links": [
+    {
+      "note": null,
+      "page_id": null,
+      "path_ref": "state/manifests/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.json",
+      "role": "input",
+      "run_id": null,
+      "source_id": "src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a"
+    },
+    {
+      "note": null,
+      "page_id": null,
+      "path_ref": "raw/imports/llm-knowledge-work/karpathy-x-llm-knowledge-bases.md",
+      "role": "input",
+      "run_id": null,
+      "source_id": "src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a"
+    },
+    {
+      "note": null,
+      "page_id": "src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a",
+      "path_ref": "wiki/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md",
+      "role": "generated-page",
+      "run_id": null,
+      "source_id": null
+    },
+    {
+      "note": null,
+      "page_id": "src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a",
+      "path_ref": null,
+      "role": "output",
+      "run_id": "run-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a-20260430T051115233135Z",
+      "source_id": null
+    }
+  ],
+  "run_id": "run-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a-20260430T051115233135Z",
+  "schema_version": "1",
+  "source_ids": [
+    "src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a"
+  ],
+  "started_at": "2026-04-30T05:11:15+00:00",
+  "status": "succeeded",
+  "task_ids": [],
+  "warnings": []
+}

--- a/state/runs/run-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac-20260430T051115103716Z.json
+++ b/state/runs/run-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac-20260430T051115103716Z.json
@@ -1,0 +1,67 @@
+{
+  "contradiction_ids": [],
+  "errors": [],
+  "finished_at": "2026-04-30T05:11:15+00:00",
+  "input_refs": [
+    "state/manifests/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.json",
+    "raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md"
+  ],
+  "job_id": "ingest-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac",
+  "job_type": "ingest_source",
+  "kind": "run",
+  "output_refs": [
+    "wiki/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md",
+    "wiki/index.md",
+    "wiki/log.md"
+  ],
+  "page_ids": [
+    "src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac"
+  ],
+  "page_refs": [
+    "wiki/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md"
+  ],
+  "pipeline_version": "0.1.0a0",
+  "provenance_links": [
+    {
+      "note": null,
+      "page_id": null,
+      "path_ref": "state/manifests/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.json",
+      "role": "input",
+      "run_id": null,
+      "source_id": "src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac"
+    },
+    {
+      "note": null,
+      "page_id": null,
+      "path_ref": "raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md",
+      "role": "input",
+      "run_id": null,
+      "source_id": "src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac"
+    },
+    {
+      "note": null,
+      "page_id": "src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac",
+      "path_ref": "wiki/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md",
+      "role": "generated-page",
+      "run_id": null,
+      "source_id": null
+    },
+    {
+      "note": null,
+      "page_id": "src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac",
+      "path_ref": null,
+      "role": "output",
+      "run_id": "run-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac-20260430T051115103716Z",
+      "source_id": null
+    }
+  ],
+  "run_id": "run-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac-20260430T051115103716Z",
+  "schema_version": "1",
+  "source_ids": [
+    "src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac"
+  ],
+  "started_at": "2026-04-30T05:11:15+00:00",
+  "status": "succeeded",
+  "task_ids": [],
+  "warnings": []
+}

--- a/state/runs/run-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41-20260430T051119086596Z.json
+++ b/state/runs/run-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41-20260430T051119086596Z.json
@@ -1,0 +1,67 @@
+{
+  "contradiction_ids": [],
+  "errors": [],
+  "finished_at": "2026-04-30T05:11:19+00:00",
+  "input_refs": [
+    "state/manifests/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.json",
+    "raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md"
+  ],
+  "job_id": "ingest-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41",
+  "job_type": "ingest_source",
+  "kind": "run",
+  "output_refs": [
+    "wiki/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md",
+    "wiki/index.md",
+    "wiki/log.md"
+  ],
+  "page_ids": [
+    "src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41"
+  ],
+  "page_refs": [
+    "wiki/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md"
+  ],
+  "pipeline_version": "0.1.0a0",
+  "provenance_links": [
+    {
+      "note": null,
+      "page_id": null,
+      "path_ref": "state/manifests/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.json",
+      "role": "input",
+      "run_id": null,
+      "source_id": "src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41"
+    },
+    {
+      "note": null,
+      "page_id": null,
+      "path_ref": "raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md",
+      "role": "input",
+      "run_id": null,
+      "source_id": "src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41"
+    },
+    {
+      "note": null,
+      "page_id": "src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41",
+      "path_ref": "wiki/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md",
+      "role": "generated-page",
+      "run_id": null,
+      "source_id": null
+    },
+    {
+      "note": null,
+      "page_id": "src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41",
+      "path_ref": null,
+      "role": "output",
+      "run_id": "run-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41-20260430T051119086596Z",
+      "source_id": null
+    }
+  ],
+  "run_id": "run-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41-20260430T051119086596Z",
+  "schema_version": "1",
+  "source_ids": [
+    "src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41"
+  ],
+  "started_at": "2026-04-30T05:11:19+00:00",
+  "status": "succeeded",
+  "task_ids": [],
+  "warnings": []
+}

--- a/state/runs/run-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd-20260430T051120687562Z.json
+++ b/state/runs/run-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd-20260430T051120687562Z.json
@@ -1,0 +1,73 @@
+{
+  "contradiction_ids": [],
+  "errors": [],
+  "finished_at": "2026-04-30T05:11:20+00:00",
+  "input_refs": [
+    "state/manifests/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.json",
+    "raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md"
+  ],
+  "job_id": "ingest-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd",
+  "job_type": "ingest_source",
+  "kind": "run",
+  "output_refs": [
+    "wiki/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.md",
+    "wiki/index.md",
+    "wiki/log.md",
+    "wiki/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md",
+    "wiki/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md",
+    "wiki/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md",
+    "planning/tasks/task-review-src-3e2ae8bad7-src-e7f25dbe0c-bafa0b9ed2.md",
+    "planning/tasks/task-review-src-51e62cdae9-src-e7f25dbe0c-63695d8d80.md",
+    "planning/tasks/task-review-src-9143c8df18-src-e7f25dbe0c-763e8f543a.md"
+  ],
+  "page_ids": [
+    "src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd"
+  ],
+  "page_refs": [
+    "wiki/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.md"
+  ],
+  "pipeline_version": "0.1.0a0",
+  "provenance_links": [
+    {
+      "note": null,
+      "page_id": null,
+      "path_ref": "state/manifests/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.json",
+      "role": "input",
+      "run_id": null,
+      "source_id": "src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd"
+    },
+    {
+      "note": null,
+      "page_id": null,
+      "path_ref": "raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md",
+      "role": "input",
+      "run_id": null,
+      "source_id": "src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd"
+    },
+    {
+      "note": null,
+      "page_id": "src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd",
+      "path_ref": "wiki/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.md",
+      "role": "generated-page",
+      "run_id": null,
+      "source_id": null
+    },
+    {
+      "note": null,
+      "page_id": "src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd",
+      "path_ref": null,
+      "role": "output",
+      "run_id": "run-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd-20260430T051120687562Z",
+      "source_id": null
+    }
+  ],
+  "run_id": "run-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd-20260430T051120687562Z",
+  "schema_version": "1",
+  "source_ids": [
+    "src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd"
+  ],
+  "started_at": "2026-04-30T05:11:20+00:00",
+  "status": "succeeded",
+  "task_ids": [],
+  "warnings": []
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,26 @@ def test_cli_repo_refresh_parser_accepts_json_flag() -> None:
     assert args.json_output is True
 
 
+def test_cli_serve_parser_uses_default_host_and_port() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["serve"])
+
+    assert args.command == "serve"
+    assert args.host == "127.0.0.1"
+    assert args.port == 8000
+
+
+def test_cli_serve_parser_accepts_host_and_port() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["serve", "--host", "0.0.0.0", "--port", "8123"])
+
+    assert args.command == "serve"
+    assert args.host == "0.0.0.0"
+    assert args.port == 8123
+
+
 def test_cli_repo_refresh_command_generates_pages(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     (tmp_path / "splendor.yaml").unlink()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,157 @@
+from pathlib import Path
+
+import yaml
+from fastapi.testclient import TestClient
+
+from splendor.commands.init import initialize_workspace
+from splendor.commands.planning import create_task
+from splendor.schemas import KnowledgePageFrontmatter
+from splendor.web import create_app
+
+
+def write_wiki_page(path: Path, *, title: str, page_id: str, body: str) -> None:
+    frontmatter = KnowledgePageFrontmatter(
+        kind="concept",
+        title=title,
+        page_id=page_id,
+        status="active",
+        confidence=0.8,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frontmatter_text = yaml.safe_dump(frontmatter.model_dump(mode="json"), sort_keys=False).strip()
+    path.write_text(f"---\n{frontmatter_text}\n---\n\n{body}", encoding="utf-8")
+
+
+def test_home_page_loads_for_initialized_workspace(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "Splendor" in response.text
+    assert "Documents" in response.text
+    assert "/browse" in response.text
+
+
+def test_browse_page_lists_wiki_and_planning_documents(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "concepts" / "web-shell.md",
+        title="Web shell",
+        page_id="concept-web-shell",
+        body="# Web shell\n",
+    )
+    create_task(
+        tmp_path,
+        "Ship web shell",
+        record_id="task-ship-web-shell",
+        status="todo",
+        priority="medium",
+        owner=None,
+        milestone_refs=[],
+        decision_refs=[],
+        question_refs=[],
+        depends_on=[],
+        source_refs=[],
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/browse")
+
+    assert response.status_code == 200
+    assert "Web shell" in response.text
+    assert "Ship web shell" in response.text
+    assert "wiki/concepts/web-shell.md" in response.text
+    assert "planning/tasks/task-ship-web-shell.md" in response.text
+
+
+def test_document_detail_renders_markdown_and_metadata(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "concepts" / "web-shell.md",
+        title="Web shell",
+        page_id="concept-web-shell",
+        body="# Web shell\n\nThis page describes local browsing.\n",
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/documents/wiki/concepts/web-shell.md")
+
+    assert response.status_code == 200
+    assert "<h1>Web shell</h1>" in response.text
+    assert "This page describes local browsing." in response.text
+    assert "concept-web-shell" in response.text
+    assert "active" in response.text
+
+
+def test_search_returns_query_matches_with_document_links(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "concepts" / "web-shell.md",
+        title="Web shell",
+        page_id="concept-web-shell",
+        body="# Web shell\n\nDeterministic browse search lives here.\n",
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/search", params={"q": "browse search"})
+
+    assert response.status_code == 200
+    assert 'href="/documents/wiki/concepts/web-shell.md"' in response.text
+    assert "Deterministic browse search lives here." in response.text
+
+
+def test_document_detail_rejects_unsafe_or_unsupported_paths(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    client = TestClient(create_app(tmp_path))
+
+    traversal = client.get("/documents/%2E%2E/pyproject.toml")
+    unsupported_root = client.get("/documents/raw/source.md")
+
+    assert traversal.status_code == 404
+    assert unsupported_root.status_code == 404
+
+
+def test_document_links_respect_custom_layout_directories(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        "schema_version: '1'\n"
+        "project_name: custom\n"
+        "layout:\n"
+        "  wiki_dir: knowledge\n"
+        "  planning_dir: plans\n",
+        encoding="utf-8",
+    )
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "knowledge" / "concepts" / "web-shell.md",
+        title="Custom web shell",
+        page_id="concept-custom-web-shell",
+        body="# Custom web shell\n",
+    )
+    client = TestClient(create_app(tmp_path))
+
+    browse = client.get("/browse")
+    detail = client.get("/documents/knowledge/concepts/web-shell.md")
+
+    assert browse.status_code == 200
+    assert 'href="/documents/knowledge/concepts/web-shell.md"' in browse.text
+    assert detail.status_code == 200
+    assert "<h1>Custom web shell</h1>" in detail.text
+
+
+def test_document_detail_escapes_raw_html_in_markdown(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "concepts" / "unsafe.md",
+        title="Unsafe",
+        page_id="concept-unsafe",
+        body="# Unsafe\n\n<script>alert('x')</script>\n",
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/documents/wiki/concepts/unsafe.md")
+
+    assert response.status_code == 200
+    assert "<script>alert" not in response.text
+    assert "&lt;script&gt;alert" in response.text

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -85,6 +85,43 @@ def test_document_detail_renders_markdown_and_metadata(tmp_path: Path) -> None:
     assert "active" in response.text
 
 
+def test_document_detail_renders_planning_task(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    create_task(
+        tmp_path,
+        "Ship web shell",
+        record_id="task-ship-web-shell",
+        status="todo",
+        priority="medium",
+        owner=None,
+        milestone_refs=[],
+        decision_refs=[],
+        question_refs=[],
+        depends_on=[],
+        source_refs=[],
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/documents/planning/tasks/task-ship-web-shell.md")
+
+    assert response.status_code == 200
+    assert "Ship web shell" in response.text
+    assert "todo" in response.text
+
+
+def test_document_detail_falls_back_for_invalid_planning_frontmatter(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    task_path = tmp_path / "planning" / "tasks" / "task-bad.md"
+    task_path.write_text("# Broken Task\n\nThis task has no frontmatter.\n", encoding="utf-8")
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/documents/planning/tasks/task-bad.md")
+
+    assert response.status_code == 200
+    assert "Broken Task" in response.text
+    assert "This task has no frontmatter." in response.text
+
+
 def test_search_returns_query_matches_with_document_links(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     write_wiki_page(
@@ -107,10 +144,37 @@ def test_document_detail_rejects_unsafe_or_unsupported_paths(tmp_path: Path) -> 
     client = TestClient(create_app(tmp_path))
 
     traversal = client.get("/documents/%2E%2E/pyproject.toml")
+    backslash_traversal = client.get("/documents/wiki%5C..%5Csplendor.yaml")
+    non_markdown = client.get("/documents/wiki/secrets.yaml")
     unsupported_root = client.get("/documents/raw/source.md")
 
     assert traversal.status_code == 404
+    assert backslash_traversal.status_code == 404
+    assert non_markdown.status_code == 404
     assert unsupported_root.status_code == 404
+
+
+def test_search_returns_generic_error_for_invalid_workspace_record(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    bad_page = tmp_path / "wiki" / "concepts" / "bad.md"
+    bad_page.write_text("---\nkind: concept\nbogus: true\n---\n\nbad body\n", encoding="utf-8")
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/search", params={"q": "bad"})
+
+    assert response.status_code == 500
+    assert "invalid records" in response.text
+    assert str(bad_page) not in response.text
+
+
+def test_search_returns_bad_request_for_invalid_query_text(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/search", params={"q": "!!!"})
+
+    assert response.status_code == 400
+    assert "Query must contain at least one ASCII letter or number" in response.text
 
 
 def test_document_links_respect_custom_layout_directories(tmp_path: Path) -> None:
@@ -138,6 +202,42 @@ def test_document_links_respect_custom_layout_directories(tmp_path: Path) -> Non
     assert 'href="/documents/knowledge/concepts/web-shell.md"' in browse.text
     assert detail.status_code == 200
     assert "<h1>Custom web shell</h1>" in detail.text
+
+
+def test_web_routes_reject_layout_roots_that_escape_workspace(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        "schema_version: '1'\n"
+        "project_name: custom\n"
+        "layout:\n"
+        "  wiki_dir: ..\n"
+        "  planning_dir: planning\n",
+        encoding="utf-8",
+    )
+    client = TestClient(create_app(tmp_path), raise_server_exceptions=False)
+
+    response = client.get("/")
+
+    assert response.status_code == 500
+    assert "Workspace configuration is invalid." in response.text
+
+
+def test_document_detail_preserves_code_text_while_sanitizing_html(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "concepts" / "code.md",
+        title="Code",
+        page_id="concept-code",
+        body="# Code\n\n```python\nx < y && y > z\n```\n\n<script>alert('x')</script>\n",
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/documents/wiki/concepts/code.md")
+
+    assert response.status_code == 200
+    assert "x &lt; y &amp;&amp; y &gt; z" in response.text
+    assert "x &amp;lt; y" not in response.text
+    assert "<script>alert" not in response.text
+    assert "&lt;script&gt;alert" in response.text
 
 
 def test_document_detail_escapes_raw_html_in_markdown(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,18 @@ wheels = [
 ]
 
 [[package]]
+name = "bleach"
+version = "6.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl", hash = "sha256:fe10ec77c93ddf3d13a73b035abaac7a9f5e436513864ccdad516693213c65d6", size = 164437, upload-time = "2025-10-27T17:57:37.538Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -529,6 +541,7 @@ name = "splendor"
 version = "0.1.0a0"
 source = { editable = "." }
 dependencies = [
+    { name = "bleach" },
     { name = "fastapi" },
     { name = "markdown" },
     { name = "pydantic" },
@@ -548,6 +561,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "bleach", specifier = ">=6.1,<7.0" },
     { name = "fastapi", specifier = ">=0.115,<1.0" },
     { name = "markdown", specifier = ">=3.7,<4.0" },
     { name = "pydantic", specifier = ">=2.8,<3.0" },
@@ -625,4 +639,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/97/c5/aff062c66b42e2183201a7ace10c6b2e959a9a16525c8e8ca8e59410d27a/virtualenv-21.2.1.tar.gz", hash = "sha256:b66ffe81301766c0d5e2208fc3576652c59d44e7b731fc5f5ed701c9b537fa78", size = 5844770, upload-time = "2026-04-09T18:47:11.482Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/0e/f083a76cb590e60dff3868779558eefefb8dfb7c9ed020babc7aa014ccbf/virtualenv-21.2.1-py3-none-any.whl", hash = "sha256:bd16b49c53562b28cf1a3ad2f36edb805ad71301dee70ddc449e5c88a9f919a2", size = 5828326, upload-time = "2026-04-09T18:47:09.331Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 2
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -12,12 +21,46 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -123,12 +166,65 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -141,12 +237,30 @@ wheels = [
 ]
 
 [[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]
@@ -415,13 +529,17 @@ name = "splendor"
 version = "0.1.0a0"
 source = { editable = "." }
 dependencies = [
+    { name = "fastapi" },
+    { name = "markdown" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "httpx" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -430,17 +548,34 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", specifier = ">=0.115,<1.0" },
+    { name = "markdown", specifier = ">=3.7,<4.0" },
     { name = "pydantic", specifier = ">=2.8,<3.0" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
+    { name = "uvicorn", specifier = ">=0.34,<1.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.6,<8.0" },
+    { name = "httpx", specifier = ">=0.27,<1.0" },
     { name = "pre-commit", specifier = ">=4.0,<5.0" },
     { name = "pytest", specifier = ">=8.3,<9.0" },
     { name = "pytest-cov", specifier = ">=6.0,<7.0" },
     { name = "ruff", specifier = ">=0.11.0,<0.12.0" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]
@@ -462,6 +597,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
 ]
 
 [[package]]

--- a/wiki/architecture/splendor-as-llm-wiki-compiler.md
+++ b/wiki/architecture/splendor-as-llm-wiki-compiler.md
@@ -1,0 +1,69 @@
+---
+schema_version: '1'
+kind: architecture
+title: Splendor as an LLM Wiki Compiler
+page_id: architecture-splendor-as-llm-wiki-compiler
+status: active
+review_state: machine-generated
+source_refs:
+- src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac
+- src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41
+- src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd
+generated_by_run_ids: []
+last_generated_at: '2026-04-30T05:18:00+00:00'
+last_reviewed_at: null
+confidence: 0.74
+related_pages:
+- concept-llm-wiki-pattern
+- topic-llm-assisted-knowledge-work
+tags:
+- architecture
+- splendor
+- llm-wiki
+provenance_links:
+- source_id: src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac
+  page_id: null
+  run_id: null
+  path_ref: raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md
+  role: generated-from
+  note: Pattern source note.
+- source_id: src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd
+  page_id: null
+  run_id: null
+  path_ref: raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md
+  role: generated-from
+  note: Implementation comparison source note.
+contradictions: []
+---
+
+# Splendor as an LLM Wiki Compiler
+
+Splendor can be understood as a schema-driven compiler from source material into durable project
+knowledge.
+
+## Architectural Mapping
+
+Karpathy's LLM Wiki pattern maps onto Splendor this way:
+
+- raw sources map to `raw/` plus source manifests under `state/manifests/sources/`,
+- generated wiki pages map to `wiki/`,
+- operating instructions map to `AGENTS.md`, `.agent-plan.md`, and roadmap docs,
+- query and filed answers map to `splendor query` and `splendor file-answer`,
+- lint and review map to `splendor lint`, `splendor health`, review states, and planning tasks.
+
+The web UI is deliberately secondary. Its job is to make the compiled artifact browsable, not to
+replace the CLI as the operational contract.
+
+## Contrast With LLM Wiki Implementations
+
+The open-source LLM Wiki implementation uses a richer local app and derived SQLite indexing.
+Splendor takes a more conservative path: tracked JSON and markdown state, deterministic commands,
+and explicit schemas before richer indexing.
+
+That tradeoff favors reviewability and git-native automation over immediate UI completeness.
+
+## Dogfood Finding
+
+Seeding these sources revealed a concrete product issue: contradiction review can produce
+false-positive review tasks when deterministic source-summary boilerplate differs only by source
+path. That is useful knowledge for future Milestone 10 or contradiction-review hardening work.

--- a/wiki/concepts/llm-wiki-pattern.md
+++ b/wiki/concepts/llm-wiki-pattern.md
@@ -1,0 +1,75 @@
+---
+schema_version: '1'
+kind: concept
+title: LLM Wiki Pattern
+page_id: concept-llm-wiki-pattern
+status: active
+review_state: machine-generated
+source_refs:
+- src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac
+- src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a
+- src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd
+generated_by_run_ids: []
+last_generated_at: '2026-04-30T05:18:00+00:00'
+last_reviewed_at: null
+confidence: 0.78
+related_pages:
+- topic-llm-assisted-knowledge-work
+- architecture-splendor-as-llm-wiki-compiler
+tags:
+- llm-wiki
+- knowledge-work
+- research
+provenance_links:
+- source_id: src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac
+  page_id: null
+  run_id: null
+  path_ref: raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md
+  role: generated-from
+  note: Karpathy idea-file source note.
+- source_id: src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd
+  page_id: null
+  run_id: null
+  path_ref: raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md
+  role: generated-from
+  note: Open-source implementation source note.
+contradictions: []
+---
+
+# LLM Wiki Pattern
+
+The LLM Wiki pattern treats an LLM as a maintainer of a persistent markdown knowledge base rather
+than as a one-shot answer generator over uploaded files.
+
+## Core Model
+
+The pattern has three durable layers:
+
+- raw sources that remain stable and auditable,
+- a generated wiki that accumulates summaries, concepts, entities, comparisons, and answers,
+- operating instructions that teach the agent how to ingest, query, lint, and maintain the wiki.
+
+The key product idea is compounding synthesis. A useful answer, source summary, contradiction note,
+or comparison should become workspace state instead of disappearing into chat history.
+
+## Why It Matters
+
+Plain retrieval can answer a question by finding fragments at query time, but it usually does not
+improve the knowledge base. The LLM Wiki pattern asks the agent to pay the maintenance cost once:
+summarize the source, update related pages, add cross-links, preserve provenance, and flag
+conflicts.
+
+That shifts LLM research from repeated rediscovery toward knowledge compilation.
+
+## Splendor Fit
+
+Splendor is an implementation of this pattern with a stronger schema and deterministic CLI bias:
+
+- source manifests track registered inputs,
+- wiki pages are markdown artifacts with frontmatter,
+- runs and queues record machine work,
+- lint and health commands validate state,
+- the web UI makes accumulated knowledge inspectable.
+
+The missing long-term piece is not the premise; it is making the maintenance loop ergonomic enough
+that humans and agents will actually use it every day.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -7,3 +7,22 @@ This wiki is maintained by Splendor.
 - `wiki/sources/` for source summary pages once ingestion starts.
 - `planning/` for milestones, tasks, decisions, and questions.
 - `state/` for machine-readable queue, run, and manifest records.
+
+## Sources
+
+- [karpathy llm wiki pattern](sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md) (`src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac`)
+- [karpathy x llm knowledge bases](sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md) (`src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a`)
+- [llm research knowledge work notes](sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md) (`src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41`)
+- [lucas astorian llmwiki implementation](sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.md) (`src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd`)
+
+## Concepts
+
+- [LLM Wiki Pattern](concepts/llm-wiki-pattern.md) (`concept-llm-wiki-pattern`)
+
+## Topics
+
+- [LLM-Assisted Knowledge Work](topics/llm-assisted-knowledge-work.md) (`topic-llm-assisted-knowledge-work`)
+
+## Architecture
+
+- [Splendor as an LLM Wiki Compiler](architecture/splendor-as-llm-wiki-compiler.md) (`architecture-splendor-as-llm-wiki-compiler`)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -3,3 +3,8 @@
 ## Timeline
 
 - Initialized Splendor workspace.
+- 2026-04-30T05:11:15+00:00 Ingested source `src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac` via run `run-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac-20260430T051115103716Z` into `wiki/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md`.
+- 2026-04-30T05:11:18+00:00 Ingested source `src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a` via run `run-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a-20260430T051115233135Z` into `wiki/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md`.
+- 2026-04-30T05:11:20+00:00 Ingested source `src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41` via run `run-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41-20260430T051119086596Z` into `wiki/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md`.
+- 2026-04-30T05:11:33+00:00 Ingested source `src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd` via run `run-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd-20260430T051120687562Z` into `wiki/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.md`.
+- 2026-04-30T05:18:00+00:00 Synthesized LLM Wiki concept, knowledge-work topic, and Splendor architecture pages from the seeded LLM knowledge-work sources.

--- a/wiki/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md
+++ b/wiki/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md
@@ -62,14 +62,13 @@ This page records deterministic ingestion output for source `src-3e2ae8bad71969d
 
 ## Extract
 
-````text
 ```text
 # Karpathy X Post: LLM Knowledge Bases
 
 Source URL: https://x.com/karpathy/status/2039805659525644595
 
 Follow-up idea file: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
-````
+```
 
 ## Provenance
 

--- a/wiki/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md
+++ b/wiki/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md
@@ -1,0 +1,79 @@
+---
+schema_version: '1'
+kind: source-summary
+title: karpathy x llm knowledge bases
+page_id: src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a
+status: active
+review_state: machine-generated
+source_refs:
+- src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a
+generated_by_run_ids:
+- run-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a-20260430T051115233135Z
+last_generated_at: '2026-04-30T05:11:15+00:00'
+last_reviewed_at: null
+confidence: 1.0
+related_pages: []
+tags:
+- source-summary
+- md
+provenance_links:
+- source_id: src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a
+  page_id: null
+  run_id: null
+  path_ref: state/manifests/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.json
+  role: generated-from
+  note: null
+- source_id: null
+  page_id: null
+  run_id: run-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a-20260430T051115233135Z
+  path_ref: null
+  role: generated-from
+  note: null
+- source_id: null
+  page_id: null
+  run_id: null
+  path_ref: raw/imports/llm-knowledge-work/karpathy-x-llm-knowledge-bases.md
+  role: input
+  note: null
+contradictions: []
+---
+
+# karpathy x llm knowledge bases
+
+## Source
+
+- Source ID: `src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a`
+- Source type: `md`
+- Registered path: `raw/imports/llm-knowledge-work/karpathy-x-llm-knowledge-bases.md`
+- Source file: `raw/imports/llm-knowledge-work/karpathy-x-llm-knowledge-bases.md`
+
+## Summary
+
+This page records deterministic ingestion output for source `src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a`, a `md` file registered from `raw/imports/llm-knowledge-work/karpathy-x-llm-knowledge-bases.md`.
+
+## Key Facts
+
+- Source ID: `src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a`
+- Source type: `md`
+- Checksum: `3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a`
+- Source ref: `raw/imports/llm-knowledge-work/karpathy-x-llm-knowledge-bases.md`
+- Added at: `2026-04-30T05:11:05+00:00`
+- Ingested at: `2026-04-30T05:11:15+00:00`
+
+## Extract
+
+````text
+```text
+# Karpathy X Post: LLM Knowledge Bases
+
+Source URL: https://x.com/karpathy/status/2039805659525644595
+
+Follow-up idea file: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+````
+
+## Provenance
+
+- Manifest: `state/manifests/sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.json`
+- Workspace source: `raw/imports/llm-knowledge-work/karpathy-x-llm-knowledge-bases.md`
+- Run ID: `run-src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a-20260430T051115233135Z`
+- Pipeline version: `0.1.0a0`

--- a/wiki/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md
+++ b/wiki/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md
@@ -1,0 +1,81 @@
+---
+schema_version: '1'
+kind: source-summary
+title: karpathy llm wiki pattern
+page_id: src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac
+status: active
+review_state: machine-generated
+source_refs:
+- src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac
+generated_by_run_ids:
+- run-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac-20260430T051115103716Z
+last_generated_at: '2026-04-30T05:11:15+00:00'
+last_reviewed_at: null
+confidence: 1.0
+related_pages: []
+tags:
+- source-summary
+- md
+provenance_links:
+- source_id: src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac
+  page_id: null
+  run_id: null
+  path_ref: state/manifests/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.json
+  role: generated-from
+  note: null
+- source_id: null
+  page_id: null
+  run_id: run-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac-20260430T051115103716Z
+  path_ref: null
+  role: generated-from
+  note: null
+- source_id: null
+  page_id: null
+  run_id: null
+  path_ref: raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md
+  role: input
+  note: null
+contradictions: []
+---
+
+# karpathy llm wiki pattern
+
+## Source
+
+- Source ID: `src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac`
+- Source type: `md`
+- Registered path: `raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md`
+- Source file: `raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md`
+
+## Summary
+
+This page records deterministic ingestion output for source `src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac`, a `md` file registered from `raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md`.
+
+## Key Facts
+
+- Source ID: `src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac`
+- Source type: `md`
+- Checksum: `51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac`
+- Source ref: `raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md`
+- Added at: `2026-04-30T05:11:04+00:00`
+- Ingested at: `2026-04-30T05:11:15+00:00`
+
+## Extract
+
+`````text
+````text
+```text
+# Karpathy LLM Wiki Pattern
+
+Source URL: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+
+Related announcement URL: https://x.com/karpathy/status/2039805659525644595
+````
+`````
+
+## Provenance
+
+- Manifest: `state/manifests/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.json`
+- Workspace source: `raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md`
+- Run ID: `run-src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac-20260430T051115103716Z`
+- Pipeline version: `0.1.0a0`

--- a/wiki/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md
+++ b/wiki/sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md
@@ -62,16 +62,13 @@ This page records deterministic ingestion output for source `src-51e62cdae9baf8d
 
 ## Extract
 
-`````text
-````text
 ```text
 # Karpathy LLM Wiki Pattern
 
 Source URL: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
 
 Related announcement URL: https://x.com/karpathy/status/2039805659525644595
-````
-`````
+```
 
 ## Provenance
 

--- a/wiki/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md
+++ b/wiki/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md
@@ -62,7 +62,6 @@ This page records deterministic ingestion output for source `src-9143c8df18710ac
 
 ## Extract
 
-````text
 ```text
 # LLM Research and Knowledge Work Notes
 
@@ -71,7 +70,7 @@ Source URLs:
 - https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
 - https://github.com/lucasastorian/llmwiki
 - https://x.com/karpathy/status/2039805659525644595
-````
+```
 
 ## Provenance
 

--- a/wiki/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md
+++ b/wiki/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md
@@ -1,0 +1,81 @@
+---
+schema_version: '1'
+kind: source-summary
+title: llm research knowledge work notes
+page_id: src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41
+status: active
+review_state: machine-generated
+source_refs:
+- src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41
+generated_by_run_ids:
+- run-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41-20260430T051119086596Z
+last_generated_at: '2026-04-30T05:11:19+00:00'
+last_reviewed_at: null
+confidence: 1.0
+related_pages: []
+tags:
+- source-summary
+- md
+provenance_links:
+- source_id: src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41
+  page_id: null
+  run_id: null
+  path_ref: state/manifests/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.json
+  role: generated-from
+  note: null
+- source_id: null
+  page_id: null
+  run_id: run-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41-20260430T051119086596Z
+  path_ref: null
+  role: generated-from
+  note: null
+- source_id: null
+  page_id: null
+  run_id: null
+  path_ref: raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md
+  role: input
+  note: null
+contradictions: []
+---
+
+# llm research knowledge work notes
+
+## Source
+
+- Source ID: `src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41`
+- Source type: `md`
+- Registered path: `raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md`
+- Source file: `raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md`
+
+## Summary
+
+This page records deterministic ingestion output for source `src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41`, a `md` file registered from `raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md`.
+
+## Key Facts
+
+- Source ID: `src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41`
+- Source type: `md`
+- Checksum: `9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41`
+- Source ref: `raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md`
+- Added at: `2026-04-30T05:11:05+00:00`
+- Ingested at: `2026-04-30T05:11:19+00:00`
+
+## Extract
+
+````text
+```text
+# LLM Research and Knowledge Work Notes
+
+Source URLs:
+
+- https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+- https://github.com/lucasastorian/llmwiki
+- https://x.com/karpathy/status/2039805659525644595
+````
+
+## Provenance
+
+- Manifest: `state/manifests/sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.json`
+- Workspace source: `raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md`
+- Run ID: `run-src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41-20260430T051119086596Z`
+- Pipeline version: `0.1.0a0`

--- a/wiki/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.md
+++ b/wiki/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.md
@@ -1,0 +1,108 @@
+---
+schema_version: '1'
+kind: source-summary
+title: lucas astorian llmwiki implementation
+page_id: src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd
+status: active
+review_state: machine-generated
+source_refs:
+- src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd
+generated_by_run_ids:
+- run-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd-20260430T051120687562Z
+last_generated_at: '2026-04-30T05:11:20+00:00'
+last_reviewed_at: null
+confidence: 1.0
+related_pages: []
+tags:
+- source-summary
+- md
+provenance_links:
+- source_id: src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd
+  page_id: null
+  run_id: null
+  path_ref: state/manifests/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.json
+  role: generated-from
+  note: null
+- source_id: null
+  page_id: null
+  run_id: run-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd-20260430T051120687562Z
+  path_ref: null
+  role: generated-from
+  note: null
+- source_id: null
+  page_id: null
+  run_id: null
+  path_ref: raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md
+  role: input
+  note: null
+contradictions: []
+---
+
+# lucas astorian llmwiki implementation
+
+## Source
+
+- Source ID: `src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd`
+- Source type: `md`
+- Registered path: `raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md`
+- Source file: `raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md`
+
+## Summary
+
+This page records deterministic ingestion output for source `src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd`, a `md` file registered from `raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md`.
+
+## Key Facts
+
+- Source ID: `src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd`
+- Source type: `md`
+- Checksum: `e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd`
+- Source ref: `raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md`
+- Added at: `2026-04-30T05:11:05+00:00`
+- Ingested at: `2026-04-30T05:11:20+00:00`
+
+## Extract
+
+```text
+# Lucas Astorian LLM Wiki Implementation
+
+Source URL: https://github.com/lucasastorian/llmwiki
+
+## Source Note
+
+`lucasastorian/llmwiki` is an open-source implementation of Karpathy's LLM Wiki pattern. Its README
+frames the system as a way to point at a research folder, run a local app, connect Claude through
+MCP, and let the agent write and maintain wiki pages with links and citations.
+
+## Implementation Pattern
+
+The project keeps source files in place, creates a `wiki/` directory for generated pages, and keeps
+a hidden local index/cache that can be rebuilt. Its architecture combines a web frontend, a FastAPI
+backend, a local SQLite index, an MCP server, and filesystem-backed source material.
+
+Claude-facing tools include guide, search, read, write, and delete operations. The system positions
+the filesystem as the source of truth while using SQLite as derived search/index infrastructure.
+
+## Useful Contrasts with Splendor
+
+- LLM Wiki emphasizes MCP tool access for Claude; Splendor currently emphasizes deterministic CLI
+  commands that agents and humans can both run.
+- LLM Wiki uses SQLite as a local derived index; Splendor currently avoids hidden caches and keeps
+  machine-readable state in tracked files.
+- LLM Wiki includes a fuller web app; Splendor's first web UI is intentionally read-only and
+  non-essential.
+- Both systems share the same core premise: raw sources should remain stable while the wiki evolves
+  as a maintained synthesis layer.
+
+## Product Lessons
+
+The implementation validates that a local web UI is useful even when the canonical state is a
+filesystem of markdown and JSON records. It also shows that agent-facing tools need clear operating
+conventions, not only storage primitives.
+```
+
+## Provenance
+
+- Manifest: `state/manifests/sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.json`
+- Workspace source: `raw/imports/llm-knowledge-work/lucas-astorian-llmwiki-implementation.md`
+- Run ID: `run-src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd-20260430T051120687562Z`
+- Pipeline version: `0.1.0a0`

--- a/wiki/topics/llm-assisted-knowledge-work.md
+++ b/wiki/topics/llm-assisted-knowledge-work.md
@@ -1,0 +1,67 @@
+---
+schema_version: '1'
+kind: topic
+title: LLM-Assisted Knowledge Work
+page_id: topic-llm-assisted-knowledge-work
+status: active
+review_state: machine-generated
+source_refs:
+- src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac
+- src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41
+- src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd
+generated_by_run_ids: []
+last_generated_at: '2026-04-30T05:18:00+00:00'
+last_reviewed_at: null
+confidence: 0.76
+related_pages:
+- concept-llm-wiki-pattern
+- architecture-splendor-as-llm-wiki-compiler
+tags:
+- research
+- knowledge-work
+- agents
+provenance_links:
+- source_id: src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41
+  page_id: null
+  run_id: null
+  path_ref: raw/imports/llm-knowledge-work/llm-research-knowledge-work-notes.md
+  role: generated-from
+  note: Local synthesis source note.
+contradictions: []
+---
+
+# LLM-Assisted Knowledge Work
+
+LLM-assisted knowledge work is most valuable when the agent changes the state of the workspace, not
+only the state of the conversation.
+
+## Working Loop
+
+A practical loop is:
+
+1. Register a source.
+2. Extract claims, vocabulary, and links.
+3. Update source summaries and related concept/topic pages.
+4. Preserve provenance back to source files and runs.
+5. File useful answers into the wiki.
+6. Run lint and health checks to find broken references, stale claims, and missing review work.
+
+The loop gives each session a durable residue. A future agent can search and browse the wiki before
+touching raw material again.
+
+## Human And Agent Responsibilities
+
+The human chooses sources, sets priorities, and reviews synthesis. The LLM handles repetitive
+bookkeeping: filing, summarizing, linking, comparing, and keeping the wiki coherent.
+
+This division is important. Without human curation, the wiki can fill with low-value generated
+pages. Without agent maintenance, a hand-maintained wiki tends to decay as source volume grows.
+
+## Product Test For Splendor
+
+The Splendor dogfood test is simple: can a new agent open the repository, inspect the wiki, and
+learn the project context without relying on prior chat history?
+
+After the LLM Wiki source seeding, the answer is closer to yes. The browse/search UI now has source
+summaries, concept pages, and planning tasks to inspect, but the false-positive contradiction tasks
+also show that review automation needs tighter semantics.


### PR DESCRIPTION
## Planning notation

- Concrete PR sub-slice: `M9-P1.1`
- Parent milestone slice: `M9-P1` Local web UI browse/search shell
- Plan source: `.agent-plan.md`, README "What Comes Next", and `docs/splendor_mvp_to_v1_roadmap.md`

## Summary

Adds the first read-only local web UI for Splendor via `splendor serve`. The UI is intentionally small: it can browse wiki/planning markdown, render document detail pages, and run deterministic search using the existing query engine.

This PR also dogfoods that UI by seeding the Splendor repo's own workspace with LLM Wiki / knowledge-work sources, ingested source summaries, synthesized wiki pages, and a follow-up planning task from the dogfood pass.

## Changes

- Adds FastAPI, Uvicorn, and Markdown runtime dependencies, plus `httpx` for route tests.
- Adds `splendor serve` with `--host` and `--port`, running a foreground local server.
- Adds `splendor.web.create_app(root)` with read-only routes for `/`, `/browse`, `/documents/{path:path}`, and `/search`.
- Escapes raw HTML before Markdown rendering and restricts document detail routes to resolved wiki/planning layout roots.
- Seeds curated source notes for Karpathy's LLM Wiki pattern, the linked X origin pointer, the `lucasastorian/llmwiki` implementation, and Splendor-specific LLM knowledge-work implications.
- Registers and ingests those sources so the repo includes source manifests, queue/run records, and source-summary pages.
- Adds synthesized wiki pages for `LLM Wiki Pattern`, `LLM-Assisted Knowledge Work`, and `Splendor as an LLM Wiki Compiler`.
- Records a dogfood follow-up task for contradiction-review false positives on source-summary boilerplate.
- Updates README, `.agent-plan.md`, and roadmap planning state for `M9-P1.1` and the next `M9-P2.1` slice.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest`
- `uv run splendor lint`
- `uv run splendor health`
- Dogfood search: `uv run splendor query "LLM Wiki persistent knowledge" --json` returns `LLM Wiki Pattern` as the best match.

## Notes

Mutating web UI actions, add-source forms, and planning/runs UI views remain deferred to later Milestone 9 slices.
