### PR TITLE
M10-P2.1: Queue recovery policy

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M9-P2.1`
-- Last action taken: `M9-P2.1` is implemented; read-only planning, queue, and run inspection views now expose durable runtime state in the local web UI.
-- Current planned slice: `M10-P1`
-- Current PR sub-slice: `M10-P1.1`
+- Previous completed PR sub-slice: `M10-P1.1`
+- Last action taken: `M10-P1.1` is implemented; CLI queue inspection, failed ingest retry, and active ingest repair now cover manual recovery.
+- Current planned slice: `M10-P2`
+- Current PR sub-slice: `M10-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M10-P2`
-- Next planned PR sub-slice: `M10-P2.1`
+- Next planned slice: `M11-P1`
+- Next planned PR sub-slice: `M11-P1.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -147,6 +147,11 @@
   - [x] Add active `repair ingest` recovery that requeues and runs immediately
   - [x] Keep dead-letter, backoff, and broader stale-lease policy deferred to `M10-P2`
   - [x] Publish a non-draft GitHub PR for `M10-P1.1` with labels, milestone, and a detailed description
+- [ ] Implement `M10-P2.1`: Backoff, dead-letter, and stale-lease recovery
+  - [ ] Add configurable queue retry/backoff policy
+  - [ ] Add explicit dead-letter queue state
+  - [ ] Recover expired leases while protecting active leases
+  - [ ] Reorder the post-M10 roadmap around agent synthesis workflow
 
 ## Context Pointers
 
@@ -167,10 +172,13 @@
 - `M9-P2` Planning/runs UI views
 - `M10-P1` Queue inspect/retry/repair commands
 - `M10-P2` Backoff, dead-letter, and stale-lease recovery
-- `M11-P1` Rich-source dispatch and PDF path
-- `M11-P2` OCR/image ingest path
-- `M12-P1` Schema/docs/migration stabilization
-- `M12-P2` Extension/performance/release finalization
+- `M11-P1` Source lifecycle, bulk registration, refresh, and readable source lookup
+- `M11-P2` Topic scaffolding, templates, and index rebuild
+- `M11-P3` Query/source lookup and agent-context improvements
+- `M12-P1` Rich-source dispatch and PDF path
+- `M12-P2` OCR/image ingest path
+- `M13-P1` Schema/docs/migration stabilization
+- `M13-P2` Extension/performance/release finalization
 
 ## PR Sub-slice Queue
 
@@ -183,3 +191,6 @@
 - `M9-P2.1` Planning/runs UI views
 - `M10-P1.1` Queue inspect/retry/repair commands
 - `M10-P2.1` Backoff, dead-letter, and stale-lease recovery
+- `M11-P1.1` Source lifecycle, bulk registration, refresh, and readable source lookup
+- `M11-P2.1` Topic scaffolding, templates, and index rebuild
+- `M11-P3.1` Query/source lookup and agent-context improvements

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ Implemented today:
 Not implemented yet:
 
 - mutating review-gated `splendor wiki compile`
-- queue backoff, dead-letter, and stale-lease recovery policies
+- source bulk registration and refresh workflows
+- topic scaffolding, templates, and index rebuild
 - OCR and image extraction flows
 - mutating web UI actions such as add-source forms
 - changed-files-driven refresh suggestions
@@ -148,12 +149,12 @@ Not implemented yet:
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M9-P2.1`
-- Current planned slice: `M10-P1`
-- Current PR sub-slice: `M10-P1.1`
+- Previous completed PR sub-slice: `M10-P1.1`
+- Current planned slice: `M10-P2`
+- Current PR sub-slice: `M10-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M10-P2`
-- Next planned PR sub-slice: `M10-P2.1`
+- Next planned slice: `M11-P1`
+- Next planned PR sub-slice: `M11-P1.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -185,6 +186,7 @@ compile/update workflows maintain concept, entity, topic, architecture, and glos
 `M9-P2.1` is implemented: it adds read-only planning and runtime inspection pages to the local web
 UI without adding mutating web actions.
 
-The current PR sub-slice is `M10-P1.1`, which adds CLI-first queue inspection, failed ingest
-retry, and active ingest repair while leaving automatic backoff, dead-letter handling, and broader
-stale-lease recovery for `M10-P2`.
+`M10-P1.1` is implemented: it adds CLI-first queue inspection, failed ingest retry, and active
+ingest repair. The current PR sub-slice is `M10-P2.1`, which adds configurable queue retry/backoff
+policy, explicit dead-letter records, and stale-lease recovery. After Milestone 10, the next
+milestone shifts to text-native agent synthesis workflows before rich-source/PDF/OCR expansion.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -85,6 +85,10 @@ Drain the pending ingest queue:
 uv run splendor --root /tmp/demo-repo ingest --pending
 ```
 
+`ingest --pending` also handles due failed retries and expired ingest leases. Failed jobs wait until
+their persisted `next_attempt_at` backoff time, and exhausted jobs move to `dead_letter` until an
+operator runs `splendor queue retry <job-id>` or `splendor repair ingest <source-id>`.
+
 This creates:
 
 - a source-summary page under `wiki/sources/`
@@ -154,6 +158,9 @@ It includes:
 - one source-summary page
 - one planning task
 - queue and run records for the ingest
+
+Queue retry behavior is configured in `splendor.yaml` under `queue.max_attempts`,
+`queue.lease_ttl_seconds`, and `queue.retry_backoff_seconds`.
 
 ## Next step
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -219,13 +219,19 @@ and the ingest run that surfaced the conflict.
 
 The runtime contracts are now used by deterministic single-source ingestion.
 
-- `QueueItemRecord` captures item lifecycle, retries, and leases.
+- `QueueItemRecord` captures item lifecycle, retries, backoff scheduling, dead-letter state, and
+  leases.
 - `RunRecord` captures pipeline inputs, outputs, warnings, and failures.
 
 Current persisted locations:
 
 - `state/queue/<job_id>.json`
 - `state/runs/<run_id>.json`
+
+Queue status values are `pending`, `leased`, `done`, `failed`, and `dead_letter`. Failed records may
+carry `next_attempt_at` to defer the next automatic `splendor ingest --pending` retry. Dead-letter
+records preserve `last_error` and require an explicit `splendor queue retry <job-id>` or
+`splendor repair ingest <source-id>` action.
 
 Run records now reserve explicit provenance fields beside the original generic refs so later
 pipeline steps can answer questions like "which page did this run generate?" without parsing

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M9-P2.1`
-- Current planned slice: `M10-P1`
-- Current PR sub-slice: `M10-P1.1`
+- Previous completed PR sub-slice: `M10-P1.1`
+- Current planned slice: `M10-P2`
+- Current PR sub-slice: `M10-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M10-P2`
-- Next planned PR sub-slice: `M10-P2.1`
+- Next planned slice: `M11-P1`
+- Next planned PR sub-slice: `M11-P1.1`
 
 `M10-P0.1` is implemented: the CLI-first wiki status and source-impact suggestion bridge is in
 place. `M10-P0.2` is implemented: project briefing and the non-mutating review-gated compile-loop
@@ -653,12 +653,44 @@ Make Splendor resilient in the face of failed ingest/maintenance jobs.
 ### Milestone 10 status
 
 `M10-P1.1` adds CLI-first queue inspection, failed ingest retry, and active ingest repair for
-recovering broken text-native ingest jobs. Backoff, dead-letter handling, and broader stale-lease
-recovery remain deferred to `M10-P2.1`.
+recovering broken text-native ingest jobs. `M10-P2.1` completes the queue robustness milestone with
+configurable retry/backoff policy, explicit dead-letter records, and stale-lease recovery.
 
 ---
 
