### PR TITLE
M10-P0.2 project briefing and compile-loop contract

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -123,7 +123,7 @@
   - [x] Queue new CLI-added sources for `splendor ingest --pending`
   - [x] Update tests and docs for the text-native maintenance bridge
   - [x] Publish a non-draft GitHub PR for `M10-P0.1` with labels, milestone, and a detailed description
-- [ ] Implement `M10-P0.2`: Project briefing and compile-loop contract
+- [x] Implement `M10-P0.2`: Project briefing and compile-loop contract
   - [x] Add an initial `splendor brief [goal]` command over wiki, planning, source, and run state
   - [x] Add a non-mutating `splendor wiki compile <source-id>` contract surface
   - [x] Preserve source-summary generation as separate from synthesis-page maintenance

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M9-P1.3`
-- Last action taken: `M9-P1.3` is implemented; knowledge-work dogfooding expanded the wiki and filed follow-up product tasks for the maintenance loop.
+- Previous completed PR sub-slice: `M10-P0.1`
+- Last action taken: `M10-P0.1` is implemented; wiki status, source-impact suggestions, and pending-ingest handoff now support the text-native maintenance loop.
 - Current planned slice: `M10-P0`
-- Current PR sub-slice: `M10-P0.1`
+- Current PR sub-slice: `M10-P0.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M10-P0`
-- Next planned PR sub-slice: `M10-P0.2`
+- Next planned PR sub-slice: `M10-P0.3`
 - Current blockers: none
 
 ## Planning Notation
@@ -117,12 +117,18 @@
   - [x] Register and ingest the new sources into source manifests, queue records, run records, and wiki summaries
   - [x] Synthesize the findings into wiki topic and architecture pages
   - [x] File product follow-up tasks for the bugs and missing workflow affordances found
-- [ ] Implement `M10-P0.1`: Wiki status and source-impact suggestions
+- [x] Implement `M10-P0.1`: Wiki status and source-impact suggestions
   - [x] Add `splendor wiki status` for source/page/queue/run/review state
   - [x] Add `splendor wiki suggest <source-id>` for deterministic synthesis-page suggestions
   - [x] Queue new CLI-added sources for `splendor ingest --pending`
   - [x] Update tests and docs for the text-native maintenance bridge
   - [x] Publish a non-draft GitHub PR for `M10-P0.1` with labels, milestone, and a detailed description
+- [ ] Implement `M10-P0.2`: Project briefing and compile-loop contract
+  - [x] Add an initial `splendor brief [goal]` command over wiki, planning, source, and run state
+  - [x] Add a non-mutating `splendor wiki compile <source-id>` contract surface
+  - [x] Preserve source-summary generation as separate from synthesis-page maintenance
+  - [x] Update tests and docs for the briefing and compile-loop contract
+  - [ ] Publish a non-draft GitHub PR for `M10-P0.2` with labels, milestone, and a detailed description
 
 ## Context Pointers
 

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -128,7 +128,7 @@
   - [x] Add a non-mutating `splendor wiki compile <source-id>` contract surface
   - [x] Preserve source-summary generation as separate from synthesis-page maintenance
   - [x] Update tests and docs for the briefing and compile-loop contract
-  - [ ] Publish a non-draft GitHub PR for `M10-P0.2` with labels, milestone, and a detailed description
+  - [x] Publish a non-draft GitHub PR for `M10-P0.2` with labels, milestone, and a detailed description
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -120,13 +120,14 @@ Implemented today:
 - `splendor repo refresh`
 - `splendor wiki status`
 - `splendor wiki suggest <source-id>`
+- `splendor wiki compile <source-id>` as a non-mutating review-gated contract description
+- `splendor brief [goal]`
 - `splendor serve` for a read-only local browse/search UI
 - `splendor lint` and `splendor health`
 
 Not implemented yet:
 
-- review-gated `splendor wiki compile`
-- project briefing over wiki, planning, source, and run state
+- mutating review-gated `splendor wiki compile`
 - broader next-action hints after query and file-answer commands
 - web status overview and source detail pages
 - OCR and image extraction flows
@@ -146,12 +147,12 @@ Not implemented yet:
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M9-P1.3`
+- Previous completed PR sub-slice: `M10-P0.1`
 - Current planned slice: `M10-P0`
-- Current PR sub-slice: `M10-P0.1`
+- Current PR sub-slice: `M10-P0.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M10-P0`
-- Next planned PR sub-slice: `M10-P0.2`
+- Next planned PR sub-slice: `M10-P0.3`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -172,10 +173,11 @@ sparse-workspace UI, non-mutating query validation, more useful source summaries
 contradiction-review noise reduction. `M9-P1.3` is implemented: knowledge-work dogfooding expanded
 the wiki and filed follow-up product tasks.
 
