### PR TITLE
M9-P2.1 Planning and runs UI views

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M10-P0.2`
-- Last action taken: `M10-P0.2` is implemented; project briefing and the non-mutating compile-loop contract now support review-gated synthesis handoff.
-- Current planned slice: `M10-P0`
-- Current PR sub-slice: `M10-P0.3`
+- Previous completed PR sub-slice: `M10-P0.3`
+- Last action taken: `M10-P0.3` is implemented; dogfood workflow hints, claim-bearing query snippets, and read-only web status/source-detail views now support the text-native maintenance bridge.
+- Current planned slice: `M9-P2`
+- Current PR sub-slice: `M9-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M9-P2`
-- Next planned PR sub-slice: `M9-P2.1`
+- Next planned slice: `M10-P1`
+- Next planned PR sub-slice: `M10-P1.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -135,6 +135,12 @@
   - [x] Add read-only web status and source-detail surfaces
   - [x] Update focused tests and docs for the dogfood workflow polish
   - [x] Publish a non-draft GitHub PR for `M10-P0.3` with labels, milestone, and a detailed description
+- [ ] Implement `M9-P2.1`: Planning/runs UI views
+  - [x] Add read-only planning index and per-kind planning list views
+  - [x] Add read-only runs and queue inspection views over durable runtime records
+  - [x] Keep web actions non-mutating and CLI-first
+  - [x] Update focused tests and docs for the planning/runtime web surfaces
+  - [ ] Publish a non-draft GitHub PR for `M9-P2.1` with labels, milestone, and a detailed description
 
 ## Context Pointers
 
@@ -169,3 +175,4 @@
 - `M10-P0.2` Project briefing and compile-loop contract
 - `M10-P0.3` Dogfood workflow polish and web status surfaces
 - `M9-P2.1` Planning/runs UI views
+- `M10-P1.1` Queue inspect/retry/repair commands

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -140,7 +140,7 @@
   - [x] Add read-only runs and queue inspection views over durable runtime records
   - [x] Keep web actions non-mutating and CLI-first
   - [x] Update focused tests and docs for the planning/runtime web surfaces
-  - [ ] Publish a non-draft GitHub PR for `M9-P2.1` with labels, milestone, and a detailed description
+  - [x] Publish a non-draft GitHub PR for `M9-P2.1` with labels, milestone, and a detailed description
 
 ## Context Pointers
 

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -135,7 +135,7 @@
   - [x] Add read-only web status and source-detail surfaces
   - [x] Update focused tests and docs for the dogfood workflow polish
   - [x] Publish a non-draft GitHub PR for `M10-P0.3` with labels, milestone, and a detailed description
-- [ ] Implement `M9-P2.1`: Planning/runs UI views
+- [x] Implement `M9-P2.1`: Planning/runs UI views
   - [x] Add read-only planning index and per-kind planning list views
   - [x] Add read-only runs and queue inspection views over durable runtime records
   - [x] Keep web actions non-mutating and CLI-first

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The companion-repo guidance and sample agent instructions live in
 ## What Splendor Is Not
 
 - A hosted service
-- A full web UI product beyond the local read-only browse/search shell
+- A full web UI product beyond the local read-only inspection shell
 - An OCR or rich-media ingestion pipeline in the current MVP
 - A mandatory GitHub-only workflow
 
@@ -122,8 +122,8 @@ Implemented today:
 - `splendor wiki suggest <source-id>`
 - `splendor wiki compile <source-id>` as a non-mutating review-gated contract description
 - `splendor brief [goal]`
-- `splendor serve` for a read-only local browse/search UI
-- read-only web `/status` and `/sources/<source-id>` views
+- `splendor serve` for a read-only local browse/search/status/planning/runtime UI
+- read-only web `/status`, `/sources/<source-id>`, `/planning`, `/runs`, and `/queue` views
 - `splendor lint` and `splendor health`
 
 Not implemented yet:
@@ -131,7 +131,6 @@ Not implemented yet:
 - mutating review-gated `splendor wiki compile`
 - OCR and image extraction flows
 - mutating web UI actions such as add-source forms
-- planning/runs UI views
 - changed-files-driven refresh suggestions
 
 ## Documentation
@@ -146,12 +145,12 @@ Not implemented yet:
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M10-P0.2`
-- Current planned slice: `M10-P0`
-- Current PR sub-slice: `M10-P0.3`
+- Previous completed PR sub-slice: `M10-P0.3`
+- Current planned slice: `M9-P2`
+- Current PR sub-slice: `M9-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M9-P2`
-- Next planned PR sub-slice: `M9-P2.1`
+- Next planned slice: `M10-P1`
+- Next planned PR sub-slice: `M10-P1.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -175,8 +174,10 @@ the wiki and filed follow-up product tasks.
 `M10-P0.1` is implemented: Splendor now has CLI-first wiki status and source-impact suggestions
 for the text-native maintenance loop. `M10-P0.2` is implemented: the first project briefing command
 and non-mutating review-gated compile-loop contract are in place without mutating synthesis pages.
