### PR TITLE
M10-P0.1 wiki status and source-impact suggestions

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M9-P1.2`
-- Last action taken: `M9-P1.2` is implemented; first-run dogfood hardening improved the sparse workspace, query, source-summary, and contradiction-review experience.
-- Current planned slice: `M9-P1`
-- Current PR sub-slice: `M9-P1.3`
+- Previous completed PR sub-slice: `M9-P1.3`
+- Last action taken: `M9-P1.3` is implemented; knowledge-work dogfooding expanded the wiki and filed follow-up product tasks for the maintenance loop.
+- Current planned slice: `M10-P0`
+- Current PR sub-slice: `M10-P0.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M10-P0`
-- Next planned PR sub-slice: `M10-P0.1`
+- Next planned PR sub-slice: `M10-P0.2`
 - Current blockers: none
 
 ## Planning Notation
@@ -117,6 +117,12 @@
   - [x] Register and ingest the new sources into source manifests, queue records, run records, and wiki summaries
   - [x] Synthesize the findings into wiki topic and architecture pages
   - [x] File product follow-up tasks for the bugs and missing workflow affordances found
+- [ ] Implement `M10-P0.1`: Wiki status and source-impact suggestions
+  - [x] Add `splendor wiki status` for source/page/queue/run/review state
+  - [x] Add `splendor wiki suggest <source-id>` for deterministic synthesis-page suggestions
+  - [x] Queue new CLI-added sources for `splendor ingest --pending`
+  - [x] Update tests and docs for the text-native maintenance bridge
+  - [x] Publish a non-draft GitHub PR for `M10-P0.1` with labels, milestone, and a detailed description
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ the wiki and filed follow-up product tasks.
 The current PR sub-slice is `M10-P0.1`, which adds a CLI-first wiki status and source-impact
 suggestion bridge before deeper planning/runs UI or rich-source work. The goal is to make the
 text-native loop explicit: ingest creates source summaries; source-impact and compile workflows
-maintain concept, topic, architecture, comparison, and overview pages.
+maintain concept, entity, topic, architecture, and glossary pages.
 
 The follow-on dogfood polish slice is `M10-P0.3`. It should smooth the visible workflow around
 `add-source -> ingest -> wiki suggest -> review`, add restrained next-action hints to command

--- a/README.md
+++ b/README.md
@@ -118,14 +118,16 @@ Implemented today:
 - `splendor task|milestone|decision|question ...`
 - `splendor repo scan`
 - `splendor repo refresh`
+- `splendor wiki status`
+- `splendor wiki suggest <source-id>`
 - `splendor serve` for a read-only local browse/search UI
 - `splendor lint` and `splendor health`
 
 Not implemented yet:
 
-- `splendor wiki status`, `splendor wiki suggest`, and review-gated `splendor wiki compile`
+- review-gated `splendor wiki compile`
 - project briefing over wiki, planning, source, and run state
-- next-action hints after add-source, ingest, query, and file-answer commands
+- broader next-action hints after query and file-answer commands
 - web status overview and source detail pages
 - OCR and image extraction flows
 - mutating web UI actions such as add-source forms
@@ -144,12 +146,12 @@ Not implemented yet:
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M9-P1.2`
-- Current planned slice: `M9-P1`
-- Current PR sub-slice: `M9-P1.3`
+- Previous completed PR sub-slice: `M9-P1.3`
+- Current planned slice: `M10-P0`
+- Current PR sub-slice: `M10-P0.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M10-P0`
-- Next planned PR sub-slice: `M10-P0.1`
+- Next planned PR sub-slice: `M10-P0.2`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -167,13 +169,13 @@ reviewable PR workflow.
 `M9-P1.1` is implemented: the first read-only local web UI shell can browse and search
 wiki/planning markdown. `M9-P1.2` is implemented: first-run dogfood hardening added clearer
 sparse-workspace UI, non-mutating query validation, more useful source summaries, and
-contradiction-review noise reduction. The current PR sub-slice is `M9-P1.3`, a knowledge-work
-dogfood pass that expands the wiki and files follow-up product tasks.
+contradiction-review noise reduction. `M9-P1.3` is implemented: knowledge-work dogfooding expanded
+the wiki and filed follow-up product tasks.
 
-Dogfooding changed the recommended next step: `M10-P0.1` should add a CLI-first wiki status and
-source-impact suggestion bridge before deeper planning/runs UI or rich-source work. The goal is to
-make the text-native loop explicit: ingest creates source summaries; source-impact and compile
-workflows maintain concept, topic, architecture, comparison, and overview pages.
+The current PR sub-slice is `M10-P0.1`, which adds a CLI-first wiki status and source-impact
+suggestion bridge before deeper planning/runs UI or rich-source work. The goal is to make the
+text-native loop explicit: ingest creates source summaries; source-impact and compile workflows
+maintain concept, topic, architecture, comparison, and overview pages.
 
 The follow-on dogfood polish slice is `M10-P0.3`. It should smooth the visible workflow around
 `add-source -> ingest -> wiki suggest -> review`, add restrained next-action hints to command

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -33,7 +33,7 @@ source-summary key facts during ingest.
 
 Ingest currently creates deterministic source summaries and run/provenance state. The first
 `M10-P0` bridge adds `splendor wiki status` and `splendor wiki suggest <source-id>` so users and
-agents can identify affected concept, topic, architecture, comparison, or overview pages before
+agents can identify affected concept, entity, topic, architecture, or glossary pages before
 manual review. Project briefing and a future review-gated compile/update workflow remain planned.
 
 Dogfood runs should record usability friction separately from knowledge gaps. Pay special attention

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -31,11 +31,10 @@ Local notes should include a clear first heading and a substantive opening parag
 as `Core Claims`, `Design Implications`, and `Implementation Pattern` are rendered into deterministic
 source-summary key facts during ingest.
 
-Ingest currently creates deterministic source summaries and run/provenance state. Until the
-`M10-P0` wiki-maintenance bridge exists, users and agents should manually update affected concept,
-topic, architecture, comparison, or overview pages after ingesting a meaningful source. The planned
-bridge should add `splendor wiki status`, `splendor wiki suggest <source-id>`, project briefing, and
-a future review-gated compile/update workflow.
+Ingest currently creates deterministic source summaries and run/provenance state. The first
+`M10-P0` bridge adds `splendor wiki status` and `splendor wiki suggest <source-id>` so users and
+agents can identify affected concept, topic, architecture, comparison, or overview pages before
+manual review. Project briefing and a future review-gated compile/update workflow remain planned.
 
 Dogfood runs should record usability friction separately from knowledge gaps. Pay special attention
 to whether each command prints the next useful command, whether long source IDs need to be copied

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -72,16 +72,17 @@ The command prints:
 - a stable `src-...` source ID
 - the manifest path under `state/manifests/sources/`
 - the source ref and storage mode
+- a pending ingest queue record and next command
 
 For in-repo files, the current default storage mode is `none`, which means Splendor tracks the
 workspace file directly instead of copying it into `raw/sources/`.
 
 ## 4. Ingest the source
 
-Copy the `src-...` identifier from the `add-source` output, then run:
+Drain the pending ingest queue:
 
 ```bash
-uv run splendor --root /tmp/demo-repo ingest <source-id>
+uv run splendor --root /tmp/demo-repo ingest --pending
 ```
 
 This creates:
@@ -90,6 +91,13 @@ This creates:
 - a queue record under `state/queue/`
 - a run record under `state/runs/`
 - updated `wiki/index.md` and `wiki/log.md`
+
+After ingest, use the source ID from the command output to inspect likely synthesis follow-up:
+
+```bash
+uv run splendor --root /tmp/demo-repo wiki status
+uv run splendor --root /tmp/demo-repo wiki suggest <source-id>
+```
 
 ## 5. Add a planning record
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,16 +334,16 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M9-P1.2`
-- Current planned slice: `M9-P1`
-- Current PR sub-slice: `M9-P1.3`
+- Previous completed PR sub-slice: `M9-P1.3`
+- Current planned slice: `M10-P0`
+- Current PR sub-slice: `M10-P0.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M10-P0`
-- Next planned PR sub-slice: `M10-P0.1`
+- Next planned PR sub-slice: `M10-P0.2`
 
-The current PR sub-slice is `M9-P1.3`, under parent slice `M9-P1`, which performs a knowledge-work
-dogfood pass after `M9-P1.2`. The lifecycle marker means `M9-P1.3` is in progress on feature
-branches and merged once the same committed state is observed on `main`.
+The current PR sub-slice is `M10-P0.1`, under parent slice `M10-P0`, which adds the CLI-first
+wiki status and source-impact suggestion bridge. The lifecycle marker means `M10-P0.1` is in
+progress on feature branches and merged once the same committed state is observed on `main`.
 
 Dogfooding also changed the recommended next slice: before deeper planning/runs UI work, Splendor
 should add a small CLI-first bridge for wiki status, source-impact suggestions, and project
@@ -566,11 +566,12 @@ empty states, explicit special-file browse treatment, non-mutating query validat
 markdown source summaries, and contradiction-review filtering for source-summary metadata
 boilerplate. `M9-P1.3` adds three researched dogfood rounds, extends the wiki with tool-landscape
 and agent-context synthesis, and files follow-up product tasks from the observed workflow friction.
-The next recommended slice is `M10-P0.1`, which should add CLI-first wiki status and source-impact
-suggestions before deeper planning/runs UI work. `M10-P0.3` should follow the status and briefing
-work with dogfood workflow polish: add-source/ingest handoff fixes, next-action hints, query
-snippet improvements, and read-only web status/source-detail surfaces. Mutating web actions,
-add-source forms, and planning/runs views remain deferred to later `M9` slices.
+The current recommended slice is `M10-P0.1`, which adds CLI-first wiki status and source-impact
+suggestions before deeper planning/runs UI work. `M10-P0.2` should follow with project briefing
+and a documented review-gated compile-loop contract. `M10-P0.3` should then polish the visible
+dogfood workflow with query snippet improvements and read-only web status/source-detail surfaces.
+Mutating web actions, add-source forms, and planning/runs views remain deferred to later `M9`
+slices.
 
 ---
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -661,8 +661,9 @@ Current implementation:
   source ID.
 - `splendor ingest <source-id>` prints the generated source-summary page/run records and the next
   `splendor wiki suggest <source-id>` command.
-- `splendor wiki status` reports source, page, queue, run, review, contested, machine-generated,
-  and missing synthesis-follow-up counts, with optional JSON output.
+- `splendor wiki status` reports source, page, queue, run, review, contested, stale,
+  machine-generated, invalid-page, actionable synthesis-review, and missing
+  synthesis-follow-up counts, with optional JSON output.
 - `splendor wiki suggest <source-id>` deterministically ranks existing synthesis pages using source
   metadata, source-summary text, frontmatter source refs, tags, source refs, and page content, with
   optional JSON output.

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -654,6 +654,21 @@ should print the exact next ingest command or enqueue the source for pending ing
 `wiki suggest` command. After query/file-answer commands, it should clearly state whether there is a
 follow-up filing or review step.
 
+Current implementation:
+
+- `splendor add-source <path>` registers the source and creates a pending ingest queue item for
+  CLI-created sources, so `splendor ingest --pending` can continue the loop without copying the
+  source ID.
+- `splendor ingest <source-id>` prints the generated source-summary page/run records and the next
+  `splendor wiki suggest <source-id>` command.
+- `splendor wiki status` reports source, page, queue, run, review, contested, machine-generated,
+  and missing synthesis-follow-up counts, with optional JSON output.
+- `splendor wiki suggest <source-id>` deterministically ranks existing synthesis pages using source
+  metadata, source-summary text, frontmatter source refs, tags, source refs, and page content, with
+  optional JSON output.
+- Mutating `splendor wiki compile <source-id>` remains deferred to the review-gated compile-loop
+  slice.
+
 Later optional support:
 - PDF
 - image-based sources

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -415,7 +415,14 @@ def handle_add_source(args: argparse.Namespace) -> int:
         try:
             queue_path = enqueue_ingest_job(root, result.source_id)
         except (FileNotFoundError, RuntimeError, ValueError) as exc:
-            return _print_error(exc)
+            warning = _error_message(exc)
+            print(f"Warning: source registered but ingest was not queued: {warning}")
+            if "Run `splendor init`" in warning:
+                print("Next: splendor init")
+                print(f"Then: splendor ingest {result.source_id}")
+            else:
+                print(f"Next: splendor ingest {result.source_id}")
+            return 0
         print(f"Queued ingest: {queue_path}")
         print("Next: splendor ingest --pending")
     else:
@@ -507,8 +514,12 @@ def handle_wiki_status(args: argparse.Namespace) -> int:
     )
     print(f"Machine-generated pages: {result.machine_generated_pages}")
     print(f"Contested pages: {result.contested_pages}")
-    print(f"Review-needed pages: {result.review_needed_pages}")
+    print(f"Stale pages: {result.stale_pages}")
+    print(f"Review-needed synthesis pages: {result.review_needed_synthesis_pages}")
     print(f"Sources missing synthesis follow-up: {result.sources_missing_synthesis}")
+    print(f"Invalid wiki pages: {result.invalid_pages}")
+    for invalid_page in result.invalid_page_examples:
+        print(f"- {invalid_page.path}: {invalid_page.error}")
     if result.recent_runs:
         print("Recent runs:")
         for run in result.recent_runs:

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -13,7 +13,7 @@ from splendor.commands.file_answer import (
     file_answer_from_last_query,
 )
 from splendor.commands.health import run_health_checks
-from splendor.commands.ingest import drain_pending_ingest_jobs, ingest_source
+from splendor.commands.ingest import drain_pending_ingest_jobs, enqueue_ingest_job, ingest_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.lint import run_lint_checks
 from splendor.commands.maintenance import execute_maintenance_command, render_report_json
@@ -30,6 +30,12 @@ from splendor.commands.planning import (
 from splendor.commands.query import run_query
 from splendor.commands.repo_refresh import refresh_repo, render_repo_refresh_json
 from splendor.commands.repo_scan import render_repo_scan_json, scan_repo
+from splendor.commands.wiki import (
+    build_wiki_status,
+    render_wiki_status_json,
+    render_wiki_suggest_json,
+    suggest_source_pages,
+)
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import (
@@ -103,6 +109,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="Drain pending ingestion jobs from the queue.",
     )
     ingest_parser.set_defaults(handler=handle_ingest)
+
+    wiki_parser = subparsers.add_parser("wiki", help="Inspect and maintain wiki state")
+    wiki_subparsers = wiki_parser.add_subparsers(dest="wiki_command", required=True)
+    wiki_status_parser = wiki_subparsers.add_parser(
+        "status", help="Summarize source, page, queue, run, and review state"
+    )
+    wiki_status_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    wiki_status_parser.set_defaults(handler=handle_wiki_status)
+    wiki_suggest_parser = wiki_subparsers.add_parser(
+        "suggest", help="Suggest synthesis pages affected by a source"
+    )
+    wiki_suggest_parser.add_argument("source_id", help="Registered source identifier to inspect")
+    wiki_suggest_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    wiki_suggest_parser.set_defaults(handler=handle_wiki_suggest)
 
     materialize_parser = subparsers.add_parser(
         "materialize-source", help="Create or refresh a source storage artifact"
@@ -381,6 +411,15 @@ def handle_add_source(args: argparse.Namespace) -> int:
     print(f"Storage mode: {result.storage_mode}")
     if result.stored_path is not None:
         print(f"Storage artifact: {result.stored_path}")
+    if not result.already_registered:
+        try:
+            queue_path = enqueue_ingest_job(root, result.source_id)
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            return _print_error(exc)
+        print(f"Queued ingest: {queue_path}")
+        print("Next: splendor ingest --pending")
+    else:
+        print(f"Next: splendor ingest {result.source_id}")
     return 0
 
 
@@ -424,6 +463,82 @@ def handle_ingest(args: argparse.Namespace) -> int:
     print(f"Page: {result.page_path}")
     print(f"Queue record: {result.queue_path}")
     print(f"Run record: {result.run_path}")
+    print(f"Next: splendor wiki suggest {result.source_id}")
+    return 0
+
+
+def handle_wiki_status(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = build_wiki_status(root)
+    except ValueError as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_wiki_status_json(result))
+        return 0
+
+    print("Wiki status")
+    print(
+        "Sources: "
+        f"total={result.source_total} "
+        f"registered={result.source_counts.get('registered', 0)} "
+        f"ingested={result.source_counts.get('ingested', 0)} "
+        f"failed={result.source_counts.get('failed', 0)}"
+    )
+    print(
+        "Pages: "
+        f"total={result.page_total} "
+        + " ".join(f"{kind}={count}" for kind, count in result.page_kind_counts.items())
+    )
+    print(
+        "Queue: "
+        f"total={result.queue_total} "
+        + " ".join(f"{status}={count}" for status, count in result.queue_status_counts.items())
+    )
+    print(
+        "Runs: "
+        f"total={result.run_total} "
+        + " ".join(f"{status}={count}" for status, count in result.run_status_counts.items())
+    )
+    print(
+        "Review: "
+        + " ".join(f"{state}={count}" for state, count in result.review_state_counts.items())
+    )
+    print(f"Machine-generated pages: {result.machine_generated_pages}")
+    print(f"Contested pages: {result.contested_pages}")
+    print(f"Review-needed pages: {result.review_needed_pages}")
+    print(f"Sources missing synthesis follow-up: {result.sources_missing_synthesis}")
+    if result.recent_runs:
+        print("Recent runs:")
+        for run in result.recent_runs:
+            finished = run.finished_at or "-"
+            print(f"- {run.run_id} {run.status} finished={finished}")
+    return 0
+
+
+def handle_wiki_suggest(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = suggest_source_pages(root, args.source_id)
+    except (FileNotFoundError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_wiki_suggest_json(result))
+        return 0
+
+    print(f"Source: {result.source_id}")
+    print(f"Title: {result.source_title}")
+    print(f"Source ref: {result.source_ref}")
+    print(f"Status: {result.source_status}")
+    if not result.suggestions:
+        print("No likely synthesis-page matches found")
+        return 0
+    print("Suggested pages:")
+    for suggestion in result.suggestions:
+        reasons = ", ".join(suggestion.reasons)
+        print(f"- {suggestion.path} [{suggestion.kind}] score={suggestion.score} reasons={reasons}")
     return 0
 
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -391,6 +391,10 @@ def _print_error(exc: Exception) -> int:
     return 1
 
 
+def _is_missing_workspace_wiki_error(exc: Exception) -> bool:
+    return str(exc).startswith("Workspace is missing required wiki files:")
+
+
 def handle_add_source(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     candidate_path = args.path.expanduser()
@@ -417,7 +421,7 @@ def handle_add_source(args: argparse.Namespace) -> int:
         except (FileNotFoundError, RuntimeError, ValueError) as exc:
             warning = _error_message(exc)
             print(f"Warning: source registered but ingest was not queued: {warning}")
-            if "Run `splendor init`" in warning:
+            if _is_missing_workspace_wiki_error(exc):
                 print("Next: splendor init")
                 print(f"Then: splendor ingest {result.source_id}")
             else:

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -1,0 +1,342 @@
+"""Read-only wiki maintenance commands."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord, SourceRecord
+from splendor.state.runtime import load_queue_item, load_run_record
+from splendor.state.source_compat import canonical_source_ref
+from splendor.state.source_registry import load_source_record, manifest_path_for
+from splendor.utils.wiki import parse_wiki_markdown
+
+_SYNTHESIS_KINDS = {"architecture", "concept", "entity", "glossary", "topic"}
+_REVIEW_NEEDED_STATES = {"draft", "machine-generated", "contested", "stale"}
+_TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]{2,}")
+_STOPWORDS = {
+    "and",
+    "are",
+    "for",
+    "from",
+    "into",
+    "source",
+    "sources",
+    "summary",
+    "the",
+    "this",
+    "that",
+    "wiki",
+    "with",
+}
+
+
+@dataclass(frozen=True)
+class WikiPageSnapshot:
+    path: str
+    frontmatter: KnowledgePageFrontmatter
+    body: str
+
+
+@dataclass(frozen=True)
+class RecentRunSnapshot:
+    run_id: str
+    status: str
+    finished_at: str | None
+    source_ids: list[str]
+    page_refs: list[str]
+
+
+@dataclass(frozen=True)
+class WikiStatus:
+    source_total: int
+    source_counts: dict[str, int]
+    page_total: int
+    page_kind_counts: dict[str, int]
+    queue_total: int
+    queue_status_counts: dict[str, int]
+    run_total: int
+    run_status_counts: dict[str, int]
+    review_state_counts: dict[str, int]
+    machine_generated_pages: int
+    contested_pages: int
+    review_needed_pages: int
+    sources_missing_synthesis: int
+    recent_runs: list[RecentRunSnapshot]
+
+
+@dataclass(frozen=True)
+class WikiSuggestion:
+    path: str
+    page_id: str
+    title: str
+    kind: str
+    score: int
+    reasons: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class WikiSuggestResult:
+    source_id: str
+    source_title: str
+    source_ref: str
+    source_status: str
+    suggestions: list[WikiSuggestion]
+
+
+def _relative(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _load_sources(layout) -> list[SourceRecord]:
+    sources: list[SourceRecord] = []
+    for manifest_path in sorted(layout.source_records_dir.glob("*.json")):
+        sources.append(load_source_record(manifest_path))
+    return sources
+
+
+def _load_queue(layout) -> list[QueueItemRecord]:
+    records: list[QueueItemRecord] = []
+    for queue_path in sorted(layout.queue_dir.glob("*.json")):
+        records.append(load_queue_item(queue_path))
+    return records
+
+
+def _load_runs(layout) -> list[RunRecord]:
+    records: list[RunRecord] = []
+    for run_path in sorted(layout.runs_dir.glob("*.json")):
+        records.append(load_run_record(run_path))
+    return records
+
+
+def _load_wiki_pages(root: Path, layout) -> list[WikiPageSnapshot]:
+    pages: list[WikiPageSnapshot] = []
+    for page_path in sorted(layout.wiki_dir.rglob("*.md")):
+        if page_path in {layout.index_file, layout.log_file}:
+            continue
+        parsed = parse_wiki_markdown(page_path)
+        pages.append(
+            WikiPageSnapshot(
+                path=_relative(root, page_path),
+                frontmatter=parsed.frontmatter,
+                body=parsed.body,
+            )
+        )
+    return pages
+
+
+def _sorted_counts(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+def _recent_runs(runs: list[RunRecord]) -> list[RecentRunSnapshot]:
+    ordered = sorted(
+        runs,
+        key=lambda run: (run.finished_at or run.started_at, run.run_id),
+        reverse=True,
+    )
+    return [
+        RecentRunSnapshot(
+            run_id=run.run_id,
+            status=run.status,
+            finished_at=run.finished_at,
+            source_ids=run.source_ids,
+            page_refs=run.page_refs,
+        )
+        for run in ordered[:5]
+    ]
+
+
+def build_wiki_status(root: Path) -> WikiStatus:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    sources = _load_sources(layout)
+    pages = _load_wiki_pages(root, layout)
+    queue_records = _load_queue(layout)
+    runs = _load_runs(layout)
+
+    source_counts = Counter(source.status for source in sources)
+    page_kind_counts = Counter(page.frontmatter.kind for page in pages)
+    queue_status_counts = Counter(record.status for record in queue_records)
+    run_status_counts = Counter(run.status for run in runs)
+    review_state_counts = Counter(page.frontmatter.review_state for page in pages)
+
+    synthesis_source_refs = {
+        source_ref
+        for page in pages
+        if page.frontmatter.kind in _SYNTHESIS_KINDS
+        for source_ref in page.frontmatter.source_refs
+    }
+    ingested_source_ids = {source.source_id for source in sources if source.status == "ingested"}
+
+    return WikiStatus(
+        source_total=len(sources),
+        source_counts=_sorted_counts(source_counts),
+        page_total=len(pages),
+        page_kind_counts=_sorted_counts(page_kind_counts),
+        queue_total=len(queue_records),
+        queue_status_counts=_sorted_counts(queue_status_counts),
+        run_total=len(runs),
+        run_status_counts=_sorted_counts(run_status_counts),
+        review_state_counts=_sorted_counts(review_state_counts),
+        machine_generated_pages=review_state_counts["machine-generated"],
+        contested_pages=review_state_counts["contested"],
+        review_needed_pages=sum(review_state_counts[state] for state in _REVIEW_NEEDED_STATES),
+        sources_missing_synthesis=len(ingested_source_ids - synthesis_source_refs),
+        recent_runs=_recent_runs(runs),
+    )
+
+
+def _tokens(*values: str) -> set[str]:
+    tokens: set[str] = set()
+    for value in values:
+        for token in _TOKEN_PATTERN.findall(value.lower()):
+            normalized = token.strip("_-")
+            if normalized and normalized not in _STOPWORDS:
+                tokens.add(normalized)
+    return tokens
+
+
+def _source_summary_pages(pages: list[WikiPageSnapshot], source_id: str) -> list[WikiPageSnapshot]:
+    return [
+        page
+        for page in pages
+        if page.frontmatter.kind == "source-summary" and source_id in page.frontmatter.source_refs
+    ]
+
+
+def _source_terms(source: SourceRecord, summary_pages: list[WikiPageSnapshot]) -> set[str]:
+    summary_text = " ".join(
+        " ".join([page.frontmatter.title, " ".join(page.frontmatter.tags), page.body])
+        for page in summary_pages
+    )
+    label_text = " ".join(source.source_labels)
+    return _tokens(
+        source.title,
+        canonical_source_ref(source),
+        Path(canonical_source_ref(source)).stem,
+        source.source_type,
+        label_text,
+        summary_text,
+    )
+
+
+def _score_page(
+    *,
+    source: SourceRecord,
+    page: WikiPageSnapshot,
+    source_terms: set[str],
+) -> WikiSuggestion | None:
+    score = 0
+    reasons: list[str] = []
+    page_text = " ".join(
+        [
+            page.frontmatter.title,
+            page.frontmatter.page_id,
+            " ".join(page.frontmatter.tags),
+            page.path,
+            page.body,
+        ]
+    )
+    page_terms = _tokens(page_text)
+
+    if source.source_id in page.frontmatter.source_refs:
+        score += 100
+        reasons.append("frontmatter-source-ref")
+    if source.source_id in page.body:
+        score += 80
+        reasons.append("body-source-id")
+    if canonical_source_ref(source) in page.body:
+        score += 60
+        reasons.append("body-source-ref")
+
+    tag_overlap = source_terms & _tokens(" ".join(page.frontmatter.tags))
+    if tag_overlap:
+        score += min(45, len(tag_overlap) * 15)
+        reasons.append("tag-overlap:" + ",".join(sorted(tag_overlap)))
+
+    term_overlap = source_terms & page_terms
+    if term_overlap:
+        score += min(50, len(term_overlap) * 5)
+        reasons.append("term-overlap:" + ",".join(sorted(term_overlap)[:8]))
+
+    if score == 0:
+        return None
+
+    return WikiSuggestion(
+        path=page.path,
+        page_id=page.frontmatter.page_id,
+        title=page.frontmatter.title,
+        kind=page.frontmatter.kind,
+        score=score,
+        reasons=reasons,
+    )
+
+
+def suggest_source_pages(root: Path, source_id: str) -> WikiSuggestResult:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    manifest_path = manifest_path_for(root, source_id)
+    if not manifest_path.exists():
+        msg = f"Unknown source ID: {source_id}"
+        raise FileNotFoundError(msg)
+
+    source = load_source_record(manifest_path)
+    pages = _load_wiki_pages(root, layout)
+    summaries = _source_summary_pages(pages, source_id)
+    source_terms = _source_terms(source, summaries)
+    suggestions = [
+        suggestion
+        for page in pages
+        if page.frontmatter.kind in _SYNTHESIS_KINDS
+        for suggestion in [_score_page(source=source, page=page, source_terms=source_terms)]
+        if suggestion is not None
+    ]
+    suggestions.sort(key=lambda suggestion: (-suggestion.score, suggestion.path))
+    return WikiSuggestResult(
+        source_id=source.source_id,
+        source_title=source.title,
+        source_ref=canonical_source_ref(source),
+        source_status=source.status,
+        suggestions=suggestions,
+    )
+
+
+def render_wiki_status_json(status: WikiStatus) -> str:
+    return json.dumps(
+        {
+            "source_total": status.source_total,
+            "source_counts": status.source_counts,
+            "page_total": status.page_total,
+            "page_kind_counts": status.page_kind_counts,
+            "queue_total": status.queue_total,
+            "queue_status_counts": status.queue_status_counts,
+            "run_total": status.run_total,
+            "run_status_counts": status.run_status_counts,
+            "review_state_counts": status.review_state_counts,
+            "machine_generated_pages": status.machine_generated_pages,
+            "contested_pages": status.contested_pages,
+            "review_needed_pages": status.review_needed_pages,
+            "sources_missing_synthesis": status.sources_missing_synthesis,
+            "recent_runs": [run.__dict__ for run in status.recent_runs],
+        },
+        indent=2,
+    )
+
+
+def render_wiki_suggest_json(result: WikiSuggestResult) -> str:
+    return json.dumps(
+        {
+            "source_id": result.source_id,
+            "source_title": result.source_title,
+            "source_ref": result.source_ref,
+            "source_status": result.source_status,
+            "suggestions": [suggestion.__dict__ for suggestion in result.suggestions],
+        },
+        indent=2,
+    )

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -19,6 +19,15 @@ from splendor.utils.wiki import parse_wiki_markdown
 _SYNTHESIS_KINDS = {"architecture", "concept", "entity", "glossary", "topic"}
 _REVIEW_NEEDED_STATES = {"draft", "machine-generated", "contested", "stale"}
 _TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]{2,}")
+_SOURCE_TERM_SECTIONS = {"summary", "key facts", "extract"}
+_GENERATED_KEY_FACT_PREFIXES = (
+    "- Source ID:",
+    "- Source type:",
+    "- Checksum:",
+    "- Source ref:",
+    "- Added at:",
+    "- Ingested at:",
+)
 _STOPWORDS = {
     "and",
     "are",
@@ -44,6 +53,12 @@ class WikiPageSnapshot:
 
 
 @dataclass(frozen=True)
+class InvalidWikiPageSnapshot:
+    path: str
+    error: str
+
+
+@dataclass(frozen=True)
 class RecentRunSnapshot:
     run_id: str
     status: str
@@ -65,8 +80,12 @@ class WikiStatus:
     review_state_counts: dict[str, int]
     machine_generated_pages: int
     contested_pages: int
+    stale_pages: int
     review_needed_pages: int
+    review_needed_synthesis_pages: int
     sources_missing_synthesis: int
+    invalid_pages: int
+    invalid_page_examples: list[InvalidWikiPageSnapshot]
     recent_runs: list[RecentRunSnapshot]
 
 
@@ -114,20 +133,28 @@ def _load_runs(layout) -> list[RunRecord]:
     return records
 
 
-def _load_wiki_pages(root: Path, layout) -> list[WikiPageSnapshot]:
+def _load_wiki_pages(
+    root: Path, layout
+) -> tuple[list[WikiPageSnapshot], list[InvalidWikiPageSnapshot]]:
     pages: list[WikiPageSnapshot] = []
+    invalid_pages: list[InvalidWikiPageSnapshot] = []
     for page_path in sorted(layout.wiki_dir.rglob("*.md")):
         if page_path in {layout.index_file, layout.log_file}:
             continue
-        parsed = parse_wiki_markdown(page_path)
+        page_ref = _relative(root, page_path)
+        try:
+            parsed = parse_wiki_markdown(page_path)
+        except ValueError as exc:
+            invalid_pages.append(InvalidWikiPageSnapshot(path=page_ref, error=str(exc)))
+            continue
         pages.append(
             WikiPageSnapshot(
-                path=_relative(root, page_path),
+                path=page_ref,
                 frontmatter=parsed.frontmatter,
                 body=parsed.body,
             )
         )
-    return pages
+    return pages, invalid_pages
 
 
 def _sorted_counts(counter: Counter[str]) -> dict[str, int]:
@@ -156,7 +183,7 @@ def build_wiki_status(root: Path) -> WikiStatus:
     config = load_config(root)
     layout = resolve_layout(root, config)
     sources = _load_sources(layout)
-    pages = _load_wiki_pages(root, layout)
+    pages, invalid_pages = _load_wiki_pages(root, layout)
     queue_records = _load_queue(layout)
     runs = _load_runs(layout)
 
@@ -165,6 +192,12 @@ def build_wiki_status(root: Path) -> WikiStatus:
     queue_status_counts = Counter(record.status for record in queue_records)
     run_status_counts = Counter(run.status for run in runs)
     review_state_counts = Counter(page.frontmatter.review_state for page in pages)
+    review_needed_synthesis_pages = sum(
+        1
+        for page in pages
+        if page.frontmatter.kind in _SYNTHESIS_KINDS
+        and page.frontmatter.review_state in _REVIEW_NEEDED_STATES
+    )
 
     synthesis_source_refs = {
         source_ref
@@ -186,8 +219,12 @@ def build_wiki_status(root: Path) -> WikiStatus:
         review_state_counts=_sorted_counts(review_state_counts),
         machine_generated_pages=review_state_counts["machine-generated"],
         contested_pages=review_state_counts["contested"],
-        review_needed_pages=sum(review_state_counts[state] for state in _REVIEW_NEEDED_STATES),
+        stale_pages=review_state_counts["stale"],
+        review_needed_pages=review_needed_synthesis_pages,
+        review_needed_synthesis_pages=review_needed_synthesis_pages,
         sources_missing_synthesis=len(ingested_source_ids - synthesis_source_refs),
+        invalid_pages=len(invalid_pages),
+        invalid_page_examples=invalid_pages[:5],
         recent_runs=_recent_runs(runs),
     )
 
@@ -210,10 +247,33 @@ def _source_summary_pages(pages: list[WikiPageSnapshot], source_id: str) -> list
     ]
 
 
+def _section_text(body: str, included_headings: set[str]) -> str:
+    sections: list[str] = []
+    active_heading: str | None = None
+    active = False
+    in_fence = False
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if line.startswith("```") or line.startswith("~~~"):
+            if active:
+                sections.append(raw_line)
+            in_fence = not in_fence
+            continue
+        if not in_fence and line.startswith("#"):
+            heading = line.lstrip("#").strip().strip("#").strip().lower()
+            active_heading = heading
+            active = heading in included_headings
+            continue
+        if active:
+            if active_heading == "key facts" and raw_line.startswith(_GENERATED_KEY_FACT_PREFIXES):
+                continue
+            sections.append(raw_line)
+    return "\n".join(sections)
+
+
 def _source_terms(source: SourceRecord, summary_pages: list[WikiPageSnapshot]) -> set[str]:
     summary_text = " ".join(
-        " ".join([page.frontmatter.title, " ".join(page.frontmatter.tags), page.body])
-        for page in summary_pages
+        _section_text(page.body, _SOURCE_TERM_SECTIONS) for page in summary_pages
     )
     label_text = " ".join(source.source_labels)
     return _tokens(
@@ -287,7 +347,7 @@ def suggest_source_pages(root: Path, source_id: str) -> WikiSuggestResult:
         raise FileNotFoundError(msg)
 
     source = load_source_record(manifest_path)
-    pages = _load_wiki_pages(root, layout)
+    pages, _invalid_pages = _load_wiki_pages(root, layout)
     summaries = _source_summary_pages(pages, source_id)
     source_terms = _source_terms(source, summaries)
     suggestions = [
@@ -321,8 +381,12 @@ def render_wiki_status_json(status: WikiStatus) -> str:
             "review_state_counts": status.review_state_counts,
             "machine_generated_pages": status.machine_generated_pages,
             "contested_pages": status.contested_pages,
+            "stale_pages": status.stale_pages,
             "review_needed_pages": status.review_needed_pages,
+            "review_needed_synthesis_pages": status.review_needed_synthesis_pages,
             "sources_missing_synthesis": status.sources_missing_synthesis,
+            "invalid_pages": status.invalid_pages,
+            "invalid_page_examples": [page.__dict__ for page in status.invalid_page_examples],
             "recent_runs": [run.__dict__ for run in status.recent_runs],
         },
         indent=2,

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from splendor.config import load_config
@@ -18,7 +18,7 @@ from splendor.utils.wiki import parse_wiki_markdown
 
 _SYNTHESIS_KINDS = {"architecture", "concept", "entity", "glossary", "topic"}
 _REVIEW_NEEDED_STATES = {"draft", "machine-generated", "contested", "stale"}
-_TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]{2,}")
+_TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]{1,}")
 _SOURCE_TERM_SECTIONS = {"summary", "key facts", "extract"}
 _GENERATED_KEY_FACT_PREFIXES = (
     "- Source ID:",
@@ -34,6 +34,7 @@ _STOPWORDS = {
     "for",
     "from",
     "into",
+    "md",
     "source",
     "sources",
     "summary",
@@ -192,6 +193,9 @@ def build_wiki_status(root: Path) -> WikiStatus:
     queue_status_counts = Counter(record.status for record in queue_records)
     run_status_counts = Counter(run.status for run in runs)
     review_state_counts = Counter(page.frontmatter.review_state for page in pages)
+    review_needed_pages = sum(
+        1 for page in pages if page.frontmatter.review_state in _REVIEW_NEEDED_STATES
+    )
     review_needed_synthesis_pages = sum(
         1
         for page in pages
@@ -199,13 +203,22 @@ def build_wiki_status(root: Path) -> WikiStatus:
         and page.frontmatter.review_state in _REVIEW_NEEDED_STATES
     )
 
-    synthesis_source_refs = {
+    synthesis_source_ids = {
         source_ref
         for page in pages
         if page.frontmatter.kind in _SYNTHESIS_KINDS
         for source_ref in page.frontmatter.source_refs
     }
-    ingested_source_ids = {source.source_id for source in sources if source.status == "ingested"}
+    synthesis_pages = [page for page in pages if page.frontmatter.kind in _SYNTHESIS_KINDS]
+    ingested_source_ids = {
+        source.source_id
+        for source in sources
+        if source.status == "ingested"
+        and not (
+            source.source_id in synthesis_source_ids
+            or any(canonical_source_ref(source) in page.body for page in synthesis_pages)
+        )
+    }
 
     return WikiStatus(
         source_total=len(sources),
@@ -220,9 +233,9 @@ def build_wiki_status(root: Path) -> WikiStatus:
         machine_generated_pages=review_state_counts["machine-generated"],
         contested_pages=review_state_counts["contested"],
         stale_pages=review_state_counts["stale"],
-        review_needed_pages=review_needed_synthesis_pages,
+        review_needed_pages=review_needed_pages,
         review_needed_synthesis_pages=review_needed_synthesis_pages,
-        sources_missing_synthesis=len(ingested_source_ids - synthesis_source_refs),
+        sources_missing_synthesis=len(ingested_source_ids),
         invalid_pages=len(invalid_pages),
         invalid_page_examples=invalid_pages[:5],
         recent_runs=_recent_runs(runs),
@@ -278,9 +291,7 @@ def _source_terms(source: SourceRecord, summary_pages: list[WikiPageSnapshot]) -
     label_text = " ".join(source.source_labels)
     return _tokens(
         source.title,
-        canonical_source_ref(source),
         Path(canonical_source_ref(source)).stem,
-        source.source_type,
         label_text,
         summary_text,
     )
@@ -386,8 +397,8 @@ def render_wiki_status_json(status: WikiStatus) -> str:
             "review_needed_synthesis_pages": status.review_needed_synthesis_pages,
             "sources_missing_synthesis": status.sources_missing_synthesis,
             "invalid_pages": status.invalid_pages,
-            "invalid_page_examples": [page.__dict__ for page in status.invalid_page_examples],
-            "recent_runs": [run.__dict__ for run in status.recent_runs],
+            "invalid_page_examples": [asdict(page) for page in status.invalid_page_examples],
+            "recent_runs": [asdict(run) for run in status.recent_runs],
         },
         indent=2,
     )
@@ -400,7 +411,7 @@ def render_wiki_suggest_json(result: WikiSuggestResult) -> str:
             "source_title": result.source_title,
             "source_ref": result.source_ref,
             "source_status": result.source_status,
-            "suggestions": [suggestion.__dict__ for suggestion in result.suggestions],
+            "suggestions": [asdict(suggestion) for suggestion in result.suggestions],
         },
         indent=2,
     )

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -13,7 +13,7 @@ from splendor.layout import resolve_layout
 from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord, SourceRecord
 from splendor.state.runtime import load_queue_item, load_run_record
 from splendor.state.source_compat import canonical_source_ref
