### PR TITLE
M10-P1.1 queue inspect retry repair commands

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M10-P0.3`
-- Last action taken: `M10-P0.3` is implemented; dogfood workflow hints, claim-bearing query snippets, and read-only web status/source-detail views now support the text-native maintenance bridge.
-- Current planned slice: `M9-P2`
-- Current PR sub-slice: `M9-P2.1`
+- Previous completed PR sub-slice: `M9-P2.1`
+- Last action taken: `M9-P2.1` is implemented; read-only planning, queue, and run inspection views now expose durable runtime state in the local web UI.
+- Current planned slice: `M10-P1`
+- Current PR sub-slice: `M10-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M10-P1`
-- Next planned PR sub-slice: `M10-P1.1`
+- Next planned slice: `M10-P2`
+- Next planned PR sub-slice: `M10-P2.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -141,6 +141,12 @@
   - [x] Keep web actions non-mutating and CLI-first
   - [x] Update focused tests and docs for the planning/runtime web surfaces
   - [x] Publish a non-draft GitHub PR for `M9-P2.1` with labels, milestone, and a detailed description
+- [x] Implement `M10-P1.1`: Queue inspect/retry/repair commands
+  - [x] Add CLI queue inspection with human and JSON output
+  - [x] Add explicit failed ingest queue retry
+  - [x] Add active `repair ingest` recovery that requeues and runs immediately
+  - [x] Keep dead-letter, backoff, and broader stale-lease policy deferred to `M10-P2`
+  - [x] Publish a non-draft GitHub PR for `M10-P1.1` with labels, milestone, and a detailed description
 
 ## Context Pointers
 
@@ -176,3 +182,4 @@
 - `M10-P0.3` Dogfood workflow polish and web status surfaces
 - `M9-P2.1` Planning/runs UI views
 - `M10-P1.1` Queue inspect/retry/repair commands
+- `M10-P2.1` Backoff, dead-letter, and stale-lease recovery

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Implemented today:
 - `splendor init`
 - `splendor add-source <path>`
 - `splendor ingest <source-id>` and `splendor ingest --pending`
+- `splendor queue inspect [job-id]` and `splendor queue retry <job-id>`
+- `splendor repair ingest <source-id>`
 - `splendor materialize-source <source-id>`
 - `splendor query "<question>"` and `splendor query "<question>" --json`
 - `splendor file-answer --from-last-query --title "..."`
@@ -129,6 +131,7 @@ Implemented today:
 Not implemented yet:
 
 - mutating review-gated `splendor wiki compile`
+- queue backoff, dead-letter, and stale-lease recovery policies
 - OCR and image extraction flows
 - mutating web UI actions such as add-source forms
 - changed-files-driven refresh suggestions
@@ -145,12 +148,12 @@ Not implemented yet:
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M10-P0.3`
-- Current planned slice: `M9-P2`
-- Current PR sub-slice: `M9-P2.1`
+- Previous completed PR sub-slice: `M9-P2.1`
+- Current planned slice: `M10-P1`
+- Current PR sub-slice: `M10-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M10-P1`
-- Next planned PR sub-slice: `M10-P1.1`
+- Next planned slice: `M10-P2`
+- Next planned PR sub-slice: `M10-P2.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -179,5 +182,9 @@ and non-mutating review-gated compile-loop contract are in place without mutatin
 file-answer, improves claim-bearing query snippets, and exposes read-only web status/source-detail
 views. The goal remains explicit separation: ingest creates source summaries; reviewed
 compile/update workflows maintain concept, entity, topic, architecture, and glossary pages.