-## Milestone 11 — Post-MVP: richer source handling
+## Milestone 11 — Post-MVP: agent synthesis workflow
+
+### Goal
+Make text-native Splendor workflows smoother for coding agents and human maintainers using real
+project knowledge bases.
+
+### Scope
+- source lifecycle refresh and bulk registration
+- readable source lookup
+- topic scaffolding and index management
+- query/source lookup improvements
+- compact agent-context handoff surfaces
+
+### Deliverables
+- bulk source registration and explicit source refresh commands
+- topic creation helpers, templates, and wiki index rebuild
+- query filters for tags and source references
+- agent-context output that packages relevant project state for a new coding-agent thread
+
+### Exit criteria
+- agents can register, refresh, find, and synthesize text-native project knowledge without manual
+  state surgery
+- topic pages and indexes stay easier to create and maintain
+- field-report gaps from the SynthBanshee dogfood session are represented by planned work
+
+### Planned PR slices
+- `M11-P1` Source lifecycle, bulk registration, refresh, and readable source lookup
+- `M11-P2` Topic scaffolding, templates, and index rebuild
+- `M11-P3` Query/source lookup and agent-context improvements
+
+---
+
+## Milestone 12 — Post-MVP: richer source handling
 
 ### Goal
 Expand supported source types where they materially increase product value.
@@ -693,12 +725,12 @@ feed the same source-impact and compile/update workflow used for markdown and te
 - failures in OCR-heavy paths do not destabilize the core system
 
 ### Planned PR slices
-- `M11-P1` Rich-source dispatch and PDF path
-- `M11-P2` OCR/image ingest path
+- `M12-P1` Rich-source dispatch and PDF path
+- `M12-P2` OCR/image ingest path
 
 ---
 
-## Milestone 12 — v1 stabilization and release
+## Milestone 13 — v1 stabilization and release
 
 ### Goal
 Publish a coherent, documented v1 that feels like a complete product.
@@ -713,8 +745,8 @@ Publish a coherent, documented v1 that feels like a complete product.
 - one or two real-world showcase repos
 
 ### Planned PR slices
-- `M12-P1` Schema/docs/migration stabilization
-- `M12-P2` Extension/performance/release finalization
+- `M13-P1` Schema/docs/migration stabilization
+- `M13-P2` Extension/performance/release finalization
 
 ### Deliverables
 - v1 schema versions
@@ -793,8 +825,8 @@ A practical initial sequence:
 2. Milestones 1–4 as the MVP core
 3. Milestone 5 to harden and publish MVP
 4. Milestones 6–8 as the first serious post-MVP wave
-5. Milestones 9–11 selectively, depending on user demand
-6. Milestone 12 for v1 release
+5. Milestones 9–12 selectively, depending on user demand
+6. Milestone 13 for v1 release
 
 ## 6. Suggested Definition of MVP
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -742,6 +742,9 @@ Splendor should use a **durable work ledger**, not an overengineered distributed
 - dead-letter after threshold
 - inspect/retry manually
 
+Queue backoff is persisted on the queue item with `next_attempt_at`. Exhausted ingest jobs move to
+the terminal `dead_letter` status and require explicit operator action before another attempt.
+
 ### 16.2 Queue persistence
 
 Initial queue persistence should be file-based under `state/queue/`.

--- a/splendor.yaml
+++ b/splendor.yaml
@@ -15,3 +15,10 @@ layout:
   state_dir: state
   reports_dir: reports
   source_records_dir: state/manifests/sources
+queue:
+  max_attempts: 3
+  lease_ttl_seconds: 300
+  retry_backoff_seconds:
+  - 60
+  - 300
+  - 900

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -599,12 +599,17 @@ def handle_queue_inspect(args: argparse.Namespace) -> int:
     print("Jobs:")
     for item in result.items:
         print(
-            f"- {item.job_id} [{item.status}] type={item.job_type} "
+            f"- {item.job_id} [{item.status}/{item.operator_state}] type={item.job_type} "
             f"attempts={item.attempt_count}/{item.max_attempts} payload={item.payload_ref}"
         )
-    if result.status_counts.get("failed", 0):
+    operator_states = {item.operator_state for item in result.items}
+    if "dead_letter" in operator_states:
+        print("Next: splendor queue retry <job-id> or splendor repair ingest <source-id>")
+    elif "failed_backoff" in operator_states:
+        print("Next: wait for retry backoff or run splendor queue retry <job-id>")
+    elif result.status_counts.get("failed", 0):
         print("Next: splendor queue retry <job-id>")
-    elif result.status_counts.get("pending", 0):
+    elif operator_states.intersection({"pending", "failed_due", "expired_leased"}):
         print("Next: splendor ingest --pending")
     return 0
 
@@ -663,13 +668,21 @@ def _print_queue_item_detail(item: QueueItemSnapshot) -> None:
     print(f"Updated: {item.updated_at}")
     print(f"Payload: {item.payload_ref}")
     print(f"Source ID: {item.source_id or '-'}")
+    print(f"Operator state: {item.operator_state}")
     print(f"Lease owner: {item.lease_owner or '-'}")
     print(f"Lease expires: {item.lease_expires_at or '-'}")
+    print(f"Next attempt: {item.next_attempt_at or '-'}")
     print(f"Last error: {item.last_error or '-'}")
     print(f"Record: {item.record_path}")
-    if item.status == "failed":
+    if item.status == "dead_letter":
+        print(
+            f"Next: splendor queue retry {item.job_id} or splendor repair ingest {item.source_id}"
+        )
+    elif item.operator_state == "failed_backoff":
+        print(f"Next: wait for retry backoff or run splendor queue retry {item.job_id}")
+    elif item.status == "failed":
         print(f"Next: splendor queue retry {item.job_id}")
-    elif item.status == "pending":
+    elif item.operator_state in {"pending", "failed_due", "expired_leased"}:
         print("Next: splendor ingest --pending")
 
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -603,14 +603,14 @@ def handle_queue_inspect(args: argparse.Namespace) -> int:
             f"attempts={item.attempt_count}/{item.max_attempts} payload={item.payload_ref}"
         )
     operator_states = {item.operator_state for item in result.items}
-    if "dead_letter" in operator_states:
+    if operator_states.intersection({"pending", "failed_due", "expired_leased"}):
+        print("Next: splendor ingest --pending")
+    elif "dead_letter" in operator_states:
         print("Next: splendor queue retry <job-id> or splendor repair ingest <source-id>")
     elif "failed_backoff" in operator_states:
         print("Next: wait for retry backoff or run splendor queue retry <job-id>")
     elif result.status_counts.get("failed", 0):
         print("Next: splendor queue retry <job-id>")
-    elif operator_states.intersection({"pending", "failed_due", "expired_leased"}):
-        print("Next: splendor ingest --pending")
     return 0
 
 

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -344,12 +344,15 @@ def _validate_queue_record(
             check_name="queue-state",
         )
 
