### PR TITLE
M10-P0.3 dogfood workflow polish and web status

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M10-P0.1`
-- Last action taken: `M10-P0.1` is implemented; wiki status, source-impact suggestions, and pending-ingest handoff now support the text-native maintenance loop.
+- Previous completed PR sub-slice: `M10-P0.2`
+- Last action taken: `M10-P0.2` is implemented; project briefing and the non-mutating compile-loop contract now support review-gated synthesis handoff.
 - Current planned slice: `M10-P0`
-- Current PR sub-slice: `M10-P0.2`
+- Current PR sub-slice: `M10-P0.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M10-P0`
-- Next planned PR sub-slice: `M10-P0.3`
+- Next planned slice: `M9-P2`
+- Next planned PR sub-slice: `M9-P2.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -129,6 +129,12 @@
   - [x] Preserve source-summary generation as separate from synthesis-page maintenance
   - [x] Update tests and docs for the briefing and compile-loop contract
   - [x] Publish a non-draft GitHub PR for `M10-P0.2` with labels, milestone, and a detailed description
+- [ ] Implement `M10-P0.3`: Dogfood workflow polish and web status surfaces
+  - [x] Add restrained next-action hints after pending ingest, query, and file-answer
+  - [x] Prefer claim-bearing query snippets over generated metadata boilerplate
+  - [x] Add read-only web status and source-detail surfaces
+  - [x] Update focused tests and docs for the dogfood workflow polish
+  - [ ] Publish a non-draft GitHub PR for `M10-P0.3` with labels, milestone, and a detailed description
 
 ## Context Pointers
 

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -129,7 +129,7 @@
   - [x] Preserve source-summary generation as separate from synthesis-page maintenance
   - [x] Update tests and docs for the briefing and compile-loop contract
   - [x] Publish a non-draft GitHub PR for `M10-P0.2` with labels, milestone, and a detailed description
-- [ ] Implement `M10-P0.3`: Dogfood workflow polish and web status surfaces
+- [x] Implement `M10-P0.3`: Dogfood workflow polish and web status surfaces
   - [x] Add restrained next-action hints after pending ingest, query, and file-answer
   - [x] Prefer claim-bearing query snippets over generated metadata boilerplate
   - [x] Add read-only web status and source-detail surfaces

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -134,7 +134,7 @@
   - [x] Prefer claim-bearing query snippets over generated metadata boilerplate
   - [x] Add read-only web status and source-detail surfaces
   - [x] Update focused tests and docs for the dogfood workflow polish
-  - [ ] Publish a non-draft GitHub PR for `M10-P0.3` with labels, milestone, and a detailed description
+  - [x] Publish a non-draft GitHub PR for `M10-P0.3` with labels, milestone, and a detailed description
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -123,13 +123,12 @@ Implemented today:
 - `splendor wiki compile <source-id>` as a non-mutating review-gated contract description
 - `splendor brief [goal]`
 - `splendor serve` for a read-only local browse/search UI
+- read-only web `/status` and `/sources/<source-id>` views
 - `splendor lint` and `splendor health`
 
 Not implemented yet:
 
 - mutating review-gated `splendor wiki compile`
-- broader next-action hints after query and file-answer commands
-- web status overview and source detail pages
 - OCR and image extraction flows
 - mutating web UI actions such as add-source forms
 - planning/runs UI views
@@ -147,12 +146,12 @@ Not implemented yet:
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M10-P0.1`
+- Previous completed PR sub-slice: `M10-P0.2`
 - Current planned slice: `M10-P0`
-- Current PR sub-slice: `M10-P0.2`
+- Current PR sub-slice: `M10-P0.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M10-P0`
-- Next planned PR sub-slice: `M10-P0.3`
+- Next planned slice: `M9-P2`
+- Next planned PR sub-slice: `M9-P2.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -174,11 +173,10 @@ contradiction-review noise reduction. `M9-P1.3` is implemented: knowledge-work d
 the wiki and filed follow-up product tasks.
 
 `M10-P0.1` is implemented: Splendor now has CLI-first wiki status and source-impact suggestions
-for the text-native maintenance loop. The current PR sub-slice is `M10-P0.2`, which adds the first
-project briefing command and documents the review-gated compile-loop contract without mutating
-synthesis pages. The goal remains explicit separation: ingest creates source summaries; reviewed
+for the text-native maintenance loop. `M10-P0.2` is implemented: the first project briefing command
+and non-mutating review-gated compile-loop contract are in place without mutating synthesis pages.
+The current PR sub-slice is `M10-P0.3`, which smooths the visible workflow around
+`add-source -> ingest -> wiki suggest -> review`, adds restrained next-action hints after query and
+file-answer, improves claim-bearing query snippets, and exposes read-only web status/source-detail
+views. The goal remains explicit separation: ingest creates source summaries; reviewed
 compile/update workflows maintain concept, entity, topic, architecture, and glossary pages.
-
-The follow-on dogfood polish slice is `M10-P0.3`. It should smooth the visible workflow around
-`add-source -> ingest -> wiki suggest -> review`, add restrained next-action hints to command
-output, and expose read-only web status/source-detail views once the CLI status contract exists.

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -31,10 +31,11 @@ Local notes should include a clear first heading and a substantive opening parag
 as `Core Claims`, `Design Implications`, and `Implementation Pattern` are rendered into deterministic
 source-summary key facts during ingest.
 
-Ingest currently creates deterministic source summaries and run/provenance state. The first
-`M10-P0` bridge adds `splendor wiki status` and `splendor wiki suggest <source-id>` so users and
-agents can identify affected concept, entity, topic, architecture, or glossary pages before
-manual review. Project briefing and a future review-gated compile/update workflow remain planned.
+Ingest currently creates deterministic source summaries and run/provenance state. The `M10-P0`
+bridge adds `splendor wiki status`, `splendor wiki suggest <source-id>`, `splendor brief [goal]`,
+and a non-mutating `splendor wiki compile <source-id>` contract so users and agents can identify
+affected concept, entity, topic, architecture, or glossary pages before manual review. Mutating
+compile/update workflow support remains planned.
 
 Dogfood runs should record usability friction separately from knowledge gaps. Pay special attention
 to whether each command prints the next useful command, whether long source IDs need to be copied