-The current PR sub-slice is `M9-P2.1`, which adds read-only planning and runtime inspection pages
-to the local web UI without adding mutating web actions.
+`M9-P2.1` is implemented: it adds read-only planning and runtime inspection pages to the local web
+UI without adding mutating web actions.
+
+The current PR sub-slice is `M10-P1.1`, which adds CLI-first queue inspection, failed ingest
+retry, and active ingest repair while leaving automatic backoff, dead-letter handling, and broader
+stale-lease recovery for `M10-P2`.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M10-P0.3`
-- Current planned slice: `M9-P2`
-- Current PR sub-slice: `M9-P2.1`
+- Previous completed PR sub-slice: `M9-P2.1`
+- Current planned slice: `M10-P1`
+- Current PR sub-slice: `M10-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M10-P1`
-- Next planned PR sub-slice: `M10-P1.1`
+- Next planned slice: `M10-P2`
+- Next planned PR sub-slice: `M10-P2.1`
 
 `M10-P0.1` is implemented: the CLI-first wiki status and source-impact suggestion bridge is in
 place. `M10-P0.2` is implemented: project briefing and the non-mutating review-gated compile-loop
@@ -645,6 +645,16 @@ Make Splendor resilient in the face of failed ingest/maintenance jobs.
 ### Planned PR slices
 - `M10-P1` Queue inspect/retry/repair commands
 - `M10-P2` Backoff, dead-letter, and stale-lease recovery
+
+### Current PR sub-slices
+- `M10-P1.1` Queue inspect/retry/repair commands
+- `M10-P2.1` Backoff, dead-letter, and stale-lease recovery
+
+### Milestone 10 status
+
+`M10-P1.1` adds CLI-first queue inspection, failed ingest retry, and active ingest repair for
+recovering broken text-native ingest jobs. Backoff, dead-letter handling, and broader stale-lease
+recovery remain deferred to `M10-P2.1`.
 
 ---
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -974,8 +974,9 @@ splendor brief "continue scraping-policy work"
 splendor file-answer --from-last-query
 splendor lint
 splendor health
-splendor queue list
+splendor queue inspect [job-id]
 splendor queue retry job-id
+splendor repair ingest source-id
 splendor task create
 splendor milestone create
 splendor decision create

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -30,6 +30,16 @@ from splendor.commands.planning import (
     update_question_answer,
 )
 from splendor.commands.query import run_query
+from splendor.commands.queue import (
+    inspect_queue,
+    inspect_queue_job,
+    render_queue_inspect_json,
+    render_queue_item_json,
+    render_queue_retry_json,
+    render_repair_ingest_json,
+    repair_ingest_source,
+    retry_queue_job,
+)
 from splendor.commands.repo_refresh import refresh_repo, render_repo_refresh_json
 from splendor.commands.repo_scan import render_repo_scan_json, scan_repo
 from splendor.commands.wiki import (
@@ -113,6 +123,45 @@ def build_parser() -> argparse.ArgumentParser:
         help="Drain pending ingestion jobs from the queue.",
     )
     ingest_parser.set_defaults(handler=handle_ingest)
+
+    queue_parser = subparsers.add_parser("queue", help="Inspect and retry queue jobs")
+    queue_subparsers = queue_parser.add_subparsers(dest="queue_command", required=True)
+    queue_inspect_parser = queue_subparsers.add_parser(
+        "inspect", help="Inspect durable queue records"
+    )
+    queue_inspect_parser.add_argument("job_id", nargs="?", help="Queue job identifier to inspect")
+    queue_inspect_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    queue_inspect_parser.set_defaults(handler=handle_queue_inspect)
+    queue_retry_parser = queue_subparsers.add_parser(
+        "retry", help="Reset a failed queue job for another ingest attempt"
+    )
+    queue_retry_parser.add_argument("job_id", help="Queue job identifier to retry")
+    queue_retry_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    queue_retry_parser.set_defaults(handler=handle_queue_retry)
+
+    repair_parser = subparsers.add_parser("repair", help="Repair failed Splendor state")
+    repair_subparsers = repair_parser.add_subparsers(dest="repair_command", required=True)
+    repair_ingest_parser = repair_subparsers.add_parser(
+        "ingest", help="Requeue and immediately run ingestion for a source"
+    )
+    repair_ingest_parser.add_argument("source_id", help="Registered source identifier to repair")
+    repair_ingest_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    repair_ingest_parser.set_defaults(handler=handle_repair_ingest)
 
     wiki_parser = subparsers.add_parser("wiki", help="Inspect and maintain wiki state")
     wiki_subparsers = wiki_parser.add_subparsers(dest="wiki_command", required=True)
@@ -518,6 +567,108 @@ def handle_ingest(args: argparse.Namespace) -> int:
     print(f"Run record: {result.run_path}")
     print(f"Next: splendor wiki suggest {result.source_id}")
     return 0
+
+
+def handle_queue_inspect(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        if args.job_id:
+            item = inspect_queue_job(root, args.job_id)
+            if args.json_output:
+                print(render_queue_item_json(item))
+                return 0
+            _print_queue_item_detail(item)
+            return 0
+
+        result = inspect_queue(root)
+    except (FileNotFoundError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_queue_inspect_json(result))
+        return 0
+
+    print("Queue inspect")
+    print(f"Total: {result.total}")
+    counts = " ".join(f"{status}={count}" for status, count in result.status_counts.items())
+    print(f"Status counts: {counts or '-'}")
+    if not result.items:
+        print("No queue records yet.")
+        return 0
+    print("Jobs:")
+    for item in result.items:
+        print(
+            f"- {item.job_id} [{item.status}] type={item.job_type} "
+            f"attempts={item.attempt_count}/{item.max_attempts} payload={item.payload_ref}"
+        )
+    if result.status_counts.get("failed", 0):
+        print("Next: splendor queue retry <job-id>")
+    elif result.status_counts.get("pending", 0):
+        print("Next: splendor ingest --pending")
+    return 0
+
+
+def handle_queue_retry(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = retry_queue_job(root, args.job_id)
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_queue_retry_json(result))
+        return 0
+
+    print(f"Retried queue job {result.item.job_id}")
+    print(f"Queue record: {result.item.record_path}")
+    print("Next: splendor ingest --pending")
+    return 0
+
+
+def handle_repair_ingest(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = repair_ingest_source(root, args.source_id)
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_repair_ingest_json(result))
+        return 0
+
+    if result.no_op:
+        print(f"Source {result.source_id} is already ingested for the current pipeline version")
+    else:
+        print(f"Repaired ingest for source {result.source_id}")
+        print(f"Run: {result.run_id}")
+    print(f"Queue record: {result.queue_path}")
+    if result.run_path is not None:
+        print(f"Run record: {result.run_path}")
+    if result.page_path is not None:
+        print(f"Page: {result.page_path}")
+    print(f"Outcome: {result.outcome} ({result.message})")
+    if not result.no_op:
+        print(f"Next: splendor wiki suggest {result.source_id}")
+    return 0
+
+
+def _print_queue_item_detail(item) -> None:
+    print(f"Queue job: {item.job_id}")
+    print(f"Status: {item.status}")
+    print(f"Job type: {item.job_type}")
+    print(f"Attempts: {item.attempt_count}/{item.max_attempts}")
+    print(f"Created: {item.created_at}")
+    print(f"Updated: {item.updated_at}")
+    print(f"Payload: {item.payload_ref}")
+    print(f"Source ID: {item.source_id or '-'}")
+    print(f"Lease owner: {item.lease_owner or '-'}")
+    print(f"Lease expires: {item.lease_expires_at or '-'}")
+    print(f"Last error: {item.last_error or '-'}")
+    print(f"Record: {item.record_path}")
+    if item.status == "failed":
+        print(f"Next: splendor queue retry {item.job_id}")
+    elif item.status == "pending":
+        print("Next: splendor ingest --pending")
 
 
 def handle_wiki_status(args: argparse.Namespace) -> int:

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -634,7 +634,7 @@ def handle_repair_ingest(args: argparse.Namespace) -> int:
         return _print_error(exc)
 
     if args.json_output:
-        print(render_repair_ingest_json(result))
+        print(render_repair_ingest_json(root, result))
         return 0
 
     if result.no_op:
@@ -642,7 +642,8 @@ def handle_repair_ingest(args: argparse.Namespace) -> int:
     else:
         print(f"Repaired ingest for source {result.source_id}")
         print(f"Run: {result.run_id}")
-    print(f"Queue record: {result.queue_path}")
+    if result.queue_path is not None:
+        print(f"Queue record: {result.queue_path}")
     if result.run_path is not None:
         print(f"Run record: {result.run_path}")
     if result.page_path is not None:

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -31,6 +31,7 @@ from splendor.commands.planning import (
 )
 from splendor.commands.query import run_query
 from splendor.commands.queue import (
+    QueueItemSnapshot,
     inspect_queue,
     inspect_queue_job,
     render_queue_inspect_json,
@@ -652,7 +653,7 @@ def handle_repair_ingest(args: argparse.Namespace) -> int:
     return 0
 
 
-def _print_queue_item_detail(item) -> None:
+def _print_queue_item_detail(item: QueueItemSnapshot) -> None:
     print(f"Queue job: {item.job_id}")
     print(f"Status: {item.status}")
     print(f"Job type: {item.job_type}")

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -21,10 +21,12 @@ from splendor.schemas import (
 from splendor.schemas.types import SummaryMode
 from splendor.state.paths import resolve_workspace_path
 from splendor.state.runtime import (
+    ingest_job_id,
     load_queue_item,
     load_run_record,
     queue_item_path_for,
     run_record_path_for,
+    source_id_from_ingest_job_id,
     write_queue_item,
     write_run_record,
 )
@@ -121,16 +123,6 @@ class DrainResult:
 def _make_run_id(source_id: str) -> str:
     stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
     return f"run-{source_id}-{stamp}"
-
-
-def _ingest_job_id(source_id: str) -> str:
-    return f"ingest-{source_id}"
-
-
-def _source_id_from_job_id(job_id: str) -> str:
-    if job_id.startswith("ingest-"):
-        return job_id.removeprefix("ingest-")
-    return job_id
 
 
 def _lease_owner() -> str:
@@ -446,7 +438,7 @@ def _load_source_for_queue(root: Path, queue_item: QueueItemRecord) -> tuple[Pat
         msg = f"Queue payload is missing source manifest: {manifest_path}"
         raise FileNotFoundError(msg)
     source = load_source_record(manifest_path)
-    expected_source_id = _source_id_from_job_id(queue_item.job_id)
+    expected_source_id = source_id_from_ingest_job_id(queue_item.job_id)
     if source.source_id != expected_source_id:
         msg = f"Queue payload source ID does not match queued job: {queue_item.job_id}"
         raise ValueError(msg)
@@ -575,7 +567,7 @@ def enqueue_ingest_job(root: Path, source_id: str) -> Path:
         raise ValueError(msg)
 
     now = _utc_now()
-    queue_path = queue_item_path_for(layout, _ingest_job_id(source_id))
+    queue_path = queue_item_path_for(layout, ingest_job_id(source_id))
     existing_queue = load_queue_item(queue_path) if queue_path.exists() else None
     if (
         existing_queue is not None
@@ -590,7 +582,7 @@ def enqueue_ingest_job(root: Path, source_id: str) -> Path:
         created_at = existing_queue.created_at
 
     queue_item = QueueItemRecord(
-        job_id=_ingest_job_id(source_id),
+        job_id=ingest_job_id(source_id),
         job_type="ingest_source",
         status="pending",
         created_at=created_at,
@@ -933,7 +925,7 @@ def drain_pending_ingest_jobs(root: Path) -> DrainResult:
     item_results: list[DrainItemResult] = []
 
     for queue_path, queue_item in ordered_items:
-        source_id = _source_id_from_job_id(queue_item.job_id)
+        source_id = source_id_from_ingest_job_id(queue_item.job_id) or queue_item.job_id
         if not _is_queue_eligible(queue_item, now):
             skipped += 1
             item_results.append(

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -427,6 +427,10 @@ def _is_no_op(root: Path, layout, source: SourceRecord) -> bool:
     return run.status == "succeeded" and run.pipeline_version == __version__
 
 
+def is_ingest_current(root: Path, layout, source: SourceRecord) -> bool:
+    return _is_no_op(root, layout, source)
+
+
 def _validate_workspace_files(layout) -> None:
     required_files = [layout.index_file, layout.log_file]
     missing = [path for path in required_files if not path.exists()]

--- a/src/splendor/commands/queue.py
+++ b/src/splendor/commands/queue.py
@@ -1,0 +1,252 @@
+"""Queue inspection and repair command helpers."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+from splendor.commands.ingest import enqueue_ingest_job, run_ingest_job
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import QueueItemRecord
+from splendor.state.runtime import (
+    load_queue_item,
+    queue_item_path_for,
+    write_queue_item,
+)
+from splendor.state.source_registry import manifest_path_for
+from splendor.utils.time import utc_now_iso
+
+
+@dataclass(frozen=True)
+class QueueItemSnapshot:
+    job_id: str
+    job_type: str
+    status: str
+    created_at: str
+    updated_at: str
+    attempt_count: int
+    max_attempts: int
+    payload_ref: str
+    lease_owner: str | None
+    lease_expires_at: str | None
+    last_error: str | None
+    source_id: str | None
+    record_path: Path
+
+
+@dataclass(frozen=True)
+class QueueInspectResult:
+    total: int
+    status_counts: dict[str, int]
+    items: list[QueueItemSnapshot]
+
+
+@dataclass(frozen=True)
+class QueueRetryResult:
+    item: QueueItemSnapshot
+
+
+@dataclass(frozen=True)
+class RepairIngestResult:
+    source_id: str
+    outcome: str
+    queue_path: Path | None
+    run_id: str | None
+    run_path: Path | None
+    page_path: Path | None
+    no_op: bool
+    message: str
+
+
+def inspect_queue(root: Path) -> QueueInspectResult:
+    layout = resolve_layout(root, load_config(root))
+    items = [
+        _snapshot_queue_item(root, queue_path, load_queue_item(queue_path))
+        for queue_path in sorted(layout.queue_dir.glob("*.json"))
+    ]
+    items = sorted(items, key=lambda item: (item.created_at, item.job_id))
+    return QueueInspectResult(
+        total=len(items),
+        status_counts=dict(sorted(Counter(item.status for item in items).items())),
+        items=items,
+    )
+
+
+def inspect_queue_job(root: Path, job_id: str) -> QueueItemSnapshot:
+    layout = resolve_layout(root, load_config(root))
+    queue_path = queue_item_path_for(layout, job_id)
+    if not queue_path.exists():
+        msg = f"Unknown queue job: {job_id}"
+        raise FileNotFoundError(msg)
+    return _snapshot_queue_item(root, queue_path, load_queue_item(queue_path))
+
+
+def retry_queue_job(root: Path, job_id: str) -> QueueRetryResult:
+    layout = resolve_layout(root, load_config(root))
+    queue_path = queue_item_path_for(layout, job_id)
+    if not queue_path.exists():
+        msg = f"Unknown queue job: {job_id}"
+        raise FileNotFoundError(msg)
+    queue_item = load_queue_item(queue_path)
+    reset = _reset_failed_ingest_queue_item(queue_item)
+    write_queue_item(queue_path, reset)
+    return QueueRetryResult(item=_snapshot_queue_item(root, queue_path, reset))
+
+
+def repair_ingest_source(root: Path, source_id: str) -> RepairIngestResult:
+    manifest_path = manifest_path_for(root, source_id)
+    if not manifest_path.exists():
+        msg = f"Unknown source ID: {source_id}"
+        raise FileNotFoundError(msg)
+
+    layout = resolve_layout(root, load_config(root))
+    job_id = _ingest_job_id(source_id)
+    queue_path = queue_item_path_for(layout, job_id)
+    if not queue_path.exists():
+        queue_path = enqueue_ingest_job(root, source_id)
+    else:
+        queue_item = load_queue_item(queue_path)
+        if queue_item.job_type != "ingest_source":
+            msg = f"Unsupported queue job type for repair: {queue_item.job_type}"
+            raise ValueError(msg)
+        if queue_item.status == "failed":
+            write_queue_item(queue_path, _reset_failed_ingest_queue_item(queue_item))
+        elif queue_item.status == "done":
+            queue_path = enqueue_ingest_job(root, source_id)
+
+    result = run_ingest_job(root, queue_path)
+    if result.no_op:
+        message = "already ingested for the current pipeline version"
+        outcome = "skipped"
+    else:
+        message = f"run {result.run_id}"
+        outcome = "succeeded"
+    return RepairIngestResult(
+        source_id=result.source_id,
+        outcome=outcome,
+        queue_path=result.queue_path,
+        run_id=result.run_id,
+        run_path=result.run_path,
+        page_path=result.page_path,
+        no_op=result.no_op,
+        message=message,
+    )
+
+
+def render_queue_inspect_json(result: QueueInspectResult) -> str:
+    return json.dumps(
+        {
+            "total": result.total,
+            "status_counts": result.status_counts,
+            "items": [_snapshot_payload(item) for item in result.items],
+        },
+        indent=2,
+    )
+
+
+def render_queue_item_json(item: QueueItemSnapshot) -> str:
+    return json.dumps(_snapshot_payload(item), indent=2)
+
+
+def render_queue_retry_json(result: QueueRetryResult) -> str:
+    return json.dumps({"item": _snapshot_payload(result.item)}, indent=2)
+
+
+def render_repair_ingest_json(result: RepairIngestResult) -> str:
+    return json.dumps(
+        {
+            "source_id": result.source_id,
+            "outcome": result.outcome,
+            "queue_path": _path_payload(result.queue_path),
+            "run_id": result.run_id,
+            "run_path": _path_payload(result.run_path),
+            "page_path": _path_payload(result.page_path),
+            "no_op": result.no_op,
+            "message": result.message,
+        },
+        indent=2,
+    )
+
+
+def _reset_failed_ingest_queue_item(queue_item: QueueItemRecord) -> QueueItemRecord:
+    if queue_item.job_type != "ingest_source":
+        msg = f"Unsupported queue job type for retry: {queue_item.job_type}"
+        raise ValueError(msg)
+    if queue_item.status == "pending":
+        msg = f"Queue item is already pending: {queue_item.job_id}"
+        raise RuntimeError(msg)
+    if queue_item.status == "leased":
+        msg = f"Queue item is already leased: {queue_item.job_id}"
+        raise RuntimeError(msg)
+    if queue_item.status == "done":
+        msg = f"Queue item is already done: {queue_item.job_id}"
+        raise RuntimeError(msg)
+    if queue_item.status != "failed":
+        msg = f"Queue item is not retryable: {queue_item.job_id}"
+        raise RuntimeError(msg)
+
+    return queue_item.model_copy(
+        update={
+            "status": "pending",
+            "updated_at": utc_now_iso(),
+            "max_attempts": max(queue_item.max_attempts, queue_item.attempt_count + 1),
+            "lease_owner": None,
+            "lease_expires_at": None,
+            "last_error": None,
+        }
+    )
+
+
+def _snapshot_queue_item(
+    root: Path, queue_path: Path, queue_item: QueueItemRecord
+) -> QueueItemSnapshot:
+    return QueueItemSnapshot(
+        job_id=queue_item.job_id,
+        job_type=queue_item.job_type,
+        status=queue_item.status,
+        created_at=queue_item.created_at,
+        updated_at=queue_item.updated_at,
+        attempt_count=queue_item.attempt_count,
+        max_attempts=queue_item.max_attempts,
+        payload_ref=queue_item.payload_ref,
+        lease_owner=queue_item.lease_owner,
+        lease_expires_at=queue_item.lease_expires_at,
+        last_error=queue_item.last_error,
+        source_id=_source_id_from_job_id(queue_item.job_id),
+        record_path=queue_path.relative_to(root),
+    )
+
+
+def _snapshot_payload(item: QueueItemSnapshot) -> dict[str, object]:
+    return {
+        "job_id": item.job_id,
+        "job_type": item.job_type,
+        "status": item.status,
+        "created_at": item.created_at,
+        "updated_at": item.updated_at,
+        "attempt_count": item.attempt_count,
+        "max_attempts": item.max_attempts,
+        "payload_ref": item.payload_ref,
+        "lease_owner": item.lease_owner,
+        "lease_expires_at": item.lease_expires_at,
+        "last_error": item.last_error,
+        "source_id": item.source_id,
+        "record_path": item.record_path.as_posix(),
+    }
+
+
+def _path_payload(path: Path | None) -> str | None:
+    return None if path is None else str(path)
+
+
+def _ingest_job_id(source_id: str) -> str:
+    return f"ingest-{source_id}"
+
+
+def _source_id_from_job_id(job_id: str) -> str | None:
+    if job_id.startswith("ingest-"):
+        return job_id.removeprefix("ingest-")
+    return None

--- a/src/splendor/commands/queue.py
+++ b/src/splendor/commands/queue.py
@@ -12,8 +12,10 @@ from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import QueueItemRecord
 from splendor.state.runtime import (
+    ingest_job_id,
     load_queue_item,
     queue_item_path_for,
+    source_id_from_ingest_job_id,
     write_queue_item,
 )
 from splendor.state.source_registry import load_source_record, manifest_path_for
@@ -119,7 +121,7 @@ def repair_ingest_source(root: Path, source_id: str) -> RepairIngestResult:
             message="already ingested for the current pipeline version",
         )
 
-    job_id = _ingest_job_id(source_id)
+    job_id = ingest_job_id(source_id)
     queue_path = queue_item_path_for(layout, job_id)
     if not queue_path.exists():
         queue_path = enqueue_ingest_job(root, source_id)
@@ -132,6 +134,8 @@ def repair_ingest_source(root: Path, source_id: str) -> RepairIngestResult:
             write_queue_item(queue_path, _reset_failed_ingest_queue_item(queue_item))
         elif queue_item.status == "done":
             queue_path = enqueue_ingest_job(root, source_id)
+            queue_item = load_queue_item(queue_path)
+            write_queue_item(queue_path, _ensure_next_attempt_allowed(queue_item))
 
     result = run_ingest_job(root, queue_path)
     if result.no_op:
@@ -208,12 +212,20 @@ def _reset_failed_ingest_queue_item(queue_item: QueueItemRecord) -> QueueItemRec
         update={
             "status": "pending",
             "updated_at": utc_now_iso(),
-            "max_attempts": max(queue_item.max_attempts, queue_item.attempt_count + 1),
+            "max_attempts": _next_attempt_budget(queue_item),
             "lease_owner": None,
             "lease_expires_at": None,
             "last_error": None,
         }
     )
+
+
+def _ensure_next_attempt_allowed(queue_item: QueueItemRecord) -> QueueItemRecord:
+    return queue_item.model_copy(update={"max_attempts": _next_attempt_budget(queue_item)})
+
+
+def _next_attempt_budget(queue_item: QueueItemRecord) -> int:
+    return max(queue_item.max_attempts, queue_item.attempt_count + 1)
 
 
 def _snapshot_queue_item(
@@ -231,7 +243,7 @@ def _snapshot_queue_item(
         lease_owner=queue_item.lease_owner,
         lease_expires_at=queue_item.lease_expires_at,
         last_error=queue_item.last_error,
-        source_id=_source_id_from_job_id(queue_item.job_id),
+        source_id=source_id_from_ingest_job_id(queue_item.job_id),
         record_path=queue_path.relative_to(root),
     )
 
@@ -256,13 +268,3 @@ def _snapshot_payload(item: QueueItemSnapshot) -> dict[str, object]:
 
 def _path_payload(path: Path | None) -> str | None:
     return None if path is None else str(path)
-
-
-def _ingest_job_id(source_id: str) -> str:
-    return f"ingest-{source_id}"
-
-
-def _source_id_from_job_id(job_id: str) -> str | None:
-    if job_id.startswith("ingest-"):
-        return job_id.removeprefix("ingest-")
-    return None

--- a/src/splendor/commands/queue.py
+++ b/src/splendor/commands/queue.py
@@ -7,7 +7,7 @@ from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 
-from splendor.commands.ingest import enqueue_ingest_job, run_ingest_job
+from splendor.commands.ingest import enqueue_ingest_job, is_ingest_current, run_ingest_job
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import QueueItemRecord
@@ -16,7 +16,7 @@ from splendor.state.runtime import (
     queue_item_path_for,
     write_queue_item,
 )
-from splendor.state.source_registry import manifest_path_for
+from splendor.state.source_registry import load_source_record, manifest_path_for
 from splendor.utils.time import utc_now_iso
 
 
@@ -103,6 +103,22 @@ def repair_ingest_source(root: Path, source_id: str) -> RepairIngestResult:
         raise FileNotFoundError(msg)
 
     layout = resolve_layout(root, load_config(root))
+    source = load_source_record(manifest_path)
+    if source.source_id != source_id:
+        msg = f"Source manifest ID does not match requested source: {source_id}"
+        raise ValueError(msg)
+    if is_ingest_current(root, layout, source):
+        return RepairIngestResult(
+            source_id=source_id,
+            outcome="skipped",
+            queue_path=None,
+            run_id=None,
+            run_path=None,
+            page_path=layout.wiki_sources_dir / f"{source_id}.md",
+            no_op=True,
+            message="already ingested for the current pipeline version",
+        )
+
     job_id = _ingest_job_id(source_id)
     queue_path = queue_item_path_for(layout, job_id)
     if not queue_path.exists():

--- a/src/splendor/commands/queue.py
+++ b/src/splendor/commands/queue.py
@@ -175,15 +175,15 @@ def render_queue_retry_json(result: QueueRetryResult) -> str:
     return json.dumps({"item": _snapshot_payload(result.item)}, indent=2)
 
 
-def render_repair_ingest_json(result: RepairIngestResult) -> str:
+def render_repair_ingest_json(root: Path, result: RepairIngestResult) -> str:
     return json.dumps(
         {
             "source_id": result.source_id,
             "outcome": result.outcome,
-            "queue_path": _path_payload(result.queue_path),
+            "queue_path": _path_payload(root, result.queue_path),
             "run_id": result.run_id,
-            "run_path": _path_payload(result.run_path),
-            "page_path": _path_payload(result.page_path),
+            "run_path": _path_payload(root, result.run_path),
+            "page_path": _path_payload(root, result.page_path),
             "no_op": result.no_op,
             "message": result.message,
         },
@@ -266,5 +266,5 @@ def _snapshot_payload(item: QueueItemSnapshot) -> dict[str, object]:
     }
 
 
-def _path_payload(path: Path | None) -> str | None:
-    return None if path is None else str(path)
+def _path_payload(root: Path, path: Path | None) -> str | None:
+    return None if path is None else path.relative_to(root).as_posix()

--- a/src/splendor/state/runtime.py
+++ b/src/splendor/state/runtime.py
@@ -10,6 +10,16 @@ from splendor.schemas import QueueItemRecord, RunRecord
 from splendor.utils.fs import ensure_directory, write_text_atomic
 
 
+def ingest_job_id(source_id: str) -> str:
+    return f"ingest-{source_id}"
+
+
+def source_id_from_ingest_job_id(job_id: str) -> str | None:
+    if job_id.startswith("ingest-"):
+        return job_id.removeprefix("ingest-")
+    return None
+
+
 def queue_item_path_for(layout: ResolvedLayout, job_id: str) -> Path:
     return layout.queue_dir / f"{job_id}.json"
 

--- a/tests/test_queue_commands.py
+++ b/tests/test_queue_commands.py
@@ -234,14 +234,18 @@ def test_cli_repair_ingest_json_reports_no_op(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "add-source", str(source)])
     source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
     main(["--root", str(tmp_path), "ingest", source_id])
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    queue_before = queue_path.read_text(encoding="utf-8")
     capsys.readouterr()
 
     exit_code = main(["--root", str(tmp_path), "repair", "ingest", source_id, "--json"])
 
     assert exit_code == 0
+    assert queue_path.read_text(encoding="utf-8") == queue_before
     payload = json.loads(capsys.readouterr().out)
     assert payload["source_id"] == source_id
     assert payload["outcome"] == "skipped"
     assert payload["no_op"] is True
+    assert payload["queue_path"] is None
     assert payload["run_id"] is None
     assert payload["page_path"].endswith(f"wiki/sources/{source_id}.md")

--- a/tests/test_queue_commands.py
+++ b/tests/test_queue_commands.py
@@ -202,6 +202,30 @@ def test_cli_queue_retry_resets_failed_job(tmp_path: Path, capsys) -> None:
     assert load_queue_item(queue_path).status == "pending"
 
 
+def test_cli_queue_retry_json_reports_reset_job(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    job_id = f"ingest-{source_id}"
+    queue_path = tmp_path / "state" / "queue" / f"{job_id}.json"
+    failed = load_queue_item(queue_path).model_copy(
+        update={"status": "failed", "attempt_count": 3, "max_attempts": 3, "last_error": "broken"}
+    )
+    write_queue_item(queue_path, failed)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "queue", "retry", job_id, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["item"]["job_id"] == job_id
+    assert payload["item"]["status"] == "pending"
+    assert payload["item"]["max_attempts"] == 4
+    assert payload["item"]["last_error"] is None
+
+
 def test_cli_repair_ingest_requeues_and_runs_fixed_failed_source(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     source = tmp_path / "brief.txt"
@@ -225,6 +249,28 @@ def test_cli_repair_ingest_requeues_and_runs_fixed_failed_source(tmp_path: Path,
     )
     assert queue_record.status == "done"
     assert source_record.status == "ingested"
+
+
+def test_repair_ingest_done_requeue_keeps_attempt_budget_valid(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    exhausted_done = load_queue_item(queue_path).model_copy(
+        update={"status": "done", "attempt_count": 3, "max_attempts": 3}
+    )
+    write_queue_item(queue_path, exhausted_done)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "repair", "ingest", source_id])
+
+    assert exit_code == 0
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.status == "done"
+    assert queue_record.attempt_count == 4
+    assert queue_record.max_attempts == 4
 
 
 def test_cli_repair_ingest_json_reports_no_op(tmp_path: Path, capsys) -> None:

--- a/tests/test_queue_commands.py
+++ b/tests/test_queue_commands.py
@@ -1,0 +1,247 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from splendor.cli import main
+from splendor.commands.add_source import add_source
+from splendor.commands.ingest import enqueue_ingest_job
+from splendor.commands.init import initialize_workspace
+from splendor.commands.queue import inspect_queue, inspect_queue_job, retry_queue_job
+from splendor.schemas import QueueItemRecord
+from splendor.state.runtime import load_queue_item, write_queue_item
+from splendor.state.source_registry import load_source_record
+
+
+def test_inspect_queue_returns_counts_and_stable_order(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    later = tmp_path / "later.md"
+    earlier = tmp_path / "earlier.md"
+    later.write_text("# Later\n\nhello\n", encoding="utf-8")
+    earlier.write_text("# Earlier\n\nhello\n", encoding="utf-8")
+    later_added = add_source(tmp_path, later)
+    earlier_added = add_source(tmp_path, earlier)
+    later_queue_path = enqueue_ingest_job(tmp_path, later_added.source_id)
+    earlier_queue_path = enqueue_ingest_job(tmp_path, earlier_added.source_id)
+    later_queue = load_queue_item(later_queue_path).model_copy(
+        update={"created_at": "2026-04-10T12:00:00+00:00"}
+    )
+    earlier_queue = load_queue_item(earlier_queue_path).model_copy(
+        update={"created_at": "2026-04-10T11:00:00+00:00", "status": "failed", "last_error": "x"}
+    )
+    write_queue_item(later_queue_path, later_queue)
+    write_queue_item(earlier_queue_path, earlier_queue)
+
+    result = inspect_queue(tmp_path)
+
+    assert result.total == 2
+    assert result.status_counts == {"failed": 1, "pending": 1}
+    assert [item.job_id for item in result.items] == [
+        f"ingest-{earlier_added.source_id}",
+        f"ingest-{later_added.source_id}",
+    ]
+
+
+def test_inspect_queue_job_returns_detail_and_rejects_missing_job(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+
+    item = inspect_queue_job(tmp_path, f"ingest-{added.source_id}")
+
+    assert item.record_path == queue_path.relative_to(tmp_path)
+    assert item.source_id == added.source_id
+    assert item.payload_ref == f"state/manifests/sources/{added.source_id}.json"
+    with pytest.raises(FileNotFoundError, match="Unknown queue job"):
+        inspect_queue_job(tmp_path, "ingest-missing")
+
+
+def test_retry_queue_job_resets_failed_ingest_record(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    failed = load_queue_item(queue_path).model_copy(
+        update={
+            "status": "failed",
+            "attempt_count": 3,
+            "max_attempts": 3,
+            "lease_owner": "local-cli:123",
+            "lease_expires_at": "2026-04-10T12:00:00+00:00",
+            "last_error": "broken",
+        }
+    )
+    write_queue_item(queue_path, failed)
+
+    result = retry_queue_job(tmp_path, f"ingest-{added.source_id}")
+
+    assert result.item.status == "pending"
+    assert result.item.attempt_count == 3
+    assert result.item.max_attempts == 4
+    assert result.item.lease_owner is None
+    assert result.item.lease_expires_at is None
+    assert result.item.last_error is None
+    assert load_queue_item(queue_path).status == "pending"
+
+
+@pytest.mark.parametrize("status", ["pending", "leased", "done"])
+def test_retry_queue_job_rejects_non_failed_records(tmp_path: Path, status: str) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue = load_queue_item(queue_path).model_copy(
+        update={
+            "status": status,
+            "lease_owner": "local-cli:123" if status == "leased" else None,
+            "lease_expires_at": "2099-01-01T00:00:00+00:00" if status == "leased" else None,
+        }
+    )
+    write_queue_item(queue_path, queue)
+
+    with pytest.raises(RuntimeError):
+        retry_queue_job(tmp_path, f"ingest-{added.source_id}")
+
+
+def test_retry_queue_job_rejects_missing_and_unsupported_jobs(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    with pytest.raises(FileNotFoundError, match="Unknown queue job"):
+        retry_queue_job(tmp_path, "ingest-missing")
+
+    unsupported_path = tmp_path / "state" / "queue" / "refresh-page.json"
+    write_queue_item(
+        unsupported_path,
+        QueueItemRecord(
+            job_id="refresh-page",
+            job_type="refresh_page",
+            status="failed",
+            created_at="2026-04-10T12:00:00+00:00",
+            updated_at="2026-04-10T12:00:00+00:00",
+            payload_ref="wiki/index.md",
+            last_error="broken",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Unsupported queue job type"):
+        retry_queue_job(tmp_path, "refresh-page")
+
+
+def test_cli_queue_inspect_human_and_json_output(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "queue", "inspect"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Queue inspect" in out
+    assert f"ingest-{source_id} [pending]" in out
+    assert "Next: splendor ingest --pending" in out
+
+    exit_code = main(["--root", str(tmp_path), "queue", "inspect", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["total"] == 1
+    assert payload["status_counts"] == {"pending": 1}
+    assert payload["items"][0]["job_id"] == f"ingest-{source_id}"
+
+
+def test_cli_queue_inspect_single_job_outputs_detail_and_json(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    job_id = f"ingest-{source_id}"
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "queue", "inspect", job_id])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert f"Queue job: {job_id}" in out
+    assert f"Source ID: {source_id}" in out
+
+    exit_code = main(["--root", str(tmp_path), "queue", "inspect", job_id, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["job_id"] == job_id
+    assert payload["record_path"] == f"state/queue/{job_id}.json"
+
+
+def test_cli_queue_retry_resets_failed_job(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    job_id = f"ingest-{source_id}"
+    queue_path = tmp_path / "state" / "queue" / f"{job_id}.json"
+    failed = load_queue_item(queue_path).model_copy(
+        update={"status": "failed", "last_error": "broken"}
+    )
+    write_queue_item(queue_path, failed)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "queue", "retry", job_id])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert f"Retried queue job {job_id}" in out
+    assert "Next: splendor ingest --pending" in out
+    assert load_queue_item(queue_path).status == "pending"
+
+
+def test_cli_repair_ingest_requeues_and_runs_fixed_failed_source(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.txt"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    source.unlink()
+    assert main(["--root", str(tmp_path), "ingest", source_id]) == 1
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "repair", "ingest", source_id])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert f"Repaired ingest for source {source_id}" in out
+    assert f"Next: splendor wiki suggest {source_id}" in out
+    queue_record = load_queue_item(tmp_path / "state" / "queue" / f"ingest-{source_id}.json")
+    source_record = load_source_record(
+        tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
+    )
+    assert queue_record.status == "done"
+    assert source_record.status == "ingested"
+
+
+def test_cli_repair_ingest_json_reports_no_op(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    main(["--root", str(tmp_path), "ingest", source_id])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "repair", "ingest", source_id, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["source_id"] == source_id
+    assert payload["outcome"] == "skipped"
+    assert payload["no_op"] is True
+    assert payload["run_id"] is None
+    assert payload["page_path"].endswith(f"wiki/sources/{source_id}.md")

--- a/tests/test_queue_commands.py
+++ b/tests/test_queue_commands.py
@@ -294,4 +294,21 @@ def test_cli_repair_ingest_json_reports_no_op(tmp_path: Path, capsys) -> None:
     assert payload["no_op"] is True
     assert payload["queue_path"] is None
     assert payload["run_id"] is None
-    assert payload["page_path"].endswith(f"wiki/sources/{source_id}.md")
+    assert payload["page_path"] == f"wiki/sources/{source_id}.md"
+
+
+def test_cli_repair_ingest_no_op_does_not_print_empty_queue_path(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    main(["--root", str(tmp_path), "ingest", source_id])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "repair", "ingest", source_id])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Queue record: None" not in out
+    assert f"Page: {tmp_path / 'wiki' / 'sources' / f'{source_id}.md'}" in out


### PR DESCRIPTION
## Summary
- add `splendor queue inspect [job-id]` with human and JSON output over durable queue records
- add `splendor queue retry &lt;job-id&gt;` for failed ingest jobs, preserving audit state while making another explicit attempt health-valid
- add active `splendor repair ingest &lt;source-id&gt;` recovery that requeues failed/missing terminal ingest work and runs it immediately
- update planning docs for `M10-P1.1` and the next `M10-P2.1` queue robustness slice

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest`
- `uv run splendor lint`

## Follow-up
- `M10-P2.1` remains responsible for automatic backoff, dead-letter handling, and broader stale-lease recovery policy.