-    if queue_record.status == "failed":
+    if queue_record.status in {"failed", "dead_letter"}:
         if not queue_record.last_error:
             _append_issue(
                 issues,
                 code="invalid-queue-error-state",
-                message="Failed queue items should persist last_error for repair diagnostics.",
+                message=(
+                    "Failed and dead-letter queue items should persist last_error for repair "
+                    "diagnostics."
+                ),
                 path=queue_relpath,
                 record_id=canonical_job_id,
                 check_name="queue-state",
@@ -358,11 +361,37 @@ def _validate_queue_record(
         _append_issue(
             issues,
             code="invalid-queue-error-state",
-            message="Only failed queue items should persist last_error details.",
+            message="Only failed or dead-letter queue items should persist last_error details.",
             path=queue_relpath,
             record_id=canonical_job_id,
             check_name="queue-state",
         )
+
+    if queue_record.next_attempt_at is not None:
+        if queue_record.status != "failed":
+            _append_issue(
+                issues,
+                code="invalid-queue-next-attempt-state",
+                message="Only failed queue items may carry next_attempt_at values.",
+                path=queue_relpath,
+                record_id=canonical_job_id,
+                check_name="queue-state",
+            )
+        else:
+            try:
+                _parse_timestamp(
+                    queue_record.next_attempt_at,
+                    context="Queue next attempt timestamp",
+                )
+            except ValueError as exc:
+                _append_issue(
+                    issues,
+                    code="invalid-queue-next-attempt",
+                    message=str(exc),
+                    path=queue_relpath,
+                    record_id=canonical_job_id,
+                    check_name="queue-state",
+                )
 
     if queue_record.attempt_count > queue_record.max_attempts:
         _append_issue(

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -49,7 +49,7 @@ from splendor.utils.contradictions import (
 )
 from splendor.utils.fs import write_text_atomic
 from splendor.utils.provenance import dedupe_provenance_links, make_provenance_link
-from splendor.utils.time import utc_now_iso
+from splendor.utils.time import parse_aware_timestamp_or_none, utc_now_iso
 from splendor.utils.wiki import (
     WikiUpdatePayload,
     append_log_entry,
@@ -283,19 +283,6 @@ def _best_available_source_ref(source: SourceRecord) -> str:
     return effective_stored_path(source) or canonical_source_ref(source)
 
 
-def _parse_timestamp(value: str | None) -> datetime | None:
-    if value is None:
-        return None
-    normalized_value = f"{value[:-1]}+00:00" if value.endswith("Z") else value
-    try:
-        parsed = datetime.fromisoformat(normalized_value)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return None
-    return parsed.astimezone(UTC)
-
-
 def _dead_letter_recovery_message(job_id: str, source_id: str) -> str:
     return (
         f"Queue item is dead-lettered: {job_id}. Run "
@@ -310,7 +297,7 @@ def _lease_expires_at(now: datetime, lease_ttl_seconds: int) -> str:
 def _lease_is_expired(queue_item: QueueItemRecord, now: datetime) -> bool:
     if queue_item.status != "leased":
         return False
-    expires_at = _parse_timestamp(queue_item.lease_expires_at)
+    expires_at = parse_aware_timestamp_or_none(queue_item.lease_expires_at)
     if expires_at is None:
         return True
     return expires_at <= now
@@ -390,7 +377,7 @@ def _run_success_provenance_links(
 
 
 def _next_attempt_is_due(queue_item: QueueItemRecord, now: datetime) -> bool:
-    next_attempt_at = _parse_timestamp(queue_item.next_attempt_at)
+    next_attempt_at = parse_aware_timestamp_or_none(queue_item.next_attempt_at)
     return next_attempt_at is None or next_attempt_at <= now
 
 
@@ -406,7 +393,7 @@ def _is_queue_eligible(queue_item: QueueItemRecord, now: datetime) -> bool:
 
 def _skip_message(queue_item: QueueItemRecord, now: datetime) -> str:
     if queue_item.status == "failed":
-        next_attempt_at = _parse_timestamp(queue_item.next_attempt_at)
+        next_attempt_at = parse_aware_timestamp_or_none(queue_item.next_attempt_at)
         if next_attempt_at is not None and next_attempt_at > now:
             return f"retry after {queue_item.next_attempt_at}"
         return "status=failed"
@@ -415,7 +402,7 @@ def _skip_message(queue_item: QueueItemRecord, now: datetime) -> str:
     if queue_item.status == "done":
         return "status=done"
     if queue_item.status == "leased":
-        expires_at = _parse_timestamp(queue_item.lease_expires_at)
+        expires_at = parse_aware_timestamp_or_none(queue_item.lease_expires_at)
         if expires_at is None:
             return "leased with no expiry"
         if expires_at > now:
@@ -503,8 +490,8 @@ def _mark_attempt_failed(
     manifest_path: Path | None = None,
     source: SourceRecord | None = None,
     run_id: str | None = None,
+    backoff_seconds: list[int],
 ) -> None:
-    config = load_config(root)
     failed_run = run
     if manifest_path is not None and source is not None:
         manifest_ref = _relative_to_root(root, manifest_path)
@@ -532,9 +519,7 @@ def _mark_attempt_failed(
     status = "dead_letter" if queue_item.attempt_count >= queue_item.max_attempts else "failed"
     next_attempt_at = None
     if status == "failed":
-        next_attempt_at = _next_attempt_at_for_failure(
-            queue_item, config.queue.retry_backoff_seconds
-        )
+        next_attempt_at = _next_attempt_at_for_failure(queue_item, backoff_seconds)
     _finalize_queue_record(
         queue_path,
         queue_item,
@@ -969,6 +954,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
             manifest_path=manifest_path,
             source=source,
             run_id=run_id,
+            backoff_seconds=config.queue.retry_backoff_seconds,
         )
         raise
     except Exception as exc:
@@ -979,6 +965,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
             run_path=run_path,
             run=run,
             error_message=str(exc),
+            backoff_seconds=config.queue.retry_backoff_seconds,
         )
         raise RuntimeError(f"Ingestion failed while committing outputs: {exc}") from exc
 

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -77,7 +77,6 @@ SUPPORTED_SOURCE_TYPES = {
     "hpp",
     "sh",
 }
-LEASE_TTL_SECONDS = 300
 _MARKDOWN_HEADING_PATTERN = re.compile(r"^(?P<level>#{1,6})\s+(?P<title>.+?)\s*#*\s*$")
 _CLAIM_SECTION_HEADINGS = {
     "core claims",
@@ -290,8 +289,8 @@ def _parse_timestamp(value: str | None) -> datetime | None:
     return datetime.fromisoformat(value)
 
 
-def _lease_expires_at(now: datetime) -> str:
-    return (now + timedelta(seconds=LEASE_TTL_SECONDS)).isoformat()
+def _lease_expires_at(now: datetime, lease_ttl_seconds: int) -> str:
+    return (now + timedelta(seconds=lease_ttl_seconds)).isoformat()
 
 
 def _lease_is_expired(queue_item: QueueItemRecord, now: datetime) -> bool:
@@ -376,17 +375,29 @@ def _run_success_provenance_links(
     )
 
 
+def _next_attempt_is_due(queue_item: QueueItemRecord, now: datetime) -> bool:
+    next_attempt_at = _parse_timestamp(queue_item.next_attempt_at)
+    return next_attempt_at is None or next_attempt_at <= now
+
+
 def _is_queue_eligible(queue_item: QueueItemRecord, now: datetime) -> bool:
     if queue_item.job_type != "ingest_source":
         return False
     if queue_item.status == "pending":
         return True
+    if queue_item.status == "failed":
+        return _next_attempt_is_due(queue_item, now)
     return _lease_is_expired(queue_item, now)
 
 
 def _skip_message(queue_item: QueueItemRecord, now: datetime) -> str:
     if queue_item.status == "failed":
+        next_attempt_at = _parse_timestamp(queue_item.next_attempt_at)
+        if next_attempt_at is not None and next_attempt_at > now:
+            return f"retry after {queue_item.next_attempt_at}"
         return "status=failed"
+    if queue_item.status == "dead_letter":
+        return "status=dead_letter"
     if queue_item.status == "done":
         return "status=done"
     if queue_item.status == "leased":
@@ -451,6 +462,7 @@ def _finalize_queue_record(
     *,
     status: str,
     last_error: str | None = None,
+    next_attempt_at: str | None = None,
 ) -> QueueItemRecord:
     finalized = queue_item.model_copy(
         update={
@@ -458,6 +470,7 @@ def _finalize_queue_record(
             "updated_at": utc_now_iso(),
             "lease_owner": None,
             "lease_expires_at": None,
+            "next_attempt_at": next_attempt_at,
             "last_error": last_error,
         }
     )
@@ -477,6 +490,7 @@ def _mark_attempt_failed(
     source: SourceRecord | None = None,
     run_id: str | None = None,
 ) -> None:
+    config = load_config(root)
     failed_run = run
     if manifest_path is not None and source is not None:
         manifest_ref = _relative_to_root(root, manifest_path)
@@ -501,7 +515,19 @@ def _mark_attempt_failed(
         }
     )
     write_run_record(run_path, failed_run)
-    _finalize_queue_record(queue_path, queue_item, status="failed", last_error=error_message)
+    status = "dead_letter" if queue_item.attempt_count >= queue_item.max_attempts else "failed"
+    next_attempt_at = None
+    if status == "failed":
+        next_attempt_at = _next_attempt_at_for_failure(
+            queue_item, config.queue.retry_backoff_seconds
+        )
+    _finalize_queue_record(
+        queue_path,
+        queue_item,
+        status=status,
+        last_error=error_message,
+        next_attempt_at=next_attempt_at,
+    )
     if manifest_path is not None and source is not None and run_id is not None:
         failed_source = source.model_copy(update={"status": "failed", "last_run_id": run_id})
         write_source_record(manifest_path, failed_source)
@@ -511,8 +537,28 @@ def _mark_queue_failed_without_run(
     queue_path: Path,
     queue_item: QueueItemRecord,
     error_message: str,
+    backoff_seconds: list[int],
 ) -> None:
-    _finalize_queue_record(queue_path, queue_item, status="failed", last_error=error_message)
+    status = "dead_letter" if queue_item.attempt_count >= queue_item.max_attempts else "failed"
+    next_attempt_at = None
+    if status == "failed":
+        next_attempt_at = _next_attempt_at_for_failure(queue_item, backoff_seconds)
+    _finalize_queue_record(
+        queue_path,
+        queue_item,
+        status=status,
+        last_error=error_message,
+        next_attempt_at=next_attempt_at,
+    )
+
+
+def _next_attempt_at_for_failure(queue_item: QueueItemRecord, backoff_seconds: list[int]) -> str:
+    if not backoff_seconds:
+        return utc_now_iso()
+    backoff_index = max(0, min(queue_item.attempt_count - 1, len(backoff_seconds) - 1))
+    return (
+        datetime.now(UTC).replace(microsecond=0) + timedelta(seconds=backoff_seconds[backoff_index])
+    ).isoformat()
 
 
 def _commit_success(
@@ -588,17 +634,22 @@ def enqueue_ingest_job(root: Path, source_id: str) -> Path:
         created_at=created_at,
         updated_at=now.isoformat(),
         attempt_count=0 if existing_queue is None else existing_queue.attempt_count,
-        max_attempts=3 if existing_queue is None else existing_queue.max_attempts,
+        max_attempts=config.queue.max_attempts
+        if existing_queue is None
+        else existing_queue.max_attempts,
         payload_ref=_relative_to_root(root, manifest_path),
         lease_owner=None,
         lease_expires_at=None,
+        next_attempt_at=None,
         last_error=None,
     )
     write_queue_item(queue_path, queue_item)
     return queue_path
 
 
-def _claim_ingest_job(queue_path: Path, queue_item: QueueItemRecord) -> QueueItemRecord:
+def _claim_ingest_job(
+    queue_path: Path, queue_item: QueueItemRecord, *, lease_ttl_seconds: int
+) -> QueueItemRecord:
     now = _utc_now()
     leased_queue = queue_item.model_copy(
         update={
@@ -606,7 +657,8 @@ def _claim_ingest_job(queue_path: Path, queue_item: QueueItemRecord) -> QueueIte
             "updated_at": now.isoformat(),
             "attempt_count": queue_item.attempt_count + 1,
             "lease_owner": _lease_owner(),
-            "lease_expires_at": _lease_expires_at(now),
+            "lease_expires_at": _lease_expires_at(now, lease_ttl_seconds),
+            "next_attempt_at": None,
             "last_error": None,
         }
     )
@@ -627,16 +679,23 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
     if queue_item.status == "leased" and not _lease_is_expired(queue_item, now):
         msg = f"Queue item is already leased: {queue_item.job_id}"
         raise RuntimeError(msg)
-    if queue_item.status not in {"pending", "leased"}:
+    if queue_item.status not in {"pending", "leased", "failed"}:
         msg = f"Queue item is not runnable: {queue_item.job_id}"
         raise RuntimeError(msg)
+    if queue_item.status == "failed" and not _next_attempt_is_due(queue_item, now):
+        msg = f"Queue item retry is not due until {queue_item.next_attempt_at}: {queue_item.job_id}"
+        raise RuntimeError(msg)
 
-    queue_item = _claim_ingest_job(queue_path, queue_item)
+    queue_item = _claim_ingest_job(
+        queue_path, queue_item, lease_ttl_seconds=config.queue.lease_ttl_seconds
+    )
 
     try:
         manifest_path, source = _load_source_for_queue(root, queue_item)
     except (FileNotFoundError, ValueError) as exc:
-        _mark_queue_failed_without_run(queue_path, queue_item, str(exc))
+        _mark_queue_failed_without_run(
+            queue_path, queue_item, str(exc), config.queue.retry_backoff_seconds
+        )
         raise
 
     if _is_no_op(root, layout, source):

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -286,7 +286,21 @@ def _best_available_source_ref(source: SourceRecord) -> str:
 def _parse_timestamp(value: str | None) -> datetime | None:
     if value is None:
         return None
-    return datetime.fromisoformat(value)
+    normalized_value = f"{value[:-1]}+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized_value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(UTC)
+
+
+def _dead_letter_recovery_message(job_id: str, source_id: str) -> str:
+    return (
+        f"Queue item is dead-lettered: {job_id}. Run "
+        f"`splendor queue retry {job_id}` or `splendor repair ingest {source_id}`."
+    )
 
 
 def _lease_expires_at(now: datetime, lease_ttl_seconds: int) -> str:
@@ -615,6 +629,9 @@ def enqueue_ingest_job(root: Path, source_id: str) -> Path:
     now = _utc_now()
     queue_path = queue_item_path_for(layout, ingest_job_id(source_id))
     existing_queue = load_queue_item(queue_path) if queue_path.exists() else None
+    if existing_queue is not None and existing_queue.status == "dead_letter":
+        msg = _dead_letter_recovery_message(existing_queue.job_id, source_id)
+        raise RuntimeError(msg)
     if (
         existing_queue is not None
         and existing_queue.status == "leased"

--- a/src/splendor/commands/queue.py
+++ b/src/splendor/commands/queue.py
@@ -20,7 +20,7 @@ from splendor.state.runtime import (
     write_queue_item,
 )
 from splendor.state.source_registry import load_source_record, manifest_path_for
-from splendor.utils.time import utc_now_iso
+from splendor.utils.time import parse_aware_timestamp_or_none, utc_now_iso
 
 
 @dataclass(frozen=True)
@@ -278,19 +278,6 @@ def _path_payload(root: Path, path: Path | None) -> str | None:
     return None if path is None else path.relative_to(root).as_posix()
 
 
-def _parse_timestamp(value: str | None) -> datetime | None:
-    if value is None:
-        return None
-    normalized_value = f"{value[:-1]}+00:00" if value.endswith("Z") else value
-    try:
-        parsed = datetime.fromisoformat(normalized_value)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return None
-    return parsed.astimezone(UTC)
-
-
 def _operator_state(queue_item: QueueItemRecord) -> str:
     now = datetime.now(UTC).replace(microsecond=0)
     if queue_item.status == "pending":
@@ -300,12 +287,12 @@ def _operator_state(queue_item: QueueItemRecord) -> str:
     if queue_item.status == "dead_letter":
         return "dead_letter"
     if queue_item.status == "leased":
-        expires_at = _parse_timestamp(queue_item.lease_expires_at)
+        expires_at = parse_aware_timestamp_or_none(queue_item.lease_expires_at)
         if expires_at is None or expires_at <= now:
             return "expired_leased"
         return "active_leased"
     if queue_item.status == "failed":
-        next_attempt_at = _parse_timestamp(queue_item.next_attempt_at)
+        next_attempt_at = parse_aware_timestamp_or_none(queue_item.next_attempt_at)
         if next_attempt_at is None or next_attempt_at <= now:
             return "failed_due"
         return "failed_backoff"

--- a/src/splendor/commands/queue.py
+++ b/src/splendor/commands/queue.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from collections import Counter
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 
 from splendor.commands.ingest import enqueue_ingest_job, is_ingest_current, run_ingest_job
@@ -34,8 +35,10 @@ class QueueItemSnapshot:
     payload_ref: str
     lease_owner: str | None
     lease_expires_at: str | None
+    next_attempt_at: str | None
     last_error: str | None
     source_id: str | None
+    operator_state: str
     record_path: Path
 
 
@@ -130,7 +133,7 @@ def repair_ingest_source(root: Path, source_id: str) -> RepairIngestResult:
         if queue_item.job_type != "ingest_source":
             msg = f"Unsupported queue job type for repair: {queue_item.job_type}"
             raise ValueError(msg)
-        if queue_item.status == "failed":
+        if queue_item.status in {"failed", "dead_letter"}:
             write_queue_item(queue_path, _reset_failed_ingest_queue_item(queue_item))
         elif queue_item.status == "done":
             queue_path = enqueue_ingest_job(root, source_id)
@@ -204,7 +207,7 @@ def _reset_failed_ingest_queue_item(queue_item: QueueItemRecord) -> QueueItemRec
     if queue_item.status == "done":
         msg = f"Queue item is already done: {queue_item.job_id}"
         raise RuntimeError(msg)
-    if queue_item.status != "failed":
+    if queue_item.status not in {"failed", "dead_letter"}:
         msg = f"Queue item is not retryable: {queue_item.job_id}"
         raise RuntimeError(msg)
 
@@ -215,6 +218,7 @@ def _reset_failed_ingest_queue_item(queue_item: QueueItemRecord) -> QueueItemRec
             "max_attempts": _next_attempt_budget(queue_item),
             "lease_owner": None,
             "lease_expires_at": None,
+            "next_attempt_at": None,
             "last_error": None,
         }
     )
@@ -242,8 +246,10 @@ def _snapshot_queue_item(
         payload_ref=queue_item.payload_ref,
         lease_owner=queue_item.lease_owner,
         lease_expires_at=queue_item.lease_expires_at,
+        next_attempt_at=queue_item.next_attempt_at,
         last_error=queue_item.last_error,
         source_id=source_id_from_ingest_job_id(queue_item.job_id),
+        operator_state=_operator_state(queue_item),
         record_path=queue_path.relative_to(root),
     )
 
@@ -260,11 +266,40 @@ def _snapshot_payload(item: QueueItemSnapshot) -> dict[str, object]:
         "payload_ref": item.payload_ref,
         "lease_owner": item.lease_owner,
         "lease_expires_at": item.lease_expires_at,
+        "next_attempt_at": item.next_attempt_at,
         "last_error": item.last_error,
         "source_id": item.source_id,
+        "operator_state": item.operator_state,
         "record_path": item.record_path.as_posix(),
     }
 
 
 def _path_payload(root: Path, path: Path | None) -> str | None:
     return None if path is None else path.relative_to(root).as_posix()
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.fromisoformat(value)
+
+
+def _operator_state(queue_item: QueueItemRecord) -> str:
+    now = datetime.now(UTC).replace(microsecond=0)
+    if queue_item.status == "pending":
+        return "pending"
+    if queue_item.status == "done":
+        return "done"
+    if queue_item.status == "dead_letter":
+        return "dead_letter"
+    if queue_item.status == "leased":
+        expires_at = _parse_timestamp(queue_item.lease_expires_at)
+        if expires_at is None or expires_at <= now:
+            return "expired_leased"
+        return "active_leased"
+    if queue_item.status == "failed":
+        next_attempt_at = _parse_timestamp(queue_item.next_attempt_at)
+        if next_attempt_at is None or next_attempt_at <= now:
+            return "failed_due"
+        return "failed_backoff"
+    return queue_item.status

--- a/src/splendor/commands/queue.py
+++ b/src/splendor/commands/queue.py
@@ -281,7 +281,14 @@ def _path_payload(root: Path, path: Path | None) -> str | None:
 def _parse_timestamp(value: str | None) -> datetime | None:
     if value is None:
         return None
-    return datetime.fromisoformat(value)
+    normalized_value = f"{value[:-1]}+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized_value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(UTC)
 
 
 def _operator_state(queue_item: QueueItemRecord) -> str:

--- a/src/splendor/config.py
+++ b/src/splendor/config.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Annotated
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field
@@ -64,7 +65,9 @@ class QueueConfig(BaseModel):
 
     max_attempts: int = Field(default=3, ge=1)
     lease_ttl_seconds: int = Field(default=300, ge=1)
-    retry_backoff_seconds: list[int] = Field(default_factory=lambda: [60, 300, 900])
+    retry_backoff_seconds: list[Annotated[int, Field(ge=0)]] = Field(
+        default_factory=lambda: [60, 300, 900]
+    )
 
 
 class SplendorConfig(BaseModel):

--- a/src/splendor/config.py
+++ b/src/splendor/config.py
@@ -59,11 +59,20 @@ class ReviewsConfig(BaseModel):
     contradictions: ContradictionsReviewConfig = Field(default_factory=ContradictionsReviewConfig)
 
 
+class QueueConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    max_attempts: int = Field(default=3, ge=1)
+    lease_ttl_seconds: int = Field(default=300, ge=1)
+    retry_backoff_seconds: list[int] = Field(default_factory=lambda: [60, 300, 900])
+
+
 class SplendorConfig(BaseModel):
     schema_version: str = "1"
     project_name: str = "Splendor workspace"
     layout: LayoutConfig = Field(default_factory=LayoutConfig)
     sources: SourcesConfig = Field(default_factory=SourcesConfig)
+    queue: QueueConfig = Field(default_factory=QueueConfig)
     reviews: ReviewsConfig = Field(default_factory=ReviewsConfig)
 
 

--- a/src/splendor/schemas/runtime.py
+++ b/src/splendor/schemas/runtime.py
@@ -14,7 +14,7 @@ class QueueItemRecord(StrictRecord):
     kind: Literal["queue_item"] = "queue_item"
     job_id: str
     job_type: str
-    status: Literal["pending", "leased", "done", "failed"] = "pending"
+    status: Literal["pending", "leased", "done", "failed", "dead_letter"] = "pending"
     created_at: str
     updated_at: str
     attempt_count: int = Field(default=0, ge=0)
@@ -22,6 +22,7 @@ class QueueItemRecord(StrictRecord):
     payload_ref: str
     lease_owner: str | None = None
     lease_expires_at: str | None = None
+    next_attempt_at: str | None = None
     last_error: str | None = None
 
 

--- a/src/splendor/utils/time.py
+++ b/src/splendor/utils/time.py
@@ -7,3 +7,16 @@ from datetime import UTC, datetime
 
 def utc_now_iso() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat()
+
+
+def parse_aware_timestamp_or_none(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    normalized_value = f"{value[:-1]}+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized_value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(UTC)

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -335,7 +335,7 @@ def create_app(root: Path) -> FastAPI:
             status_counts[item.record.status] = status_counts.get(item.record.status, 0) + 1
         rows = "\n".join(_queue_row(item) for item in queue_records[:50])
         if not rows:
-            rows = '<tr><td colspan="10" class="empty">No queue records yet.</td></tr>'
+            rows = '<tr><td colspan="11" class="empty">No queue records yet.</td></tr>'
         body = (
             '<p class="breadcrumbs"><a href="/">Home</a> / Queue</p>'
             '<section class="stats">'
@@ -346,8 +346,8 @@ def create_app(root: Path) -> FastAPI:
             '<p class="empty">Queue state is read-only here. Use CLI commands for ingestion, '
             "repair, retry, or other mutations.</p>"
             "<table><thead><tr><th>Job</th><th>Status</th><th>Type</th><th>Attempts</th>"
-            "<th>Created</th><th>Updated</th><th>Payload</th><th>Lease</th><th>Error</th>"
-            "<th>Record</th></tr></thead>"
+            "<th>Created</th><th>Updated</th><th>Payload</th><th>Lease</th>"
+            "<th>Next attempt</th><th>Error</th><th>Record</th></tr></thead>"
             f"<tbody>{rows}</tbody></table>"
         )
         return _page("Queue", body)
@@ -961,6 +961,7 @@ def _queue_row(item: _QueueSummary) -> str:
         f"<td>{html.escape(queue.updated_at)}</td>"
         f"<td><code>{html.escape(queue.payload_ref)}</code></td>"
         f"<td>{html.escape(lease)}</td>"
+        f"<td>{html.escape(queue.next_attempt_at or '-')}</td>"
         f"<td>{html.escape(queue.last_error or '-')}</td>"
         f"<td><code>{html.escape(item.path)}</code></td>"
         "</tr>"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,9 @@ def test_default_config_includes_source_policy_defaults() -> None:
     assert config.sources.capture_source_commit is True
     assert config.sources.summarize_in_repo_extracts_as == "excerpt"
     assert config.sources.summarize_external_extracts_as == "full"
+    assert config.queue.max_attempts == 3
+    assert config.queue.lease_ttl_seconds == 300
+    assert config.queue.retry_backoff_seconds == [60, 300, 900]
 
 
 def test_load_config_accepts_yaml_without_sources_block(tmp_path: Path) -> None:
@@ -55,6 +58,36 @@ def test_load_config_rejects_invalid_sources_values(tmp_path: Path) -> None:
 def test_load_config_rejects_unknown_sources_keys(tmp_path: Path) -> None:
     (tmp_path / "splendor.yaml").write_text(
         ("schema_version: '1'\nproject_name: Example\nsources:\n  external_storage_mdoe: copy\n"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError):
+        load_config(tmp_path)
+
+
+def test_load_config_accepts_queue_policy(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        (
+            "schema_version: '1'\n"
+            "project_name: Example\n"
+            "queue:\n"
+            "  max_attempts: 5\n"
+            "  lease_ttl_seconds: 120\n"
+            "  retry_backoff_seconds: [1, 2, 3]\n"
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(tmp_path)
+
+    assert config.queue.max_attempts == 5
+    assert config.queue.lease_ttl_seconds == 120
+    assert config.queue.retry_backoff_seconds == [1, 2, 3]
+
+
+def test_load_config_rejects_unknown_queue_keys(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        ("schema_version: '1'\nproject_name: Example\nqueue:\n  max_attemptz: 5\n"),
         encoding="utf-8",
     )
 
@@ -105,5 +138,6 @@ def test_write_config_serializes_sources_block(tmp_path: Path) -> None:
     written = (tmp_path / "splendor.yaml").read_text(encoding="utf-8")
 
     assert "sources:" in written
+    assert "queue:" in written
     assert "in_repo_storage_mode: none" in written
     assert "external_storage_mode: copy" in written

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -95,6 +95,16 @@ def test_load_config_rejects_unknown_queue_keys(tmp_path: Path) -> None:
         load_config(tmp_path)
 
 
+def test_load_config_rejects_negative_queue_backoff(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        ("schema_version: '1'\nproject_name: Example\nqueue:\n  retry_backoff_seconds: [60, -1]\n"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError):
+        load_config(tmp_path)
+
+
 def test_load_config_accepts_unknown_top_level_keys(tmp_path: Path) -> None:
     (tmp_path / "splendor.yaml").write_text(
         (

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -519,6 +519,44 @@ def test_run_health_checks_reports_invalid_queue_runtime_details(tmp_path: Path)
     assert [issue.code for issue in result.issues] == ["invalid-queue-lease-state"]
 
 
+def test_run_health_checks_reports_invalid_queue_next_attempt_state(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    invalid_queue = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+    invalid_queue = invalid_queue.model_copy(
+        update={"status": "pending", "next_attempt_at": "2026-04-20T09:00:00+00:00"}
+    )
+    write_queue_item(queue_path, invalid_queue)
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["invalid-queue-next-attempt-state"]
+
+
+def test_run_health_checks_reports_invalid_queue_next_attempt_timestamp(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    invalid_queue = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+    invalid_queue = invalid_queue.model_copy(
+        update={"status": "failed", "last_error": "temporary", "next_attempt_at": "bad-time"}
+    )
+    write_queue_item(queue_path, invalid_queue)
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["invalid-queue-next-attempt"]
+
+
 def test_run_health_checks_reports_invalid_leased_queue_shape(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -565,6 +565,51 @@ def test_exhausted_failed_ingest_becomes_dead_letter(tmp_path: Path) -> None:
     assert queue_record.next_attempt_at is None
 
 
+def test_direct_ingest_rejects_dead_letter_queue_without_mutation(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    dead_letter = load_queue_item(queue_path).model_copy(
+        update={
+            "status": "dead_letter",
+            "attempt_count": 3,
+            "max_attempts": 3,
+            "last_error": "broken",
+        }
+    )
+    write_queue_item(queue_path, dead_letter)
+    queue_before = queue_path.read_text(encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="Queue item is dead-lettered"):
+        ingest_source(tmp_path, added.source_id)
+
+    assert queue_path.read_text(encoding="utf-8") == queue_before
+
+
+def test_invalid_failed_next_attempt_is_treated_as_due(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    failed_queue = load_queue_item(queue_path).model_copy(
+        update={
+            "status": "failed",
+            "attempt_count": 1,
+            "last_error": "temporary",
+            "next_attempt_at": "not-a-timestamp",
+        }
+    )
+    write_queue_item(queue_path, failed_queue)
+
+    result = drain_pending_ingest_jobs(tmp_path)
+
+    assert result.succeeded == 1
+    assert load_queue_item(queue_path).status == "done"
+
+
 def test_drain_pending_ingest_jobs_continues_after_failure(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     ok_source = tmp_path / "brief.md"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -17,7 +17,7 @@ from splendor.commands.init import initialize_workspace
 from splendor.config import load_config, write_config
 from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord
 from splendor.schemas.types import SummaryMode
-from splendor.state.runtime import load_queue_item, load_run_record
+from splendor.state.runtime import load_queue_item, load_run_record, write_queue_item
 from splendor.state.source_pointer import load_source_pointer, write_source_pointer
 from splendor.state.source_registry import load_source_record, write_source_record
 
@@ -477,7 +477,13 @@ def test_drain_pending_ingest_jobs_skips_nonexpired_and_failed_items(tmp_path: P
     failed_source.write_bytes(b"\xff\xfe\xfa")
     failed_added = add_source(tmp_path, failed_source)
     failed_queue_path = enqueue_ingest_job(tmp_path, failed_added.source_id)
-    failed_queue = load_queue_item(failed_queue_path).model_copy(update={"status": "failed"})
+    failed_queue = load_queue_item(failed_queue_path).model_copy(
+        update={
+            "status": "failed",
+            "next_attempt_at": (datetime.now(UTC) + timedelta(minutes=5)).isoformat(),
+            "last_error": "broken",
+        }
+    )
     failed_queue_path.write_text(failed_queue.model_dump_json(indent=2) + "\n", encoding="utf-8")
 
     result = drain_pending_ingest_jobs(tmp_path)
@@ -490,7 +496,73 @@ def test_drain_pending_ingest_jobs_skips_nonexpired_and_failed_items(tmp_path: P
     assert len(result.items) == 2
     messages = {item.source_id: item.message for item in result.items}
     assert "lease active until" in messages[added.source_id]
-    assert messages[failed_added.source_id] == "status=failed"
+    assert "retry after" in messages[failed_added.source_id]
+
+
+def test_failed_ingest_sets_retry_backoff_and_clears_lease(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "broken.md"
+    source.write_bytes(b"\xff\xfe\xfa")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+
+    with pytest.raises(ValueError):
+        run_ingest_job(tmp_path, queue_path)
+
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.status == "failed"
+    assert queue_record.attempt_count == 1
+    assert queue_record.last_error is not None
+    assert queue_record.lease_owner is None
+    assert queue_record.lease_expires_at is None
+    assert queue_record.next_attempt_at is not None
+
+
+def test_due_failed_jobs_are_retried_by_pending_drain(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    failed_queue = load_queue_item(queue_path).model_copy(
+        update={
+            "status": "failed",
+            "attempt_count": 1,
+            "last_error": "temporary",
+            "next_attempt_at": (datetime.now(UTC) - timedelta(minutes=1)).isoformat(),
+        }
+    )
+    write_queue_item(queue_path, failed_queue)
+
+    result = drain_pending_ingest_jobs(tmp_path)
+
+    assert result.processed == 1
+    assert result.succeeded == 1
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.status == "done"
+    assert queue_record.attempt_count == 2
+    assert queue_record.next_attempt_at is None
+
+
+def test_exhausted_failed_ingest_becomes_dead_letter(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.queue.max_attempts = 1
+    write_config(tmp_path, config)
+    source = tmp_path / "broken.md"
+    source.write_bytes(b"\xff\xfe\xfa")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+
+    with pytest.raises(ValueError):
+        run_ingest_job(tmp_path, queue_path)
+
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.status == "dead_letter"
+    assert queue_record.attempt_count == 1
+    assert queue_record.max_attempts == 1
+    assert queue_record.last_error is not None
+    assert queue_record.next_attempt_at is None
 
 
 def test_drain_pending_ingest_jobs_continues_after_failure(tmp_path: Path) -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -610,6 +610,87 @@ def test_invalid_failed_next_attempt_is_treated_as_due(tmp_path: Path) -> None:
     assert load_queue_item(queue_path).status == "done"
 
 
+def test_failed_ingest_with_empty_backoff_is_immediately_due(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.queue.retry_backoff_seconds = []
+    write_config(tmp_path, config)
+    source = tmp_path / "broken.md"
+    source.write_bytes(b"\xff\xfe\xfa")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+
+    with pytest.raises(ValueError):
+        run_ingest_job(tmp_path, queue_path)
+
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.status == "failed"
+    assert queue_record.next_attempt_at is not None
+    result = drain_pending_ingest_jobs(tmp_path)
+    assert result.failed == 1
+
+
+def test_drain_pending_reports_dead_letter_and_done_as_skipped(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    dead_source = tmp_path / "dead.md"
+    dead_source.write_text("# Dead\n\nhello world\n", encoding="utf-8")
+    dead_added = add_source(tmp_path, dead_source)
+    dead_queue_path = enqueue_ingest_job(tmp_path, dead_added.source_id)
+    write_queue_item(
+        dead_queue_path,
+        load_queue_item(dead_queue_path).model_copy(
+            update={"status": "dead_letter", "last_error": "broken"}
+        ),
+    )
+    done_source = tmp_path / "done.md"
+    done_source.write_text("# Done\n\nhello world\n", encoding="utf-8")
+    done_added = add_source(tmp_path, done_source)
+    done_queue_path = enqueue_ingest_job(tmp_path, done_added.source_id)
+    write_queue_item(
+        done_queue_path,
+        load_queue_item(done_queue_path).model_copy(update={"status": "done"}),
+    )
+
+    result = drain_pending_ingest_jobs(tmp_path)
+
+    assert result.processed == 0
+    assert result.skipped == 2
+    messages = {item.source_id: item.message for item in result.items}
+    assert messages[dead_added.source_id] == "status=dead_letter"
+    assert messages[done_added.source_id] == "status=done"
+
+
+def test_run_ingest_job_rejects_future_backoff_and_terminal_records(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    write_queue_item(
+        queue_path,
+        load_queue_item(queue_path).model_copy(
+            update={
+                "status": "failed",
+                "last_error": "temporary",
+                "next_attempt_at": (datetime.now(UTC) + timedelta(minutes=5)).isoformat(),
+            }
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="retry is not due"):
+        run_ingest_job(tmp_path, queue_path)
+
+    write_queue_item(
+        queue_path,
+        load_queue_item(queue_path).model_copy(
+            update={"status": "dead_letter", "last_error": "broken", "next_attempt_at": None}
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Queue item is not runnable"):
+        run_ingest_job(tmp_path, queue_path)
+
+
 def test_drain_pending_ingest_jobs_continues_after_failure(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     ok_source = tmp_path / "brief.md"

--- a/tests/test_queue_commands.py
+++ b/tests/test_queue_commands.py
@@ -346,6 +346,92 @@ def test_cli_queue_inspect_prioritizes_runnable_next_action(tmp_path: Path, caps
     assert "Next: splendor ingest --pending" in out
 
 
+def test_cli_queue_inspect_reports_dead_letter_next_action(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "dead.md"
+    source.write_text("# Dead\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    write_queue_item(
+        queue_path,
+        load_queue_item(queue_path).model_copy(
+            update={"status": "dead_letter", "last_error": "broken"}
+        ),
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "queue", "inspect"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Next: splendor queue retry <job-id> or splendor repair ingest <source-id>" in out
+
+
+def test_cli_queue_inspect_reports_backoff_next_action(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "backoff.md"
+    source.write_text("# Backoff\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    write_queue_item(
+        queue_path,
+        load_queue_item(queue_path).model_copy(
+            update={
+                "status": "failed",
+                "last_error": "temporary",
+                "next_attempt_at": (datetime.now(UTC) + timedelta(minutes=5)).isoformat(),
+            }
+        ),
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "queue", "inspect"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Next: wait for retry backoff or run splendor queue retry <job-id>" in out
+
+
+def test_cli_queue_inspect_single_job_dead_letter_and_backoff_next_actions(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    dead_source = tmp_path / "dead.md"
+    dead_source.write_text("# Dead\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(dead_source)])
+    dead_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    dead_job_id = f"ingest-{dead_id}"
+    dead_queue_path = tmp_path / "state" / "queue" / f"{dead_job_id}.json"
+    write_queue_item(
+        dead_queue_path,
+        load_queue_item(dead_queue_path).model_copy(
+            update={"status": "dead_letter", "last_error": "broken"}
+        ),
+    )
+    capsys.readouterr()
+
+    assert main(["--root", str(tmp_path), "queue", "inspect", dead_job_id]) == 0
+    out = capsys.readouterr().out
+    assert f"Next: splendor queue retry {dead_job_id} or splendor repair ingest {dead_id}" in out
+
+    write_queue_item(
+        dead_queue_path,
+        load_queue_item(dead_queue_path).model_copy(
+            update={
+                "status": "failed",
+                "last_error": "temporary",
+                "next_attempt_at": (datetime.now(UTC) + timedelta(minutes=5)).isoformat(),
+            }
+        ),
+    )
+
+    assert main(["--root", str(tmp_path), "queue", "inspect", dead_job_id]) == 0
+    out = capsys.readouterr().out
+    assert f"Next: wait for retry backoff or run splendor queue retry {dead_job_id}" in out
+
+
 def test_queue_inspect_handles_z_and_invalid_timestamps(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     z_source = tmp_path / "z.md"

--- a/tests/test_queue_commands.py
+++ b/tests/test_queue_commands.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -83,8 +84,32 @@ def test_retry_queue_job_resets_failed_ingest_record(tmp_path: Path) -> None:
     assert result.item.max_attempts == 4
     assert result.item.lease_owner is None
     assert result.item.lease_expires_at is None
+    assert result.item.next_attempt_at is None
     assert result.item.last_error is None
     assert load_queue_item(queue_path).status == "pending"
+
+
+def test_retry_queue_job_resets_dead_letter_ingest_record(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    dead_letter = load_queue_item(queue_path).model_copy(
+        update={
+            "status": "dead_letter",
+            "attempt_count": 3,
+            "max_attempts": 3,
+            "last_error": "broken",
+        }
+    )
+    write_queue_item(queue_path, dead_letter)
+
+    result = retry_queue_job(tmp_path, f"ingest-{added.source_id}")
+
+    assert result.item.status == "pending"
+    assert result.item.max_attempts == 4
+    assert result.item.last_error is None
 
 
 @pytest.mark.parametrize("status", ["pending", "leased", "done"])
@@ -143,7 +168,7 @@ def test_cli_queue_inspect_human_and_json_output(tmp_path: Path, capsys) -> None
     assert exit_code == 0
     out = capsys.readouterr().out
     assert "Queue inspect" in out
-    assert f"ingest-{source_id} [pending]" in out
+    assert f"ingest-{source_id} [pending/pending]" in out
     assert "Next: splendor ingest --pending" in out
 
     exit_code = main(["--root", str(tmp_path), "queue", "inspect", "--json"])
@@ -153,6 +178,8 @@ def test_cli_queue_inspect_human_and_json_output(tmp_path: Path, capsys) -> None
     assert payload["total"] == 1
     assert payload["status_counts"] == {"pending": 1}
     assert payload["items"][0]["job_id"] == f"ingest-{source_id}"
+    assert payload["items"][0]["operator_state"] == "pending"
+    assert payload["items"][0]["next_attempt_at"] is None
 
 
 def test_cli_queue_inspect_single_job_outputs_detail_and_json(tmp_path: Path, capsys) -> None:
@@ -224,6 +251,68 @@ def test_cli_queue_retry_json_reports_reset_job(tmp_path: Path, capsys) -> None:
     assert payload["item"]["status"] == "pending"
     assert payload["item"]["max_attempts"] == 4
     assert payload["item"]["last_error"] is None
+    assert payload["item"]["next_attempt_at"] is None
+
+
+def test_cli_queue_inspect_distinguishes_backoff_expired_lease_and_dead_letter(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    paths = []
+    for name in ["backoff.md", "expired.md", "dead.md"]:
+        source = tmp_path / name
+        source.write_text(f"# {name}\n\nhello\n", encoding="utf-8")
+        manifests_before = set((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+        main(["--root", str(tmp_path), "add-source", str(source)])
+        manifests_after = set((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+        source_id = (manifests_after - manifests_before).pop().stem
+        paths.append((source_id, tmp_path / "state" / "queue" / f"ingest-{source_id}.json"))
+    backoff_id, backoff_path = paths[0]
+    expired_id, expired_path = paths[1]
+    dead_id, dead_path = paths[2]
+    write_queue_item(
+        backoff_path,
+        load_queue_item(backoff_path).model_copy(
+            update={
+                "status": "failed",
+                "last_error": "temporary",
+                "next_attempt_at": (datetime.now(UTC) + timedelta(minutes=5)).isoformat(),
+            }
+        ),
+    )
+    write_queue_item(
+        expired_path,
+        load_queue_item(expired_path).model_copy(
+            update={
+                "status": "leased",
+                "lease_owner": "local-cli:123",
+                "lease_expires_at": (datetime.now(UTC) - timedelta(minutes=1)).isoformat(),
+            }
+        ),
+    )
+    write_queue_item(
+        dead_path,
+        load_queue_item(dead_path).model_copy(
+            update={"status": "dead_letter", "last_error": "broken"}
+        ),
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "queue", "inspect", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    states = {item["source_id"]: item["operator_state"] for item in payload["items"]}
+    assert states[backoff_id] == "failed_backoff"
+    assert states[expired_id] == "expired_leased"
+    assert states[dead_id] == "dead_letter"
+
+    exit_code = main(["--root", str(tmp_path), "queue", "inspect"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "dead_letter" in out
+    assert "Next: splendor queue retry <job-id> or splendor repair ingest <source-id>" in out
 
 
 def test_cli_repair_ingest_requeues_and_runs_fixed_failed_source(tmp_path: Path, capsys) -> None:
@@ -249,6 +338,35 @@ def test_cli_repair_ingest_requeues_and_runs_fixed_failed_source(tmp_path: Path,
     )
     assert queue_record.status == "done"
     assert source_record.status == "ingested"
+
+
+def test_cli_repair_ingest_recovers_dead_letter_source(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.txt"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    write_queue_item(
+        queue_path,
+        load_queue_item(queue_path).model_copy(
+            update={
+                "status": "dead_letter",
+                "attempt_count": 3,
+                "max_attempts": 3,
+                "last_error": "x",
+            }
+        ),
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "repair", "ingest", source_id])
+
+    assert exit_code == 0
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.status == "done"
+    assert queue_record.attempt_count == 4
+    assert queue_record.max_attempts == 4
 
 
 def test_repair_ingest_done_requeue_keeps_attempt_budget_valid(tmp_path: Path, capsys) -> None:

--- a/tests/test_queue_commands.py
+++ b/tests/test_queue_commands.py
@@ -312,7 +312,76 @@ def test_cli_queue_inspect_distinguishes_backoff_expired_lease_and_dead_letter(
     assert exit_code == 0
     out = capsys.readouterr().out
     assert "dead_letter" in out
-    assert "Next: splendor queue retry <job-id> or splendor repair ingest <source-id>" in out
+    assert "Next: splendor ingest --pending" in out
+
+
+def test_cli_queue_inspect_prioritizes_runnable_next_action(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    pending_source = tmp_path / "pending.md"
+    pending_source.write_text("# Pending\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(pending_source)])
+    backoff_source = tmp_path / "backoff.md"
+    backoff_source.write_text("# Backoff\n\nhello\n", encoding="utf-8")
+    manifests_before = set((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    main(["--root", str(tmp_path), "add-source", str(backoff_source)])
+    manifests_after = set((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    backoff_id = (manifests_after - manifests_before).pop().stem
+    backoff_path = tmp_path / "state" / "queue" / f"ingest-{backoff_id}.json"
+    write_queue_item(
+        backoff_path,
+        load_queue_item(backoff_path).model_copy(
+            update={
+                "status": "failed",
+                "last_error": "temporary",
+                "next_attempt_at": (datetime.now(UTC) + timedelta(minutes=5)).isoformat(),
+            }
+        ),
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "queue", "inspect"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Next: splendor ingest --pending" in out
+
+
+def test_queue_inspect_handles_z_and_invalid_timestamps(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    z_source = tmp_path / "z.md"
+    z_source.write_text("# Z\n\nhello\n", encoding="utf-8")
+    z_added = add_source(tmp_path, z_source)
+    z_queue_path = enqueue_ingest_job(tmp_path, z_added.source_id)
+    invalid_source = tmp_path / "invalid.md"
+    invalid_source.write_text("# Invalid\n\nhello\n", encoding="utf-8")
+    invalid_added = add_source(tmp_path, invalid_source)
+    invalid_queue_path = enqueue_ingest_job(tmp_path, invalid_added.source_id)
+    write_queue_item(
+        z_queue_path,
+        load_queue_item(z_queue_path).model_copy(
+            update={
+                "status": "failed",
+                "last_error": "temporary",
+                "next_attempt_at": "2099-01-01T00:00:00Z",
+            }
+        ),
+    )
+    write_queue_item(
+        invalid_queue_path,
+        load_queue_item(invalid_queue_path).model_copy(
+            update={
+                "status": "failed",
+                "last_error": "temporary",
+                "next_attempt_at": "not-a-timestamp",
+            }
+        ),
+    )
+
+    result = inspect_queue(tmp_path)
+
+    states = {item.source_id: item.operator_state for item in result.items}
+    assert states[z_added.source_id] == "failed_backoff"
+    assert states[invalid_added.source_id] == "failed_due"
 
 
 def test_cli_repair_ingest_requeues_and_runs_fixed_failed_source(tmp_path: Path, capsys) -> None:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -6,6 +6,7 @@ from splendor.schemas import (
     ContradictionEvidence,
     KnowledgePageFrontmatter,
     ProvenanceLink,
+    QueueItemRecord,
     RunRecord,
     SourcePointerArtifact,
     SourceRecord,
@@ -264,6 +265,26 @@ def test_source_pointer_artifact_accepts_valid_payload() -> None:
     )
 
     assert artifact.kind == "source-pointer"
+
+
+def test_queue_item_accepts_dead_letter_and_next_attempt_payload() -> None:
+    record = QueueItemRecord(
+        job_id="ingest-src-123",
+        job_type="ingest_source",
+        status="dead_letter",
+        created_at="2026-04-10T15:00:00+00:00",
+        updated_at="2026-04-10T15:01:00+00:00",
+        attempt_count=3,
+        max_attempts=3,
+        payload_ref="state/manifests/sources/src-123.json",
+        last_error="broken",
+    )
+    failed = record.model_copy(
+        update={"status": "failed", "next_attempt_at": "2026-04-10T15:05:00+00:00"}
+    )
+
+    assert record.status == "dead_letter"
+    assert failed.next_attempt_at == "2026-04-10T15:05:00+00:00"
 
 
 def test_source_pointer_artifact_rejects_bad_checksum() -> None:


### PR DESCRIPTION
## Summary

Implements `M10-P2.1` as the completion slice for Milestone 10 queue robustness.

## What changed

- Added queue policy config defaults in `splendor.yaml` for max attempts, lease TTL, and retry backoff seconds.
- Extended queue records with `dead_letter` status and persisted `next_attempt_at` scheduling.
- Updated ingest draining to process pending jobs, due failed retries, and expired leases while skipping active leases and future-backoff jobs.
- Dead-letter exhausted ingest jobs until an explicit `splendor queue retry <job-id>` or `splendor repair ingest <source-id>` action.
- Expanded `queue inspect` human/JSON output with derived operator state and next-attempt details.
- Kept web queue/runs views read-only while showing next-attempt state.
- Updated README, quickstart, schema/product docs, and roadmap planning state.
- Inserted the new post-M10 Agent Synthesis Workflow milestone before rich-source/PDF/OCR work.

## Validation

- `uv run pytest`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`

## Follow-up

- `M11-P1.1` should start source lifecycle, bulk registration, refresh, and readable source lookup work.