@@ -53,5 +54,6 @@ uv run splendor health
 uv run splendor serve
 ```
 
-Then inspect `/browse` and `/search?q=LLM+Wiki+persistent+knowledge` in the local web UI. A sparse
-workspace should show an explicit empty state with next commands instead of appearing broken.
+Then inspect `/browse`, `/status`, `/sources/<source-id>`, and
+`/search?q=LLM+Wiki+persistent+knowledge` in the local web UI. A sparse workspace should show an
+explicit empty state with next commands instead of appearing broken.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -99,6 +99,14 @@ uv run splendor --root /tmp/demo-repo wiki status
 uv run splendor --root /tmp/demo-repo wiki suggest <source-id>
 ```
 
+For a read-only browser view over the same status and source-detail contracts:
+
+```bash
+uv run splendor --root /tmp/demo-repo serve
+```
+
+Then open `/status` or `/sources/<source-id>` on the local server.
+
 ## 5. Add a planning record
 
 Planning records should link back to sources by source ID, not by raw file path.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,18 +334,19 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M10-P0.1`
+- Previous completed PR sub-slice: `M10-P0.2`
 - Current planned slice: `M10-P0`
-- Current PR sub-slice: `M10-P0.2`
+- Current PR sub-slice: `M10-P0.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M10-P0`
-- Next planned PR sub-slice: `M10-P0.3`
+- Next planned slice: `M9-P2`
+- Next planned PR sub-slice: `M9-P2.1`
 
 `M10-P0.1` is implemented: the CLI-first wiki status and source-impact suggestion bridge is in
-place. The current PR sub-slice is `M10-P0.2`, under parent slice `M10-P0`, which adds project
-briefing and the non-mutating review-gated compile-loop contract. The lifecycle marker means
-`M10-P0.2` is in progress on feature branches and merged once the same committed state is observed
-on `main`.
+place. `M10-P0.2` is implemented: project briefing and the non-mutating review-gated compile-loop
+contract are available. The current PR sub-slice is `M10-P0.3`, under parent slice `M10-P0`, which
+polishes the visible dogfood workflow with restrained next-action hints, claim-bearing snippets,
+and read-only web status/source-detail surfaces. The lifecycle marker means `M10-P0.3` is in
+progress on feature branches and merged once the same committed state is observed on `main`.
 
 Dogfooding also changed the recommended next slice: before deeper planning/runs UI work, Splendor
 should add a small CLI-first bridge for wiki status, source-impact suggestions, and project
@@ -569,9 +570,10 @@ markdown source summaries, and contradiction-review filtering for source-summary
 boilerplate. `M9-P1.3` adds three researched dogfood rounds, extends the wiki with tool-landscape
 and agent-context synthesis, and files follow-up product tasks from the observed workflow friction.
 `M10-P0.1` adds CLI-first wiki status and source-impact suggestions before deeper planning/runs UI
-work. The current recommended slice is `M10-P0.2`, which adds project briefing and a documented,
-non-mutating review-gated compile-loop contract. `M10-P0.3` should then polish the visible dogfood
-workflow with query snippet improvements and read-only web status/source-detail surfaces.
+work. `M10-P0.2` adds project briefing and a documented, non-mutating review-gated compile-loop
+contract. The current recommended slice is `M10-P0.3`, which polishes the visible dogfood workflow
+with query snippet improvements, restrained next-action hints, and read-only web
+status/source-detail surfaces.
 Mutating web actions, add-source forms, and planning/runs views remain deferred to later `M9`
 slices.
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -667,6 +667,8 @@ Current implementation:
   source ID.
 - `splendor ingest <source-id>` prints the generated source-summary page/run records and the next
   `splendor wiki suggest <source-id>` command.
+- `splendor ingest --pending` prints the next `wiki suggest` command when exactly one source was
+  ingested, or points back to `wiki status` for batch follow-up.
 - `splendor wiki status` reports source, page, queue, run, review, contested, stale,
   machine-generated, invalid-page, actionable synthesis-review, and missing
   synthesis-follow-up counts, with optional JSON output.
@@ -675,6 +677,10 @@ Current implementation:
   optional JSON output.
 - `splendor wiki compile <source-id>` exposes the review-gated compile-loop contract, validates the
   source, and reports that it does not mutate synthesis pages yet.
+- `splendor query` prefers claim-bearing source-summary sections over generated metadata
+  boilerplate when selecting snippets, and text output points to `file-answer` when a saved query
+  has matches.
+- `splendor file-answer` prints the created page and a restrained review hint after filing.
 - Mutating `splendor wiki compile <source-id>` remains deferred to a later reviewed compile-loop
   slice.
 
@@ -998,6 +1004,11 @@ Early web UI should be intentionally modest.
 The web UI should make generated versus maintained pages visible without requiring raw frontmatter
 inspection. Users should be able to distinguish generated source summaries, draft synthesis,
 reviewed synthesis, contested pages, and stale pages while browsing or searching.
+
+Current implementation includes read-only `/status` and `/sources/{source-id}` pages layered on
+the CLI wiki status/suggest contracts. They expose source/page/queue/run/review counts, source
+manifests, linked source-summary pages, latest ingest run state, and deterministic affected
+synthesis-page suggestions without adding mutating web actions.
 
 ### Avoid early
 - heavy collaborative editing

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 from pathlib import Path
 
 from splendor import __version__
@@ -776,7 +777,7 @@ def handle_query(args: argparse.Namespace) -> int:
             print(f"   Review tasks: {', '.join(match.review_task_ids)}")
     if result.matches and not args.no_save:
         title = _suggested_answer_title(result.query)
-        print(f'Next: splendor file-answer --from-last-query --title "{title}"')
+        print(f"Next: splendor file-answer --from-last-query --title {shlex.quote(title)}")
     elif result.matches and args.no_save:
         print("Next: rerun without --no-save to enable file-answer")
     return 0

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -417,6 +417,14 @@ def _print_error(exc: Exception) -> int:
     return 1
 
 
+def _suggested_answer_title(query: str) -> str:
+    words = query.split()
+    title = " ".join(words[:6]).strip() or "Filed answer"
+    if len(words) > 6:
+        title = f"{title} answer"
+    return title
+
+
 def _is_missing_workspace_wiki_error(exc: Exception) -> bool:
     return str(exc).startswith("Workspace is missing required wiki files:")
 
@@ -481,6 +489,13 @@ def handle_ingest(args: argparse.Namespace) -> int:
             f"failed={result.failed} "
             f"skipped={result.skipped}"
         )
+        succeeded_source_ids = [
+            item.source_id for item in result.items if item.outcome == "succeeded"
+        ]
+        if len(succeeded_source_ids) == 1:
+            print(f"Next: splendor wiki suggest {succeeded_source_ids[0]}")
+        elif len(succeeded_source_ids) > 1:
+            print("Next: splendor wiki status")
         return 1 if result.failed else 0
 
     try:
@@ -759,6 +774,11 @@ def handle_query(args: argparse.Namespace) -> int:
             print(f"   Contradictions: {match.contradiction_count}")
         if match.review_task_ids:
             print(f"   Review tasks: {', '.join(match.review_task_ids)}")
+    if result.matches and not args.no_save:
+        title = _suggested_answer_title(result.query)
+        print(f'Next: splendor file-answer --from-last-query --title "{title}"')
+    elif result.matches and args.no_save:
+        print("Next: rerun without --no-save to enable file-answer")
     return 0
 
 
@@ -926,6 +946,7 @@ def handle_file_answer(args: argparse.Namespace) -> int:
     print(f"Query: {result.query}")
     if result.linked_question_id is not None:
         print(f"Updated question: {result.linked_question_id}")
+    print(f"Next: review {result.page_path}")
     return 0
 
 

--- a/src/splendor/commands/query.py
+++ b/src/splendor/commands/query.py
@@ -300,11 +300,7 @@ def _best_snippet(text: str, query_tokens: list[str]) -> str:
         return ""
 
     paragraphs = _candidate_segments(normalized)
-    lines = [
-        line.strip()
-        for line in normalized.splitlines()
-        if line.strip() and not _is_heading(line) and not _is_fence(line)
-    ]
+    lines = _snippet_lines(normalized)
     candidates = _unique_in_order([*paragraphs, *lines])
     if not candidates:
         return ""
@@ -346,6 +342,9 @@ def _candidate_segments(text: str) -> list[str]:
         line = raw_line.strip()
         if _is_fence(line):
             in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
         if not in_fence and _is_heading(line):
             if active_lines:
                 segments.extend(_section_segments(active_heading, active_lines))
@@ -356,6 +355,20 @@ def _candidate_segments(text: str) -> list[str]:
     if active_lines:
         segments.extend(_section_segments(active_heading, active_lines))
     return segments
+
+
+def _snippet_lines(text: str) -> list[str]:
+    lines: list[str] = []
+    in_fence = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if _is_fence(line):
+            in_fence = not in_fence
+            continue
+        if in_fence or not line or _is_heading(line):
+            continue
+        lines.append(line)
+    return lines
 
 
 def _section_segments(heading: str | None, lines: list[str]) -> list[str]:

--- a/src/splendor/commands/query.py
+++ b/src/splendor/commands/query.py
@@ -20,6 +20,36 @@ from splendor.utils.wiki import parse_wiki_markdown
 _PLANNING_KINDS = ("task", "milestone", "decision", "question")
 _TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
 _WHITESPACE_PATTERN = re.compile(r"\s+")
+_CLAIM_SECTION_HEADINGS = {
+    "core claims",
+    "design implications",
+    "product experience notes",
+    "extract",
+    "summary",
+    "key facts",
+}
+_BOILERPLATE_PREFIXES = (
+    "- Source ID:",
+    "- Source type:",
+    "- Source ref:",
+    "- Checksum:",
+    "- Added at:",
+    "- Ingested at:",
+    "- Pipeline version:",
+    "- Storage mode:",
+)
+_BOILERPLATE_TERMS = {
+    "checksum",
+    "generated",
+    "ingested",
+    "machine",
+    "metadata",
+    "pipeline",
+    "provenance",
+    "source",
+    "summary",
+    "version",
+}
 
 
 class QueryValidationError(ValueError):
@@ -269,18 +299,26 @@ def _best_snippet(text: str, query_tokens: list[str]) -> str:
     if not normalized:
         return ""
 
-    paragraphs = [
-        segment.strip() for segment in re.split(r"\n\s*\n", normalized) if segment.strip()
+    paragraphs = _candidate_segments(normalized)
+    lines = [
+        line.strip()
+        for line in normalized.splitlines()
+        if line.strip() and not _is_heading(line) and not _is_fence(line)
     ]
-    lines = [line.strip() for line in normalized.splitlines() if line.strip()]
     candidates = _unique_in_order([*paragraphs, *lines])
+    if not candidates:
+        return ""
     best = max(
         candidates,
-        key=lambda candidate: (_candidate_score(candidate, query_tokens), -len(candidate)),
+        key=lambda candidate: (
+            _candidate_score(candidate, query_tokens),
+            -_boilerplate_score(candidate),
+            -len(candidate),
+        ),
     )
     if _candidate_score(best, query_tokens) == 0:
         best = paragraphs[0] if paragraphs else lines[0]
-    collapsed = _WHITESPACE_PATTERN.sub(" ", best).strip()
+    collapsed = _WHITESPACE_PATTERN.sub(" ", _strip_candidate_heading(best)).strip()
     if len(collapsed) <= 240:
         return collapsed
     return collapsed[:237].rstrip() + "..."
@@ -288,7 +326,81 @@ def _best_snippet(text: str, query_tokens: list[str]) -> str:
 
 def _candidate_score(candidate: str, query_tokens: list[str]) -> int:
     candidate_tokens = _content_tokens(candidate)
-    return sum(candidate_tokens.count(token) for token in query_tokens)
+    token_score = sum(candidate_tokens.count(token) for token in query_tokens)
+    if token_score == 0:
+        return 0
+    heading = _candidate_heading(candidate)
+    heading_bonus = 0
+    if heading in _CLAIM_SECTION_HEADINGS:
+        heading_bonus = 3
+    boilerplate_penalty = _boilerplate_score(candidate)
+    return token_score + heading_bonus - boilerplate_penalty
+
+
+def _candidate_segments(text: str) -> list[str]:
+    segments: list[str] = []
+    active_heading: str | None = None
+    active_lines: list[str] = []
+    in_fence = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if _is_fence(line):
+            in_fence = not in_fence
+        if not in_fence and _is_heading(line):
+            if active_lines:
+                segments.extend(_section_segments(active_heading, active_lines))
+            active_heading = line.lstrip("#").strip().strip("#").strip().lower()
+            active_lines = []
+            continue
+        active_lines.append(raw_line)
+    if active_lines:
+        segments.extend(_section_segments(active_heading, active_lines))
+    return segments
+
+
+def _section_segments(heading: str | None, lines: list[str]) -> list[str]:
+    text = "\n".join(lines).strip()
+    if not text:
+        return []
+    prefix = f"__heading__:{heading}\n" if heading else ""
+    return [
+        prefix + segment.strip()
+        for segment in re.split(r"\n\s*\n", text)
+        if segment.strip() and not _is_boilerplate_line(segment.strip())
+    ]
+
+
+def _candidate_heading(candidate: str) -> str | None:
+    if not candidate.startswith("__heading__:"):
+        return None
+    first_line, *_rest = candidate.split("\n", 1)
+    return first_line.removeprefix("__heading__:") or None
+
+
+def _strip_candidate_heading(candidate: str) -> str:
+    if not candidate.startswith("__heading__:"):
+        return candidate
+    return candidate.split("\n", 1)[1] if "\n" in candidate else ""
+
+
+def _boilerplate_score(candidate: str) -> int:
+    stripped = _strip_candidate_heading(candidate)
+    if _is_boilerplate_line(stripped):
+        return 4
+    tokens = set(_content_tokens(stripped))
+    return min(3, len(tokens & _BOILERPLATE_TERMS))
+
+
+def _is_boilerplate_line(line: str) -> bool:
+    return line.startswith(_BOILERPLATE_PREFIXES)
+
+
+def _is_heading(line: str) -> bool:
+    return line.startswith("#")
+
+
+def _is_fence(line: str) -> bool:
+    return line.startswith("```") or line.startswith("~~~")
 
 
 def _unique_in_order(values: list[str]) -> list[str]:

--- a/src/splendor/commands/query.py
+++ b/src/splendor/commands/query.py
@@ -47,7 +47,6 @@ _BOILERPLATE_TERMS = {
     "pipeline",
     "provenance",
     "source",
-    "summary",
     "version",
 }
 
@@ -312,7 +311,7 @@ def _best_snippet(text: str, query_tokens: list[str]) -> str:
             -len(candidate),
         ),
     )
-    if _candidate_score(best, query_tokens) == 0:
+    if _candidate_score(best, query_tokens) <= 0:
         best = paragraphs[0] if paragraphs else lines[0]
     collapsed = _WHITESPACE_PATTERN.sub(" ", _strip_candidate_heading(best)).strip()
     if len(collapsed) <= 240:

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -16,9 +16,13 @@ from fastapi.responses import HTMLResponse
 
 from splendor.commands.planning import model_for_planning_kind
 from splendor.commands.query import QueryMatch, QueryValidationError, run_query
+from splendor.commands.wiki import build_wiki_status, load_sources, suggest_source_pages
 from splendor.config import load_config
 from splendor.layout import ResolvedLayout, resolve_layout
 from splendor.state.paths import resolve_workspace_path
+from splendor.state.runtime import load_run_record
+from splendor.state.source_compat import canonical_source_ref
+from splendor.state.source_registry import load_source_record
 from splendor.utils.planning import parse_planning_document
 from splendor.utils.wiki import parse_wiki_markdown
 
