### PR TITLE
Add planning-validator pilot workflow

### DIFF
--- a/.github/planning-validator.yml
+++ b/.github/planning-validator.yml
@@ -1,0 +1,61 @@
+schema_version: v1alpha1
+
+planning_files:
+  - README.md
+  - .agent-plan.md
+  - docs/splendor_mvp_to_v1_roadmap.md
+  - docs/splendor_product_spec.md
+
+tracking_files:
+  - planning/tasks/*.md
+
+lookback:
+  merged_pr_hours: 72
+  commit_hours: 72
+
+staleness:
+  require_pr_reflection: true
+  require_issue_reflection: false
+  min_signal_score: 0.55
+  max_files_to_update: 4
+  ignore_pr_labels:
+    - skip-planning-validator
+  ignore_paths:
+    - .github/workflows/**
+    - state/**
+    - raw/**
+    - reports/**
+    - derived/**
+    - examples/**
+    - tests/**
+
+patching:
+  provider: openai
+  model: gpt-5.4-thinking
+  temperature: 0.1
+  allowed_update_globs:
+    - README.md
+    - .agent-plan.md
+    - docs/splendor_mvp_to_v1_roadmap.md
+    - docs/splendor_product_spec.md
+    - planning/tasks/*.md
+  forbidden_update_globs:
+    - .github/**
+    - src/**
+    - tests/**
+    - state/**
+    - raw/**
+    - reports/**
+    - derived/**
+    - wiki/**
+    - examples/**
+
+pull_request:
+  branch: automation/planning-validator
+  draft: true
+  update_existing: true
+  title_template: "docs: refresh planning state"
+  labels:
+    - documentation
+    - area/planning
+    - type/automation

--- a/.github/planning-validator.yml
+++ b/.github/planning-validator.yml
@@ -21,7 +21,7 @@ staleness:
   ignore_pr_labels:
     - skip-planning-validator
   ignore_paths:
-    - .github/workflows/**
+    - .github/**
     - state/**
     - raw/**
     - reports/**
@@ -31,7 +31,7 @@ staleness:
 
 patching:
   provider: openai
-  model: gpt-5.4-thinking
+  model: gpt-5.4
   temperature: 0.1
   allowed_update_globs:
     - README.md

--- a/.github/workflows/planning-validator.yml
+++ b/.github/workflows/planning-validator.yml
@@ -1,0 +1,21 @@
+name: planning-validator
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: planning-validator
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  run:
+    uses: shaypal5/planning-validator/.github/workflows/reusable-planning-validator.yml@main
+    with:
+      config_path: .github/planning-validator.yml
+    secrets:
+      openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/planning-validator.yml
+++ b/.github/workflows/planning-validator.yml
@@ -13,8 +13,28 @@ permissions:
   pull-requests: write
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Check automation secret availability
+        id: check
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -n "${OPENAI_API_KEY}" ]; then
+            echo "enabled=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "enabled=false" >> "${GITHUB_OUTPUT}"
+          fi
+
   run:
-    uses: shaypal5/planning-validator/.github/workflows/reusable-planning-validator.yml@main
+    needs: gate
+    if: ${{ needs.gate.outputs.enabled == 'true' }}
+    uses: shaypal5/planning-validator/.github/workflows/reusable-planning-validator.yml@017c24056d7fca224285f1a395d3afa8db721182
     with:
       config_path: .github/planning-validator.yml
     secrets:

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -124,7 +124,9 @@ Runs on:
 
 What it does:
 
-- invokes `shaypal5/planning-validator/.github/workflows/reusable-planning-validator.yml@main`
+- checks that `OPENAI_API_KEY` is configured before invoking the reusable workflow
+- invokes
+  `shaypal5/planning-validator/.github/workflows/reusable-planning-validator.yml@017c24056d7fca224285f1a395d3afa8db721182`
 - validates configured planning and tracking markdown against recent merged PR evidence
 - opens or updates one draft PR from `automation/planning-validator` when evidence-backed planning
   updates are proposed
@@ -137,9 +139,12 @@ Reviewed output paths:
 - `docs/splendor_product_spec.md`
 - `planning/tasks/*.md`
 
-Explicitly forbidden paths include source, tests, workflows, generated state, raw imports, reports,
-derived files, examples, and wiki pages. The pilot is intentionally manual-only until at least one
-generated PR has been reviewed after the active planning/runs UI work lands on `main`.
+The reusable workflow is pinned to an immutable `planning-validator` commit for the pilot. Move to a
+version tag once `planning-validator` publishes a release tag suitable for client repositories.
+
+Explicitly ignored or forbidden paths include source, tests, workflows, repository automation config,
+generated state, raw imports, reports, derived files, examples, and wiki pages. The pilot is
+intentionally manual-only until at least one generated PR has been reviewed.
 
 Permissions:
 
@@ -150,6 +155,11 @@ Permissions:
 Required secrets:
 
 - `OPENAI_API_KEY`
+
+Behavior without secret:
+
+- the workflow still triggers, but the reusable planning-validator job is skipped cleanly when
+  `OPENAI_API_KEY` is not configured
 
 ## `pr-agent-context-refresh`
 

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -114,6 +114,43 @@ Review expectations:
 - confirm the generating workflow's Splendor lint job passed
 - manually dispatch or rerun normal CI if repository policy requires checks on the generated PR
 
+## `planning-validator`
+
+File: `.github/workflows/planning-validator.yml`
+
+Runs on:
+
+- manual dispatch only during the first client-repo pilot
+
+What it does:
+
+- invokes `shaypal5/planning-validator/.github/workflows/reusable-planning-validator.yml@main`
+- validates configured planning and tracking markdown against recent merged PR evidence
+- opens or updates one draft PR from `automation/planning-validator` when evidence-backed planning
+  updates are proposed
+
+Reviewed output paths:
+
+- `README.md`
+- `.agent-plan.md`
+- `docs/splendor_mvp_to_v1_roadmap.md`
+- `docs/splendor_product_spec.md`
+- `planning/tasks/*.md`
+
+Explicitly forbidden paths include source, tests, workflows, generated state, raw imports, reports,
+derived files, examples, and wiki pages. The pilot is intentionally manual-only until at least one
+generated PR has been reviewed after the active planning/runs UI work lands on `main`.
+
+Permissions:
+
+- `contents: write`
+- `issues: write`
+- `pull-requests: write`
+
+Required secrets:
+
+- `OPENAI_API_KEY`
+
 ## `pr-agent-context-refresh`
 
 File: `.github/workflows/pr-agent-context-refresh.yml`


### PR DESCRIPTION
## Summary

- Add a manual-only `planning-validator` caller workflow for a first client-repo pilot.
- Add a narrow `.github/planning-validator.yml` that targets maintained planning and tracking markdown only.
- Document the workflow, required secret, permissions, reviewed paths, and pilot constraints in `docs/ci_and_repo_automation.md`.

## Merge readiness

PR #51 has landed, and this branch has been rebased over the updated `main`. The pilot is ready for review, with schedule disabled until at least one generated planning-validator PR has been reviewed manually.

## Pilot boundaries

The workflow has no schedule during the pilot. It only runs through `workflow_dispatch`.

The planning-validator config allows edits only to:

- `README.md`
- `.agent-plan.md`
- `docs/splendor_mvp_to_v1_roadmap.md`
- `docs/splendor_product_spec.md`
- `planning/tasks/*.md`

It explicitly forbids source, tests, workflows, generated state, raw imports, reports, derived files, examples, and wiki pages.

## Validation

Before the rebase:

- `planning-validator validate-config --config .github/planning-validator.yml --repo-root .`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run pytest` (`357 passed`)

After rebasing over PR #51:

- `planning-validator validate-config --config .github/planning-validator.yml --repo-root .`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run pytest` (`364 passed`)

## Follow-up

After merge, manually dispatch the workflow once and review the generated `automation/planning-validator` draft PR before considering any scheduled run.