### PR TITLE
M11-P1.1: Source lifecycle commands

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M10-P1.1`
-- Last action taken: `M10-P1.1` is implemented; CLI queue inspection, failed ingest retry, and active ingest repair now cover manual recovery.
-- Current planned slice: `M10-P2`
-- Current PR sub-slice: `M10-P2.1`
+- Previous completed PR sub-slice: `M10-P2.1`
+- Last action taken: `M10-P2.1` is implemented; retry/backoff, dead-letter, and stale-lease recovery now cover queue robustness.
+- Current planned slice: `M11-P1`
+- Current PR sub-slice: `M11-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M11-P1`
-- Next planned PR sub-slice: `M11-P1.1`
+- Next planned slice: `M11-P2`
+- Next planned PR sub-slice: `M11-P2.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -147,11 +147,16 @@
   - [x] Add active `repair ingest` recovery that requeues and runs immediately
   - [x] Keep dead-letter, backoff, and broader stale-lease policy deferred to `M10-P2`
   - [x] Publish a non-draft GitHub PR for `M10-P1.1` with labels, milestone, and a detailed description
-- [ ] Implement `M10-P2.1`: Backoff, dead-letter, and stale-lease recovery
-  - [ ] Add configurable queue retry/backoff policy
-  - [ ] Add explicit dead-letter queue state
-  - [ ] Recover expired leases while protecting active leases
-  - [ ] Reorder the post-M10 roadmap around agent synthesis workflow
+- [x] Implement `M10-P2.1`: Backoff, dead-letter, and stale-lease recovery
+  - [x] Add configurable queue retry/backoff policy
+  - [x] Add explicit dead-letter queue state
+  - [x] Recover expired leases while protecting active leases
+  - [x] Reorder the post-M10 roadmap around agent synthesis workflow
+- [x] Implement `M11-P1.1`: Source lifecycle, bulk registration, refresh, and readable source lookup
+  - [x] Add deterministic `add-source --glob` and `add-source --dir` registration
+  - [x] Add explicit source refresh workflow through the existing ingest queue
+  - [x] Add readable source lookup by title/path without changing canonical IDs
+  - [x] Update docs, tests, and planning state for the source lifecycle contract
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ The companion-repo guidance and sample agent instructions live in
 Implemented today:
 
 - `splendor init`
-- `splendor add-source <path>`
+- `splendor add-source <path>`, `splendor add-source --glob "pattern"`, and
+  `splendor add-source --dir path`
+- `splendor source list`, `splendor source lookup [query]`, and
+  `splendor source refresh <source-id|title|path>`
 - `splendor ingest <source-id>` and `splendor ingest --pending`
 - `splendor queue inspect [job-id]` and `splendor queue retry <job-id>`
 - `splendor repair ingest <source-id>`
@@ -131,7 +134,6 @@ Implemented today:
 Not implemented yet:
 
 - mutating review-gated `splendor wiki compile`
-- source bulk registration and refresh workflows
 - topic scaffolding, templates, and index rebuild
 - OCR and image extraction flows
 - mutating web UI actions such as add-source forms
@@ -149,12 +151,12 @@ Not implemented yet:
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M10-P1.1`
-- Current planned slice: `M10-P2`
-- Current PR sub-slice: `M10-P2.1`
+- Previous completed PR sub-slice: `M10-P2.1`
+- Current planned slice: `M11-P1`
+- Current PR sub-slice: `M11-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M11-P1`
-- Next planned PR sub-slice: `M11-P1.1`
+- Next planned slice: `M11-P2`
+- Next planned PR sub-slice: `M11-P2.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -187,6 +189,10 @@ compile/update workflows maintain concept, entity, topic, architecture, and glos
 UI without adding mutating web actions.
 
 `M10-P1.1` is implemented: it adds CLI-first queue inspection, failed ingest retry, and active
-ingest repair. The current PR sub-slice is `M10-P2.1`, which adds configurable queue retry/backoff
-policy, explicit dead-letter records, and stale-lease recovery. After Milestone 10, the next
-milestone shifts to text-native agent synthesis workflows before rich-source/PDF/OCR expansion.
+ingest repair. `M10-P2.1` is implemented: it adds configurable queue retry/backoff policy,
+explicit dead-letter records, and stale-lease recovery.
+
+The current PR sub-slice is `M11-P1.1`, which adds deterministic bulk source registration,
+explicit source refresh through the existing ingest queue, and readable source lookup by title or
+path without changing canonical source IDs. After `M11-P1`, the next Milestone 11 work moves to
+topic scaffolding, templates, and index rebuild.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -77,6 +77,21 @@ The command prints:
 For in-repo files, the current default storage mode is `none`, which means Splendor tracks the
 workspace file directly instead of copying it into `raw/sources/`.
 
+To register a batch, use a glob or direct directory scan. Both forms process files in deterministic
+path order and create pending ingest jobs for newly registered sources:
+
+```bash
+uv run splendor --root /tmp/demo-repo add-source --glob "docs/*.md"
+uv run splendor --root /tmp/demo-repo add-source --dir docs
+```
+
+Readable source lookup maps titles and paths back to canonical source IDs without renaming source
+records or generated `wiki/sources/src-...md` pages:
+
+```bash
+uv run splendor --root /tmp/demo-repo source lookup product-note
+```
+
 ## 4. Ingest the source
 
 Drain the pending ingest queue:
@@ -102,6 +117,18 @@ After ingest, use the source ID from the command output to inspect likely synthe
 uv run splendor --root /tmp/demo-repo wiki status
 uv run splendor --root /tmp/demo-repo wiki suggest <source-id>
 ```
+
+When a tracked source file changes, refresh it by ID, title, or path. Refresh detects changed
+content, registers the current content as a new canonical source version when needed, and queues
+ingest through the same ledger used by `add-source`:
+
+```bash
+uv run splendor --root /tmp/demo-repo source refresh product-note.md
+uv run splendor --root /tmp/demo-repo ingest --pending
+```
+
+Refresh does not override active ingest leases or dead-letter protections; use `queue retry` or
+`repair ingest` for those recovery cases.
 
 For a read-only browser view over the same status and source-detail contracts:
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -135,6 +135,22 @@ Implemented fields:
     - `manual`
     - `repo_scan`
 
+### Source lifecycle commands
+
+- `splendor add-source <path>` preserves single-file registration behavior.
+- `splendor add-source --glob "pattern"` expands matching files in deterministic path order.
+- `splendor add-source --dir path` registers direct child files in deterministic path order.
+- Newly registered CLI sources are handed to the existing ingest queue as `ingest-<source-id>`
+  records; already registered sources are reported without creating duplicate work.
+- `splendor source list` and `splendor source lookup [query]` provide a readable title/path to
+  `source_id` mapping. They are lookup surfaces only and do not rename canonical source IDs or
+  generated `wiki/sources/src-...md` pages.
+- `splendor source refresh <source-id|title|path>` resolves the tracked workspace or external path,
+  compares current bytes to the manifest checksum, registers changed content as a new canonical
+  source version, and queues ingest through the same queue handoff used by `add-source`.
+- Refresh uses the queue ledger directly, so active leases remain protected and dead-lettered jobs
+  still require `splendor queue retry <job-id>` or `splendor repair ingest <source-id>`.
+
 ### Recommended default policy
 
 Recommended defaults:

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M10-P1.1`
-- Current planned slice: `M10-P2`
-- Current PR sub-slice: `M10-P2.1`
+- Previous completed PR sub-slice: `M10-P2.1`
+- Current planned slice: `M11-P1`
+- Current PR sub-slice: `M11-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M11-P1`
-- Next planned PR sub-slice: `M11-P1.1`
+- Next planned slice: `M11-P2`
+- Next planned PR sub-slice: `M11-P2.1`
 
 `M10-P0.1` is implemented: the CLI-first wiki status and source-impact suggestion bridge is in
 place. `M10-P0.2` is implemented: project briefing and the non-mutating review-gated compile-loop