@@ -128,6 +132,7 @@ def create_app(root: Path) -> FastAPI:
             '<button type="submit">Search</button>'
             "</form>"
             '<a class="button" href="/browse">Browse documents</a>'
+            '<a class="button secondary" href="/status">Status</a>'
             "</section>"
             f"{empty_state}"
             '<section class="stats">'
@@ -139,6 +144,102 @@ def create_app(root: Path) -> FastAPI:
             "</section>"
         )
         return _page("Splendor", body)
+
+    @app.get("/status", response_class=HTMLResponse)
+    def status() -> HTMLResponse:
+        layout = _layout_for(workspace_root)
+        status_result = build_wiki_status(workspace_root)
+        source_rows = "\n".join(
+            _source_row(workspace_root, source) for source in load_sources(layout)
+        )
+        if not source_rows:
+            source_rows = '<tr><td colspan="5" class="empty">No source manifests yet.</td></tr>'
+        recent_runs = "\n".join(
+            "<li>"
+            f"<code>{html.escape(run.run_id)}</code> {html.escape(run.status)} "
+            f"finished={html.escape(run.finished_at or '-')}"
+            "</li>"
+            for run in status_result.recent_runs
+        )
+        if not recent_runs:
+            recent_runs = '<li class="empty">No runs yet.</li>'
+        invalid_pages = "\n".join(
+            f"<li><code>{html.escape(page.path)}</code>: {html.escape(page.error)}</li>"
+            for page in status_result.invalid_page_examples
+        )
+        invalid_section = ""
+        if invalid_pages:
+            invalid_section = f"<h2>Invalid wiki pages</h2><ul>{invalid_pages}</ul>"
+        body = (
+            '<p class="breadcrumbs"><a href="/">Home</a> / Status</p>'
+            '<section class="stats">'
+            f"<div><strong>{status_result.source_total}</strong><span>Sources</span></div>"
+            f"<div><strong>{status_result.page_total}</strong><span>Pages</span></div>"
+            f"<div><strong>{status_result.queue_total}</strong><span>Queue records</span></div>"
+            f"<div><strong>{status_result.run_total}</strong><span>Runs</span></div>"
+            f"<div><strong>{status_result.review_needed_pages}</strong>"
+            "<span>Review needed</span></div>"
+            f"<div><strong>{status_result.sources_missing_synthesis}</strong>"
+            "<span>Synthesis follow-up</span></div>"
+            "</section>"
+            "<h2>Review state</h2>"
+            f"<p>{html.escape(_format_counts(status_result.review_state_counts)) or '-'}</p>"
+            "<h2>Queue</h2>"
+            f"<p>{html.escape(_format_counts(status_result.queue_status_counts)) or '-'}</p>"
+            "<h2>Recent runs</h2>"
+            f"<ul>{recent_runs}</ul>"
+            f"{invalid_section}"
+            "<h2>Sources</h2>"
+            "<table><thead><tr><th>Source</th><th>Status</th><th>Review</th>"
+            "<th>Summary page</th><th>Source ref</th></tr></thead>"
+            f"<tbody>{source_rows}</tbody></table>"
+        )
+        return _page("Status", body)
+
+    @app.get("/sources/{source_id}", response_class=HTMLResponse)
+    def source_detail(source_id: str) -> HTMLResponse:
+        layout = _layout_for(workspace_root)
+        source = _load_source_for_web(layout, source_id)
+        summary_links = "".join(
+            f'<li><a href="/documents/{quote(path, safe="/")}">'
+            f"<code>{html.escape(path)}</code></a></li>"
+            for path in source.linked_pages
+        )
+        if not summary_links:
+            summary_links = '<li class="empty">No generated source-summary page linked yet.</li>'
+        run_section = _source_run_section(workspace_root, layout, source.last_run_id)
+        suggestions = suggest_source_pages(workspace_root, source.source_id).suggestions
+        suggestion_rows = "\n".join(_suggestion_row(suggestion) for suggestion in suggestions)
+        if not suggestion_rows:
+            suggestion_rows = (
+                '<tr><td colspan="4" class="empty">'
+                "No likely synthesis-page matches found.</td></tr>"
+            )
+        manifest_ref = (layout.source_records_dir / f"{source.source_id}.json").relative_to(
+            workspace_root
+        )
+        body = (
+            '<p class="breadcrumbs"><a href="/status">Status</a> / '
+            f"{html.escape(source.source_id)}</p>"
+            '<section class="metadata">'
+            f"<div><strong>Status</strong><span>{html.escape(source.status)}</span></div>"
+            f"<div><strong>Review</strong><span>{html.escape(source.review_state)}</span></div>"
+            f"<div><strong>Type</strong><span>{html.escape(source.source_type)}</span></div>"
+            f"<div><strong>Storage</strong><span>{html.escape(source.storage_mode or '-')}"
+            "</span></div>"
+            f"<div><strong>Manifest</strong><span><code>{html.escape(manifest_ref.as_posix())}"
+            "</code></span></div>"
+            "</section>"
+            "<h2>Source ref</h2>"
+            f"<p><code>{html.escape(canonical_source_ref(source))}</code></p>"
+            "<h2>Generated source-summary pages</h2>"
+            f"<ul>{summary_links}</ul>"
+            f"{run_section}"
+            "<h2>Affected synthesis-page suggestions</h2>"
+            "<table><thead><tr><th>Page</th><th>Kind</th><th>Score</th><th>Reasons</th></tr></thead>"
+            f"<tbody>{suggestion_rows}</tbody></table>"
+        )
+        return _page(source.title, body)
 
     @app.get("/browse", response_class=HTMLResponse)
     def browse() -> HTMLResponse:
@@ -306,6 +407,10 @@ def _workspace_counts(
     )
 
 
+def _format_counts(counts: dict[str, int]) -> str:
+    return " ".join(f"{key}={counts[key]}" for key in sorted(counts))
+
+
 def _empty_workspace_panel() -> str:
     return (
         '<section class="empty-state">'
@@ -461,6 +566,76 @@ def _document_row(document: _DocumentSummary) -> str:
     )
 
 
+def _source_row(root: Path, source) -> str:
+    href = f"/sources/{quote(source.source_id)}"
+    summary = source.linked_pages[0] if source.linked_pages else "-"
+    summary_html = html.escape(summary)
+    if source.linked_pages:
+        summary_href = f"/documents/{quote(summary, safe='/')}"
+        summary_html = f'<a href="{summary_href}"><code>{summary_html}</code></a>'
+    return (
+        "<tr>"
+        f'<td><a href="{href}">{html.escape(source.title)}</a><br />'
+        f"<code>{html.escape(source.source_id)}</code></td>"
+        f"<td>{html.escape(source.status)}</td>"
+        f"<td>{html.escape(source.review_state)}</td>"
+        f"<td>{summary_html}</td>"
+        f"<td><code>{html.escape(canonical_source_ref(source))}</code></td>"
+        "</tr>"
+    )
+
+
+def _load_source_for_web(layout: ResolvedLayout, source_id: str):
+    if "\\" in source_id or "/" in source_id or ".." in source_id:
+        raise HTTPException(status_code=404, detail="Source not found")
+    manifest_path = layout.source_records_dir / f"{source_id}.json"
+    if not manifest_path.is_file():
+        raise HTTPException(status_code=404, detail="Source not found")
+    try:
+        return load_source_record(manifest_path)
+    except ValueError:
+        _LOGGER.exception("Source manifest failed validation.")
+        raise HTTPException(status_code=500, detail="Source manifest is invalid") from None
+
+
+def _source_run_section(root: Path, layout: ResolvedLayout, run_id: str | None) -> str:
+    if run_id is None:
+        return '<h2>Latest ingest run</h2><p class="empty">No ingest run linked yet.</p>'
+    run_path = layout.runs_dir / f"{run_id}.json"
+    if not run_path.is_file():
+        return (
+            "<h2>Latest ingest run</h2>"
+            f'<p class="empty">Linked run <code>{html.escape(run_id)}</code> is missing.</p>'
+        )
+    run = load_run_record(run_path)
+    run_ref = run_path.relative_to(root).as_posix()
+    pages = ", ".join(run.page_refs) if run.page_refs else "-"
+    return (
+        "<h2>Latest ingest run</h2>"
+        '<section class="metadata">'
+        f"<div><strong>Run</strong><span><code>{html.escape(run.run_id)}</code></span></div>"
+        f"<div><strong>Status</strong><span>{html.escape(run.status)}</span></div>"
+        f"<div><strong>Finished</strong><span>{html.escape(run.finished_at or '-')}</span></div>"
+        f"<div><strong>Record</strong><span><code>{html.escape(run_ref)}</code></span></div>"
+        f"<div><strong>Pages</strong><span>{html.escape(pages)}</span></div>"
+        "</section>"
+    )
+
+
+def _suggestion_row(suggestion) -> str:
+    href = f"/documents/{quote(suggestion.path, safe='/')}"
+    reasons = ", ".join(suggestion.reasons) if suggestion.reasons else "-"
+    return (
+        "<tr>"
+        f'<td><a href="{href}">{html.escape(suggestion.title)}</a><br />'
+        f"<code>{html.escape(suggestion.path)}</code></td>"
+        f"<td>{html.escape(suggestion.kind)}</td>"
+        f"<td>{suggestion.score}</td>"
+        f"<td>{html.escape(reasons)}</td>"
+        "</tr>"
+    )
+
+
 def _search_row(match: QueryMatch) -> str:
     href = f"/documents/{quote(match.path, safe='/')}"
     status = f" · {html.escape(match.status)}" if match.status else ""