-The current PR sub-slice is `M10-P0.1`, which adds a CLI-first wiki status and source-impact
-suggestion bridge before deeper planning/runs UI or rich-source work. The goal is to make the
-text-native loop explicit: ingest creates source summaries; source-impact and compile workflows
-maintain concept, entity, topic, architecture, and glossary pages.
+`M10-P0.1` is implemented: Splendor now has CLI-first wiki status and source-impact suggestions
+for the text-native maintenance loop. The current PR sub-slice is `M10-P0.2`, which adds the first
+project briefing command and documents the review-gated compile-loop contract without mutating
+synthesis pages. The goal remains explicit separation: ingest creates source summaries; reviewed
+compile/update workflows maintain concept, entity, topic, architecture, and glossary pages.
 
 The follow-on dogfood polish slice is `M10-P0.3`. It should smooth the visible workflow around
 `add-source -> ingest -> wiki suggest -> review`, add restrained next-action hints to command

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,16 +334,18 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M9-P1.3`
+- Previous completed PR sub-slice: `M10-P0.1`
 - Current planned slice: `M10-P0`
-- Current PR sub-slice: `M10-P0.1`
+- Current PR sub-slice: `M10-P0.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M10-P0`
-- Next planned PR sub-slice: `M10-P0.2`
+- Next planned PR sub-slice: `M10-P0.3`
 
-The current PR sub-slice is `M10-P0.1`, under parent slice `M10-P0`, which adds the CLI-first
-wiki status and source-impact suggestion bridge. The lifecycle marker means `M10-P0.1` is in
-progress on feature branches and merged once the same committed state is observed on `main`.
+`M10-P0.1` is implemented: the CLI-first wiki status and source-impact suggestion bridge is in
+place. The current PR sub-slice is `M10-P0.2`, under parent slice `M10-P0`, which adds project
+briefing and the non-mutating review-gated compile-loop contract. The lifecycle marker means
+`M10-P0.2` is in progress on feature branches and merged once the same committed state is observed
+on `main`.
 
 Dogfooding also changed the recommended next slice: before deeper planning/runs UI work, Splendor
 should add a small CLI-first bridge for wiki status, source-impact suggestions, and project
@@ -566,10 +568,10 @@ empty states, explicit special-file browse treatment, non-mutating query validat
 markdown source summaries, and contradiction-review filtering for source-summary metadata
 boilerplate. `M9-P1.3` adds three researched dogfood rounds, extends the wiki with tool-landscape
 and agent-context synthesis, and files follow-up product tasks from the observed workflow friction.
-The current recommended slice is `M10-P0.1`, which adds CLI-first wiki status and source-impact
-suggestions before deeper planning/runs UI work. `M10-P0.2` should follow with project briefing
-and a documented review-gated compile-loop contract. `M10-P0.3` should then polish the visible
-dogfood workflow with query snippet improvements and read-only web status/source-detail surfaces.
+`M10-P0.1` adds CLI-first wiki status and source-impact suggestions before deeper planning/runs UI
+work. The current recommended slice is `M10-P0.2`, which adds project briefing and a documented,
+non-mutating review-gated compile-loop contract. `M10-P0.3` should then polish the visible dogfood
+workflow with query snippet improvements and read-only web status/source-detail surfaces.
 Mutating web actions, add-source forms, and planning/runs views remain deferred to later `M9`
 slices.
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -648,6 +648,12 @@ This workflow should start with text-native sources and deterministic page-impac
 compile step may remain human-reviewed or LLM-assisted behind explicit confirmation until the
 contract is trustworthy.
 
+Initial `splendor wiki compile <source-id>` support is intentionally non-mutating. It validates the
+source record and prints the review-gated contract: inspect the source summary, run source-impact
+suggestions, propose synthesis-page edits with provenance/run state, keep generated source-summary
+pages separate from maintained synthesis pages, and require human review before wiki synthesis is
+changed.
+
 Command output should support the workflow without becoming noisy. After `add-source`, Splendor
 should print the exact next ingest command or enqueue the source for pending ingestion. After
 `ingest`, it should point to the generated source-summary page and, once available, the relevant
@@ -667,7 +673,9 @@ Current implementation:
 - `splendor wiki suggest <source-id>` deterministically ranks existing synthesis pages using source
   metadata, source-summary text, frontmatter source refs, tags, source refs, and page content, with
   optional JSON output.
-- Mutating `splendor wiki compile <source-id>` remains deferred to the review-gated compile-loop
+- `splendor wiki compile <source-id>` exposes the review-gated compile-loop contract, validates the
+  source, and reports that it does not mutate synthesis pages yet.
+- Mutating `splendor wiki compile <source-id>` remains deferred to a later reviewed compile-loop
   slice.
 
 Later optional support:
@@ -797,6 +805,14 @@ A briefing command or UI view should assemble:
 
 This is the natural bridge between repository-local memory and limited model context. Search finds
 records; a briefing prepares compact working context for a session.
+
+Current implementation:
+
+- `splendor brief [goal]` assembles a terminal-friendly and JSON project brief from deterministic
+  query matches, wiki status, active planning records, recent sources/runs, latest lint/health
+  reports, the last query snapshot, and likely next actions.
+- Briefing is read-only and does not replace `splendor query`; query finds records, while briefing
+  packages the surrounding project state needed to resume work.
 
 ## 18. Search Model
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -810,6 +810,11 @@ def handle_brief(args: argparse.Namespace) -> int:
             print(f"- {report.command}: {report.status} issues={report.issue_count}")
     if result.last_query is not None:
         print(f"Last query: {result.last_query.query} ({result.last_query.match_count} matches)")
+    if result.warnings:
+        print("Warnings:")
+        for warning in result.warnings:
+            subject = warning.path or warning.area
+            print(f"- {subject}: {warning.message}")
     print("Next actions:")
     for action in result.next_actions:
         print(f"- {action}")

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from splendor import __version__
 from splendor.commands.add_source import add_source
+from splendor.commands.brief import build_project_brief, render_project_brief_json
 from splendor.commands.file_answer import (
     default_answer_page_id,
     file_answer_from_last_query,
@@ -32,6 +33,8 @@ from splendor.commands.repo_refresh import refresh_repo, render_repo_refresh_jso
 from splendor.commands.repo_scan import render_repo_scan_json, scan_repo
 from splendor.commands.wiki import (
     build_wiki_status,
+    describe_wiki_compile_contract,
+    render_wiki_compile_contract_json,
     render_wiki_status_json,
     render_wiki_suggest_json,
     suggest_source_pages,
@@ -133,6 +136,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     wiki_suggest_parser.set_defaults(handler=handle_wiki_suggest)
+    wiki_compile_parser = wiki_subparsers.add_parser(
+        "compile", help="Describe the review-gated synthesis compile contract for a source"
+    )
+    wiki_compile_parser.add_argument("source_id", help="Registered source identifier to inspect")
+    wiki_compile_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    wiki_compile_parser.set_defaults(handler=handle_wiki_compile)
 
     materialize_parser = subparsers.add_parser(
         "materialize-source", help="Create or refresh a source storage artifact"
@@ -180,6 +194,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Do not update the last-query snapshot.",
     )
     query_parser.set_defaults(handler=handle_query)
+
+    brief_parser = subparsers.add_parser(
+        "brief", help="Assemble a compact project briefing for a goal"
+    )
+    brief_parser.add_argument("goal", nargs="*", help="Optional goal or search phrase.")
+    brief_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    brief_parser.set_defaults(handler=handle_brief)
 
     serve_parser = subparsers.add_parser("serve", help="Run the read-only local web UI")
     serve_parser.add_argument(
@@ -557,6 +583,31 @@ def handle_wiki_suggest(args: argparse.Namespace) -> int:
     return 0
 
 
+def handle_wiki_compile(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = describe_wiki_compile_contract(root, args.source_id)
+    except (FileNotFoundError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_wiki_compile_contract_json(result))
+        return 0
+
+    print(f"Source: {result.source_id}")
+    print(f"Title: {result.source_title}")
+    print(f"Source ref: {result.source_ref}")
+    print(f"Status: {result.source_status}")
+    print("Compile contract: review-gated synthesis maintenance")
+    print("Mutates wiki: no")
+    for item in result.contract:
+        print(f"- {item}")
+    print("Next steps:")
+    for item in result.next_steps:
+        print(f"- {item}")
+    return 0
+
+
 def handle_materialize_source(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     try:
@@ -708,6 +759,60 @@ def handle_query(args: argparse.Namespace) -> int:
             print(f"   Contradictions: {match.contradiction_count}")
         if match.review_task_ids:
             print(f"   Review tasks: {', '.join(match.review_task_ids)}")
+    return 0
+
+
+def handle_brief(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    goal = " ".join(args.goal).strip() or None
+    try:
+        result = build_project_brief(root, goal)
+    except (OSError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_project_brief_json(result))
+        return 0
+
+    print("Project brief")
+    print(f"Goal: {result.goal or '-'}")
+    if result.query_summary is not None:
+        print(f"Query: {result.query_summary}")
+    print(
+        "State: "
+        f"sources={result.status.source_total} "
+        f"pages={result.status.page_total} "
+        f"queue={result.status.queue_total} "
+        f"runs={result.status.run_total} "
+        f"review_needed={result.status.review_needed_pages} "
+        f"synthesis_followup={result.status.sources_missing_synthesis}"
+    )
+    if result.matches:
+        print("Relevant records:")
+        for match in result.matches:
+            print(f"- {match.path} [{match.kind}] score={match.score}: {match.title}")
+    if result.planning_items:
+        print("Active planning:")
+        for item in result.planning_items:
+            print(f"- {item.record_id} [{item.kind}/{item.status}] {item.title}")
+    if result.recent_sources:
+        print("Recent sources:")
+        for source in result.recent_sources:
+            print(f"- {source.source_id} [{source.status}] {source.title}")
+    if result.recent_runs:
+        print("Recent runs:")
+        for run in result.recent_runs:
+            finished = run.finished_at or "-"
+            print(f"- {run.run_id} {run.status} finished={finished}")
+    if result.latest_reports:
+        print("Latest maintenance:")
+        for report in result.latest_reports:
+            print(f"- {report.command}: {report.status} issues={report.issue_count}")
+    if result.last_query is not None:
+        print(f"Last query: {result.last_query.query} ({result.last_query.match_count} matches)")
+    print("Next actions:")
+    for action in result.next_actions:
+        print(f"- {action}")
     return 0
 
 

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -24,7 +24,6 @@ from .wiki import (
     RecentRunSnapshot,
     WikiStatus,
     build_wiki_status,
-    load_recent_runs,
     load_sources,
 )
 
@@ -61,6 +60,13 @@ class BriefPlanningItem:
     title: str
     status: str
     path: str
+
+
+@dataclass(frozen=True)
+class BriefWarning:
+    area: str
+    path: str | None
+    message: str
 
 
 @dataclass(frozen=True)
@@ -101,6 +107,7 @@ class ProjectBrief:
     recent_runs: list[RecentRunSnapshot]
     latest_reports: list[BriefReportSnapshot]
     last_query: BriefLastQuery | None
+    warnings: list[BriefWarning]
     next_actions: list[str]
 
 
@@ -114,18 +121,24 @@ def build_project_brief(root: Path, goal: str | None) -> ProjectBrief:
     if normalized_goal:
         try:
             query_result = run_query(root, normalized_goal)
-        except QueryValidationError:
+        except (QueryValidationError, OSError, ValueError) as exc:
             query_result = None
+            query_summary = f"Query skipped: {_brief_error(exc)}"
         if query_result is not None:
             query_summary = query_result.summary
             matches = [_brief_match(match) for match in query_result.matches[:_BRIEF_MATCH_LIMIT]]
 
-    planning_items = _active_planning_items(root, layout)
+    planning_items, warnings = _active_planning_items(root, layout)
     recent_sources = _recent_sources(root, layout)
-    recent_runs = load_recent_runs(layout)
+    recent_runs = status.recent_runs
     latest_reports = _latest_reports(root, layout)
     last_query = _last_query(layout)
-    next_actions = _next_actions(status=status, matches=matches, planning_items=planning_items)
+    next_actions = _next_actions(
+        status=status,
+        matches=matches,
+        planning_items=planning_items,
+        warnings=warnings,
+    )
     return ProjectBrief(
         goal=normalized_goal or None,
         query_summary=query_summary,
@@ -136,6 +149,7 @@ def build_project_brief(root: Path, goal: str | None) -> ProjectBrief:
         recent_runs=recent_runs,
         latest_reports=latest_reports,
         last_query=last_query,
+        warnings=warnings,
         next_actions=next_actions,
     )
 
@@ -155,13 +169,30 @@ def _brief_match(match: QueryMatch) -> BriefMatch:
     )
 
 
-def _active_planning_items(root: Path, layout) -> list[BriefPlanningItem]:
+def _brief_error(exc: Exception) -> str:
+    return " ".join(str(exc).splitlines()).strip() or exc.__class__.__name__
+
+
+def _active_planning_items(
+    root: Path, layout
+) -> tuple[list[BriefPlanningItem], list[BriefWarning]]:
     items: list[BriefPlanningItem] = []
+    warnings: list[BriefWarning] = []
     for kind, statuses in _PLANNING_STATUSES.items():
         model = model_for_planning_kind(kind)
         id_field = record_id_field(kind)
         for path in iter_planning_paths(planning_directory(layout, kind)):
-            parsed = parse_planning_document(path, model)
+            try:
+                parsed = parse_planning_document(path, model)
+            except (OSError, ValueError) as exc:
+                warnings.append(
+                    BriefWarning(
+                        area="planning",
+                        path=path.relative_to(root).as_posix(),
+                        message=_brief_error(exc),
+                    )
+                )
+                continue
             record = parsed.record
             status = record.status
             if status not in statuses:
@@ -176,7 +207,7 @@ def _active_planning_items(root: Path, layout) -> list[BriefPlanningItem]:
                 )
             )
     items.sort(key=lambda item: (item.kind, item.status, item.record_id))
-    return items[:_BRIEF_PLANNING_LIMIT]
+    return items[:_BRIEF_PLANNING_LIMIT], warnings
 
 
 def _recent_sources(root: Path, layout) -> list[BriefSourceItem]:
@@ -232,6 +263,7 @@ def _next_actions(
     status: WikiStatus,
     matches: list[BriefMatch],
     planning_items: list[BriefPlanningItem],
+    warnings: list[BriefWarning],
 ) -> list[str]:
     actions: list[str] = []
     if status.queue_status_counts.get("pending", 0):
@@ -249,6 +281,8 @@ def _next_actions(
         actions.append("Open the top matching wiki or planning records for the stated goal.")
     if planning_items:
         actions.append("Continue or close the active planning records listed in this brief.")
+    if warnings:
+        actions.append("Fix skipped planning records so future briefs include the full plan state.")
     if not actions:
         actions.append(
             "Run `splendor add-source <path>` or `splendor query <question>` to extend "
@@ -262,27 +296,14 @@ def render_project_brief_json(brief: ProjectBrief) -> str:
         {
             "goal": brief.goal,
             "query_summary": brief.query_summary,
-            "status": {
-                "source_total": brief.status.source_total,
-                "source_counts": brief.status.source_counts,
-                "page_total": brief.status.page_total,
-                "page_kind_counts": brief.status.page_kind_counts,
-                "queue_total": brief.status.queue_total,
-                "queue_status_counts": brief.status.queue_status_counts,
-                "run_total": brief.status.run_total,
-                "run_status_counts": brief.status.run_status_counts,
-                "review_state_counts": brief.status.review_state_counts,
-                "review_needed_pages": brief.status.review_needed_pages,
-                "review_needed_synthesis_pages": brief.status.review_needed_synthesis_pages,
-                "sources_missing_synthesis": brief.status.sources_missing_synthesis,
-                "invalid_pages": brief.status.invalid_pages,
-            },
+            "status": asdict(brief.status),
             "matches": [asdict(match) for match in brief.matches],
             "planning_items": [asdict(item) for item in brief.planning_items],
             "recent_sources": [asdict(source) for source in brief.recent_sources],
             "recent_runs": [asdict(run) for run in brief.recent_runs],
             "latest_reports": [asdict(report) for report in brief.latest_reports],
             "last_query": asdict(brief.last_query) if brief.last_query else None,
+            "warnings": [asdict(warning) for warning in brief.warnings],
             "next_actions": brief.next_actions,
         },
         indent=2,

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -1,0 +1,289 @@
+"""Project briefing command implementation."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import MaintenanceReport, QuerySnapshot
+from splendor.state.query_snapshot import last_query_path_for
+from splendor.state.source_compat import canonical_source_ref
+from splendor.utils.planning import (
+    iter_planning_paths,
+    parse_planning_document,
+    planning_directory,
+    record_id_field,
+)
+
+from .planning import model_for_planning_kind
+from .query import QueryMatch, QueryValidationError, run_query
+from .wiki import (
+    RecentRunSnapshot,
+    WikiStatus,
+    build_wiki_status,
+    load_recent_runs,
+    load_sources,
+)
+
+_BRIEF_MATCH_LIMIT = 5
+_BRIEF_PLANNING_LIMIT = 8
+_BRIEF_SOURCE_LIMIT = 5
+_BRIEF_REPORT_COMMANDS = ("lint", "health")
+_PLANNING_STATUSES = {
+    "task": {"todo", "in_progress", "blocked"},
+    "milestone": {"planned", "active"},
+    "decision": {"proposed"},
+    "question": {"open", "deferred"},
+}
+
+
+@dataclass(frozen=True)
+class BriefMatch:
+    rank: int
+    score: int
+    document_class: str
+    kind: str
+    record_id: str
+    title: str
+    path: str
+    review_state: str | None
+    source_refs: list[str]
+    snippet: str
+
+
+@dataclass(frozen=True)
+class BriefPlanningItem:
+    kind: str
+    record_id: str
+    title: str
+    status: str
+    path: str
+
+
+@dataclass(frozen=True)
+class BriefSourceItem:
+    source_id: str
+    title: str
+    status: str
+    review_state: str
+    source_ref: str
+    last_run_id: str | None
+
+
+@dataclass(frozen=True)
+class BriefReportSnapshot:
+    command: str
+    status: str
+    created_at: str
+    issue_count: int
+    path: str
+
+
+@dataclass(frozen=True)
+class BriefLastQuery:
+    query: str
+    created_at: str
+    match_count: int
+    summary: str
+
+
+@dataclass(frozen=True)
+class ProjectBrief:
+    goal: str | None
+    query_summary: str | None
+    status: WikiStatus
+    matches: list[BriefMatch]
+    planning_items: list[BriefPlanningItem]
+    recent_sources: list[BriefSourceItem]
+    recent_runs: list[RecentRunSnapshot]
+    latest_reports: list[BriefReportSnapshot]
+    last_query: BriefLastQuery | None
+    next_actions: list[str]
+
+
+def build_project_brief(root: Path, goal: str | None) -> ProjectBrief:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    status = build_wiki_status(root)
+    normalized_goal = goal.strip() if goal is not None else ""
+    query_summary: str | None = None
+    matches: list[BriefMatch] = []
+    if normalized_goal:
+        try:
+            query_result = run_query(root, normalized_goal)
+        except QueryValidationError:
+            query_result = None
+        if query_result is not None:
+            query_summary = query_result.summary
+            matches = [_brief_match(match) for match in query_result.matches[:_BRIEF_MATCH_LIMIT]]
+
+    planning_items = _active_planning_items(root, layout)
+    recent_sources = _recent_sources(root, layout)
+    recent_runs = load_recent_runs(layout)
+    latest_reports = _latest_reports(root, layout)
+    last_query = _last_query(layout)
+    next_actions = _next_actions(status=status, matches=matches, planning_items=planning_items)
+    return ProjectBrief(
+        goal=normalized_goal or None,
+        query_summary=query_summary,
+        status=status,
+        matches=matches,
+        planning_items=planning_items,
+        recent_sources=recent_sources,
+        recent_runs=recent_runs,
+        latest_reports=latest_reports,
+        last_query=last_query,
+        next_actions=next_actions,
+    )
+
+
+def _brief_match(match: QueryMatch) -> BriefMatch:
+    return BriefMatch(
+        rank=match.rank,
+        score=match.score,
+        document_class=match.document_class,
+        kind=match.kind,
+        record_id=match.record_id,
+        title=match.title,
+        path=match.path,
+        review_state=match.review_state,
+        source_refs=match.source_refs,
+        snippet=match.snippet,
+    )
+
+
+def _active_planning_items(root: Path, layout) -> list[BriefPlanningItem]:
+    items: list[BriefPlanningItem] = []
+    for kind, statuses in _PLANNING_STATUSES.items():
+        model = model_for_planning_kind(kind)
+        id_field = record_id_field(kind)
+        for path in iter_planning_paths(planning_directory(layout, kind)):
+            parsed = parse_planning_document(path, model)
+            record = parsed.record
+            status = record.status
+            if status not in statuses:
+                continue
+            items.append(
+                BriefPlanningItem(
+                    kind=kind,
+                    record_id=str(getattr(record, id_field)),
+                    title=record.title,
+                    status=status,
+                    path=path.relative_to(root).as_posix(),
+                )
+            )
+    items.sort(key=lambda item: (item.kind, item.status, item.record_id))
+    return items[:_BRIEF_PLANNING_LIMIT]
+
+
+def _recent_sources(root: Path, layout) -> list[BriefSourceItem]:
+    sources = sorted(load_sources(layout), key=lambda source: (source.added_at, source.source_id))
+    return [
+        BriefSourceItem(
+            source_id=source.source_id,
+            title=source.title,
+            status=source.status,
+            review_state=source.review_state,
+            source_ref=canonical_source_ref(source),
+            last_run_id=source.last_run_id,
+        )
+        for source in reversed(sources[-_BRIEF_SOURCE_LIMIT:])
+    ]
+
+
+def _latest_reports(root: Path, layout) -> list[BriefReportSnapshot]:
+    reports: list[BriefReportSnapshot] = []
+    for command in _BRIEF_REPORT_COMMANDS:
+        report_paths = sorted((layout.reports_dir / command).glob("*.json"))
+        if not report_paths:
+            continue
+        path = report_paths[-1]
+        report = MaintenanceReport.model_validate_json(path.read_text(encoding="utf-8"))
+        reports.append(
+            BriefReportSnapshot(
+                command=command,
+                status=report.status,
+                created_at=report.created_at,
+                issue_count=report.issue_count,
+                path=path.relative_to(root).as_posix(),
+            )
+        )
+    return reports
+
+
+def _last_query(layout) -> BriefLastQuery | None:
+    path = last_query_path_for(layout)
+    if not path.exists():
+        return None
+    snapshot = QuerySnapshot.model_validate_json(path.read_text(encoding="utf-8"))
+    return BriefLastQuery(
+        query=snapshot.query,
+        created_at=snapshot.created_at,
+        match_count=snapshot.match_count,
+        summary=snapshot.summary,
+    )
+
+
+def _next_actions(
+    *,
+    status: WikiStatus,
+    matches: list[BriefMatch],
+    planning_items: list[BriefPlanningItem],
+) -> list[str]:
+    actions: list[str] = []
+    if status.queue_status_counts.get("pending", 0):
+        actions.append("Run `splendor ingest --pending` to drain pending source ingests.")
+    if status.invalid_pages:
+        actions.append("Fix invalid wiki pages before relying on synthesis or query output.")
+    if status.sources_missing_synthesis:
+        actions.append(
+            "Run `splendor wiki suggest <source-id>` for ingested sources missing "
+            "synthesis follow-up."
+        )
+    if status.review_needed_synthesis_pages:
+        actions.append("Review draft, stale, contested, or machine-generated synthesis pages.")
+    if matches:
+        actions.append("Open the top matching wiki or planning records for the stated goal.")
+    if planning_items:
+        actions.append("Continue or close the active planning records listed in this brief.")
+    if not actions:
+        actions.append(
+            "Run `splendor add-source <path>` or `splendor query <question>` to extend "
+            "the project context."
+        )
+    return actions
+
+
+def render_project_brief_json(brief: ProjectBrief) -> str:
+    return json.dumps(
+        {
+            "goal": brief.goal,
+            "query_summary": brief.query_summary,
+            "status": {
+                "source_total": brief.status.source_total,
+                "source_counts": brief.status.source_counts,
+                "page_total": brief.status.page_total,
+                "page_kind_counts": brief.status.page_kind_counts,
+                "queue_total": brief.status.queue_total,
+                "queue_status_counts": brief.status.queue_status_counts,
+                "run_total": brief.status.run_total,
+                "run_status_counts": brief.status.run_status_counts,
+                "review_state_counts": brief.status.review_state_counts,
+                "review_needed_pages": brief.status.review_needed_pages,
+                "review_needed_synthesis_pages": brief.status.review_needed_synthesis_pages,
+                "sources_missing_synthesis": brief.status.sources_missing_synthesis,
+                "invalid_pages": brief.status.invalid_pages,
+            },
+            "matches": [asdict(match) for match in brief.matches],
+            "planning_items": [asdict(item) for item in brief.planning_items],
+            "recent_sources": [asdict(source) for source in brief.recent_sources],
+            "recent_runs": [asdict(run) for run in brief.recent_runs],
+            "latest_reports": [asdict(report) for report in brief.latest_reports],
+            "last_query": asdict(brief.last_query) if brief.last_query else None,
+            "next_actions": brief.next_actions,
+        },
+        indent=2,
+    )

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -109,11 +109,23 @@ class WikiSuggestResult:
     suggestions: list[WikiSuggestion]
 
 
+@dataclass(frozen=True)
+class WikiCompileContract:
+    source_id: str
+    source_title: str
+    source_ref: str
+    source_status: str
+    mutates: bool
+    status: str
+    contract: list[str]
+    next_steps: list[str]
+
+
 def _relative(root: Path, path: Path) -> str:
     return path.relative_to(root).as_posix()
 
 
-def _load_sources(layout) -> list[SourceRecord]:
+def load_sources(layout) -> list[SourceRecord]:
     sources: list[SourceRecord] = []
     for manifest_path in sorted(layout.source_records_dir.glob("*.json")):
         sources.append(load_source_record(manifest_path))
@@ -180,10 +192,14 @@ def _recent_runs(runs: list[RunRecord]) -> list[RecentRunSnapshot]:
     ]
 
 
+def load_recent_runs(layout) -> list[RecentRunSnapshot]:
+    return _recent_runs(_load_runs(layout))
+
+
 def build_wiki_status(root: Path) -> WikiStatus:
     config = load_config(root)
     layout = resolve_layout(root, config)
-    sources = _load_sources(layout)
+    sources = load_sources(layout)
     pages, invalid_pages = _load_wiki_pages(root, layout)
     queue_records = _load_queue(layout)
     runs = _load_runs(layout)
@@ -375,6 +391,38 @@ def suggest_source_pages(root: Path, source_id: str) -> WikiSuggestResult:
     )
 
 
+def describe_wiki_compile_contract(root: Path, source_id: str) -> WikiCompileContract:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    manifest_path = layout.source_records_dir / f"{source_id}.json"
+    if not manifest_path.exists():
+        msg = f"Unknown source ID: {source_id}"
+        raise FileNotFoundError(msg)
+
+    source = load_source_record(manifest_path)
+    return WikiCompileContract(
+        source_id=source.source_id,
+        source_title=source.title,
+        source_ref=canonical_source_ref(source),
+        source_status=source.status,
+        mutates=False,
+        status="contract-only",
+        contract=[
+            "Validate the source record and current source-summary page.",
+            "Use `splendor wiki suggest <source-id>` to identify affected synthesis pages.",
+            "Propose synthesis-page edits with source refs, provenance links, run state, "
+            "and review state.",
+            "Keep generated source-summary pages separate from maintained synthesis pages.",
+            "Require human review before mutating wiki synthesis pages.",
+        ],
+        next_steps=[
+            f"Run `splendor wiki suggest {source.source_id}`.",
+            "Review suggested synthesis pages and apply changes through a reviewed future "
+            "compile loop.",
+        ],
+    )
+
+
 def render_wiki_status_json(status: WikiStatus) -> str:
     return json.dumps(
         {
@@ -412,3 +460,7 @@ def render_wiki_suggest_json(result: WikiSuggestResult) -> str:
         },
         indent=2,
     )
+
+
+def render_wiki_compile_contract_json(result: WikiCompileContract) -> str:
+    return json.dumps(asdict(result), indent=2)

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -192,10 +192,6 @@ def _recent_runs(runs: list[RunRecord]) -> list[RecentRunSnapshot]:
     ]
 
 
-def load_recent_runs(layout) -> list[RecentRunSnapshot]:
-    return _recent_runs(_load_runs(layout))
-
-
 def build_wiki_status(root: Path) -> WikiStatus:
     config = load_config(root)
     layout = resolve_layout(root, config)

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -393,6 +393,30 @@ def test_wiki_compile_reports_review_gated_contract_without_mutating(
     assert page_path.read_text(encoding="utf-8") == before
 
 
+def test_wiki_compile_text_reports_review_gated_contract_without_mutating(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-contract.md"
+    source.write_text("# Compile contract\n\nSynthesis remains review-gated.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    page_path = tmp_path / "wiki" / "sources" / f"{added.source_id}.md"
+    before = page_path.read_text(encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "compile", added.source_id])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert f"Source: {added.source_id}" in out
+    assert "Compile contract" in out
+    assert "Mutates wiki: no" in out
+    assert "Next steps:" in out
+    assert "Run `splendor wiki suggest" in out
+    assert page_path.read_text(encoding="utf-8") == before
+
+
 def test_wiki_compile_reports_unknown_source(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
 
@@ -441,6 +465,8 @@ def test_brief_json_includes_goal_state_matches_planning_and_next_actions(
     payload = json.loads(capsys.readouterr().out)
     assert payload["goal"] == "project briefing"
     assert payload["status"]["source_total"] == 1
+    assert "recent_runs" in payload["status"]
+    assert "machine_generated_pages" in payload["status"]
     assert payload["matches"][0]["path"] == "wiki/topics/project-briefing.md"
     assert payload["planning_items"][0]["record_id"] == "task-briefing"
     assert payload["recent_sources"][0]["source_id"] == added.source_id
@@ -459,3 +485,48 @@ def test_brief_text_output_is_available_without_goal(tmp_path: Path, capsys) -> 
     assert "Project brief" in out
     assert "Goal: -" in out
     assert "Next actions:" in out
+
+
+def test_brief_skips_invalid_query_matches_without_failing(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    bad_page = tmp_path / "wiki" / "topics" / "bad.md"
+    bad_page.write_text("---\nkind: topic\nbogus: true\n---\n\n# Bad\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "brief", "bad", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["query_summary"].startswith("Query skipped:")
+    assert payload["matches"] == []
+    assert payload["status"]["invalid_pages"] == 1
+    assert any("invalid wiki pages" in action for action in payload["next_actions"])
+
+
+def test_brief_skips_invalid_planning_records_without_failing(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    bad_task = tmp_path / "planning" / "tasks" / "bad.md"
+    bad_task.write_text("---\nkind: task\nbogus: true\n---\n\n# Bad\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "brief", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["planning_items"] == []
+    assert payload["warnings"][0]["area"] == "planning"
+    assert payload["warnings"][0]["path"] == "planning/tasks/bad.md"
+    assert any("skipped planning records" in action for action in payload["next_actions"])
+
+
+def test_brief_skips_invalid_goal_without_failing(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "brief", "???", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["goal"] == "???"
+    assert payload["query_summary"].startswith("Query skipped:")
+    assert payload["matches"] == []

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -368,3 +368,94 @@ def test_wiki_suggest_ignores_extract_fence_info_string(tmp_path: Path, capsys) 
     suggestion_paths = [suggestion["path"] for suggestion in payload["suggestions"]]
     assert "wiki/topics/substantive-alpha.md" in suggestion_paths
     assert "wiki/topics/fence-info.md" not in suggestion_paths
+
+
+def test_wiki_compile_reports_review_gated_contract_without_mutating(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-contract.md"
+    source.write_text("# Compile contract\n\nSynthesis remains review-gated.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    page_path = tmp_path / "wiki" / "sources" / f"{added.source_id}.md"
+    before = page_path.read_text(encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "compile", added.source_id, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["source_id"] == added.source_id
+    assert payload["mutates"] is False
+    assert payload["status"] == "contract-only"
+    assert "Run `splendor wiki suggest" in payload["next_steps"][0]
+    assert page_path.read_text(encoding="utf-8") == before
+
+
+def test_wiki_compile_reports_unknown_source(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "compile", "src-missing"])
+
+    assert exit_code == 1
+    assert "Unknown source ID: src-missing" in capsys.readouterr().out
+
+
+def test_brief_json_includes_goal_state_matches_planning_and_next_actions(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "briefing.md"
+    source.write_text(
+        "# Briefing\n\nProject briefing should surface wiki context.\n", encoding="utf-8"
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "project-briefing.md",
+        kind="topic",
+        title="Project briefing",
+        page_id="topic-project-briefing",
+        source_refs=[added.source_id],
+        body="Project briefing assembles source-backed working context.",
+    )
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "create",
+            "Continue project briefing",
+            "--id",
+            "task-briefing",
+            "--status",
+            "in_progress",
+        ]
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "brief", "project", "briefing", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["goal"] == "project briefing"
+    assert payload["status"]["source_total"] == 1
+    assert payload["matches"][0]["path"] == "wiki/topics/project-briefing.md"
+    assert payload["planning_items"][0]["record_id"] == "task-briefing"
+    assert payload["recent_sources"][0]["source_id"] == added.source_id
+    assert payload["recent_runs"][0]["source_ids"] == [added.source_id]
+    assert any("Open the top matching" in action for action in payload["next_actions"])
+
+
+def test_brief_text_output_is_available_without_goal(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "brief"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Project brief" in out
+    assert "Goal: -" in out
+    assert "Next actions:" in out

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -6,7 +6,7 @@ import yaml
 from splendor.cli import main
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
-from splendor.schemas import KnowledgePageFrontmatter
+from splendor.schemas import KnowledgePageFrontmatter, MaintenanceReport
 from splendor.state.source_registry import load_source_record
 
 
@@ -457,6 +457,17 @@ def test_brief_json_includes_goal_state_matches_planning_and_next_actions(
             "in_progress",
         ]
     )
+    report = MaintenanceReport(
+        command="lint",
+        created_at="2026-04-30T00:00:00Z",
+        status="passed",
+        checked_count=3,
+        issue_count=0,
+    )
+    report_path = tmp_path / "reports" / "lint" / "20260430T000000Z.json"
+    report_path.write_text(
+        json.dumps(report.model_dump(mode="json"), indent=2) + "\n", encoding="utf-8"
+    )
     capsys.readouterr()
 
     exit_code = main(["--root", str(tmp_path), "brief", "project", "briefing", "--json"])
@@ -471,6 +482,15 @@ def test_brief_json_includes_goal_state_matches_planning_and_next_actions(
     assert payload["planning_items"][0]["record_id"] == "task-briefing"
     assert payload["recent_sources"][0]["source_id"] == added.source_id
     assert payload["recent_runs"][0]["source_ids"] == [added.source_id]
+    assert payload["latest_reports"] == [
+        {
+            "command": "lint",
+            "status": "passed",
+            "created_at": "2026-04-30T00:00:00Z",
+            "issue_count": 0,
+            "path": "reports/lint/20260430T000000Z.json",
+        }
+    ]
     assert any("Open the top matching" in action for action in payload["next_actions"])
 
 
@@ -485,6 +505,20 @@ def test_brief_text_output_is_available_without_goal(tmp_path: Path, capsys) -> 
     assert "Project brief" in out
     assert "Goal: -" in out
     assert "Next actions:" in out
+
+
+def test_brief_json_output_is_available_without_goal(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "brief", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["goal"] is None
+    assert "status" in payload
+    assert "latest_reports" in payload
+    assert "next_actions" in payload
 
 
 def test_brief_skips_invalid_query_matches_without_failing(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Implements the M10-P0.2 text-native maintenance bridge slice.

- Adds `splendor brief [goal]` with text and JSON output over deterministic query matches, wiki status, active planning records, recent sources/runs, latest lint/health reports, last query state, and next actions.
- Adds a non-mutating `splendor wiki compile <source-id>` contract surface that validates the source and documents the review-gated synthesis maintenance loop.
- Keeps source-summary generation distinct from synthesis-page maintenance by making compile contract-only for now.
- Updates tests, product docs, README, roadmap, and planning-state markers for M10-P0.2.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/test_wiki_commands.py -q`
- `uv run splendor lint`
- `uv run pytest`

## Notes

Mutating synthesis compile behavior remains deferred. The current `wiki compile` command is intentionally read-only and reports `mutates: false`.