@@ -687,6 +687,18 @@ project knowledge bases.
 - `M11-P1` Source lifecycle, bulk registration, refresh, and readable source lookup
 - `M11-P2` Topic scaffolding, templates, and index rebuild
 - `M11-P3` Query/source lookup and agent-context improvements
+
+### Current PR sub-slices
+- `M11-P1.1` Source lifecycle, bulk registration, refresh, and readable source lookup
+- `M11-P2.1` Topic scaffolding, templates, and index rebuild
+- `M11-P3.1` Query/source lookup and agent-context improvements
+
+### Milestone 11 status
+
+`M11-P1.1` is in progress: it adds deterministic bulk registration through `add-source --glob`
+and `add-source --dir`, explicit source refresh via the existing ingest queue, and readable source
+lookup by title/path without changing canonical source IDs. Topic scaffolding and broader
+query/source lookup work remain planned for `M11-P2.1` and `M11-P3.1`.
 
 ---
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -665,6 +665,13 @@ Current implementation:
 - `splendor add-source <path>` registers the source and creates a pending ingest queue item for
   CLI-created sources, so `splendor ingest --pending` can continue the loop without copying the
   source ID.
+- `splendor add-source --glob "pattern"` and `splendor add-source --dir path` register batches in
+  deterministic path order with filename-derived titles.
+- `splendor source list` and `splendor source lookup [query]` map human-readable titles and paths
+  back to canonical source IDs without renaming existing source-summary pages.
+- `splendor source refresh <source-id|title|path>` detects changed source content, registers the
+  current bytes as a new canonical source version when the checksum changed, and queues ingest via
+  the existing queue ledger while preserving active-lease and dead-letter protections.
 - `splendor ingest <source-id>` prints the generated source-summary page/run records and the next
   `splendor wiki suggest <source-id>` command.
 - `splendor ingest --pending` prints the next `wiki suggest` command when exactly one source was
@@ -727,6 +734,7 @@ A source should not be re-ingested merely because it exists in the repo. Re-inge
 - the pipeline version changed
 - the user explicitly requests re-ingestion
 - a repair job targets the source
+- a source refresh detects changed content and registers the current source version
 
 ## 16. Queue Model
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -8,7 +8,7 @@ import shlex
 from pathlib import Path
 
 from splendor import __version__