@@ -498,6 +673,7 @@ def _page(title: str, body: str, *, status_code: int = 200) -> HTMLResponse:
         "font:inherit;flex:1}"
         "button,.button{border:1px solid var(--accent);border-radius:6px;background:var(--accent);"
         "color:white;padding:9px 12px;font:inherit;cursor:pointer}"
+        ".button.secondary{background:white;color:var(--accent)}"
         ".stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px}"
         ".stats div,.metadata,.result,.empty-state{border:1px solid var(--border);"
         "border-radius:8px;"

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -150,15 +150,13 @@ def create_app(root: Path) -> FastAPI:
         layout = _layout_for(workspace_root)
         try:
             status_result = build_wiki_status(workspace_root)
-            source_rows = "\n".join(
-                _source_row(workspace_root, source) for source in load_sources(layout)
-            )
+            source_rows = "\n".join(_source_row(source) for source in load_sources(layout))
         except ValueError:
-            _LOGGER.exception("Status failed while parsing source records.")
+            _LOGGER.exception("Status failed while parsing workspace records.")
             return _page(
                 "Status Error",
                 '<p class="empty">'
-                "Status failed because the workspace contains invalid source records."
+                "Status failed because the workspace contains invalid records."
                 "</p>",
                 status_code=500,
             )
@@ -576,7 +574,7 @@ def _document_row(document: _DocumentSummary) -> str:
     )
 
 
-def _source_row(root: Path, source) -> str:
+def _source_row(source) -> str:
     href = f"/sources/{quote(source.source_id)}"
     summary = source.linked_pages[0] if source.linked_pages else "-"
     summary_html = html.escape(summary)
@@ -617,7 +615,15 @@ def _source_run_section(root: Path, layout: ResolvedLayout, run_id: str | None) 
             "<h2>Latest ingest run</h2>"
             f'<p class="empty">Linked run <code>{html.escape(run_id)}</code> is missing.</p>'
         )
