### PR TITLE
M9-P1.2: Dogfood hardening after first local web UI trial

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,10 +3,10 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M8-P2.1`
-- Last action taken: `M8-P2.1` is implemented; generated-change automation can propose deterministic repo-refresh output through a reviewable PR workflow.
+- Previous completed PR sub-slice: `M9-P1.1`
+- Last action taken: `M9-P1.1` is implemented; the read-only local web UI can browse and search wiki/planning markdown.
 - Current planned slice: `M9-P1`
-- Current PR sub-slice: `M9-P1.1`
+- Current PR sub-slice: `M9-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M9-P2`
 - Next planned PR sub-slice: `M9-P2.1`
@@ -106,6 +106,11 @@
   - [x] Render read-only wiki and planning markdown detail pages
   - [x] Provide browse and deterministic search pages
   - [x] Keep mutating UI actions and runs views deferred to later slices
+- [x] Implement `M9-P1.2`: Dogfood hardening after first local web UI trial
+  - [x] Add sparse-workspace empty states and special-file browse treatment
+  - [x] Add non-mutating `splendor query --no-save`
+  - [x] Improve deterministic markdown source summaries
+  - [x] Filter contradiction review away from source-summary metadata boilerplate
 
 ## Context Pointers
 
@@ -133,4 +138,5 @@
 ## PR Sub-slice Queue
 
 - `M9-P1.1` Local web UI browse/search shell
+- `M9-P1.2` Dogfood hardening after first local web UI trial
 - `M9-P2.1` Planning/runs UI views

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Not implemented yet:
 
 - [docs/quickstart.md](docs/quickstart.md)
 - [docs/companion_repo_setup.md](docs/companion_repo_setup.md)
+- [docs/dogfooding.md](docs/dogfooding.md)
 - [docs/splendor_product_spec.md](docs/splendor_product_spec.md)
 - [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md)
 - [docs/schema_contracts.md](docs/schema_contracts.md)
@@ -139,9 +140,9 @@ Not implemented yet:
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M8-P2.1`
+- Previous completed PR sub-slice: `M9-P1.1`
 - Current planned slice: `M9-P1`
-- Current PR sub-slice: `M9-P1.1`
+- Current PR sub-slice: `M9-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M9-P2`
 - Next planned PR sub-slice: `M9-P2.1`
@@ -159,5 +160,7 @@ run Splendor health nightly, and publish generated maintenance reports as artifa
 implemented: generated-change automation can propose deterministic repo-refresh output through a
 reviewable PR workflow.
 