-from splendor.state.source_registry import load_source_record, manifest_path_for
+from splendor.state.source_registry import load_source_record
 from splendor.utils.wiki import parse_wiki_markdown
 
 _SYNTHESIS_KINDS = {"architecture", "concept", "entity", "glossary", "topic"}
@@ -268,8 +268,6 @@ def _section_text(body: str, included_headings: set[str]) -> str:
     for raw_line in body.splitlines():
         line = raw_line.strip()
         if line.startswith("```") or line.startswith("~~~"):
-            if active:
-                sections.append(raw_line)
             in_fence = not in_fence
             continue
         if not in_fence and line.startswith("#"):
@@ -309,7 +307,6 @@ def _score_page(
         [
             page.frontmatter.title,
             page.frontmatter.page_id,
-            " ".join(page.frontmatter.tags),
             page.path,
             page.body,
         ]
@@ -352,7 +349,7 @@ def _score_page(
 def suggest_source_pages(root: Path, source_id: str) -> WikiSuggestResult:
     config = load_config(root)
     layout = resolve_layout(root, config)
-    manifest_path = manifest_path_for(root, source_id)
+    manifest_path = layout.source_records_dir / f"{source_id}.json"
     if not manifest_path.exists():
         msg = f"Unknown source ID: {source_id}"
         raise FileNotFoundError(msg)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -494,7 +494,7 @@ def test_cli_health_command_passes_for_valid_sources(tmp_path: Path, capsys) -> 
 
     assert exit_code == 0
     captured = capsys.readouterr()
-    assert "Checked records: 1" in captured.out
+    assert "Checked records: 2" in captured.out
     assert "Health check passed" in captured.out
     json_report, markdown_report = latest_report_paths(tmp_path, "health")
     assert json_report.stem == markdown_report.stem
@@ -502,7 +502,7 @@ def test_cli_health_command_passes_for_valid_sources(tmp_path: Path, capsys) -> 
     payload = json.loads(json_report.read_text(encoding="utf-8"))
     assert payload["command"] == "health"
     assert payload["status"] == "passed"
-    assert payload["checked_count"] == 1
+    assert payload["checked_count"] == 2
     assert payload["issue_count"] == 0
     markdown = markdown_report.read_text(encoding="utf-8")
     assert "# Splendor Health Report" in markdown

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -494,6 +494,7 @@ def test_cli_health_command_passes_for_valid_sources(tmp_path: Path, capsys) -> 
 
     assert exit_code == 0
     captured = capsys.readouterr()
+    # add-source now creates one source manifest and one pending queue record.
     assert "Checked records: 2" in captured.out
     assert "Health check passed" in captured.out
     json_report, markdown_report = latest_report_paths(tmp_path, "health")

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -96,11 +96,40 @@ def test_wiki_status_reports_state_counts(tmp_path: Path, capsys) -> None:
     assert payload["queue_status_counts"]["done"] == 1
     assert payload["run_status_counts"]["succeeded"] == 1
     assert payload["machine_generated_pages"] == 1
-    assert payload["review_needed_pages"] == 0
+    assert payload["review_needed_pages"] == 1
     assert payload["review_needed_synthesis_pages"] == 0
     assert payload["sources_missing_synthesis"] == 1
     assert payload["invalid_pages"] == 0
     assert payload["recent_runs"][0]["source_ids"] == [added.source_id]
+
+
+def test_wiki_status_text_output_reports_stable_counts(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "status-note.md"
+    source.write_text("# Status note\n\nWiki status text output.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "status"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Wiki status" in out
+    assert "Sources: total=1 registered=0 ingested=1 failed=0" in out
+    assert "Machine-generated pages: 1" in out
+    assert "Review-needed synthesis pages: 0" in out
+
+
+def test_wiki_status_uninitialized_workspace_reports_empty_state(tmp_path: Path, capsys) -> None:
+    exit_code = main(["--root", str(tmp_path), "wiki", "status", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["source_total"] == 0
+    assert payload["page_total"] == 0
+    assert payload["queue_total"] == 0
+    assert payload["run_total"] == 0
 
 
 def test_wiki_status_reports_invalid_pages_without_failing(tmp_path: Path, capsys) -> None:
@@ -116,6 +145,60 @@ def test_wiki_status_reports_invalid_pages_without_failing(tmp_path: Path, capsy
     assert payload["invalid_pages"] == 1
     assert payload["invalid_page_examples"][0]["path"] == "wiki/topics/bad.md"
     assert "failed schema validation" in payload["invalid_page_examples"][0]["error"]
+
+
+def test_wiki_status_counts_all_review_needed_pages_and_synthesis_subset(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "sources" / "src-123.md",
+        kind="source-summary",
+        title="Generated source summary",
+        page_id="src-123",
+        review_state="machine-generated",
+        source_refs=["src-123"],
+        body="Generated source summary.",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "draft-topic.md",
+        kind="topic",
+        title="Draft topic",
+        page_id="topic-draft",
+        review_state="draft",
+        body="Draft synthesis page.",
+    )
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "status", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["review_needed_pages"] == 2
+    assert payload["review_needed_synthesis_pages"] == 1
+
+
+def test_wiki_status_treats_canonical_source_ref_mentions_as_synthesis_followup(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "canonical-ref.md"
+    source.write_text("# Canonical ref\n\nA source cited by path.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "manual-followup.md",
+        kind="topic",
+        title="Manual follow-up",
+        page_id="topic-manual-followup",
+        body="This synthesis cites canonical-ref.md directly.",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "status", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["sources_missing_synthesis"] == 0
 
 
 def test_wiki_suggest_ranks_source_impact_pages(tmp_path: Path, capsys) -> None:
@@ -156,6 +239,66 @@ def test_wiki_suggest_ranks_source_impact_pages(tmp_path: Path, capsys) -> None:
         suggestion["path"] != "wiki/architecture/unrelated.md"
         for suggestion in payload["suggestions"]
     )
+
+
+def test_wiki_suggest_text_output_reports_top_suggestion(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "wiki-maintenance.md"
+    source.write_text(
+        "# Wiki maintenance\n\nThis source explains deterministic wiki suggest workflows.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "wiki-maintenance.md",
+        kind="topic",
+        title="Wiki maintenance workflow",
+        page_id="topic-wiki-maintenance",
+        source_refs=[added.source_id],
+        body="This page cites deterministic source-impact suggestions.",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "suggest", added.source_id])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Suggested pages:" in out
+    assert "wiki/topics/wiki-maintenance.md" in out
+
+
+def test_wiki_suggest_reports_unknown_source(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "suggest", "src-missing"])
+
+    assert exit_code == 1
+    assert "Unknown source ID: src-missing" in capsys.readouterr().out
+
+
+def test_wiki_suggest_scores_two_character_tags(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "ai-note.md"
+    source.write_text("# AI note\n\nShort tags should work.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "ai.md",
+        kind="topic",
+        title="AI",
+        page_id="topic-ai",
+        tags=["ai"],
+        body="Short tag page.",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "suggest", added.source_id, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["suggestions"][0]["path"] == "wiki/topics/ai.md"
+    assert "tag-overlap:ai" in payload["suggestions"][0]["reasons"]
 
 
 def test_wiki_suggest_ignores_source_summary_boilerplate_terms(tmp_path: Path, capsys) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -61,6 +61,22 @@ def test_add_source_queues_pending_ingest_for_cli_handoff(tmp_path: Path, capsys
     assert source_record.status == "ingested"
 
 
+def test_add_source_reports_warning_when_queue_handoff_fails(tmp_path: Path, capsys) -> None:
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nThis source is registered before init.\n", encoding="utf-8")
+
+    exit_code = main(["--root", str(tmp_path), "add-source", str(source)])
+
+    assert exit_code == 0
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    assert not (tmp_path / "state" / "queue" / f"ingest-{source_id}.json").exists()
+    out = capsys.readouterr().out
+    assert f"Registered source {source_id}" in out
+    assert "Warning: source registered but ingest was not queued:" in out
+    assert "Next: splendor init" in out
+    assert f"Then: splendor ingest {source_id}" in out
+
+
 def test_wiki_status_reports_state_counts(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "status-note.md"
@@ -80,9 +96,26 @@ def test_wiki_status_reports_state_counts(tmp_path: Path, capsys) -> None:
     assert payload["queue_status_counts"]["done"] == 1
     assert payload["run_status_counts"]["succeeded"] == 1
     assert payload["machine_generated_pages"] == 1
-    assert payload["review_needed_pages"] == 1
+    assert payload["review_needed_pages"] == 0
+    assert payload["review_needed_synthesis_pages"] == 0
     assert payload["sources_missing_synthesis"] == 1
+    assert payload["invalid_pages"] == 0
     assert payload["recent_runs"][0]["source_ids"] == [added.source_id]
+
+
+def test_wiki_status_reports_invalid_pages_without_failing(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    bad_page = tmp_path / "wiki" / "topics" / "bad.md"
+    bad_page.write_text("---\nkind: topic\nbogus: true\n---\n\n# Bad\n", encoding="utf-8")
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "status", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["page_total"] == 0
+    assert payload["invalid_pages"] == 1
+    assert payload["invalid_page_examples"][0]["path"] == "wiki/topics/bad.md"
+    assert "failed schema validation" in payload["invalid_page_examples"][0]["error"]
 
 
 def test_wiki_suggest_ranks_source_impact_pages(tmp_path: Path, capsys) -> None:
@@ -123,3 +156,37 @@ def test_wiki_suggest_ranks_source_impact_pages(tmp_path: Path, capsys) -> None:
         suggestion["path"] != "wiki/architecture/unrelated.md"
         for suggestion in payload["suggestions"]
     )
+
+
+def test_wiki_suggest_ignores_source_summary_boilerplate_terms(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "semantic-impact.md"
+    source.write_text(
+        "# Semantic impact\n\nThis source explains substantivealpha maintenance behavior.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "substantive-alpha.md",
+        kind="topic",
+        title="Substantive alpha",
+        page_id="topic-substantive-alpha",
+        body="This page discusses substantivealpha behavior.",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "generated-boilerplate.md",
+        kind="topic",
+        title="Generated boilerplate",
+        page_id="topic-generated-boilerplate",
+        body="This page only mentions checksum provenance pipeline version and run id.",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "suggest", added.source_id, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    suggestion_paths = [suggestion["path"] for suggestion in payload["suggestions"]]
+    assert "wiki/topics/substantive-alpha.md" in suggestion_paths
+    assert "wiki/topics/generated-boilerplate.md" not in suggestion_paths

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -1,0 +1,125 @@
+import json
+from pathlib import Path
+
+import yaml
+
+from splendor.cli import main
+from splendor.commands.add_source import add_source
+from splendor.commands.init import initialize_workspace
+from splendor.schemas import KnowledgePageFrontmatter
+from splendor.state.source_registry import load_source_record
+
+
+def write_wiki_page(
+    path: Path,
+    *,
+    kind: str,
+    title: str,
+    page_id: str,
+    review_state: str = "draft",
+    source_refs: list[str] | None = None,
+    tags: list[str] | None = None,
+    body: str = "",
+) -> None:
+    frontmatter = KnowledgePageFrontmatter(
+        kind=kind,
+        title=title,
+        page_id=page_id,
+        status="active",
+        review_state=review_state,
+        source_refs=source_refs or [],
+        tags=tags or [],
+        confidence=0.8,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frontmatter_text = yaml.safe_dump(frontmatter.model_dump(mode="json"), sort_keys=False).strip()
+    path.write_text(f"---\n{frontmatter_text}\n---\n\n{body}", encoding="utf-8")
+
+
+def test_add_source_queues_pending_ingest_for_cli_handoff(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nThis source covers wiki maintenance.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "add-source", str(source)])
+
+    assert exit_code == 0
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    assert queue_path.exists()
+    out = capsys.readouterr().out
+    assert "Queued ingest:" in out
+    assert "Next: splendor ingest --pending" in out
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+
+    assert exit_code == 0
+    source_record = load_source_record(
+        tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
+    )
+    assert source_record.status == "ingested"
+
+
+def test_wiki_status_reports_state_counts(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "status-note.md"
+    source.write_text(
+        "# Status note\n\nWiki status should find missing synthesis.\n", encoding="utf-8"
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "status", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["source_counts"]["ingested"] == 1
+    assert payload["page_kind_counts"]["source-summary"] == 1
+    assert payload["queue_status_counts"]["done"] == 1
+    assert payload["run_status_counts"]["succeeded"] == 1
+    assert payload["machine_generated_pages"] == 1
+    assert payload["review_needed_pages"] == 1
+    assert payload["sources_missing_synthesis"] == 1
+    assert payload["recent_runs"][0]["source_ids"] == [added.source_id]
+
+
+def test_wiki_suggest_ranks_source_impact_pages(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "wiki-maintenance.md"
+    source.write_text(
+        "# Wiki maintenance\n\nThis source explains deterministic wiki suggest workflows.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "wiki-maintenance.md",
+        kind="topic",
+        title="Wiki maintenance workflow",
+        page_id="topic-wiki-maintenance",
+        source_refs=[added.source_id],
+        tags=["wiki", "maintenance"],
+        body="This page cites deterministic source-impact suggestions.",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "architecture" / "unrelated.md",
+        kind="architecture",
+        title="Storage layout",
+        page_id="architecture-storage-layout",
+        body="This page covers raw artifact storage.",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "suggest", added.source_id, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["source_id"] == added.source_id
+    assert payload["suggestions"][0]["path"] == "wiki/topics/wiki-maintenance.md"
+    assert "frontmatter-source-ref" in payload["suggestions"][0]["reasons"]
+    assert all(
+        suggestion["path"] != "wiki/architecture/unrelated.md"
+        for suggestion in payload["suggestions"]
+    )

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -299,6 +299,7 @@ def test_wiki_suggest_scores_two_character_tags(tmp_path: Path, capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["suggestions"][0]["path"] == "wiki/topics/ai.md"
     assert "tag-overlap:ai" in payload["suggestions"][0]["reasons"]
+    assert "term-overlap:ai" not in payload["suggestions"][0]["reasons"]
 
 
 def test_wiki_suggest_ignores_source_summary_boilerplate_terms(tmp_path: Path, capsys) -> None:
@@ -333,3 +334,37 @@ def test_wiki_suggest_ignores_source_summary_boilerplate_terms(tmp_path: Path, c
     suggestion_paths = [suggestion["path"] for suggestion in payload["suggestions"]]
     assert "wiki/topics/substantive-alpha.md" in suggestion_paths
     assert "wiki/topics/generated-boilerplate.md" not in suggestion_paths
+
+
+def test_wiki_suggest_ignores_extract_fence_info_string(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "semantic-impact.md"
+    source.write_text(
+        "# Semantic impact\n\nThis source explains substantivealpha behavior.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "substantive-alpha.md",
+        kind="topic",
+        title="Substantive alpha",
+        page_id="topic-substantive-alpha",
+        body="This page discusses substantivealpha behavior.",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "fence-info.md",
+        kind="topic",
+        title="Fence info",
+        page_id="topic-fence-info",
+        body="This page only mentions text fences.",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "suggest", added.source_id, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    suggestion_paths = [suggestion["path"] for suggestion in payload["suggestions"]]
+    assert "wiki/topics/substantive-alpha.md" in suggestion_paths
+    assert "wiki/topics/fence-info.md" not in suggestion_paths


### PR DESCRIPTION
## Summary

Implements the `M10-P0.1` text-native wiki maintenance bridge:

- adds `splendor wiki status` with human and JSON output for source/page/queue/run/review state, recent runs, contested pages, machine-generated pages, and missing synthesis follow-up counts
- adds `splendor wiki suggest <source-id>` with deterministic synthesis-page ranking over source metadata, source-summary text, frontmatter source refs, tags, source refs, and page content
- queues CLI-added sources for `splendor ingest --pending` and prints next-step hints after add-source and ingest
- updates quickstart, dogfooding guidance, product spec, roadmap, README, and planning state for `M10-P0.1`

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest`
- `uv run splendor lint`
- dogfood check: `uv run splendor wiki status --json`

## Follow-up

`M10-P0.2` should add project briefing and define the review-gated compile/update contract. Mutating `splendor wiki compile` is intentionally not implemented in this PR.

Closes #40.
Related #43.