-    run = load_run_record(run_path)
+    try:
+        run = load_run_record(run_path)
+    except ValueError:
+        _LOGGER.exception("Run record failed validation.")
+        return (
+            "<h2>Latest ingest run</h2>"
+            f'<p class="empty">Linked run record <code>{html.escape(run_id)}</code> '
+            "is invalid.</p>"
+        )
     run_ref = run_path.relative_to(root).as_posix()
     pages = ", ".join(run.page_refs) if run.page_refs else "-"
     return (

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -148,10 +148,20 @@ def create_app(root: Path) -> FastAPI:
     @app.get("/status", response_class=HTMLResponse)
     def status() -> HTMLResponse:
         layout = _layout_for(workspace_root)
-        status_result = build_wiki_status(workspace_root)
-        source_rows = "\n".join(
-            _source_row(workspace_root, source) for source in load_sources(layout)
-        )
+        try:
+            status_result = build_wiki_status(workspace_root)
+            source_rows = "\n".join(
+                _source_row(workspace_root, source) for source in load_sources(layout)
+            )
+        except ValueError:
+            _LOGGER.exception("Status failed while parsing source records.")
+            return _page(
+                "Status Error",
+                '<p class="empty">'
+                "Status failed because the workspace contains invalid source records."
+                "</p>",
+                status_code=500,
+            )
         if not source_rows:
             source_rows = '<tr><td colspan="5" class="empty">No source manifests yet.</td></tr>'
         recent_runs = "\n".join(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -787,10 +787,29 @@ def test_cli_query_command_persists_last_query_snapshot(tmp_path: Path, capsys) 
 
     assert exit_code == 0
     captured = capsys.readouterr()
-    assert 'Next: splendor file-answer --from-last-query --title "query"' in captured.out
+    assert "Next: splendor file-answer --from-last-query --title query" in captured.out
     snapshot = load_query_snapshot(tmp_path / "state" / "queries" / "last-query.json")
     assert snapshot.query == "query"
     assert snapshot.match_count == 1
+
+
+def test_cli_query_command_shell_escapes_file_answer_title_hint(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    write_queryable_wiki_page(
+        tmp_path / "wiki" / "topics" / "quoted.md",
+        title='Quoted "ranking" note',
+        page_id="topic-quoted-ranking",
+        body='Quoted "ranking" evidence appears here.\n',
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "query", 'quoted "ranking"'])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert (
+        "Next: splendor file-answer --from-last-query --title 'quoted \"ranking\"'" in captured.out
+    )
 
 
 def test_cli_query_command_persists_snapshot_for_json_output(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -786,6 +786,8 @@ def test_cli_query_command_persists_last_query_snapshot(tmp_path: Path, capsys) 
     exit_code = main(["--root", str(tmp_path), "query", "query"])
 
     assert exit_code == 0
+    captured = capsys.readouterr()
+    assert 'Next: splendor file-answer --from-last-query --title "query"' in captured.out
     snapshot = load_query_snapshot(tmp_path / "state" / "queries" / "last-query.json")
     assert snapshot.query == "query"
     assert snapshot.match_count == 1
@@ -818,6 +820,7 @@ def test_cli_query_command_no_save_skips_last_query_snapshot(tmp_path: Path, cap
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "Summary: Found 1 matching records." in captured.out
+    assert "Next: rerun without --no-save to enable file-answer" in captured.out
     assert not last_query_path_for(layout).exists()
 
 
@@ -1044,6 +1047,7 @@ def test_cli_file_answer_from_last_query_creates_topic_page_and_updates_index_an
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "Filed answer answer-ranking-answer" in captured.out
+    assert "Next: review" in captured.out
     page_path = tmp_path / "wiki" / "topics" / "answer-ranking-answer.md"
     page = page_path.read_text(encoding="utf-8")
     assert "## Query" in page

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -247,6 +247,28 @@ def test_run_query_prefers_claim_sections_over_source_summary_boilerplate(
     )
 
 
+def test_run_query_ignores_fenced_blocks_when_selecting_snippets(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "fenced-snippet.md",
+        title="Fenced snippet",
+        page_id="topic-fenced-snippet",
+        body=(
+            "# Fenced snippet\n\n"
+            "```text\n"
+            "ranking evidence inside generated fenced metadata should not win\n"
+            "```\n\n"
+            "The prose ranking evidence should become the selected snippet.\n"
+        ),
+    )
+
+    result = run_query(tmp_path, "ranking evidence")
+
+    assert result.matches[0].snippet == (
+        "The prose ranking evidence should become the selected snippet."
+    )
+
+
 def test_run_query_result_is_json_serializable(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     create_task(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -218,6 +218,35 @@ def test_run_query_uses_best_matching_snippet_and_truncates(tmp_path: Path) -> N
     )
 
 
+def test_run_query_prefers_claim_sections_over_source_summary_boilerplate(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "sources" / "src-claim.md",
+        title="Generated source summary",
+        page_id="src-claim",
+        kind="source-summary",
+        source_refs=["src-claim"],
+        body=(
+            "# Generated source summary\n\n"
+            "## Key Facts\n\n"
+            "- Source ID: src-claim\n"
+            "- Source type: markdown\n\n"
+            "## Core Claims\n\n"
+            "Dogfood workflow polish should keep source-summary pages separate from "
+            "maintained synthesis pages.\n"
+        ),
+    )
+
+    result = run_query(tmp_path, "source summary pages")
+
+    assert result.matches[0].snippet == (
+        "Dogfood workflow polish should keep source-summary pages separate from maintained "
+        "synthesis pages."
+    )
+
+
 def test_run_query_result_is_json_serializable(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     create_task(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -188,6 +188,19 @@ def test_status_page_shows_source_run_and_review_counts(tmp_path: Path) -> None:
     assert "machine-generated" in response.text
 
 
+def test_status_page_reports_invalid_source_manifest_without_path_leak(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    manifest_path = tmp_path / "state" / "manifests" / "sources" / "src-bad.json"
+    manifest_path.write_text("{not valid json", encoding="utf-8")
+    client = TestClient(create_app(tmp_path), raise_server_exceptions=False)
+
+    response = client.get("/status")
+
+    assert response.status_code == 500
+    assert "invalid source records" in response.text
+    assert str(tmp_path) not in response.text
+
+
 def test_source_detail_shows_summary_run_and_synthesis_suggestions(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "dogfood-workflow.md"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import yaml
 from fastapi.testclient import TestClient
 
+from splendor.cli import main
+from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.planning import create_task
 from splendor.schemas import KnowledgePageFrontmatter
@@ -32,6 +34,7 @@ def test_home_page_loads_for_initialized_workspace(tmp_path: Path) -> None:
     assert "Splendor" in response.text
     assert "Wiki content pages" in response.text
     assert "/browse" in response.text
+    assert "/status" in response.text
 
 
 def test_home_page_shows_empty_state_for_initialized_workspace(tmp_path: Path) -> None:
@@ -165,6 +168,52 @@ def test_search_returns_query_matches_with_document_links(tmp_path: Path) -> Non
     assert response.status_code == 200
     assert 'href="/documents/wiki/concepts/web-shell.md"' in response.text
     assert "Deterministic browse search lives here." in response.text
+
+
+def test_status_page_shows_source_run_and_review_counts(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "status-source.md"
+    source.write_text("# Status source\n\nWeb status should show source state.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/status")
+
+    assert response.status_code == 200
+    assert "Synthesis follow-up" in response.text
+    assert added.source_id in response.text
+    assert f'href="/sources/{added.source_id}"' in response.text
+    assert "wiki/sources/" in response.text
+    assert "machine-generated" in response.text
+
+
+def test_source_detail_shows_summary_run_and_synthesis_suggestions(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "dogfood-workflow.md"
+    source.write_text(
+        "# Dogfood workflow\n\nDogfood workflow polish improves review handoff.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "dogfood-workflow.md",
+        title="Dogfood workflow",
+        page_id="topic-dogfood-workflow",
+        body="# Dogfood workflow\n\nReview handoff uses dogfood workflow polish.\n",
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get(f"/sources/{added.source_id}")
+
+    assert response.status_code == 200
+    assert "Generated source-summary pages" in response.text
+    assert "Latest ingest run" in response.text
+    assert "Affected synthesis-page suggestions" in response.text
+    assert "wiki/sources/" in response.text
+    assert "Dogfood workflow" in response.text
+    assert "wiki/topics/dogfood-workflow.md" in response.text
 
 
 def test_document_detail_rejects_unsafe_or_unsupported_paths(tmp_path: Path) -> None:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -229,6 +229,16 @@ def test_source_detail_shows_summary_run_and_synthesis_suggestions(tmp_path: Pat
     assert "wiki/topics/dogfood-workflow.md" in response.text
 
 
+def test_source_detail_returns_not_found_for_unknown_source_id(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/sources/src-missing")
+
+    assert response.status_code == 404
+    assert "Source not found" in response.text
+
+
 def test_document_detail_rejects_unsafe_or_unsupported_paths(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     client = TestClient(create_app(tmp_path))

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -8,6 +8,7 @@ from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.planning import create_task
 from splendor.schemas import KnowledgePageFrontmatter
+from splendor.state.source_registry import load_source_record
 from splendor.web import create_app
 
 
@@ -197,7 +198,7 @@ def test_status_page_reports_invalid_source_manifest_without_path_leak(tmp_path:
     response = client.get("/status")
 
     assert response.status_code == 500
-    assert "invalid source records" in response.text
+    assert "invalid records" in response.text
     assert str(tmp_path) not in response.text
 
 
@@ -227,6 +228,26 @@ def test_source_detail_shows_summary_run_and_synthesis_suggestions(tmp_path: Pat
     assert "wiki/sources/" in response.text
     assert "Dogfood workflow" in response.text
     assert "wiki/topics/dogfood-workflow.md" in response.text
+
+
+def test_source_detail_reports_invalid_linked_run_without_path_leak(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "invalid-run.md"
+    source.write_text("# Invalid run\n\nSource with a corrupt run record.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    manifest_path = tmp_path / "state" / "manifests" / "sources" / f"{added.source_id}.json"
+    run_id = load_source_record(manifest_path).last_run_id
+    assert run_id is not None
+    (tmp_path / "state" / "runs" / f"{run_id}.json").write_text("{not valid json", encoding="utf-8")
+    client = TestClient(create_app(tmp_path), raise_server_exceptions=False)
+
+    response = client.get(f"/sources/{added.source_id}")
+
+    assert response.status_code == 200
+    assert "Linked run record" in response.text
+    assert "is invalid" in response.text
+    assert str(tmp_path) not in response.text
 
 
 def test_source_detail_returns_not_found_for_unknown_source_id(tmp_path: Path) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -63,6 +63,24 @@ def test_add_source_queues_pending_ingest_for_cli_handoff(tmp_path: Path, capsys
     assert f"Next: splendor wiki suggest {source_id}" in out
 
 
+def test_pending_ingest_multiple_sources_points_back_to_status(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    first = tmp_path / "first.md"
+    second = tmp_path / "second.md"
+    first.write_text("# First\n\nFirst source covers workflow polish.\n", encoding="utf-8")
+    second.write_text("# Second\n\nSecond source covers web status.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(first)])
+    main(["--root", str(tmp_path), "add-source", str(second)])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Drain summary: processed=2 succeeded=2 failed=0 skipped=0" in out
+    assert "Next: splendor wiki status" in out
+
+
 def test_add_source_reports_warning_when_queue_handoff_fails(tmp_path: Path, capsys) -> None:
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nThis source is registered before init.\n", encoding="utf-8")

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -55,10 +55,12 @@ def test_add_source_queues_pending_ingest_for_cli_handoff(tmp_path: Path, capsys
     exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
 
     assert exit_code == 0
+    out = capsys.readouterr().out
     source_record = load_source_record(
         tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
     )
     assert source_record.status == "ingested"
+    assert f"Next: splendor wiki suggest {source_id}" in out
 
 
 def test_add_source_reports_warning_when_queue_handoff_fails(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

- Adds restrained next-action hints for the dogfood loop after pending ingest, query, and file-answer.
- Improves query snippet selection so generated source-summary matches prefer claim-bearing sections over metadata boilerplate.
- Adds read-only web `/status` and `/sources/<source-id>` surfaces that expose source, run, review, and synthesis-suggestion state without adding mutating web actions.
- Updates tests, docs, and planning-state lines for M10-P0.3.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run pytest`

## Notes

This preserves the generated source-summary versus maintained synthesis-page distinction. Mutating `splendor wiki compile <source-id>`, web add-source forms, and planning/runs UI views remain deferred.