-The current PR sub-slice is `M10-P0.3`, which smooths the visible workflow around
+`M10-P0.3` is implemented: it smooths the visible workflow around
 `add-source -> ingest -> wiki suggest -> review`, adds restrained next-action hints after query and
 file-answer, improves claim-bearing query snippets, and exposes read-only web status/source-detail
 views. The goal remains explicit separation: ingest creates source summaries; reviewed
 compile/update workflows maintain concept, entity, topic, architecture, and glossary pages.
+The current PR sub-slice is `M9-P2.1`, which adds read-only planning and runtime inspection pages
+to the local web UI without adding mutating web actions.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,23 +334,21 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M10-P0.2`
-- Current planned slice: `M10-P0`
-- Current PR sub-slice: `M10-P0.3`
+- Previous completed PR sub-slice: `M10-P0.3`
+- Current planned slice: `M9-P2`
+- Current PR sub-slice: `M9-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M9-P2`
-- Next planned PR sub-slice: `M9-P2.1`
+- Next planned slice: `M10-P1`
+- Next planned PR sub-slice: `M10-P1.1`
 
 `M10-P0.1` is implemented: the CLI-first wiki status and source-impact suggestion bridge is in
 place. `M10-P0.2` is implemented: project briefing and the non-mutating review-gated compile-loop
-contract are available. The current PR sub-slice is `M10-P0.3`, under parent slice `M10-P0`, which
-polishes the visible dogfood workflow with restrained next-action hints, claim-bearing snippets,
-and read-only web status/source-detail surfaces. The lifecycle marker means `M10-P0.3` is in
-progress on feature branches and merged once the same committed state is observed on `main`.
-
-Dogfooding also changed the recommended next slice: before deeper planning/runs UI work, Splendor
-should add a small CLI-first bridge for wiki status, source-impact suggestions, and project
-briefing. That slice is tracked as `M10-P0`.
+contract are available. `M10-P0.3` is implemented: it polishes the visible dogfood workflow with
+restrained next-action hints, claim-bearing snippets, and read-only web status/source-detail
+surfaces. The current PR sub-slice is `M9-P2.1`, under parent slice `M9-P2`, which returns to
+read-only planning and runtime inspection pages for the local web UI. The lifecycle marker means
+`M9-P2.1` is in progress on feature branches and merged once the same committed state is observed
+on `main`.
 
 ---
 
@@ -559,6 +557,7 @@ Provide a modest but useful human UI without changing the system’s center of g
 - `M10-P0.1` Wiki status and source-impact suggestions
 - `M10-P0.2` Project briefing and compile-loop contract
 - `M10-P0.3` Dogfood workflow polish and web status surfaces
+- `M9-P2.1` Planning/runs UI views
 
 ### Milestone 9 status
 
@@ -571,11 +570,10 @@ boilerplate. `M9-P1.3` adds three researched dogfood rounds, extends the wiki wi
 and agent-context synthesis, and files follow-up product tasks from the observed workflow friction.
 `M10-P0.1` adds CLI-first wiki status and source-impact suggestions before deeper planning/runs UI
 work. `M10-P0.2` adds project briefing and a documented, non-mutating review-gated compile-loop
-contract. The current recommended slice is `M10-P0.3`, which polishes the visible dogfood workflow
-with query snippet improvements, restrained next-action hints, and read-only web
-status/source-detail surfaces.
-Mutating web actions, add-source forms, and planning/runs views remain deferred to later `M9`
-slices.
+contract. `M10-P0.3` polishes the visible dogfood workflow with query snippet improvements,
+restrained next-action hints, and read-only web status/source-detail surfaces. `M9-P2.1` adds
+read-only planning record lists plus queue and run inspection views to the same local web shell.
+Mutating web actions and add-source forms remain deferred to later `M9` slices.
 
 ---
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -999,7 +999,7 @@ Early web UI should be intentionally modest.
 - source detail pages showing source metadata, generated summary page, ingest run, provenance, and
   affected synthesis-page suggestions
 - source add form
-- basic queue/runs page later
+- basic queue/runs page
 
 The web UI should make generated versus maintained pages visible without requiring raw frontmatter
 inspection. Users should be able to distinguish generated source summaries, draft synthesis,
@@ -1008,7 +1008,9 @@ reviewed synthesis, contested pages, and stale pages while browsing or searching
 Current implementation includes read-only `/status` and `/sources/{source-id}` pages layered on
 the CLI wiki status/suggest contracts. They expose source/page/queue/run/review counts, source
 manifests, linked source-summary pages, latest ingest run state, and deterministic affected
-synthesis-page suggestions without adding mutating web actions.
+synthesis-page suggestions without adding mutating web actions. It also includes read-only
+`/planning`, `/planning/{kind}`, `/runs`, and `/queue` pages that list durable planning and runtime
+records and link planning rows back to their markdown detail pages.
 
 ### Avoid early
 - heavy collaborative editing

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -19,11 +19,17 @@ from splendor.commands.query import QueryMatch, QueryValidationError, run_query
 from splendor.commands.wiki import build_wiki_status, load_sources, suggest_source_pages
 from splendor.config import load_config
 from splendor.layout import ResolvedLayout, resolve_layout
+from splendor.schemas import QueueItemRecord, RunRecord
 from splendor.state.paths import resolve_workspace_path
-from splendor.state.runtime import load_run_record
+from splendor.state.runtime import load_queue_item, load_run_record
 from splendor.state.source_compat import canonical_source_ref
 from splendor.state.source_registry import load_source_record
-from splendor.utils.planning import parse_planning_document
+from splendor.utils.planning import (
+    iter_planning_paths,
+    parse_planning_document,
+    planning_directory,
+    record_id_field,
+)
 from splendor.utils.wiki import parse_wiki_markdown
 
 _LOGGER = logging.getLogger(__name__)
@@ -93,6 +99,28 @@ class _DocumentDetail:
     body: str
 
 
+@dataclass(frozen=True)
+class _PlanningSummary:
+    path: str
+    kind: str
+    record_id: str
+    title: str
+    status: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class _QueueSummary:
+    path: str
+    record: QueueItemRecord
+
+
+@dataclass(frozen=True)
+class _RunSummary:
+    path: str
+    record: RunRecord
+
+
 class WebLayoutError(ValueError):
     """Raised when configured web document roots are unsafe to serve."""
 
@@ -132,6 +160,9 @@ def create_app(root: Path) -> FastAPI:
             '<button type="submit">Search</button>'
             "</form>"
             '<a class="button" href="/browse">Browse documents</a>'
+            '<a class="button secondary" href="/planning">Planning</a>'
+            '<a class="button secondary" href="/runs">Runs</a>'
+            '<a class="button secondary" href="/queue">Queue</a>'
             '<a class="button secondary" href="/status">Status</a>'
             "</section>"
             f"{empty_state}"
@@ -203,6 +234,120 @@ def create_app(root: Path) -> FastAPI:
             f"<tbody>{source_rows}</tbody></table>"
         )
         return _page("Status", body)
+
+    @app.get("/planning", response_class=HTMLResponse)
+    def planning() -> HTMLResponse:
+        layout = _layout_for(workspace_root)
+        try:
+            grouped = {
+                kind: _planning_records(workspace_root, layout, kind)
+                for kind in ("task", "milestone", "decision", "question")
+            }
+        except ValueError:
+            _LOGGER.exception("Planning view failed while parsing planning records.")
+            return _page(
+                "Planning Error",
+                '<p class="empty">'
+                "Planning view failed because the workspace contains invalid planning records."
+                "</p>",
+                status_code=500,
+            )
+        stats = "".join(
+            f"<div><strong>{len(grouped[kind])}</strong>"
+            f"<span>{html.escape(_planning_label(kind))}</span></div>"
+            for kind in ("task", "milestone", "decision", "question")
+        )
+        sections = "".join(_planning_section(kind, records) for kind, records in grouped.items())
+        body = (
+            '<p class="breadcrumbs"><a href="/">Home</a> / Planning</p>'
+            f'<section class="stats">{stats}</section>'
+            f"{sections}"
+        )
+        return _page("Planning", body)
+
+    @app.get("/planning/{kind}", response_class=HTMLResponse)
+    def planning_kind(kind: str) -> HTMLResponse:
+        layout = _layout_for(workspace_root)
+        normalized_kind = _normalize_planning_kind(kind)
+        try:
+            records = _planning_records(workspace_root, layout, normalized_kind)
+        except ValueError:
+            _LOGGER.exception("Planning view failed while parsing planning records.")
+            return _page(
+                "Planning Error",
+                '<p class="empty">'
+                "Planning view failed because the workspace contains invalid planning records."
+                "</p>",
+                status_code=500,
+            )
+        body = (
+            '<p class="breadcrumbs"><a href="/planning">Planning</a> / '
+            f"{html.escape(_planning_label(normalized_kind))}</p>"
+            f"{_planning_table(normalized_kind, records)}"
+        )
+        return _page(_planning_label(normalized_kind), body)
+
+    @app.get("/runs", response_class=HTMLResponse)
+    def runs() -> HTMLResponse:
+        layout = _layout_for(workspace_root)
+        try:
+            run_records = _run_records(workspace_root, layout)
+        except ValueError:
+            _LOGGER.exception("Runs view failed while parsing run records.")
+            return _page(
+                "Runs Error",
+                '<p class="empty">'
+                "Runs view failed because the workspace contains invalid run records."
+                "</p>",
+                status_code=500,
+            )
+        rows = "\n".join(_run_row(run) for run in run_records[:25])
+        if not rows:
+            rows = '<tr><td colspan="8" class="empty">No run records yet.</td></tr>'
+        body = (
+            '<p class="breadcrumbs"><a href="/">Home</a> / Runs</p>'
+            '<p class="empty">Recent run records are shown from durable filesystem state. '
+            "This page does not start, retry, or mutate jobs.</p>"
+            "<table><thead><tr><th>Run</th><th>Status</th><th>Job</th><th>Started</th>"
+            "<th>Finished</th><th>Sources</th><th>Pages</th><th>Record</th></tr></thead>"
+            f"<tbody>{rows}</tbody></table>"
+        )
+        return _page("Runs", body)
+
+    @app.get("/queue", response_class=HTMLResponse)
+    def queue() -> HTMLResponse:
+        layout = _layout_for(workspace_root)
+        try:
+            queue_records = _queue_records(workspace_root, layout)
+        except ValueError:
+            _LOGGER.exception("Queue view failed while parsing queue records.")
+            return _page(
+                "Queue Error",
+                '<p class="empty">'
+                "Queue view failed because the workspace contains invalid queue records."
+                "</p>",
+                status_code=500,
+            )
+        status_counts: dict[str, int] = {}
+        for item in queue_records:
+            status_counts[item.record.status] = status_counts.get(item.record.status, 0) + 1
+        rows = "\n".join(_queue_row(item) for item in queue_records[:50])
+        if not rows:
+            rows = '<tr><td colspan="8" class="empty">No queue records yet.</td></tr>'
+        body = (
+            '<p class="breadcrumbs"><a href="/">Home</a> / Queue</p>'
+            '<section class="stats">'
+            f"<div><strong>{len(queue_records)}</strong><span>Queue records</span></div>"
+            f"<div><strong>{html.escape(_format_counts(status_counts)) or '-'}</strong>"
+            "<span>Status counts</span></div>"
+            "</section>"
+            '<p class="empty">Queue state is read-only here. Use CLI commands for ingestion, '
+            "repair, retry, or other mutations.</p>"
+            "<table><thead><tr><th>Job</th><th>Status</th><th>Type</th><th>Attempts</th>"
+            "<th>Payload</th><th>Lease</th><th>Error</th><th>Record</th></tr></thead>"
+            f"<tbody>{rows}</tbody></table>"
+        )
+        return _page("Queue", body)
 
     @app.get("/sources/{source_id}", response_class=HTMLResponse)
     def source_detail(source_id: str) -> HTMLResponse:
@@ -413,6 +558,142 @@ def _workspace_counts(
         ),
         runs=sum(1 for path in layout.runs_dir.glob("*.json") if path.is_file()),
     )
+
+
+def _normalize_planning_kind(kind: str) -> str:
+    normalized = kind.removesuffix("s")
+    if normalized not in {"task", "milestone", "decision", "question"}:
+        raise HTTPException(status_code=404, detail="Planning kind not found")
+    return normalized
+
+
+def _planning_label(kind: str) -> str:
+    return {
+        "task": "Tasks",
+        "milestone": "Milestones",
+        "decision": "Decisions",
+        "question": "Questions",
+    }[kind]
+
+
+def _planning_records(root: Path, layout: ResolvedLayout, kind: str) -> list[_PlanningSummary]:
+    model = model_for_planning_kind(kind)
+    id_field = record_id_field(kind)
+    records: list[_PlanningSummary] = []
+    for path in iter_planning_paths(planning_directory(layout, kind)):
+        parsed = parse_planning_document(path, model)
+        record = parsed.record
+        metadata = record.model_dump(mode="json")
+        record_id = getattr(record, id_field)
+        status = metadata.get("status")
+        records.append(
+            _PlanningSummary(
+                path=path.relative_to(root).as_posix(),
+                kind=kind,
+                record_id=record_id,
+                title=record.title,
+                status=status if isinstance(status, str) else "-",
+                detail=_planning_detail(kind, metadata),
+            )
+        )
+    return sorted(records, key=lambda item: (item.status, item.record_id))
+
+
+def _planning_detail(kind: str, metadata: dict[str, object]) -> str:
+    if kind == "task":
+        parts = [f"priority={metadata.get('priority', '-')}"]
+        owner = metadata.get("owner")
+        if owner:
+            parts.append(f"owner={owner}")
+        milestone_refs = metadata.get("milestone_refs")
+        if isinstance(milestone_refs, list) and milestone_refs:
+            parts.append(f"milestones={len(milestone_refs)}")
+        return " ".join(parts)
+    if kind == "milestone":
+        parts = []
+        target_date = metadata.get("target_date")
+        if target_date:
+            parts.append(f"target={target_date}")
+        task_refs = metadata.get("task_refs")
+        if isinstance(task_refs, list):
+            parts.append(f"tasks={len(task_refs)}")
+        return " ".join(parts) or "-"
+    if kind == "decision":
+        decided_at = metadata.get("decided_at")
+        related_tasks = metadata.get("related_tasks")
+        parts = [f"decided={decided_at or '-'}"]
+        if isinstance(related_tasks, list) and related_tasks:
+            parts.append(f"tasks={len(related_tasks)}")
+        return " ".join(parts)
+    answer_page = metadata.get("answer_page_ref")
+    related_tasks = metadata.get("related_tasks")
+    parts = []
+    if answer_page:
+        parts.append(f"answer={answer_page}")
+    if isinstance(related_tasks, list) and related_tasks:
+        parts.append(f"tasks={len(related_tasks)}")
+    return " ".join(parts) or "-"
+
+
+def _planning_section(kind: str, records: list[_PlanningSummary]) -> str:
+    return (
+        f'<h2><a href="/planning/{kind}s">{html.escape(_planning_label(kind))}</a></h2>'
+        f"{_planning_table(kind, records)}"
+    )
+
+
+def _planning_table(kind: str, records: list[_PlanningSummary]) -> str:
+    rows = "\n".join(_planning_row(item) for item in records)
+    if not rows:
+        rows = (
+            f'<tr><td colspan="5" class="empty">No '
+            f"{html.escape(_planning_label(kind).lower())} yet.</td></tr>"
+        )
+    return (
+        "<table><thead><tr><th>Title</th><th>ID</th><th>Status</th><th>Detail</th>"
+        f"<th>Path</th></tr></thead><tbody>{rows}</tbody></table>"
+    )
+
+
+def _planning_row(item: _PlanningSummary) -> str:
+    href = f"/documents/{quote(item.path, safe='/')}"
+    return (
+        "<tr>"
+        f'<td><a href="{href}">{html.escape(item.title)}</a></td>'
+        f"<td><code>{html.escape(item.record_id)}</code></td>"
+        f"<td>{html.escape(item.status)}</td>"
+        f"<td>{html.escape(item.detail)}</td>"
+        f"<td><code>{html.escape(item.path)}</code></td>"
+        "</tr>"
+    )
+
+
+def _run_records(root: Path, layout: ResolvedLayout) -> list[_RunSummary]:
+    records: list[_RunSummary] = []
+    for run_path in sorted(layout.runs_dir.glob("*.json")):
+        records.append(
+            _RunSummary(
+                path=run_path.relative_to(root).as_posix(),
+                record=load_run_record(run_path),
+            )
+        )
+    return sorted(
+        records,
+        key=lambda item: (item.record.finished_at or item.record.started_at, item.record.run_id),
+        reverse=True,
+    )
+
+
+def _queue_records(root: Path, layout: ResolvedLayout) -> list[_QueueSummary]:
+    records: list[_QueueSummary] = []
+    for queue_path in sorted(layout.queue_dir.glob("*.json")):
+        records.append(
+            _QueueSummary(
+                path=queue_path.relative_to(root).as_posix(),
+                record=load_queue_item(queue_path),
+            )
+        )
+    return sorted(records, key=lambda item: (item.record.status, item.record.job_id))
 
 
 def _format_counts(counts: dict[str, int]) -> str:
@@ -635,6 +916,47 @@ def _source_run_section(root: Path, layout: ResolvedLayout, run_id: str | None) 
         f"<div><strong>Record</strong><span><code>{html.escape(run_ref)}</code></span></div>"
         f"<div><strong>Pages</strong><span>{html.escape(pages)}</span></div>"
         "</section>"
+    )
+
+
+def _run_row(item: _RunSummary) -> str:
+    run = item.record
+    page_refs = ", ".join(run.page_refs[:3])
+    if len(run.page_refs) > 3:
+        page_refs += f" (+{len(run.page_refs) - 3})"
+    source_ids = ", ".join(run.source_ids[:3])
+    if len(run.source_ids) > 3:
+        source_ids += f" (+{len(run.source_ids) - 3})"
+    return (
+        "<tr>"
+        f"<td><code>{html.escape(run.run_id)}</code></td>"
+        f"<td>{html.escape(run.status)}</td>"
+        f"<td><code>{html.escape(run.job_id)}</code><br />{html.escape(run.job_type)}</td>"
+        f"<td>{html.escape(run.started_at)}</td>"
+        f"<td>{html.escape(run.finished_at or '-')}</td>"
+        f"<td>{html.escape(source_ids or '-')}</td>"
+        f"<td>{html.escape(page_refs or '-')}</td>"
+        f"<td><code>{html.escape(item.path)}</code></td>"
+        "</tr>"
+    )
+
+
+def _queue_row(item: _QueueSummary) -> str:
+    queue = item.record
+    lease = "-"
+    if queue.lease_owner or queue.lease_expires_at:
+        lease = f"{queue.lease_owner or '-'} until {queue.lease_expires_at or '-'}"
+    return (
+        "<tr>"
+        f"<td><code>{html.escape(queue.job_id)}</code></td>"
+        f"<td>{html.escape(queue.status)}</td>"
+        f"<td>{html.escape(queue.job_type)}</td>"
+        f"<td>{queue.attempt_count}/{queue.max_attempts}</td>"
+        f"<td><code>{html.escape(queue.payload_ref)}</code></td>"
+        f"<td>{html.escape(lease)}</td>"
+        f"<td>{html.escape(queue.last_error or '-')}</td>"
+        f"<td><code>{html.escape(item.path)}</code></td>"
+        "</tr>"
     )
 
 

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -13,6 +13,7 @@ import bleach
 import markdown as markdown_lib
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse
+from pydantic import ValidationError
 
 from splendor.commands.planning import model_for_planning_kind
 from splendor.commands.query import QueryMatch, QueryValidationError, run_query
@@ -292,7 +293,7 @@ def create_app(root: Path) -> FastAPI:
         layout = _layout_for(workspace_root)
         try:
             run_records = _run_records(workspace_root, layout)
-        except ValueError:
+        except (ValueError, ValidationError):
             _LOGGER.exception("Runs view failed while parsing run records.")
             return _page(
                 "Runs Error",
@@ -320,7 +321,7 @@ def create_app(root: Path) -> FastAPI:
         layout = _layout_for(workspace_root)
         try:
             queue_records = _queue_records(workspace_root, layout)
-        except ValueError:
+        except (ValueError, ValidationError):
             _LOGGER.exception("Queue view failed while parsing queue records.")
             return _page(
                 "Queue Error",

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -303,13 +303,14 @@ def create_app(root: Path) -> FastAPI:
             )
         rows = "\n".join(_run_row(run) for run in run_records[:25])
         if not rows:
-            rows = '<tr><td colspan="8" class="empty">No run records yet.</td></tr>'
+            rows = '<tr><td colspan="9" class="empty">No run records yet.</td></tr>'
         body = (
             '<p class="breadcrumbs"><a href="/">Home</a> / Runs</p>'
             '<p class="empty">Recent run records are shown from durable filesystem state. '
             "This page does not start, retry, or mutate jobs.</p>"
             "<table><thead><tr><th>Run</th><th>Status</th><th>Job</th><th>Started</th>"
-            "<th>Finished</th><th>Sources</th><th>Pages</th><th>Record</th></tr></thead>"
+            "<th>Finished</th><th>Sources</th><th>Pages</th><th>Warnings / Errors</th>"
+            "<th>Record</th></tr></thead>"
             f"<tbody>{rows}</tbody></table>"
         )
         return _page("Runs", body)
@@ -333,7 +334,7 @@ def create_app(root: Path) -> FastAPI:
             status_counts[item.record.status] = status_counts.get(item.record.status, 0) + 1
         rows = "\n".join(_queue_row(item) for item in queue_records[:50])
         if not rows:
-            rows = '<tr><td colspan="8" class="empty">No queue records yet.</td></tr>'
+            rows = '<tr><td colspan="10" class="empty">No queue records yet.</td></tr>'
         body = (
             '<p class="breadcrumbs"><a href="/">Home</a> / Queue</p>'
             '<section class="stats">'
@@ -344,7 +345,8 @@ def create_app(root: Path) -> FastAPI:
             '<p class="empty">Queue state is read-only here. Use CLI commands for ingestion, '
             "repair, retry, or other mutations.</p>"
             "<table><thead><tr><th>Job</th><th>Status</th><th>Type</th><th>Attempts</th>"
-            "<th>Payload</th><th>Lease</th><th>Error</th><th>Record</th></tr></thead>"
+            "<th>Created</th><th>Updated</th><th>Payload</th><th>Lease</th><th>Error</th>"
+            "<th>Record</th></tr></thead>"
             f"<tbody>{rows}</tbody></table>"
         )
         return _page("Queue", body)
@@ -927,6 +929,7 @@ def _run_row(item: _RunSummary) -> str:
     source_ids = ", ".join(run.source_ids[:3])
     if len(run.source_ids) > 3:
         source_ids += f" (+{len(run.source_ids) - 3})"
+    diagnostics = _bounded_detail([*run.errors, *run.warnings])
     return (
         "<tr>"
         f"<td><code>{html.escape(run.run_id)}</code></td>"
@@ -936,6 +939,7 @@ def _run_row(item: _RunSummary) -> str:
         f"<td>{html.escape(run.finished_at or '-')}</td>"
         f"<td>{html.escape(source_ids or '-')}</td>"
         f"<td>{html.escape(page_refs or '-')}</td>"
+        f"<td>{html.escape(diagnostics)}</td>"
         f"<td><code>{html.escape(item.path)}</code></td>"
         "</tr>"
     )
@@ -952,12 +956,23 @@ def _queue_row(item: _QueueSummary) -> str:
         f"<td>{html.escape(queue.status)}</td>"
         f"<td>{html.escape(queue.job_type)}</td>"
         f"<td>{queue.attempt_count}/{queue.max_attempts}</td>"
+        f"<td>{html.escape(queue.created_at)}</td>"
+        f"<td>{html.escape(queue.updated_at)}</td>"
         f"<td><code>{html.escape(queue.payload_ref)}</code></td>"
         f"<td>{html.escape(lease)}</td>"
         f"<td>{html.escape(queue.last_error or '-')}</td>"
         f"<td><code>{html.escape(item.path)}</code></td>"
         "</tr>"
     )
+
+
+def _bounded_detail(values: list[str], *, limit: int = 3) -> str:
+    if not values:
+        return "-"
+    detail = "; ".join(values[:limit])
+    if len(values) > limit:
+        detail += f" (+{len(values) - limit})"
+    return detail
 
 
 def _suggestion_row(suggestion) -> str:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -312,10 +312,13 @@ def test_runs_and_queue_pages_show_runtime_state(tmp_path: Path) -> None:
     assert "run-src-web" in runs.text
     assert "ingest-src-web" in runs.text
     assert "wiki/sources/src-web.md" in runs.text
+    assert "source missing" in runs.text
     assert "state/runs/run-src-web.json" in runs.text
     assert queue.status_code == 200
     assert "failed=1" in queue.text
     assert "2/3" in queue.text
+    assert "2026-04-30T10:00:00+00:00" in queue.text
+    assert "2026-04-30T10:05:00+00:00" in queue.text
     assert "source missing" in queue.text
     assert "state/queue/ingest-src-web.json" in queue.text
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -6,8 +6,16 @@ from fastapi.testclient import TestClient
 from splendor.cli import main
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
-from splendor.commands.planning import create_task
-from splendor.schemas import KnowledgePageFrontmatter
+from splendor.commands.planning import (
+    create_decision,
+    create_milestone,
+    create_question,
+    create_task,
+)
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord
+from splendor.state.runtime import write_queue_item, write_run_record
 from splendor.state.source_registry import load_source_record
 from splendor.web import create_app
 
@@ -35,6 +43,9 @@ def test_home_page_loads_for_initialized_workspace(tmp_path: Path) -> None:
     assert "Splendor" in response.text
     assert "Wiki content pages" in response.text
     assert "/browse" in response.text
+    assert "/planning" in response.text
+    assert "/runs" in response.text
+    assert "/queue" in response.text
     assert "/status" in response.text
 
 
@@ -139,6 +150,193 @@ def test_document_detail_renders_planning_task(tmp_path: Path) -> None:
     assert response.status_code == 200
     assert "Ship web shell" in response.text
     assert "todo" in response.text
+
+
+def test_planning_page_lists_and_links_all_planning_kinds(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    create_milestone(
+        tmp_path,
+        "Milestone UI",
+        record_id="milestone-ui",
+        status="active",
+        target_date="2026-05-01",
+        task_refs=["task-ship-planning-ui"],
+        decision_refs=["decision-read-only-web"],
+        question_refs=["question-runtime-state"],
+    )
+    create_task(
+        tmp_path,
+        "Ship planning UI",
+        record_id="task-ship-planning-ui",
+        status="in_progress",
+        priority="high",
+        owner="codex",
+        milestone_refs=["milestone-ui"],
+        decision_refs=["decision-read-only-web"],
+        question_refs=["question-runtime-state"],
+        depends_on=[],
+        source_refs=[],
+    )
+    create_decision(
+        tmp_path,
+        "Keep web read only",
+        record_id="decision-read-only-web",
+        status="accepted",
+        decided_at="2026-04-30",
+        supersedes=[],
+        source_refs=[],
+        related_tasks=["task-ship-planning-ui"],
+        related_questions=["question-runtime-state"],
+    )
+    create_question(
+        tmp_path,
+        "How visible should runtime state be",
+        record_id="question-runtime-state",
+        status="open",
+        source_refs=[],
+        related_tasks=["task-ship-planning-ui"],
+        related_decisions=["decision-read-only-web"],
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/planning")
+
+    assert response.status_code == 200
+    assert "Tasks" in response.text
+    assert "Milestones" in response.text
+    assert "Decisions" in response.text
+    assert "Questions" in response.text
+    assert 'href="/documents/planning/tasks/task-ship-planning-ui.md"' in response.text
+    assert 'href="/documents/planning/milestones/milestone-ui.md"' in response.text
+    assert 'href="/documents/planning/decisions/decision-read-only-web.md"' in response.text
+    assert 'href="/documents/planning/questions/question-runtime-state.md"' in response.text
+    assert "priority=high" in response.text
+    assert "owner=codex" in response.text
+
+
+def test_planning_kind_page_lists_one_kind_and_rejects_unknown_kind(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    create_task(
+        tmp_path,
+        "Ship planning UI",
+        record_id="task-ship-planning-ui",
+        status="todo",
+        priority="medium",
+        owner=None,
+        milestone_refs=[],
+        decision_refs=[],
+        question_refs=[],
+        depends_on=[],
+        source_refs=[],
+    )
+    client = TestClient(create_app(tmp_path))
+
+    tasks = client.get("/planning/tasks")
+    missing = client.get("/planning/sources")
+
+    assert tasks.status_code == 200
+    assert "Ship planning UI" in tasks.text
+    assert "planning/tasks/task-ship-planning-ui.md" in tasks.text
+    assert missing.status_code == 404
+    assert "Planning kind not found" in missing.text
+
+
+def test_planning_page_reports_invalid_records_without_path_leak(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    bad_task = tmp_path / "planning" / "tasks" / "task-bad.md"
+    bad_task.write_text("---\nkind: task\ntask_id: task-bad\nbogus: true\n---\n", encoding="utf-8")
+    client = TestClient(create_app(tmp_path), raise_server_exceptions=False)
+
+    response = client.get("/planning")
+
+    assert response.status_code == 500
+    assert "invalid planning records" in response.text
+    assert str(bad_task) not in response.text
+
+
+def test_runs_and_queue_pages_show_empty_states(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    client = TestClient(create_app(tmp_path))
+
+    runs = client.get("/runs")
+    queue = client.get("/queue")
+
+    assert runs.status_code == 200
+    assert "No run records yet." in runs.text
+    assert "does not start, retry, or mutate jobs" in runs.text
+    assert queue.status_code == 200
+    assert "No queue records yet." in queue.text
+    assert "Queue state is read-only here" in queue.text
+
+
+def test_runs_and_queue_pages_show_runtime_state(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    write_queue_item(
+        layout.queue_dir / "ingest-src-web.json",
+        QueueItemRecord(
+            job_id="ingest-src-web",
+            job_type="ingest_source",
+            status="failed",
+            created_at="2026-04-30T10:00:00+00:00",
+            updated_at="2026-04-30T10:05:00+00:00",
+            attempt_count=2,
+            max_attempts=3,
+            payload_ref="state/manifests/sources/src-web.json",
+            last_error="source missing",
+        ),
+    )
+    write_run_record(
+        layout.runs_dir / "run-src-web.json",
+        RunRecord(
+            run_id="run-src-web",
+            job_id="ingest-src-web",
+            job_type="ingest_source",
+            started_at="2026-04-30T10:01:00+00:00",
+            finished_at="2026-04-30T10:02:00+00:00",
+            status="failed",
+            input_refs=["state/manifests/sources/src-web.json"],
+            output_refs=[],
+            errors=["source missing"],
+            pipeline_version="test",
+            source_ids=["src-web"],
+            page_refs=["wiki/sources/src-web.md"],
+        ),
+    )
+    client = TestClient(create_app(tmp_path))
+
+    runs = client.get("/runs")
+    queue = client.get("/queue")
+
+    assert runs.status_code == 200
+    assert "run-src-web" in runs.text
+    assert "ingest-src-web" in runs.text
+    assert "wiki/sources/src-web.md" in runs.text
+    assert "state/runs/run-src-web.json" in runs.text
+    assert queue.status_code == 200
+    assert "failed=1" in queue.text
+    assert "2/3" in queue.text
+    assert "source missing" in queue.text
+    assert "state/queue/ingest-src-web.json" in queue.text
+
+
+def test_runs_and_queue_pages_report_invalid_records_without_path_leak(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    bad_run = tmp_path / "state" / "runs" / "run-bad.json"
+    bad_queue = tmp_path / "state" / "queue" / "queue-bad.json"
+    bad_run.write_text("{not valid json", encoding="utf-8")
+    bad_queue.write_text("{not valid json", encoding="utf-8")
+    client = TestClient(create_app(tmp_path), raise_server_exceptions=False)
+
+    runs = client.get("/runs")
+    queue = client.get("/queue")
+
+    assert runs.status_code == 500
+    assert "invalid run records" in runs.text
+    assert str(bad_run) not in runs.text
+    assert queue.status_code == 500
+    assert "invalid queue records" in queue.text
+    assert str(bad_queue) not in queue.text
 
 
 def test_document_detail_falls_back_for_invalid_planning_frontmatter(tmp_path: Path) -> None:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -342,6 +342,30 @@ def test_runs_and_queue_pages_report_invalid_records_without_path_leak(tmp_path:
     assert str(bad_queue) not in queue.text
 
 
+def test_runs_and_queue_pages_report_schema_invalid_records_without_path_leak(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    bad_run = tmp_path / "state" / "runs" / "run-schema-bad.json"
+    bad_queue = tmp_path / "state" / "queue" / "queue-schema-bad.json"
+    bad_run.write_text('{"kind": "run", "run_id": "run-schema-bad"}\n', encoding="utf-8")
+    bad_queue.write_text(
+        '{"kind": "queue_item", "job_id": "queue-schema-bad"}\n',
+        encoding="utf-8",
+    )
+    client = TestClient(create_app(tmp_path), raise_server_exceptions=False)
+
+    runs = client.get("/runs")
+    queue = client.get("/queue")
+
+    assert runs.status_code == 500
+    assert "invalid run records" in runs.text
+    assert str(bad_run) not in runs.text
+    assert queue.status_code == 500
+    assert "invalid queue records" in queue.text
+    assert str(bad_queue) not in queue.text
+
+
 def test_document_detail_falls_back_for_invalid_planning_frontmatter(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     task_path = tmp_path / "planning" / "tasks" / "task-bad.md"


### PR DESCRIPTION
## Summary
- Add read-only local web planning indexes for tasks, milestones, decisions, and questions, with links back to the existing markdown document detail pages.
- Add read-only `/runs` and `/queue` inspection pages over durable filesystem runtime records, including empty states and generic invalid-record errors.
- Update README, product spec, roadmap, and `.agent-plan.md` planning-state lines for `M9-P2.1` and the next `M10-P1.1` slice.

## Why
This resumes the deferred Milestone 9 planning/runs UI track after the `M10-P0.3` dogfood workflow bridge. The web UI stays secondary and read-only while making planning and runtime state easier for humans to inspect locally.

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run pytest`

## Follow-up / limits
- No mutating web actions were added.
- Queue retry/repair commands remain in the next planned `M10-P1.1` slice.