-from splendor.commands.add_source import add_sources, expand_source_paths
+from splendor.commands.add_source import add_source, expand_source_paths
 from splendor.commands.brief import build_project_brief, render_project_brief_json
 from splendor.commands.file_answer import (
     default_answer_page_id,
@@ -550,21 +550,29 @@ def handle_add_source(args: argparse.Namespace) -> int:
         if not source_paths:
             print("Error: add-source requires a path, --glob match, or --dir with files")
             return 1
-        results = add_sources(
-            root,
-            source_paths,
-            storage_mode=args.storage_mode,
-            capture_source_commit=args.capture_source_commit,
-        )
     except (FileNotFoundError, IsADirectoryError, NotADirectoryError, ValueError) as exc:
         return _print_error(exc)
 
-    if len(results) > 1:
-        print(f"Registered sources: {sum(not result.already_registered for result in results)}")
-        print(f"Already registered: {sum(result.already_registered for result in results)}")
-        queued = 0
+    if len(source_paths) > 1:
+        results = []
+        registration_errors = 0
         queue_warnings = 0
-        for result in results:
+        missing_init_warning = False
+        queued = 0
+        for source_path in source_paths:
+            try:
+                result = add_source(
+                    root,
+                    source_path,
+                    storage_mode=args.storage_mode,
+                    capture_source_commit=args.capture_source_commit,
+                )
+            except (FileNotFoundError, IsADirectoryError, ValueError) as exc:
+                registration_errors += 1
+                print(f"- {source_path}: registration failed: {_error_message(exc)}")
+                continue
+
+            results.append(result)
             action = "already registered" if result.already_registered else "registered"
             print(f"- {result.source_id} ({action}) {result.source_ref}")
             if result.already_registered:
@@ -573,21 +581,38 @@ def handle_add_source(args: argparse.Namespace) -> int:
                 enqueue_ingest_job(root, result.source_id)
             except (FileNotFoundError, RuntimeError, ValueError) as exc:
                 queue_warnings += 1
+                missing_init_warning = missing_init_warning or _is_missing_workspace_wiki_error(exc)
                 print(
                     f"  Warning: source registered but ingest was not queued: {_error_message(exc)}"
                 )
                 continue
             queued += 1
+
+        print(f"Registered sources: {sum(not result.already_registered for result in results)}")
+        print(f"Already registered: {sum(result.already_registered for result in results)}")
+        print(f"Registration failures: {registration_errors}")
         print(f"Queued ingest jobs: {queued}")
-        if queue_warnings:
-            print("Next: inspect warnings, then run splendor ingest --pending")
+        print(f"Queue warnings: {queue_warnings}")
+        if missing_init_warning:
+            print("Next: splendor init")
+            print("Then: splendor ingest --pending")
+        elif queue_warnings:
+            print("Next: splendor queue inspect")
         elif queued:
             print("Next: splendor ingest --pending")
         else:
             print("Next: splendor source lookup")
-        return 0
+        return 1 if registration_errors or queue_warnings else 0
 
-    result = results[0]
+    try:
+        result = add_source(
+            root,
+            source_paths[0],
+            storage_mode=args.storage_mode,
+            capture_source_commit=args.capture_source_commit,
+        )
+    except (FileNotFoundError, IsADirectoryError, ValueError) as exc:
+        return _print_error(exc)
     action = "Already registered" if result.already_registered else "Registered"
     print(f"{action} source {result.source_id}")
     print(f"Manifest: {result.manifest_path}")

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -8,7 +8,7 @@ import shlex
 from pathlib import Path
 
 from splendor import __version__
-from splendor.commands.add_source import add_source
+from splendor.commands.add_source import add_sources, expand_source_paths
 from splendor.commands.brief import build_project_brief, render_project_brief_json
 from splendor.commands.file_answer import (
     default_answer_page_id,
@@ -43,6 +43,13 @@ from splendor.commands.queue import (
 )
 from splendor.commands.repo_refresh import refresh_repo, render_repo_refresh_json
 from splendor.commands.repo_scan import render_repo_scan_json, scan_repo
+from splendor.commands.source import (
+    list_sources,
+    lookup_sources,
+    refresh_source,
+    render_source_lookup_json,
+    render_source_refresh_json,
+)
 from splendor.commands.wiki import (
     build_wiki_status,
     describe_wiki_compile_contract,
@@ -88,8 +95,24 @@ def build_parser() -> argparse.ArgumentParser:
     add_source_parser = subparsers.add_parser("add-source", help="Register a new immutable source")
     add_source_parser.add_argument(
         "path",
+        nargs="?",
         type=Path,
         help="Path to the source file to register.",
+    )
+    add_source_parser.add_argument(
+        "--glob",
+        action="append",
+        default=[],
+        dest="glob_patterns",
+        help="Register all files matching a glob pattern, in deterministic order.",
+    )
+    add_source_parser.add_argument(
+        "--dir",
+        action="append",
+        default=[],
+        dest="directories",
+        type=Path,
+        help="Register direct child files from a directory, in deterministic order.",
     )
     add_source_parser.add_argument(
         "--storage-mode",
@@ -111,6 +134,41 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_source_parser.set_defaults(capture_source_commit=None)
     add_source_parser.set_defaults(handler=handle_add_source)
+
+    source_parser = subparsers.add_parser("source", help="Inspect and refresh source records")
+    source_subparsers = source_parser.add_subparsers(dest="source_command", required=True)
+    source_list_parser = source_subparsers.add_parser(
+        "list", help="List registered sources with readable titles and paths"
+    )
+    source_list_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    source_list_parser.set_defaults(handler=handle_source_list)
+    source_lookup_parser = source_subparsers.add_parser(
+        "lookup", help="Find source IDs by title, path, or source ID"
+    )
+    source_lookup_parser.add_argument("query", nargs="?", help="Title, path, or source ID to find")
+    source_lookup_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    source_lookup_parser.set_defaults(handler=handle_source_lookup)
+    source_refresh_parser = source_subparsers.add_parser(
+        "refresh", help="Detect source content changes and queue ingest work"
+    )
+    source_refresh_parser.add_argument("query", help="Source ID, title, or path to refresh")
+    source_refresh_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    source_refresh_parser.set_defaults(handler=handle_source_refresh)
 
     ingest_parser = subparsers.add_parser("ingest", help="Ingest registered sources into the wiki")
     ingest_parser.add_argument(
@@ -482,17 +540,54 @@ def _is_missing_workspace_wiki_error(exc: Exception) -> bool:
 
 def handle_add_source(args: argparse.Namespace) -> int:
     root = args.root.resolve()
-    candidate_path = args.path.expanduser()
-    source_path = candidate_path if candidate_path.is_absolute() else root / candidate_path
     try:
-        result = add_source(
+        source_paths = expand_source_paths(
             root,
-            source_path,
+            source_path=args.path,
+            glob_patterns=args.glob_patterns,
+            directories=args.directories,
+        )
+        if not source_paths:
+            print("Error: add-source requires a path, --glob match, or --dir with files")
+            return 1
+        results = add_sources(
+            root,
+            source_paths,
             storage_mode=args.storage_mode,
             capture_source_commit=args.capture_source_commit,
         )
-    except (FileNotFoundError, IsADirectoryError, ValueError) as exc:
+    except (FileNotFoundError, IsADirectoryError, NotADirectoryError, ValueError) as exc:
         return _print_error(exc)
+
+    if len(results) > 1:
+        print(f"Registered sources: {sum(not result.already_registered for result in results)}")
+        print(f"Already registered: {sum(result.already_registered for result in results)}")
+        queued = 0
+        queue_warnings = 0
+        for result in results:
+            action = "already registered" if result.already_registered else "registered"
+            print(f"- {result.source_id} ({action}) {result.source_ref}")
+            if result.already_registered:
+                continue
+            try:
+                enqueue_ingest_job(root, result.source_id)
+            except (FileNotFoundError, RuntimeError, ValueError) as exc:
+                queue_warnings += 1
+                print(
+                    f"  Warning: source registered but ingest was not queued: {_error_message(exc)}"
+                )
+                continue
+            queued += 1
+        print(f"Queued ingest jobs: {queued}")
+        if queue_warnings:
+            print("Next: inspect warnings, then run splendor ingest --pending")
+        elif queued:
+            print("Next: splendor ingest --pending")
+        else:
+            print("Next: splendor source lookup")
+        return 0
+
+    result = results[0]
     action = "Already registered" if result.already_registered else "Registered"
     print(f"{action} source {result.source_id}")
     print(f"Manifest: {result.manifest_path}")
@@ -516,6 +611,58 @@ def handle_add_source(args: argparse.Namespace) -> int:
         print("Next: splendor ingest --pending")
     else:
         print(f"Next: splendor ingest {result.source_id}")
+    return 0
+
+
+def handle_source_list(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        results = list_sources(root)
+    except (FileNotFoundError, ValueError) as exc:
+        return _print_error(exc)
+    if args.json_output:
+        print(render_source_lookup_json(root, results))
+        return 0
+    _print_source_lookup_results(results)
+    return 0
+
+
+def handle_source_lookup(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        results = lookup_sources(root, args.query)
+    except (FileNotFoundError, ValueError) as exc:
+        return _print_error(exc)
+    if args.json_output:
+        print(render_source_lookup_json(root, results))
+        return 0
+    _print_source_lookup_results(results)
+    return 0
+
+
+def handle_source_refresh(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = refresh_source(root, args.query)
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        return _print_error(exc)
+    if args.json_output:
+        print(render_source_refresh_json(root, result))
+        return 0
+
+    if result.changed:
+        print(f"Detected changed source content for {result.requested.source_id}")
+        if result.refreshed.record.source_id != result.requested.source_id:
+            print(f"Registered refreshed source {result.refreshed.record.source_id}")
+    else:
+        print(f"No source content change detected for {result.requested.source_id}")
+    print(f"Source ref: {result.refreshed.source_ref}")
+    if result.queued and result.queue_path is not None:
+        print(f"Queued ingest: {result.queue_path}")
+        print("Next: splendor ingest --pending")
+    else:
+        print(f"Refresh skipped: {result.message}")
+        print(f"Next: splendor wiki suggest {result.refreshed.record.source_id}")
     return 0
 
 
@@ -684,6 +831,21 @@ def _print_queue_item_detail(item: QueueItemSnapshot) -> None:
         print(f"Next: splendor queue retry {item.job_id}")
     elif item.operator_state in {"pending", "failed_due", "expired_leased"}:
         print("Next: splendor ingest --pending")
+
+
+def _print_source_lookup_results(results) -> None:
+    print(f"Sources: {len(results)}")
+    if not results:
+        print("No matching sources.")
+        return
+    for result in results:
+        source = result.source
+        print(
+            f"- {source.source_id} [{source.status}] {source.title} "
+            f"ref={source.source_ref or source.path}"
+        )
+        print(f"  Manifest: {result.manifest_path}")
+    print("Next: splendor source refresh <source-id|title|path>")
 
 
 def handle_wiki_status(args: argparse.Namespace) -> int:

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -44,6 +44,7 @@ from splendor.commands.queue import (
 from splendor.commands.repo_refresh import refresh_repo, render_repo_refresh_json
 from splendor.commands.repo_scan import render_repo_scan_json, scan_repo
 from splendor.commands.source import (
+    SourceLookupResult,
     list_sources,
     lookup_sources,
     refresh_source,
@@ -859,7 +860,7 @@ def _print_queue_item_detail(item: QueueItemSnapshot) -> None:
         print("Next: splendor ingest --pending")
 
 
-def _print_source_lookup_results(results) -> None:
+def _print_source_lookup_results(results: list[SourceLookupResult]) -> None:
     print(f"Sources: {len(results)}")
     if not results:
         print("No matching sources.")

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -680,7 +680,10 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
     if result.changed:
         print(f"Detected changed source content for {result.requested.source_id}")
         if result.refreshed.record.source_id != result.requested.source_id:
-            print(f"Registered refreshed source {result.refreshed.record.source_id}")
+            if result.refreshed.already_registered:
+                print(f"Matched existing source version {result.refreshed.record.source_id}")
+            else:
+                print(f"Registered refreshed source {result.refreshed.record.source_id}")
     else:
         print(f"No source content change detected for {result.requested.source_id}")
     print(f"Source ref: {result.refreshed.source_ref}")

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -70,6 +70,7 @@ from splendor.schemas import (
 )
 from splendor.schemas.types import STORAGE_MODES
 from splendor.state.query_snapshot import last_query_path_for, write_query_snapshot
+from splendor.state.source_compat import canonical_source_ref
 from splendor.utils.provenance import summarize_provenance_links
 from splendor.utils.time import utc_now_iso
 
@@ -867,7 +868,7 @@ def _print_source_lookup_results(results) -> None:
         source = result.source
         print(
             f"- {source.source_id} [{source.status}] {source.title} "
-            f"ref={source.source_ref or source.path}"
+            f"ref={canonical_source_ref(source)}"
         )
         print(f"  Manifest: {result.manifest_path}")
     print("Next: splendor source refresh <source-id|title|path>")

--- a/src/splendor/commands/add_source.py
+++ b/src/splendor/commands/add_source.py
@@ -41,10 +41,11 @@ def expand_source_paths(
         candidates.append(source_path)
 
     for pattern in glob_patterns or []:
-        if Path(pattern).is_absolute():
-            matches = [Path(match) for match in glob(pattern, recursive=True)]
+        expanded_pattern = str(Path(pattern).expanduser())
+        if Path(expanded_pattern).is_absolute():
+            matches = [Path(match) for match in glob(expanded_pattern, recursive=True)]
         else:
-            matches = list(root.glob(pattern))
+            matches = list(root.glob(expanded_pattern))
         candidates.extend(match for match in matches if match.is_file())
 
     for directory in directories or []:
@@ -90,21 +91,3 @@ def add_source(
         source_ref=registered.source_ref,
         already_registered=registered.already_registered,
     )
-
-
-def add_sources(
-    root: Path,
-    source_paths: list[Path],
-    *,
-    storage_mode: StorageMode | None = None,
-    capture_source_commit: bool | None = None,
-) -> list[AddSourceResult]:
-    return [
-        add_source(
-            root,
-            source_path,
-            storage_mode=storage_mode,
-            capture_source_commit=capture_source_commit,
-        )
-        for source_path in source_paths
-    ]

--- a/src/splendor/commands/add_source.py
+++ b/src/splendor/commands/add_source.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from glob import glob
 from pathlib import Path
 
 from splendor.schemas.types import StorageMode
@@ -17,6 +18,55 @@ class AddSourceResult:
     storage_mode: StorageMode
     source_ref: str
     already_registered: bool
+
+
+def _sort_key(root: Path, path: Path) -> tuple[str, str]:
+    resolved = path.expanduser().resolve()
+    try:
+        return ("workspace", resolved.relative_to(root.resolve()).as_posix())
+    except ValueError:
+        return ("external", str(resolved))
+
+
+def expand_source_paths(
+    root: Path,
+    *,
+    source_path: Path | None = None,
+    glob_patterns: list[str] | None = None,
+    directories: list[Path] | None = None,
+) -> list[Path]:
+    """Expand add-source selectors into a deterministic file list."""
+    candidates: list[Path] = []
+    if source_path is not None:
+        candidates.append(source_path)
+
+    for pattern in glob_patterns or []:
+        if Path(pattern).is_absolute():
+            matches = [Path(match) for match in glob(pattern, recursive=True)]
+        else:
+            matches = list(root.glob(pattern))
+        candidates.extend(match for match in matches if match.is_file())
+
+    for directory in directories or []:
+        resolved_dir = directory.expanduser()
+        if not resolved_dir.is_absolute():
+            resolved_dir = root / resolved_dir
+        if not resolved_dir.exists():
+            msg = f"Source directory does not exist: {directory}"
+            raise FileNotFoundError(msg)
+        if not resolved_dir.is_dir():
+            msg = f"Source directory must be a directory: {directory}"
+            raise NotADirectoryError(msg)
+        candidates.extend(path for path in resolved_dir.iterdir() if path.is_file())
+
+    unique: dict[Path, Path] = {}
+    for candidate in candidates:
+        resolved = candidate.expanduser()
+        if not resolved.is_absolute():
+            resolved = root / resolved
+        unique[resolved.resolve()] = resolved
+
+    return sorted(unique.values(), key=lambda path: _sort_key(root, path))
 
 
 def add_source(
@@ -40,3 +90,21 @@ def add_source(
         source_ref=registered.source_ref,
         already_registered=registered.already_registered,
     )
+
+
+def add_sources(
+    root: Path,
+    source_paths: list[Path],
+    *,
+    storage_mode: StorageMode | None = None,
+    capture_source_commit: bool | None = None,
+) -> list[AddSourceResult]:
+    return [
+        add_source(
+            root,
+            source_path,
+            storage_mode=storage_mode,
+            capture_source_commit=capture_source_commit,
+        )
+        for source_path in source_paths
+    ]

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -12,11 +12,16 @@ from splendor.layout import resolve_layout
 from splendor.schemas import SourceRecord
 from splendor.state.paths import resolve_workspace_path
 from splendor.state.runtime import ingest_job_id
-from splendor.state.source_compat import canonical_source_ref, effective_storage_mode
+from splendor.state.source_compat import (
+    canonical_source_ref,
+    effective_materialized_path,
+    effective_storage_mode,
+)
 from splendor.state.source_registry import (
     RegisteredSource,
     load_source_record,
     register_source,
+    resolve_manifest_storage_path,
 )
 from splendor.utils.hashing import sha256_file
 
@@ -89,7 +94,7 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
         refreshed = RegisteredSource(
             record=requested,
             manifest_path=requested_match.manifest_path,
-            stored_path=None,
+            stored_path=_existing_materialized_path(root, requested),
             storage_mode=effective_storage_mode(requested),
             source_ref=canonical_source_ref(requested),
             copied=False,
@@ -139,6 +144,13 @@ def _select_refresh_candidate(
 
 def _latest_source_sort_key(result: SourceLookupResult) -> tuple[str, str]:
     return (result.source.added_at, result.source.source_id)
+
+
+def _existing_materialized_path(root: Path, source: SourceRecord) -> Path | None:
+    stored_path_value = effective_materialized_path(source)
+    if stored_path_value is None:
+        return None
+    return resolve_manifest_storage_path(root, stored_path_value)
 
 
 def render_source_lookup_json(root: Path, results: list[SourceLookupResult]) -> str:

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -80,6 +80,7 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
             root,
             current_path,
             storage_mode=requested.storage_mode,
+            capture_source_commit=requested.source_commit is not None,
             source_class=requested.source_class,
             source_labels=requested.source_labels,
             discovered_by=requested.discovered_by,
@@ -174,11 +175,12 @@ def _lookup_sort_key(result: SourceLookupResult) -> tuple[str, str, str]:
 
 
 def _matches_source(source: SourceRecord, needle: str) -> bool:
+    legacy_path = source.path if source.source_ref is None and source.storage_path is None else ""
     haystacks = [
         source.source_id,
         source.title,
         canonical_source_ref(source),
-        source.path,
+        legacy_path,
         source.original_path or "",
     ]
     return any(needle in value.casefold() for value in haystacks)
@@ -189,9 +191,15 @@ def _refreshable_source_path(root: Path, source: SourceRecord) -> Path:
         return resolve_workspace_path(root, source.source_ref, context="Workspace source")
     if source.source_ref_kind == "external_path" and source.source_ref:
         return Path(source.source_ref).expanduser().resolve()
+    if source.source_ref is None and source.original_path:
+        legacy_path = Path(source.original_path).expanduser()
+        if legacy_path.is_absolute():
+            return legacy_path.resolve()
+        return resolve_workspace_path(root, source.original_path, context="Legacy workspace source")
     msg = (
-        "Only workspace-backed and external-path sources can be refreshed by canonical source "
-        f"reference: {source.source_id}"
+        "Only workspace-backed, external-path, and original_path-backed legacy sources can be "
+        f"refreshed by canonical source reference: {source.source_id}. Re-register the source "
+        "with `splendor add-source <path>` to create a refreshable source_ref."
     )
     raise ValueError(msg)
 

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -68,13 +68,9 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
     if not candidates:
         msg = f"Unknown source: {source_query}"
         raise FileNotFoundError(msg)
-    if len(candidates) > 1:
-        ids = ", ".join(candidate.source.source_id for candidate in candidates[:5])
-        suffix = "" if len(candidates) <= 5 else ", ..."
-        msg = f"Source lookup is ambiguous for {source_query!r}: {ids}{suffix}"
-        raise ValueError(msg)
+    requested_match = _select_refresh_candidate(source_query, candidates)
 
-    requested = candidates[0].source
+    requested = requested_match.source
     current_path = _refreshable_source_path(root, requested)
     current_checksum = sha256_file(current_path)
     changed = current_checksum != requested.checksum
@@ -91,7 +87,7 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
     else:
         refreshed = RegisteredSource(
             record=requested,
-            manifest_path=candidates[0].manifest_path,
+            manifest_path=requested_match.manifest_path,
             stored_path=None,
             storage_mode=effective_storage_mode(requested),
             source_ref=canonical_source_ref(requested),
@@ -119,6 +115,29 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
         queue_path=queue_path,
         message="queued ingest",
     )
+
+
+def _select_refresh_candidate(
+    source_query: str, candidates: list[SourceLookupResult]
+) -> SourceLookupResult:
+    if len(candidates) == 1:
+        return candidates[0]
+
+    candidates_by_ref: dict[str, list[SourceLookupResult]] = {}
+    for candidate in candidates:
+        candidates_by_ref.setdefault(canonical_source_ref(candidate.source), []).append(candidate)
+
+    if len(candidates_by_ref) == 1:
+        return max(candidates, key=_latest_source_sort_key)
+
+    ids = ", ".join(candidate.source.source_id for candidate in candidates[:5])
+    suffix = "" if len(candidates) <= 5 else ", ..."
+    msg = f"Source lookup is ambiguous for {source_query!r}: {ids}{suffix}"
+    raise ValueError(msg)
+
+
+def _latest_source_sort_key(result: SourceLookupResult) -> tuple[str, str]:
+    return (result.source.added_at, result.source.source_id)
 
 
 def render_source_lookup_json(root: Path, results: list[SourceLookupResult]) -> str:

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -1,0 +1,194 @@
+"""Source lifecycle and lookup command helpers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from splendor.commands.ingest import enqueue_ingest_job, is_ingest_current
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import SourceRecord
+from splendor.state.paths import resolve_workspace_path
+from splendor.state.runtime import ingest_job_id
+from splendor.state.source_compat import canonical_source_ref, effective_storage_mode
+from splendor.state.source_registry import (
+    RegisteredSource,
+    load_source_record,
+    register_source,
+)
+from splendor.utils.hashing import sha256_file
+
+
+@dataclass(frozen=True)
+class SourceLookupResult:
+    source: SourceRecord
+    manifest_path: Path
+
+
+@dataclass(frozen=True)
+class SourceRefreshResult:
+    requested: SourceRecord
+    refreshed: RegisteredSource
+    changed: bool
+    queued: bool
+    queue_path: Path | None
+    message: str
+
+
+def list_sources(root: Path) -> list[SourceLookupResult]:
+    layout = resolve_layout(root, load_config(root))
+    results = [
+        SourceLookupResult(source=load_source_record(path), manifest_path=path)
+        for path in sorted(layout.source_records_dir.glob("*.json"))
+    ]
+    return sorted(results, key=_lookup_sort_key)
+
+
+def lookup_sources(root: Path, query: str | None = None) -> list[SourceLookupResult]:
+    results = list_sources(root)
+    if query is None or not query.strip():
+        return results
+    needle = query.strip().casefold()
+    return [result for result in results if _matches_source(result.source, needle)]
+
+
+def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
+    matches = lookup_sources(root, source_query)
+    exact_matches = [
+        match
+        for match in matches
+        if match.source.source_id == source_query
+        or match.source.title.casefold() == source_query.casefold()
+        or canonical_source_ref(match.source) == source_query
+        or (match.source.original_path is not None and match.source.original_path == source_query)
+    ]
+    candidates = exact_matches or matches
+    if not candidates:
+        msg = f"Unknown source: {source_query}"
+        raise FileNotFoundError(msg)
+    if len(candidates) > 1:
+        ids = ", ".join(candidate.source.source_id for candidate in candidates[:5])
+        suffix = "" if len(candidates) <= 5 else ", ..."
+        msg = f"Source lookup is ambiguous for {source_query!r}: {ids}{suffix}"
+        raise ValueError(msg)
+
+    requested = candidates[0].source
+    current_path = _refreshable_source_path(root, requested)
+    current_checksum = sha256_file(current_path)
+    changed = current_checksum != requested.checksum
+
+    if changed:
+        refreshed = register_source(
+            root,
+            current_path,
+            storage_mode=requested.storage_mode,
+            source_class=requested.source_class,
+            source_labels=requested.source_labels,
+            discovered_by=requested.discovered_by,
+        )
+    else:
+        refreshed = RegisteredSource(
+            record=requested,
+            manifest_path=candidates[0].manifest_path,
+            stored_path=None,
+            storage_mode=effective_storage_mode(requested),
+            source_ref=canonical_source_ref(requested),
+            copied=False,
+            already_registered=True,
+        )
+
+    layout = resolve_layout(root, load_config(root))
+    if is_ingest_current(root, layout, refreshed.record):
+        return SourceRefreshResult(
+            requested=requested,
+            refreshed=refreshed,
+            changed=changed,
+            queued=False,
+            queue_path=None,
+            message="source is already ingested for the current pipeline version",
+        )
+
+    queue_path = enqueue_ingest_job(root, refreshed.record.source_id)
+    return SourceRefreshResult(
+        requested=requested,
+        refreshed=refreshed,
+        changed=changed,
+        queued=True,
+        queue_path=queue_path,
+        message="queued ingest",
+    )
+
+
+def render_source_lookup_json(root: Path, results: list[SourceLookupResult]) -> str:
+    return json.dumps(
+        {"sources": [_source_payload(root, result) for result in results]},
+        indent=2,
+    )
+
+
+def render_source_refresh_json(root: Path, result: SourceRefreshResult) -> str:
+    return json.dumps(
+        {
+            "requested_source_id": result.requested.source_id,
+            "source_id": result.refreshed.record.source_id,
+            "changed": result.changed,
+            "queued": result.queued,
+            "queue_path": (
+                None
+                if result.queue_path is None
+                else result.queue_path.relative_to(root).as_posix()
+            ),
+            "message": result.message,
+        },
+        indent=2,
+    )
+
+
+def _lookup_sort_key(result: SourceLookupResult) -> tuple[str, str, str]:
+    return (
+        result.source.title.casefold(),
+        canonical_source_ref(result.source).casefold(),
+        result.source.source_id,
+    )
+
+
+def _matches_source(source: SourceRecord, needle: str) -> bool:
+    haystacks = [
+        source.source_id,
+        source.title,
+        canonical_source_ref(source),
+        source.path,
+        source.original_path or "",
+    ]
+    return any(needle in value.casefold() for value in haystacks)
+
+
+def _refreshable_source_path(root: Path, source: SourceRecord) -> Path:
+    if source.source_ref_kind == "workspace_path" and source.source_ref:
+        return resolve_workspace_path(root, source.source_ref, context="Workspace source")
+    if source.source_ref_kind == "external_path" and source.source_ref:
+        return Path(source.source_ref).expanduser().resolve()
+    msg = (
+        "Only workspace-backed and external-path sources can be refreshed by canonical source "
+        f"reference: {source.source_id}"
+    )
+    raise ValueError(msg)
+
+
+def _source_payload(root: Path, result: SourceLookupResult) -> dict[str, object]:
+    source = result.source
+    return {
+        "source_id": source.source_id,
+        "title": source.title,
+        "source_type": source.source_type,
+        "status": source.status,
+        "source_ref": canonical_source_ref(source),
+        "source_ref_kind": source.source_ref_kind,
+        "original_path": source.original_path,
+        "checksum": source.checksum,
+        "manifest_path": result.manifest_path.relative_to(root).as_posix(),
+        "queue_job_id": ingest_job_id(source.source_id),
+        "linked_pages": source.linked_pages,
+    }

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from splendor.commands.add_source import add_source
+from splendor.commands.add_source import add_source, expand_source_paths
 from splendor.commands.init import initialize_workspace
 from splendor.commands.materialize_source import materialize_source
 from splendor.state.source_pointer import load_source_pointer
@@ -67,6 +67,28 @@ def test_add_source_registers_workspace_file_without_copy_by_default(tmp_path: P
     assert manifest.discovered_by is None
     assert manifest.original_path == "note.md"
     assert not (tmp_path / "raw" / "sources" / result.source_id).exists()
+
+
+def test_expand_source_paths_deduplicates_and_sorts_bulk_selectors(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "zeta.md").write_text("# Zeta\n", encoding="utf-8")
+    (docs / "alpha.md").write_text("# Alpha\n", encoding="utf-8")
+    (docs / "notes.txt").write_text("Notes\n", encoding="utf-8")
+
+    paths = expand_source_paths(
+        tmp_path,
+        source_path=Path("docs/zeta.md"),
+        glob_patterns=["docs/*.md"],
+        directories=[Path("docs")],
+    )
+
+    assert [path.relative_to(tmp_path).as_posix() for path in paths] == [
+        "docs/alpha.md",
+        "docs/notes.txt",
+        "docs/zeta.md",
+    ]
 
 
 def test_resolve_manifest_storage_path_rejects_absolute_paths(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ import splendor.cli as cli_module
 from splendor import __version__
 from splendor.cli import build_parser, main
 from splendor.commands.ingest import enqueue_ingest_job
+from splendor.commands.source import refresh_source
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import KnowledgePageFrontmatter, MaintenanceIssue, MaintenanceReport
@@ -345,6 +346,41 @@ def test_cli_source_refresh_registers_changed_workspace_source_and_queues_it(
     refreshed_id = [path.stem for path in manifests if path.stem != original_id][0]
     assert f"Registered refreshed source {refreshed_id}" in out
     assert (tmp_path / "state" / "queue" / f"ingest-{refreshed_id}.json").exists()
+
+
+def test_cli_source_refresh_reports_existing_version_match(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert f"Matched existing source version {original_id}" in out
+    assert f"Registered refreshed source {original_id}" not in out
+
+
+def test_source_refresh_noop_returns_existing_materialized_path(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "--storage-mode", "copy", str(source)])
+    capsys.readouterr()
+
+    result = refresh_source(tmp_path, "brief.md")
+
+    assert result.changed is False
+    assert result.refreshed.stored_path == (
+        tmp_path / "raw" / "sources" / result.refreshed.record.source_id / "brief.md"
+    )
+    assert result.refreshed.stored_path.exists()
 
 
 def test_cli_source_refresh_json_reports_queue_handoff(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ from splendor.layout import resolve_layout
 from splendor.schemas import KnowledgePageFrontmatter, MaintenanceIssue, MaintenanceReport
 from splendor.state.query_snapshot import last_query_path_for, load_query_snapshot
 from splendor.state.runtime import load_queue_item
-from splendor.state.source_registry import load_source_record
+from splendor.state.source_registry import load_source_record, write_source_record
 
 
 def latest_report_paths(root: Path, command: str) -> tuple[Path, Path]:
@@ -241,6 +241,72 @@ def test_cli_source_lookup_maps_readable_path_to_source_id(tmp_path: Path, capsy
     assert "docs/audio-quality-feedback.md" in out
 
 
+def test_cli_source_list_reports_registered_sources(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "list"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Sources: 1" in out
+    assert "brief" in out
+    assert "ref=brief.md" in out
+
+
+def test_cli_source_lookup_json_reports_source_payload(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "lookup", "brief", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["sources"] == [
+        {
+            "source_id": source_id,
+            "title": "brief",
+            "source_type": "md",
+            "status": "registered",
+            "source_ref": "brief.md",
+            "source_ref_kind": "workspace_path",
+            "original_path": "brief.md",
+            "checksum": load_source_record(
+                tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
+            ).checksum,
+            "manifest_path": f"state/manifests/sources/{source_id}.json",
+            "queue_job_id": f"ingest-{source_id}",
+            "linked_pages": [],
+        }
+    ]
+
+
+def test_cli_source_lookup_does_not_match_copy_storage_paths(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    external_dir = tmp_path.parent / f"{tmp_path.name}-external"
+    external_dir.mkdir()
+    external_source = external_dir / "outside.md"
+    external_source.write_text("# Outside\n", encoding="utf-8")
+    try:
+        main(["--root", str(tmp_path), "add-source", str(external_source)])
+        capsys.readouterr()
+
+        exit_code = main(["--root", str(tmp_path), "source", "lookup", "raw/sources"])
+
+        assert exit_code == 0
+        assert "Sources: 0" in capsys.readouterr().out
+    finally:
+        external_source.unlink(missing_ok=True)
+        external_dir.rmdir()
+
+
 def test_cli_source_refresh_registers_changed_workspace_source_and_queues_it(
     tmp_path: Path, capsys
 ) -> None:
@@ -263,6 +329,82 @@ def test_cli_source_refresh_registers_changed_workspace_source_and_queues_it(
     refreshed_id = [path.stem for path in manifests if path.stem != original_id][0]
     assert f"Registered refreshed source {refreshed_id}" in out
     assert (tmp_path / "state" / "queue" / f"ingest-{refreshed_id}.json").exists()
+
+
+def test_cli_source_refresh_json_reports_queue_handoff(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    refreshed_ids = [
+        path.stem
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if path.stem != original_id
+    ]
+    assert payload == {
+        "requested_source_id": original_id,
+        "source_id": refreshed_ids[0],
+        "changed": True,
+        "queued": True,
+        "queue_path": f"state/queue/ingest-{refreshed_ids[0]}.json",
+        "message": "queued ingest",
+    }
+
+
+def test_cli_source_refresh_preserves_no_commit_capture_intent(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "--no-capture-source-commit", str(source)])
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("source commit capture should remain disabled")
+
+    monkeypatch.setattr("splendor.state.source_registry.captured_source_commit", fail_if_called)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+
+    assert exit_code == 0
+
+
+def test_cli_source_refresh_supports_original_path_legacy_manifest(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    manifest = load_source_record(manifest_path)
+    write_source_record(
+        manifest_path,
+        manifest.model_copy(
+            update={
+                "source_ref": None,
+                "source_ref_kind": None,
+                "storage_mode": None,
+                "storage_path": None,
+                "path": "raw/sources/legacy/brief.md",
+            }
+        ),
+    )
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+
+    assert exit_code == 0
+    assert "Detected changed source content" in capsys.readouterr().out
 
 
 def test_cli_source_refresh_by_path_uses_latest_matching_source_ref(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -265,6 +265,23 @@ def test_cli_source_refresh_registers_changed_workspace_source_and_queues_it(
     assert (tmp_path / "state" / "queue" / f"ingest-{refreshed_id}.json").exists()
 
 
+def test_cli_source_refresh_by_path_uses_latest_matching_source_ref(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "ambiguous" not in out
+    assert "No source content change detected" in out
+
+
 def test_cli_source_refresh_preserves_active_lease_protection(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     source = tmp_path / "brief.md"
@@ -307,6 +324,58 @@ def test_cli_source_refresh_preserves_dead_letter_protection(tmp_path: Path, cap
     out = capsys.readouterr().out
     assert "dead-lettered" in out
     assert "splendor queue retry" in out
+
+
+def test_cli_bulk_add_source_queues_successes_before_later_registration_failure(
+    tmp_path: Path, capsys
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    workspace_source = repo_root / "brief.md"
+    external_source = external_dir / "outside.md"
+    workspace_source.write_text("# Brief\n", encoding="utf-8")
+    external_source.write_text("# Outside\n", encoding="utf-8")
+
+    main(["--root", str(repo_root), "init"])
+    capsys.readouterr()
+    exit_code = main(
+        [
+            "--root",
+            str(repo_root),
+            "add-source",
+            "--storage-mode",
+            "none",
+            str(workspace_source),
+            "--glob",
+            str(external_source),
+        ]
+    )
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "Registration failures: 1" in out
+    assert "Queued ingest jobs: 1" in out
+    source_id = next((repo_root / "state" / "manifests" / "sources").glob("*.json")).stem
+    assert (repo_root / "state" / "queue" / f"ingest-{source_id}.json").exists()
+
+
+def test_cli_bulk_add_source_returns_nonzero_when_queue_handoff_fails(
+    tmp_path: Path, capsys
+) -> None:
+    first = tmp_path / "first.md"
+    second = tmp_path / "second.md"
+    first.write_text("# First\n", encoding="utf-8")
+    second.write_text("# Second\n", encoding="utf-8")
+
+    exit_code = main(["--root", str(tmp_path), "add-source", "--glob", "*.md"])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "Queue warnings: 2" in out
+    assert "Next: splendor init" in out
+    assert "Then: splendor ingest --pending" in out
 
 
 def test_cli_add_source_expands_user_paths(tmp_path: Path, capsys, monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ from splendor.layout import resolve_layout
 from splendor.schemas import KnowledgePageFrontmatter, MaintenanceIssue, MaintenanceReport
 from splendor.state.query_snapshot import last_query_path_for, load_query_snapshot
 from splendor.state.runtime import load_queue_item
+from splendor.state.source_registry import load_source_record
 
 
 def latest_report_paths(root: Path, command: str) -> tuple[Path, Path]:
@@ -48,12 +49,31 @@ def test_cli_add_source_capture_source_commit_flags_are_tri_state() -> None:
     parser = build_parser()
 
     no_flag = parser.parse_args(["add-source", "brief.md"])
+    glob_flag = parser.parse_args(["add-source", "--glob", "docs/*.md"])
+    dir_flag = parser.parse_args(["add-source", "--dir", "docs"])
     yes_flag = parser.parse_args(["add-source", "--capture-source-commit", "brief.md"])
     no_capture_flag = parser.parse_args(["add-source", "--no-capture-source-commit", "brief.md"])
 
     assert no_flag.capture_source_commit is None
+    assert glob_flag.glob_patterns == ["docs/*.md"]
+    assert dir_flag.directories == [Path("docs")]
     assert yes_flag.capture_source_commit is True
     assert no_capture_flag.capture_source_commit is False
+
+
+def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
+    parser = build_parser()
+
+    lookup = parser.parse_args(["source", "lookup", "brief", "--json"])
+    refresh = parser.parse_args(["source", "refresh", "docs/brief.md", "--json"])
+
+    assert lookup.command == "source"
+    assert lookup.source_command == "lookup"
+    assert lookup.query == "brief"
+    assert lookup.json_output is True
+    assert refresh.source_command == "refresh"
+    assert refresh.query == "docs/brief.md"
+    assert refresh.json_output is True
 
 
 def test_cli_repo_scan_parser_accepts_json_flag() -> None:
@@ -145,6 +165,47 @@ def test_cli_add_source_command_reports_workspace_backed_registration(
     assert "Storage artifact:" not in captured.out
 
 
+def test_cli_add_source_glob_registers_sources_in_deterministic_order(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "zeta.md").write_text("# Zeta\n", encoding="utf-8")
+    (docs / "alpha.md").write_text("# Alpha\n", encoding="utf-8")
+    (docs / "ignore.txt").write_text("Ignore\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "add-source", "--glob", "docs/*.md"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Registered sources: 2" in out
+    assert out.index("docs/alpha.md") < out.index("docs/zeta.md")
+    manifests = sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    assert len(manifests) == 2
+    refs = sorted(load_source_record(path).source_ref for path in manifests)
+    assert refs == ["docs/alpha.md", "docs/zeta.md"]
+    assert len(list((tmp_path / "state" / "queue").glob("*.json"))) == 2
+
+
+def test_cli_add_source_dir_registers_direct_child_files(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    docs = tmp_path / "docs"
+    nested = docs / "nested"
+    nested.mkdir(parents=True)
+    (docs / "brief.md").write_text("# Brief\n", encoding="utf-8")
+    (nested / "skip.md").write_text("# Skip\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "add-source", "--dir", "docs"])
+
+    assert exit_code == 0
+    manifests = list((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    assert len(manifests) == 1
+    assert load_source_record(manifests[0]).source_ref == "docs/brief.md"
+
+
 def test_cli_add_source_resolves_relative_paths_against_root(tmp_path: Path, capsys) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
@@ -160,6 +221,92 @@ def test_cli_add_source_resolves_relative_paths_against_root(tmp_path: Path, cap
     captured = capsys.readouterr()
     assert "Source ref: docs/brief.md" in captured.out
     assert "Storage mode: none" in captured.out
+
+
+def test_cli_source_lookup_maps_readable_path_to_source_id(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    source = docs / "audio-quality-feedback.md"
+    source.write_text("# Audio Quality Feedback\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "lookup", "audio quality"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Sources: 1" in out
+    assert "Audio Quality Feedback" in out or "audio quality feedback" in out
+    assert "docs/audio-quality-feedback.md" in out
+
+
+def test_cli_source_refresh_registers_changed_workspace_source_and_queues_it(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    original_manifest = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    original_id = original_manifest.stem
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert f"Detected changed source content for {original_id}" in out
+    manifests = sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    assert len(manifests) == 2
+    refreshed_id = [path.stem for path in manifests if path.stem != original_id][0]
+    assert f"Registered refreshed source {refreshed_id}" in out
+    assert (tmp_path / "state" / "queue" / f"ingest-{refreshed_id}.json").exists()
+
+
+def test_cli_source_refresh_preserves_active_lease_protection(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    queue = load_queue_item(queue_path).model_copy(
+        update={
+            "status": "leased",
+            "lease_owner": "local-cli:test",
+            "lease_expires_at": "2999-01-01T00:00:00+00:00",
+        }
+    )
+    queue_path.write_text(queue.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+
+    assert exit_code == 1
+    assert f"Error: Queue item is already leased: ingest-{source_id}" in capsys.readouterr().out
+
+
+def test_cli_source_refresh_preserves_dead_letter_protection(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    queue = load_queue_item(queue_path).model_copy(
+        update={"status": "dead_letter", "last_error": "too many failures"}
+    )
+    queue_path.write_text(queue.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "dead-lettered" in out
+    assert "splendor queue retry" in out
 
 
 def test_cli_add_source_expands_user_paths(tmp_path: Path, capsys, monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -257,6 +257,22 @@ def test_cli_source_list_reports_registered_sources(tmp_path: Path, capsys) -> N
     assert "ref=brief.md" in out
 
 
+def test_cli_source_list_json_reports_registered_sources(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "list", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [source["source_id"] for source in payload["sources"]] == [source_id]
+    assert payload["sources"][0]["source_ref"] == "brief.md"
+
+
 def test_cli_source_lookup_json_reports_source_payload(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     source = tmp_path / "brief.md"
@@ -377,6 +393,34 @@ def test_cli_source_refresh_preserves_no_commit_capture_intent(
     exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
 
     assert exit_code == 0
+
+
+def test_cli_source_refresh_preserves_positive_commit_capture_intent(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    manifest = load_source_record(manifest_path)
+    write_source_record(manifest_path, manifest.model_copy(update={"source_commit": "old"}))
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "splendor.state.source_registry.captured_source_commit",
+        lambda *_args, **_kwargs: "new",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+
+    assert exit_code == 0
+    refreshed_records = [
+        load_source_record(path)
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if path != manifest_path
+    ]
+    assert refreshed_records[0].source_commit == "new"
 
 
 def test_cli_source_refresh_supports_original_path_legacy_manifest(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Implements M11-P1.1 for issue #57: source lifecycle, bulk registration, refresh, and readable source lookup.

- add deterministic bulk registration via `splendor add-source --glob "pattern"` and `splendor add-source --dir path`, while preserving existing single-file `add-source <path>` behavior
- add `splendor source list`, `splendor source lookup [query]`, and `splendor source refresh <source-id|title|path>` for readable source lookup and explicit refresh/re-ingest handoff
- keep canonical `src-...` IDs and generated source-summary page names stable; lookup maps titles/paths to IDs instead of renaming existing artifacts
- route refresh work through the existing ingest queue so active leases and dead-letter protections continue to apply
- update quickstart, schema/product docs, README, roadmap, and agent planning state for M11-P1.1

Closes #57.

## Validation

- `uv run pytest`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`

## Notes

Milestone 11 is not currently present in the repository milestone list, so this PR is left without a milestone rather than creating one implicitly. Follow-up M11 work remains scoped to M11-P2.1 topic scaffolding/index/templates and M11-P3.1 query/source lookup/agent-context improvements.