-The current PR sub-slice is `M9-P1.1`, under the parent slice `M9-P1`, which adds the first
-read-only local web UI shell for browsing and searching wiki/planning markdown.
+`M9-P1.1` is implemented: the first read-only local web UI shell can browse and search
+wiki/planning markdown. The current PR sub-slice is `M9-P1.2`, under the parent slice `M9-P1`, which
+hardens the first-run dogfood experience with clearer sparse-workspace UI, non-mutating query
+validation, more useful source summaries, and contradiction-review noise reduction.

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -1,0 +1,47 @@
+# Dogfooding Splendor
+
+This guide describes a deterministic way to seed and inspect a Splendor workspace from the Splendor
+repository itself.
+
+## Self-bootstrap
+
+From the repository root:
+
+```bash
+uv run splendor init
+uv run splendor repo refresh
+uv run splendor lint
+uv run splendor health
+```
+
+`repo refresh` scans supported in-repo files, registers source manifests, and generates the
+repository architecture/topic pages that make a fresh workspace useful before any manual curation.
+
+## Curated Notes
+
+For external references or synthesized research notes, keep the source material as local markdown
+under `raw/imports/`, then register and ingest it:
+
+```bash
+uv run splendor add-source raw/imports/example-note.md
+uv run splendor ingest --pending
+```
+
+Local notes should include a clear first heading and a substantive opening paragraph. Sections such
+as `Core Claims`, `Design Implications`, and `Implementation Pattern` are rendered into deterministic
+source-summary key facts during ingest.
+
+## Validation
+
+Use `--no-save` for validation queries when you do not want to update
+`state/queries/last-query.json`:
+
+```bash
+uv run splendor query --no-save "LLM Wiki persistent knowledge" --json
+uv run splendor lint
+uv run splendor health
+uv run splendor serve
+```
+
+Then inspect `/browse` and `/search?q=LLM+Wiki+persistent+knowledge` in the local web UI. A sparse
+workspace should show an explicit empty state with next commands instead of appearing broken.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,16 +334,16 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M8-P2.1`
+- Previous completed PR sub-slice: `M9-P1.1`
 - Current planned slice: `M9-P1`
-- Current PR sub-slice: `M9-P1.1`
+- Current PR sub-slice: `M9-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M9-P2`
 - Next planned PR sub-slice: `M9-P2.1`
 
-The current PR sub-slice is `M9-P1.1`, under parent slice `M9-P1`, which moves the roadmap forward
-into the first local web UI browse/search shell. The lifecycle marker means `M9-P1.1` is in
-progress on feature branches and merged once the same committed state is observed on `main`.
+The current PR sub-slice is `M9-P1.2`, under parent slice `M9-P1`, which hardens the first local web
+UI dogfood experience after `M9-P1.1`. The lifecycle marker means `M9-P1.2` is in progress on
+feature branches and merged once the same committed state is observed on `main`.
 
 ---
 
@@ -546,13 +546,17 @@ Provide a modest but useful human UI without changing the system’s center of g
 
 ### Current PR sub-slices
 - `M9-P1.1` Read-only `splendor serve` browse/search shell
+- `M9-P1.2` Dogfood hardening after first local web UI trial
 
 ### Milestone 9 status
 
 `M9-P1.1` implements the first local web UI shell: a foreground FastAPI-backed `splendor serve`
 command with read-only browsing, markdown detail rendering, and deterministic search over existing
-wiki and planning records. Mutating web actions, add-source forms, and planning/runs views remain
-deferred to later `M9` slices.
+wiki and planning records. `M9-P1.2` follows up on the first dogfood pass with sparse-workspace
+empty states, explicit special-file browse treatment, non-mutating query validation, more useful
+markdown source summaries, and contradiction-review filtering for source-summary metadata
+boilerplate. Mutating web actions, add-source forms, and planning/runs views remain deferred to
+later `M9` slices.
 
 ---
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -144,6 +144,11 @@ def build_parser() -> argparse.ArgumentParser:
         dest="json_output",
         help="Emit machine-readable JSON output.",
     )
+    query_parser.add_argument(
+        "--no-save",
+        action="store_true",
+        help="Do not update state/queries/last-query.json.",
+    )
     query_parser.set_defaults(handler=handle_query)
 
     serve_parser = subparsers.add_parser("serve", help="Run the read-only local web UI")
@@ -485,39 +490,40 @@ def handle_query(args: argparse.Namespace) -> int:
     except ValueError as exc:
         return _print_error(exc)
 
-    try:
-        layout = resolve_layout(root, load_config(root))
-        snapshot = QuerySnapshot(
-            query=result.query,
-            summary=result.summary,
-            match_count=result.match_count,
-            created_at=utc_now_iso(),
-            matches=[
-                QueryMatchSnapshot(
-                    rank=match.rank,
-                    score=match.score,
-                    document_class=match.document_class,
-                    kind=match.kind,
-                    record_id=match.record_id,
-                    title=match.title,
-                    path=match.path,
-                    status=match.status,
-                    review_state=match.review_state,
-                    last_generated_at=match.last_generated_at,
-                    snippet=match.snippet,
-                    source_refs=match.source_refs,
-                    generated_by_run_ids=match.generated_by_run_ids,
-                    provenance_links=match.provenance_links,
-                    contradiction_count=match.contradiction_count,
-                    review_task_ids=match.review_task_ids,
-                    tags=match.tags,
-                )
-                for match in result.matches
-            ],
-        )
-        write_query_snapshot(last_query_path_for(layout), snapshot)
-    except OSError as exc:
-        return _print_error(exc)
+    if not args.no_save:
+        try:
+            layout = resolve_layout(root, load_config(root))
+            snapshot = QuerySnapshot(
+                query=result.query,
+                summary=result.summary,
+                match_count=result.match_count,
+                created_at=utc_now_iso(),
+                matches=[
+                    QueryMatchSnapshot(
+                        rank=match.rank,
+                        score=match.score,
+                        document_class=match.document_class,
+                        kind=match.kind,
+                        record_id=match.record_id,
+                        title=match.title,
+                        path=match.path,
+                        status=match.status,
+                        review_state=match.review_state,
+                        last_generated_at=match.last_generated_at,
+                        snippet=match.snippet,
+                        source_refs=match.source_refs,
+                        generated_by_run_ids=match.generated_by_run_ids,
+                        provenance_links=match.provenance_links,
+                        contradiction_count=match.contradiction_count,
+                        review_task_ids=match.review_task_ids,
+                        tags=match.tags,
+                    )
+                    for match in result.matches
+                ],
+            )
+            write_query_snapshot(last_query_path_for(layout), snapshot)
+        except OSError as exc:
+            return _print_error(exc)
 
     if args.json_output:
         payload = {

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -147,7 +147,7 @@ def build_parser() -> argparse.ArgumentParser:
     query_parser.add_argument(
         "--no-save",
         action="store_true",
-        help="Do not update state/queries/last-query.json.",
+        help="Do not update the last-query snapshot.",
     )
     query_parser.set_defaults(handler=handle_query)
 

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -75,6 +76,16 @@ SUPPORTED_SOURCE_TYPES = {
     "sh",
 }
 LEASE_TTL_SECONDS = 300
+_MARKDOWN_HEADING_PATTERN = re.compile(r"^(?P<level>#{1,6})\s+(?P<title>.+?)\s*#*\s*$")
+_CLAIM_SECTION_HEADINGS = {
+    "core claims",
+    "design implications",
+    "implementation pattern",
+    "implementation patterns",
+    "key facts",
+    "claims",
+    "findings",
+}
 
 
 @dataclass(frozen=True)
@@ -175,12 +186,98 @@ def _rendered_extract(text: str, mode: SummaryMode) -> str | None:
     return text
 
 
-def _build_summary(source: SourceRecord) -> str:
+def _build_summary(source: SourceRecord, source_text: str) -> str:
     path_fragment = canonical_source_ref(source)
+    content_summary = _build_content_summary(source_text)
+    if source.source_type in {"md", "txt"} and content_summary is not None:
+        return f"{content_summary} registered from `{path_fragment}`."
     return (
         f"This page records deterministic ingestion output for source `{source.source_id}`, "
         f"a `{source.source_type}` file registered from `{path_fragment}`."
     )
+
+
+def _build_content_summary(text: str) -> str | None:
+    heading: str | None = None
+    paragraph_lines: list[str] = []
+    in_fence = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("```") or line.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if not line:
+            if paragraph_lines:
+                break
+            continue
+        heading_match = _MARKDOWN_HEADING_PATTERN.match(line)
+        if heading_match:
+            if heading is None:
+                heading = _strip_markdown_inline(heading_match.group("title"))
+            if paragraph_lines:
+                break
+            continue
+        if line.startswith(("- ", "* ", "+ ", ">")):
+            continue
+        paragraph_lines.append(_strip_markdown_inline(line))
+        if len(paragraph_lines) >= 3:
+            break
+
+    paragraph = _bounded_summary_text(" ".join(paragraph_lines).strip())
+    if heading and paragraph:
+        return f"{heading}. {paragraph}"
+    if paragraph:
+        return paragraph
+    if heading:
+        return heading
+    return None
+
+
+def _bounded_summary_text(text: str) -> str:
+    if len(text) <= 360:
+        return text
+    return text[:357].rstrip() + "..."
+
+
+def _build_content_key_facts(text: str) -> list[str]:
+    facts: list[str] = []
+    active = False
+    in_fence = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("```") or line.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        heading_match = _MARKDOWN_HEADING_PATTERN.match(line)
+        if heading_match:
+            heading = _strip_markdown_inline(heading_match.group("title")).lower()
+            active = heading in _CLAIM_SECTION_HEADINGS
+            continue
+        if not active:
+            continue
+        if line.startswith(("- ", "* ", "+ ")):
+            fact = _strip_markdown_inline(line[2:].strip())
+            if fact:
+                facts.append(fact)
+        elif line and not line.startswith(">"):
+            fact = _strip_markdown_inline(line)
+            if fact:
+                facts.append(fact)
+        if len(facts) >= 6:
+            break
+    return facts
+
+
+def _strip_markdown_inline(text: str) -> str:
+    stripped = text.strip().strip("#").strip()
+    stripped = re.sub(r"`([^`]+)`", r"\1", stripped)
+    stripped = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", stripped)
+    stripped = stripped.replace("**", "").replace("__", "").replace("*", "")
+    return " ".join(stripped.split())
 
 
 def _content_origin_kind(storage_mode: str) -> str:
@@ -646,6 +743,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
             f"Source ref: `{canonical_source_ref(source)}`",
             f"Added at: `{source.added_at}`",
             f"Ingested at: `{finished_at}`",
+            *_build_content_key_facts(source_text),
         ]
         provenance_lines = [
             f"Manifest: `{_relative_to_root(root, manifest_path)}`",
@@ -656,7 +754,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
         page_content = render_source_summary_page(
             frontmatter,
             source_section=source_section,
-            summary=_build_summary(source),
+            summary=_build_summary(source, source_text),
             key_facts=key_facts,
             extract=_rendered_extract(source_text, extract_mode),
             contradictions=render_contradiction_lines(
@@ -681,7 +779,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
         page_content = render_source_summary_page(
             frontmatter,
             source_section=source_section,
-            summary=_build_summary(source),
+            summary=_build_summary(source, source_text),
             key_facts=key_facts,
             extract=_rendered_extract(source_text, extract_mode),
             contradictions=render_contradiction_lines(

--- a/src/splendor/utils/contradictions.py
+++ b/src/splendor/utils/contradictions.py
@@ -285,17 +285,24 @@ def review_source_summary_contradictions(
     task_updates: list[ReviewTaskUpdate] = []
     contradiction_ids: list[str] = []
     task_ids: list[str] = []
+    current_review_snapshot = _claim_review_snapshot(current_snapshot)
+    if not _has_review_claim_text(current_review_snapshot):
+        return ContradictionReviewResult(
+            frontmatter=_normalize_review_state(current_frontmatter),
+            task_updates=[],
+            page_updates=[],
+            contradiction_ids=[],
+            task_ids=[],
+            warnings=[],
+        )
     for candidate in _load_candidate_snapshots(
         root=root,
         layout=layout,
         current_page=current_snapshot.page_path,
         max_candidates=contradiction_config.max_candidate_pages,
     ):
-        current_review_snapshot = _claim_review_snapshot(current_snapshot)
         candidate_review_snapshot = _claim_review_snapshot(candidate)
-        if not _has_review_claim_text(current_review_snapshot) or not _has_review_claim_text(
-            candidate_review_snapshot
-        ):
+        if not _has_review_claim_text(candidate_review_snapshot):
             continue
         for contradiction in analyzer.detect(
             current=current_review_snapshot, candidate=candidate_review_snapshot
@@ -664,7 +671,10 @@ def _unfenced_extract_text(text: str) -> str:
             body_lines = body_lines[1:]
         return "\n".join(body_lines)
     if len(lines) >= 2 and lines[0].startswith("~~~") and lines[-1].startswith("~~~"):
-        return "\n".join(lines[1:-1])
+        body_lines = lines[1:-1]
+        if body_lines and not body_lines[0].strip():
+            body_lines = body_lines[1:]
+        return "\n".join(body_lines)
     return text
 
 
@@ -676,12 +686,9 @@ def _is_metadata_line(value: str) -> bool:
 
 
 def _is_metadata_only_contradiction(contradiction: DetectedContradiction) -> bool:
-    if _is_metadata_line(contradiction.current_excerpt) and _is_metadata_line(
+    return _is_metadata_line(contradiction.current_excerpt) and _is_metadata_line(
         contradiction.candidate_excerpt
-    ):
-        return True
-    values = [contradiction.summary, contradiction.current_excerpt, contradiction.candidate_excerpt]
-    return all(_is_metadata_line(value) for value in values)
+    )
 
 
 def _normalized_summary(value: str) -> str:

--- a/src/splendor/utils/contradictions.py
+++ b/src/splendor/utils/contradictions.py
@@ -7,7 +7,7 @@ import json
 import os
 import posixpath
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from urllib import error, request
 
@@ -27,6 +27,25 @@ from splendor.utils.wiki import parse_wiki_markdown
 DEFAULT_OPENAI_CONTRADICTION_MODEL = "gpt-4.1-mini"
 _SECTION_PATTERN = re.compile(r"^## (?P<name>[^\n]+)\n\n", re.MULTILINE)
 _WHITESPACE_PATTERN = re.compile(r"\s+")
+_GENERIC_SUMMARY_PATTERN = re.compile(
+    r"^This page records deterministic ingestion output for source `[^`]+`, "
+    r"a `[^`]+` file registered from `[^`]+`\.$"
+)
+_METADATA_PREFIXES = (
+    "source id:",
+    "source type:",
+    "checksum:",
+    "source ref:",
+    "added at:",
+    "ingested at:",
+    "registered path:",
+    "source file:",
+    "manifest:",
+    "workspace source:",
+    "stored artifact:",
+    "run id:",
+    "pipeline version:",
+)
 
 
 @dataclass(frozen=True)
@@ -272,7 +291,17 @@ def review_source_summary_contradictions(
         current_page=current_snapshot.page_path,
         max_candidates=contradiction_config.max_candidate_pages,
     ):
-        for contradiction in analyzer.detect(current=current_snapshot, candidate=candidate):
+        current_review_snapshot = _claim_review_snapshot(current_snapshot)
+        candidate_review_snapshot = _claim_review_snapshot(candidate)
+        if not _has_review_claim_text(current_review_snapshot) or not _has_review_claim_text(
+            candidate_review_snapshot
+        ):
+            continue
+        for contradiction in analyzer.detect(
+            current=current_review_snapshot, candidate=candidate_review_snapshot
+        ):
+            if _is_metadata_only_contradiction(contradiction):
+                continue
             annotation = _build_annotation(
                 current=current_snapshot,
                 candidate=candidate,
@@ -587,6 +616,72 @@ def _normalize_optional_text(value: str | None) -> str | None:
         return None
     normalized = value.strip()
     return normalized or None
+
+
+def _claim_review_snapshot(snapshot: SourceSummarySnapshot) -> SourceSummarySnapshot:
+    summary = snapshot.summary.strip()
+    if _GENERIC_SUMMARY_PATTERN.match(summary):
+        summary = ""
+    key_facts = [fact for fact in snapshot.key_facts if not _is_metadata_line(fact)]
+    extract = _normalize_optional_text(
+        _filter_review_text(_unfenced_extract_text(snapshot.extract or ""))
+    )
+    return replace(
+        snapshot,
+        source_section="",
+        summary=summary,
+        key_facts=key_facts,
+        extract=extract,
+        provenance_lines=[],
+    )
+
+
+def _has_review_claim_text(snapshot: SourceSummarySnapshot) -> bool:
+    return bool(snapshot.summary or snapshot.key_facts or snapshot.extract)
+
+
+def _filter_review_text(text: str) -> str:
+    filtered_lines: list[str] = []
+    in_fence = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("```") or line.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if not line or _is_metadata_line(line):
+            continue
+        filtered_lines.append(raw_line)
+    return "\n".join(filtered_lines).strip()
+
+
+def _unfenced_extract_text(text: str) -> str:
+    lines = text.strip().splitlines()
+    if len(lines) >= 2 and lines[0].startswith("```") and lines[-1].startswith("```"):
+        body_lines = lines[1:-1]
+        if body_lines and not body_lines[0].strip():
+            body_lines = body_lines[1:]
+        return "\n".join(body_lines)
+    if len(lines) >= 2 and lines[0].startswith("~~~") and lines[-1].startswith("~~~"):
+        return "\n".join(lines[1:-1])
+    return text
+
+
+def _is_metadata_line(value: str) -> bool:
+    normalized = _normalized_summary(value).lower()
+    if normalized.startswith("- "):
+        normalized = normalized[2:].strip()
+    return normalized.startswith(_METADATA_PREFIXES)
+
+
+def _is_metadata_only_contradiction(contradiction: DetectedContradiction) -> bool:
+    if _is_metadata_line(contradiction.current_excerpt) and _is_metadata_line(
+        contradiction.candidate_excerpt
+    ):
+        return True
+    values = [contradiction.summary, contradiction.current_excerpt, contradiction.candidate_excerpt]
+    return all(_is_metadata_line(value) for value in values)
 
 
 def _normalized_summary(value: str) -> str:

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -119,7 +119,7 @@ def create_app(root: Path) -> FastAPI:
     def home() -> HTMLResponse:
         layout = _layout_for(workspace_root)
         content_documents = _iter_content_documents(workspace_root, layout)
-        counts = _workspace_counts(workspace_root, layout, content_documents=content_documents)
+        counts = _workspace_counts(layout, content_documents=content_documents)
         empty_state = _empty_workspace_panel() if counts.is_sparse else ""
         body = (
             '<section class="toolbar">'
@@ -145,7 +145,7 @@ def create_app(root: Path) -> FastAPI:
         layout = _layout_for(workspace_root)
         content_documents = _iter_content_documents(workspace_root, layout)
         special_documents = _iter_special_documents(workspace_root, layout)
-        counts = _workspace_counts(workspace_root, layout, content_documents=content_documents)
+        counts = _workspace_counts(layout, content_documents=content_documents)
         content_rows = "\n".join(_document_row(item) for item in content_documents)
         special_rows = "\n".join(_document_row(item) for item in special_documents)
         if not content_rows:
@@ -211,6 +211,7 @@ def create_app(root: Path) -> FastAPI:
         )
         if not query:
             return _page("Search", form)
+        layout = _layout_for(workspace_root)
         try:
             result = run_query(workspace_root, query)
         except QueryValidationError as exc:
@@ -228,9 +229,8 @@ def create_app(root: Path) -> FastAPI:
 
         rows = "\n".join(_search_row(match) for match in result.matches)
         if not rows:
-            layout = _layout_for(workspace_root)
             content_documents = _iter_content_documents(workspace_root, layout)
-            counts = _workspace_counts(workspace_root, layout, content_documents=content_documents)
+            counts = _workspace_counts(layout, content_documents=content_documents)
             if counts.is_sparse:
                 rows = (
                     '<p class="empty">No matches found. This workspace only has special '
@@ -294,7 +294,7 @@ def _iter_special_documents(root: Path, layout: ResolvedLayout) -> list[_Documen
 
 
 def _workspace_counts(
-    root: Path, layout: ResolvedLayout, *, content_documents: list[_DocumentSummary]
+    layout: ResolvedLayout, *, content_documents: list[_DocumentSummary]
 ) -> _WorkspaceCounts:
     return _WorkspaceCounts(
         wiki_content_pages=sum(1 for item in content_documents if item.document_class == "wiki"),

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -62,6 +62,23 @@ class _DocumentSummary:
 
 
 @dataclass(frozen=True)
+class _WorkspaceCounts:
+    wiki_content_pages: int
+    planning_records: int
+    source_manifests: int
+    runs: int
+
+    @property
+    def is_sparse(self) -> bool:
+        return (
+            self.wiki_content_pages == 0
+            and self.planning_records == 0
+            and self.source_manifests == 0
+            and self.runs == 0
+        )
+
+
+@dataclass(frozen=True)
 class _DocumentDetail:
     path: str
     title: str
@@ -101,9 +118,9 @@ def create_app(root: Path) -> FastAPI:
     @app.get("/", response_class=HTMLResponse)
     def home() -> HTMLResponse:
         layout = _layout_for(workspace_root)
-        documents = _iter_documents(workspace_root, layout)
-        wiki_count = sum(1 for item in documents if item.document_class == "wiki")
-        planning_count = sum(1 for item in documents if item.document_class == "planning")
+        content_documents = _iter_content_documents(workspace_root, layout)
+        counts = _workspace_counts(workspace_root, layout, content_documents=content_documents)
+        empty_state = _empty_workspace_panel() if counts.is_sparse else ""
         body = (
             '<section class="toolbar">'
             '<form action="/search" method="get">'
@@ -112,10 +129,13 @@ def create_app(root: Path) -> FastAPI:
             "</form>"
             '<a class="button" href="/browse">Browse documents</a>'
             "</section>"
+            f"{empty_state}"
             '<section class="stats">'
-            f"<div><strong>{len(documents)}</strong><span>Documents</span></div>"
-            f"<div><strong>{wiki_count}</strong><span>Wiki pages</span></div>"
-            f"<div><strong>{planning_count}</strong><span>Planning records</span></div>"
+            f"<div><strong>{counts.wiki_content_pages}</strong>"
+            "<span>Wiki content pages</span></div>"
+            f"<div><strong>{counts.planning_records}</strong><span>Planning records</span></div>"
+            f"<div><strong>{counts.source_manifests}</strong><span>Source manifests</span></div>"
+            f"<div><strong>{counts.runs}</strong><span>Runs</span></div>"
             "</section>"
         )
         return _page("Splendor", body)
@@ -123,8 +143,25 @@ def create_app(root: Path) -> FastAPI:
     @app.get("/browse", response_class=HTMLResponse)
     def browse() -> HTMLResponse:
         layout = _layout_for(workspace_root)
-        documents = _iter_documents(workspace_root, layout)
-        rows = "\n".join(_document_row(item) for item in documents)
+        content_documents = _iter_content_documents(workspace_root, layout)
+        special_documents = _iter_special_documents(workspace_root, layout)
+        counts = _workspace_counts(workspace_root, layout, content_documents=content_documents)
+        content_rows = "\n".join(_document_row(item) for item in content_documents)
+        special_rows = "\n".join(_document_row(item) for item in special_documents)
+        if not content_rows:
+            content_rows = (
+                '<tr><td colspan="4" class="empty">No searchable content records yet.</td></tr>'
+            )
+        special_section = ""
+        if special_rows:
+            special_section = (
+                "<h2>Special files</h2>"
+                '<p class="empty">Index and log files are navigation records shown here, '
+                "but excluded from search results.</p>"
+                "<table><thead><tr><th>Title</th><th>Kind</th><th>Status</th><th>Path</th></tr></thead>"
+                f"<tbody>{special_rows}</tbody></table>"
+            )
+        empty_state = _empty_workspace_panel() if counts.is_sparse else ""
         body = (
             '<section class="toolbar">'
             '<form action="/search" method="get">'
@@ -132,8 +169,11 @@ def create_app(root: Path) -> FastAPI:
             '<button type="submit">Search</button>'
             "</form>"
             "</section>"
-            f"<table><thead><tr><th>Title</th><th>Kind</th><th>Status</th><th>Path</th></tr></thead>"
-            f"<tbody>{rows}</tbody></table>"
+            f"{empty_state}"
+            "<h2>Content records</h2>"
+            "<table><thead><tr><th>Title</th><th>Kind</th><th>Status</th><th>Path</th></tr></thead>"
+            f"<tbody>{content_rows}</tbody></table>"
+            f"{special_section}"
         )
         return _page("Browse", body)
 
@@ -188,7 +228,19 @@ def create_app(root: Path) -> FastAPI:
 
         rows = "\n".join(_search_row(match) for match in result.matches)
         if not rows:
-            rows = '<p class="empty">No matches found.</p>'
+            layout = _layout_for(workspace_root)
+            content_documents = _iter_content_documents(workspace_root, layout)
+            counts = _workspace_counts(workspace_root, layout, content_documents=content_documents)
+            if counts.is_sparse:
+                rows = (
+                    '<p class="empty">No matches found. This workspace only has special '
+                    "navigation files like index/log, which are excluded from search. "
+                    "Use <code>uv run splendor repo refresh</code> or "
+                    "<code>uv run splendor add-source &lt;path&gt;</code> to add searchable "
+                    "knowledge records.</p>"
+                )
+            else:
+                rows = '<p class="empty">No matches found.</p>'
         body = f"{form}<p>{html.escape(result.summary)}</p><section>{rows}</section>"
         return _page("Search", body)
 
@@ -218,10 +270,12 @@ def _validate_layout_root(root: Path, value: str, *, label: str) -> None:
         ) from exc
 
 
-def _iter_documents(root: Path, layout: ResolvedLayout) -> list[_DocumentSummary]:
+def _iter_content_documents(root: Path, layout: ResolvedLayout) -> list[_DocumentSummary]:
     documents: list[_DocumentSummary] = []
     for path in sorted(layout.wiki_dir.rglob("*.md")):
         if path.name == ".gitkeep" or not path.is_file():
+            continue
+        if path in {layout.index_file, layout.log_file}:
             continue
         documents.append(_document_summary(root, layout, path))
     for path in sorted(layout.planning_dir.rglob("*.md")):
@@ -229,6 +283,39 @@ def _iter_documents(root: Path, layout: ResolvedLayout) -> list[_DocumentSummary
             continue
         documents.append(_document_summary(root, layout, path))
     return sorted(documents, key=lambda item: (item.document_class, item.kind or "", item.title))
+
+
+def _iter_special_documents(root: Path, layout: ResolvedLayout) -> list[_DocumentSummary]:
+    documents: list[_DocumentSummary] = []
+    for path in (layout.index_file, layout.log_file):
+        if path.is_file():
+            documents.append(_document_summary(root, layout, path))
+    return documents
+
+
+def _workspace_counts(
+    root: Path, layout: ResolvedLayout, *, content_documents: list[_DocumentSummary]
+) -> _WorkspaceCounts:
+    return _WorkspaceCounts(
+        wiki_content_pages=sum(1 for item in content_documents if item.document_class == "wiki"),
+        planning_records=sum(1 for item in content_documents if item.document_class == "planning"),
+        source_manifests=sum(
+            1 for path in layout.source_records_dir.glob("*.json") if path.is_file()
+        ),
+        runs=sum(1 for path in layout.runs_dir.glob("*.json") if path.is_file()),
+    )
+
+
+def _empty_workspace_panel() -> str:
+    return (
+        '<section class="empty-state">'
+        "<h2>No workspace knowledge yet</h2>"
+        "<p>This workspace has only navigation files. Seed it with deterministic repo pages or "
+        "register a source before browsing/searching knowledge records.</p>"
+        "<p><code>uv run splendor repo refresh</code></p>"
+        "<p><code>uv run splendor add-source &lt;path&gt;</code></p>"
+        "</section>"
+    )
 
 
 def _document_summary(root: Path, layout: ResolvedLayout, path: Path) -> _DocumentSummary:
@@ -412,9 +499,13 @@ def _page(title: str, body: str, *, status_code: int = 200) -> HTMLResponse:
         "button,.button{border:1px solid var(--accent);border-radius:6px;background:var(--accent);"
         "color:white;padding:9px 12px;font:inherit;cursor:pointer}"
         ".stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px}"
-        ".stats div,.metadata,.result{border:1px solid var(--border);border-radius:8px;"
+        ".stats div,.metadata,.result,.empty-state{border:1px solid var(--border);"
+        "border-radius:8px;"
         "padding:14px}"
         ".stats strong{display:block;font-size:26px}.stats span,.breadcrumbs{color:var(--muted)}"
+        ".empty-state{background:var(--surface);margin-bottom:22px}"
+        ".empty-state h2{margin-bottom:8px}"
+        ".empty-state p{margin:8px 0}"
         "table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--border);"
         "padding:10px;text-align:left;vertical-align:top}th{background:var(--surface)}"
         "code,pre{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,8 +11,10 @@ import splendor.cli as cli_module
 from splendor import __version__
 from splendor.cli import build_parser, main
 from splendor.commands.ingest import enqueue_ingest_job
+from splendor.config import load_config
+from splendor.layout import resolve_layout
 from splendor.schemas import KnowledgePageFrontmatter, MaintenanceIssue, MaintenanceReport
-from splendor.state.query_snapshot import load_query_snapshot
+from splendor.state.query_snapshot import last_query_path_for, load_query_snapshot
 from splendor.state.runtime import load_queue_item
 
 
@@ -801,8 +803,13 @@ def test_cli_query_command_persists_snapshot_for_json_output(tmp_path: Path, cap
 
 
 def test_cli_query_command_no_save_skips_last_query_snapshot(tmp_path: Path, capsys) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        "schema_version: '1'\nproject_name: custom\nlayout:\n  state_dir: custom-state\n",
+        encoding="utf-8",
+    )
     main(["--root", str(tmp_path), "init"])
     main(["--root", str(tmp_path), "task", "create", "Ship", "query"])
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
     capsys.readouterr()
 
     exit_code = main(["--root", str(tmp_path), "query", "--no-save", "query"])
@@ -810,12 +817,13 @@ def test_cli_query_command_no_save_skips_last_query_snapshot(tmp_path: Path, cap
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "Summary: Found 1 matching records." in captured.out
-    assert not (tmp_path / "state" / "queries" / "last-query.json").exists()
+    assert not last_query_path_for(layout).exists()
 
 
 def test_cli_query_command_no_save_json_preserves_output_shape(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     main(["--root", str(tmp_path), "task", "create", "Ship", "query"])
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
     capsys.readouterr()
 
     exit_code = main(["--root", str(tmp_path), "query", "--no-save", "query", "--json"])
@@ -825,7 +833,7 @@ def test_cli_query_command_no_save_json_preserves_output_shape(tmp_path: Path, c
     assert payload["query"] == "query"
     assert payload["match_count"] == 1
     assert payload["matches"][0]["path"] == "planning/tasks/task-ship-query.md"
-    assert not (tmp_path / "state" / "queries" / "last-query.json").exists()
+    assert not last_query_path_for(layout).exists()
 
 
 def test_cli_query_command_reports_snapshot_write_failure(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -800,6 +800,34 @@ def test_cli_query_command_persists_snapshot_for_json_output(tmp_path: Path, cap
     assert snapshot.query == "query"
 
 
+def test_cli_query_command_no_save_skips_last_query_snapshot(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    main(["--root", str(tmp_path), "task", "create", "Ship", "query"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "query", "--no-save", "query"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Summary: Found 1 matching records." in captured.out
+    assert not (tmp_path / "state" / "queries" / "last-query.json").exists()
+
+
+def test_cli_query_command_no_save_json_preserves_output_shape(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    main(["--root", str(tmp_path), "task", "create", "Ship", "query"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "query", "--no-save", "query", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["query"] == "query"
+    assert payload["match_count"] == 1
+    assert payload["matches"][0]["path"] == "planning/tasks/task-ship-query.md"
+    assert not (tmp_path / "state" / "queries" / "last-query.json").exists()
+
+
 def test_cli_query_command_reports_snapshot_write_failure(
     tmp_path: Path, capsys, monkeypatch
 ) -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -662,6 +662,33 @@ def test_ingest_source_workspace_backed_default_uses_excerpt(tmp_path: Path) -> 
     assert "line 119" not in body
 
 
+def test_ingest_source_markdown_summary_uses_heading_and_paragraph(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text(
+        "# LLM Wiki Pattern\n\n"
+        "Persistent knowledge should live in durable markdown pages that agents can inspect.\n\n"
+        "## Core Claims\n\n"
+        "- Agents need a repo-local memory substrate.\n"
+        "- Deterministic search should find curated concepts before review noise.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    assert (
+        "LLM Wiki Pattern. Persistent knowledge should live in durable markdown pages "
+        "that agents can inspect."
+    ) in body
+    assert "Agents need a repo-local memory substrate." in body
+    assert "Deterministic search should find curated concepts before review noise." in body
+    assert "Manifest:" in body
+    assert "## Extract" in body
+
+
 def test_ingest_source_workspace_backed_none_omits_extract_section(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     update_summary_modes(tmp_path, in_repo="none")
@@ -1243,6 +1270,39 @@ def test_ingest_source_marks_contradictions_and_creates_review_task(
     run_record = load_run_record(second_result.run_path)
     assert run_record.task_ids == [task_id]
     assert run_record.contradiction_ids == [second_page.contradictions[0].contradiction_id]
+
+
+def test_ingest_source_skips_boilerplate_only_contradiction_review(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    initialize_workspace(tmp_path)
+    update_summary_modes(tmp_path, external="none")
+
+    class FakeAnalyzer:
+        def detect(self, *, current, candidate):
+            pytest.fail("boilerplate-only source summaries should not be reviewed")
+
+    monkeypatch.setattr(
+        contradictions_module,
+        "build_contradiction_analyzer",
+        lambda config: FakeAnalyzer(),
+    )
+
+    first_source = tmp_path / "first.json"
+    first_source.write_text('{"path": "first"}\n', encoding="utf-8")
+    first_added = add_source(tmp_path, first_source, storage_mode="copy")
+    ingest_source(tmp_path, first_added.source_id)
+
+    second_source = tmp_path / "second.json"
+    second_source.write_text('{"path": "second"}\n', encoding="utf-8")
+    second_added = add_source(tmp_path, second_source, storage_mode="copy")
+    second_result = ingest_source(tmp_path, second_added.source_id)
+
+    first_page = parse_frontmatter(tmp_path / "wiki" / "sources" / f"{first_added.source_id}.md")[0]
+    second_page = parse_frontmatter(second_result.page_path)[0]
+    assert first_page.contradictions == []
+    assert second_page.contradictions == []
+    assert list((tmp_path / "planning" / "tasks").glob("task-review-*.md")) == []
 
 
 def test_ingest_source_dedupes_existing_contradictions_and_review_tasks(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -344,8 +344,8 @@ def test_run_query_ranks_dogfood_concept_above_review_task_noise(tmp_path: Path)
     )
     create_task(
         tmp_path,
-        "Review contradiction: source summary path mismatch",
-        record_id="task-review-source-summary-path-mismatch",
+        "Review contradiction: LLM Wiki persistent knowledge source summary path mismatch",
+        record_id="task-review-llm-wiki-persistent-knowledge-source-summary-path-mismatch",
         status="todo",
         priority="high",
         owner=None,
@@ -360,8 +360,11 @@ def test_run_query_ranks_dogfood_concept_above_review_task_noise(tmp_path: Path)
 
     result = run_query(tmp_path, "LLM Wiki persistent knowledge")
 
-    assert result.match_count >= 1
+    assert result.match_count >= 2
     assert result.matches[0].path == "wiki/concepts/llm-wiki-pattern.md"
+    assert result.matches[1].path == (
+        "planning/tasks/task-review-llm-wiki-persistent-knowledge-source-summary-path-mismatch.md"
+    )
 
 
 def test_query_snapshot_schema_round_trip(tmp_path: Path) -> None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -328,6 +328,42 @@ def test_run_query_surfaces_contradiction_counts_and_review_tasks(tmp_path: Path
     assert match.review_task_ids == ["task-review-src-123-src-456-1234567890"]
 
 
+def test_run_query_ranks_dogfood_concept_above_review_task_noise(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "concepts" / "llm-wiki-pattern.md",
+        title="LLM Wiki Persistent Knowledge",
+        page_id="concept-llm-wiki-persistent-knowledge",
+        kind="concept",
+        tags=["llm-wiki", "persistent-knowledge"],
+        body=(
+            "# LLM Wiki Persistent Knowledge\n\n"
+            "LLM Wiki persistent knowledge keeps durable project memory in markdown pages "
+            "that agents can search and inspect.\n"
+        ),
+    )
+    create_task(
+        tmp_path,
+        "Review contradiction: source summary path mismatch",
+        record_id="task-review-source-summary-path-mismatch",
+        status="todo",
+        priority="high",
+        owner=None,
+        milestone_refs=[],
+        decision_refs=[],
+        question_refs=[],
+        depends_on=[],
+        source_refs=[],
+        page_refs=[],
+        run_refs=[],
+    )
+
+    result = run_query(tmp_path, "LLM Wiki persistent knowledge")
+
+    assert result.match_count >= 1
+    assert result.matches[0].path == "wiki/concepts/llm-wiki-pattern.md"
+
+
 def test_query_snapshot_schema_round_trip(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     create_task(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -263,6 +263,23 @@ def test_web_routes_reject_layout_roots_that_escape_workspace(tmp_path: Path) ->
     assert "Workspace configuration is invalid." in response.text
 
 
+def test_search_rejects_layout_roots_that_escape_workspace(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        "schema_version: '1'\n"
+        "project_name: custom\n"
+        "layout:\n"
+        "  wiki_dir: ..\n"
+        "  planning_dir: planning\n",
+        encoding="utf-8",
+    )
+    client = TestClient(create_app(tmp_path), raise_server_exceptions=False)
+
+    response = client.get("/search", params={"q": "secret"})
+
+    assert response.status_code == 500
+    assert "Workspace configuration is invalid." in response.text
+
+
 def test_document_detail_preserves_code_text_while_sanitizing_html(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     write_wiki_page(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -30,8 +30,22 @@ def test_home_page_loads_for_initialized_workspace(tmp_path: Path) -> None:
 
     assert response.status_code == 200
     assert "Splendor" in response.text
-    assert "Documents" in response.text
+    assert "Wiki content pages" in response.text
     assert "/browse" in response.text
+
+
+def test_home_page_shows_empty_state_for_initialized_workspace(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "No workspace knowledge yet" in response.text
+    assert "uv run splendor repo refresh" in response.text
+    assert "uv run splendor add-source" in response.text
+    assert "Wiki content pages" in response.text
+    assert "Source manifests" in response.text
 
 
 def test_browse_page_lists_wiki_and_planning_documents(tmp_path: Path) -> None:
@@ -64,6 +78,20 @@ def test_browse_page_lists_wiki_and_planning_documents(tmp_path: Path) -> None:
     assert "Ship web shell" in response.text
     assert "wiki/concepts/web-shell.md" in response.text
     assert "planning/tasks/task-ship-web-shell.md" in response.text
+
+
+def test_browse_page_separates_index_and_log_as_special_files(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/browse")
+
+    assert response.status_code == 200
+    assert "No searchable content records yet." in response.text
+    assert "Special files" in response.text
+    assert "excluded from search results" in response.text
+    assert "wiki/index.md" in response.text
+    assert "wiki/log.md" in response.text
 
 
 def test_document_detail_renders_markdown_and_metadata(tmp_path: Path) -> None:
@@ -175,6 +203,20 @@ def test_search_returns_bad_request_for_invalid_query_text(tmp_path: Path) -> No
 
     assert response.status_code == 400
     assert "Query must contain at least one ASCII letter or number" in response.text
+
+
+def test_search_empty_state_mentions_special_files_for_sparse_workspace(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/search", params={"q": "splendor"})
+
+    assert response.status_code == 200
+    assert "special navigation files" in response.text
+    assert "excluded from search" in response.text
+    assert "uv run splendor repo refresh" in response.text
 
 
 def test_document_links_respect_custom_layout_directories(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #36.

Implements the M9-P1.2 dogfood-hardening slice after the first local web UI trial:

- adds sparse-workspace empty states and separates index/log as special browse-only navigation files
- adds `splendor query --no-save` for validation runs that should not update `state/queries/last-query.json`
- makes deterministic markdown/text source summaries content-aware while preserving provenance and registered-source context
- filters contradiction review inputs so source-summary metadata and deterministic boilerplate do not create false review tasks
- documents a reproducible self-dogfood flow and advances planning state from `M9-P1.1` to `M9-P1.2`

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest`
- `uv run splendor lint`
- `uv run splendor health`
- `uv run splendor query --no-save "LLM Wiki persistent knowledge" --json`
- `uv run splendor serve --host 127.0.0.1 --port 8765`, then checked `/browse` and `/search?q=LLM+Wiki+persistent+knowledge`

## Notes

This intentionally does not add mutating web actions, add-source web forms, runs/queue views, vector search, SQLite, or hosted behavior.