### PR TITLE
M11-P2.1 Topic scaffolding, templates, and index rebuild

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M10-P2.1`
-- Last action taken: `M10-P2.1` is implemented; retry/backoff, dead-letter, and stale-lease recovery now cover queue robustness.
-- Current planned slice: `M11-P1`
-- Current PR sub-slice: `M11-P1.1`
+- Previous completed PR sub-slice: `M11-P1.1`
+- Last action taken: `M11-P1.1` is implemented; source lifecycle refresh, bulk registration, and readable source lookup are available.
+- Current planned slice: `M11-P2`
+- Current PR sub-slice: `M11-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M11-P2`
-- Next planned PR sub-slice: `M11-P2.1`
+- Next planned slice: `M11-P3`
+- Next planned PR sub-slice: `M11-P3.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -157,6 +157,11 @@
   - [x] Add explicit source refresh workflow through the existing ingest queue
   - [x] Add readable source lookup by title/path without changing canonical IDs
   - [x] Update docs, tests, and planning state for the source lifecycle contract
+- [x] Implement `M11-P2.1`: Topic scaffolding, templates, and index rebuild
+  - [x] Add deterministic `splendor add-topic` topic page scaffolding
+  - [x] Add default, research-synthesis, and issue-tracker markdown templates
+  - [x] Add `splendor wiki rebuild-index` from wiki page frontmatter
+  - [x] Update docs, tests, and planning state for the topic/index contract
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ Implemented today:
 - `splendor task|milestone|decision|question ...`
 - `splendor repo scan`
 - `splendor repo refresh`
+- `splendor add-topic "Title"` with optional `--tags`, `--source-refs`, and `--template`
 - `splendor wiki status`
 - `splendor wiki suggest <source-id>`
 - `splendor wiki compile <source-id>` as a non-mutating review-gated contract description
+- `splendor wiki rebuild-index`
 - `splendor brief [goal]`
 - `splendor serve` for a read-only local browse/search/status/planning/runtime UI
 - read-only web `/status`, `/sources/<source-id>`, `/planning`, `/runs`, and `/queue` views
@@ -134,7 +136,6 @@ Implemented today:
 Not implemented yet:
 
 - mutating review-gated `splendor wiki compile`
-- topic scaffolding, templates, and index rebuild
 - OCR and image extraction flows
 - mutating web UI actions such as add-source forms
 - changed-files-driven refresh suggestions
@@ -151,12 +152,12 @@ Not implemented yet:
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M10-P2.1`
-- Current planned slice: `M11-P1`
-- Current PR sub-slice: `M11-P1.1`
+- Previous completed PR sub-slice: `M11-P1.1`
+- Current planned slice: `M11-P2`
+- Current PR sub-slice: `M11-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M11-P2`
-- Next planned PR sub-slice: `M11-P2.1`
+- Next planned slice: `M11-P3`
+- Next planned PR sub-slice: `M11-P3.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -192,7 +193,8 @@ UI without adding mutating web actions.
 ingest repair. `M10-P2.1` is implemented: it adds configurable queue retry/backoff policy,
 explicit dead-letter records, and stale-lease recovery.
 
-The current PR sub-slice is `M11-P1.1`, which adds deterministic bulk source registration,
-explicit source refresh through the existing ingest queue, and readable source lookup by title or
-path without changing canonical source IDs. After `M11-P1`, the next Milestone 11 work moves to
-topic scaffolding, templates, and index rebuild.
+`M11-P1.1` is implemented: it adds deterministic bulk source registration, explicit source
+refresh through the existing ingest queue, and readable source lookup by title or path without
+changing canonical source IDs. The current PR sub-slice is `M11-P2.1`, which adds CLI-first topic
+scaffolding, deterministic templates, and wiki index rebuild support. After `M11-P2`, the next
+Milestone 11 work moves to query/source lookup and agent-context improvements.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -118,6 +118,21 @@ uv run splendor --root /tmp/demo-repo wiki status
 uv run splendor --root /tmp/demo-repo wiki suggest <source-id>
 ```
 
+To start a maintained synthesis page without hand-writing the schema-bound frontmatter, scaffold a
+topic and rebuild the index from current wiki page metadata:
+
+```bash
+uv run splendor --root /tmp/demo-repo add-topic "Preprocessing Pipeline" \
+  --tags preprocessing,audio \
+  --source-refs <source-id> \
+  --template research-synthesis
+uv run splendor --root /tmp/demo-repo wiki rebuild-index
+```
+
+`add-topic` writes `wiki/topics/<slug>.md`, validates the frontmatter contract, and refreshes
+`wiki/index.md`. `wiki rebuild-index` is idempotent and reads existing wiki page frontmatter; it
+does not rewrite generated source-summary pages.
+
 When a tracked source file changes, refresh it by ID, title, or path. Refresh detects changed
 content, registers the current content as a new canonical source version when needed, and queues
 ingest through the same ledger used by `add-source`:

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -202,6 +202,13 @@ Minimal frontmatter contract for wiki pages:
 
 Current runtime behavior:
 
+- `splendor add-topic "Title"` writes maintained topic pages under `wiki/topics/<slug>.md` with
+  `kind: topic`, `page_id: topic-<slug>`, `status: active`, `review_state: draft`, optional tags,
+  and optional source refs
+- `splendor add-topic --template default|research-synthesis|issue-tracker` uses deterministic
+  markdown scaffolds; templates do not generate source-summary content or LLM-authored synthesis
+- `splendor wiki rebuild-index` rewrites `wiki/index.md` from validated wiki page frontmatter and
+  does not mutate generated source-summary pages
 - source-summary pages written by `splendor ingest` now use `review_state: machine-generated`
 - those pages persist `last_generated_at`
 - those pages persist structured provenance links back to the source manifest, ingest run, and

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M10-P2.1`
-- Current planned slice: `M11-P1`
-- Current PR sub-slice: `M11-P1.1`
+- Previous completed PR sub-slice: `M11-P1.1`
+- Current planned slice: `M11-P2`
+- Current PR sub-slice: `M11-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M11-P2`
-- Next planned PR sub-slice: `M11-P2.1`
+- Next planned slice: `M11-P3`
+- Next planned PR sub-slice: `M11-P3.1`
 
 `M10-P0.1` is implemented: the CLI-first wiki status and source-impact suggestion bridge is in
 place. `M10-P0.2` is implemented: project briefing and the non-mutating review-gated compile-loop
@@ -695,10 +695,11 @@ project knowledge bases.
 
 ### Milestone 11 status
 
-`M11-P1.1` is in progress: it adds deterministic bulk registration through `add-source --glob`
+`M11-P1.1` is implemented: it adds deterministic bulk registration through `add-source --glob`
 and `add-source --dir`, explicit source refresh via the existing ingest queue, and readable source
-lookup by title/path without changing canonical source IDs. Topic scaffolding and broader
-query/source lookup work remain planned for `M11-P2.1` and `M11-P3.1`.
+lookup by title/path without changing canonical source IDs. `M11-P2.1` is in progress: it adds
+CLI-first topic scaffolding, deterministic topic templates, and a frontmatter-driven wiki index
+rebuild. Broader query/source lookup and agent-context work remains planned for `M11-P3.1`.
 
 ---
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -672,6 +672,9 @@ Current implementation:
 - `splendor source refresh <source-id|title|path>` detects changed source content, registers the
   current bytes as a new canonical source version when the checksum changed, and queues ingest via
   the existing queue ledger while preserving active-lease and dead-letter protections.
+- `splendor add-topic "Title"` scaffolds a maintained topic page under `wiki/topics/<slug>.md`
+  with valid knowledge-page frontmatter, optional tags/source refs, and deterministic markdown
+  templates for default synthesis, research synthesis, and issue tracking.
 - `splendor ingest <source-id>` prints the generated source-summary page/run records and the next
   `splendor wiki suggest <source-id>` command.
 - `splendor ingest --pending` prints the next `wiki suggest` command when exactly one source was
@@ -684,6 +687,9 @@ Current implementation:
   optional JSON output.
 - `splendor wiki compile <source-id>` exposes the review-gated compile-loop contract, validates the
   source, and reports that it does not mutate synthesis pages yet.
+- `splendor wiki rebuild-index` rewrites `wiki/index.md` from validated wiki page frontmatter,
+  including maintained synthesis pages and generated source-summary pages, without mutating the
+  pages themselves.
 - `splendor query` prefers claim-bearing source-summary sections over generated metadata
   boilerplate when selecting snippets, and text output points to `file-answer` when a saved query
   has matches.

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -52,9 +52,13 @@ from splendor.commands.source import (
     render_source_refresh_json,
 )
 from splendor.commands.wiki import (
+    add_topic_page,
     build_wiki_status,
     describe_wiki_compile_contract,
+    rebuild_wiki_index,
+    render_topic_scaffold_json,
     render_wiki_compile_contract_json,
+    render_wiki_index_rebuild_json,
     render_wiki_status_json,
     render_wiki_suggest_json,
     suggest_source_pages,
@@ -136,6 +140,34 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_source_parser.set_defaults(capture_source_commit=None)
     add_source_parser.set_defaults(handler=handle_add_source)
+
+    add_topic_parser = subparsers.add_parser("add-topic", help="Scaffold a maintained topic page")
+    add_topic_parser.add_argument("title", help="Topic title")
+    add_topic_parser.add_argument(
+        "--tags",
+        action="append",
+        default=[],
+        help="Comma-separated or repeated topic tags.",
+    )
+    add_topic_parser.add_argument(
+        "--source-refs",
+        action="append",
+        default=[],
+        help="Comma-separated or repeated source IDs to reference.",
+    )
+    add_topic_parser.add_argument(
+        "--template",
+        choices=("default", "research-synthesis", "issue-tracker"),
+        default="default",
+        help="Deterministic markdown scaffold to use.",
+    )
+    add_topic_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    add_topic_parser.set_defaults(handler=handle_add_topic)
 
     source_parser = subparsers.add_parser("source", help="Inspect and refresh source records")
     source_subparsers = source_parser.add_subparsers(dest="source_command", required=True)
@@ -258,6 +290,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     wiki_compile_parser.set_defaults(handler=handle_wiki_compile)
+    wiki_rebuild_index_parser = wiki_subparsers.add_parser(
+        "rebuild-index", help="Regenerate wiki/index.md from wiki page frontmatter"
+    )
+    wiki_rebuild_index_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    wiki_rebuild_index_parser.set_defaults(handler=handle_wiki_rebuild_index)
 
     materialize_parser = subparsers.add_parser(
         "materialize-source", help="Create or refresh a source storage artifact"
@@ -641,6 +683,42 @@ def handle_add_source(args: argparse.Namespace) -> int:
     return 0
 
 
+def _split_repeated_csv(values: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        for part in value.split(","):
+            normalized = part.strip()
+            if normalized and normalized not in seen:
+                seen.add(normalized)
+                result.append(normalized)
+    return result
+
+
+def handle_add_topic(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = add_topic_page(
+            root,
+            args.title,
+            tags=_split_repeated_csv(args.tags),
+            source_refs=_split_repeated_csv(args.source_refs),
+            template=args.template,
+        )
+    except (FileExistsError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_topic_scaffold_json(result))
+        return 0
+
+    print(f"Created topic: {result.path}")
+    print(f"Page ID: {result.page_id}")
+    print(f"Template: {result.template}")
+    print("Updated index: wiki/index.md")
+    return 0
+
+
 def handle_source_list(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     try:
@@ -979,6 +1057,27 @@ def handle_wiki_compile(args: argparse.Namespace) -> int:
     print("Next steps:")
     for item in result.next_steps:
         print(f"- {item}")
+    return 0
+
+
+def handle_wiki_rebuild_index(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = rebuild_wiki_index(root)
+    except ValueError as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_wiki_index_rebuild_json(result))
+        return 0
+
+    print(f"Rebuilt index: {result.path}")
+    print(f"Pages indexed: {result.page_count}")
+    if result.sections:
+        print(
+            "Sections: "
+            + " ".join(f"{section}={count}" for section, count in result.sections.items())
+        )
     return 0
 
 

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -164,6 +164,27 @@ def _relative(root: Path, path: Path) -> str:
     return path.relative_to(root).as_posix()
 
 
+def _require_initialized_wiki(root: Path, layout) -> None:
+    missing = [
+        _relative(root, path) for path in (layout.index_file, layout.log_file) if not path.exists()
+    ]
+    if missing:
+        joined = ", ".join(missing)
+        msg = f"Workspace is missing required wiki files: {joined}. Run `splendor init`."
+        raise ValueError(msg)
+
+
+def _validated_source_refs(layout, source_refs: list[str]) -> list[str]:
+    validated_refs = _dedupe_preserve_order(source_refs)
+    for source_ref in validated_refs:
+        manifest_path = layout.source_records_dir / f"{source_ref}.json"
+        if not manifest_path.exists():
+            msg = f"Unknown source ref for topic page: {source_ref}"
+            raise ValueError(msg)
+        load_source_record(manifest_path)
+    return validated_refs
+
+
 def _slugify_title(title: str) -> str:
     slug = "-".join(_SLUG_TOKEN_PATTERN.findall(title.lower()))
     if not slug:
@@ -239,6 +260,8 @@ def add_topic_page(
         raise ValueError(msg)
     config = load_config(root)
     layout = resolve_layout(root, config)
+    _require_initialized_wiki(root, layout)
+    validated_source_refs = _validated_source_refs(layout, source_refs or [])
     slug = _slugify_title(title)
     page_id = f"topic-{slug}"
     page_path = layout.wiki_dir / "topics" / f"{slug}.md"
@@ -265,7 +288,7 @@ def add_topic_page(
         page_id=page_id,
         status="active",
         review_state="draft",
-        source_refs=_dedupe_preserve_order(source_refs or []),
+        source_refs=validated_source_refs,
         tags=_dedupe_preserve_order(tags or []),
         confidence=0.0,
     )

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -1,4 +1,4 @@
-"""Read-only wiki maintenance commands."""
+"""Wiki maintenance commands."""
 
 from __future__ import annotations
 
@@ -14,11 +14,13 @@ from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecor
 from splendor.state.runtime import load_queue_item, load_run_record
 from splendor.state.source_compat import canonical_source_ref
 from splendor.state.source_registry import load_source_record
-from splendor.utils.wiki import parse_wiki_markdown
+from splendor.utils.fs import write_text_atomic
+from splendor.utils.wiki import parse_wiki_markdown, render_frontmatter
 
 _SYNTHESIS_KINDS = {"architecture", "concept", "entity", "glossary", "topic"}
 _REVIEW_NEEDED_STATES = {"draft", "machine-generated", "contested", "stale"}
 _TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]{1,}")
+_SLUG_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
 _SOURCE_TERM_SECTIONS = {"summary", "key facts", "extract"}
 _GENERATED_KEY_FACT_PREFIXES = (
     "- Source ID:",
@@ -44,6 +46,16 @@ _STOPWORDS = {
     "wiki",
     "with",
 }
+_TOPIC_TEMPLATES = {"default", "research-synthesis", "issue-tracker"}
+_INDEX_SECTION_LABELS = {
+    "architecture": "Architecture",
+    "concept": "Concepts",
+    "entity": "Entities",
+    "glossary": "Glossary",
+    "topic": "Topics",
+    "source-summary": "Sources",
+}
+_INDEX_KIND_ORDER = ("architecture", "concept", "entity", "glossary", "topic", "source-summary")
 
 
 @dataclass(frozen=True)
@@ -121,8 +133,219 @@ class WikiCompileContract:
     next_steps: list[str]
 
 
+@dataclass(frozen=True)
+class TopicScaffoldResult:
+    title: str
+    page_id: str
+    path: str
+    tags: list[str]
+    source_refs: list[str]
+    template: str
+
+
+@dataclass(frozen=True)
+class WikiIndexEntry:
+    kind: str
+    title: str
+    page_id: str
+    path: str
+    status: str
+    review_state: str
+
+
+@dataclass(frozen=True)
+class WikiIndexRebuildResult:
+    path: str
+    page_count: int
+    sections: dict[str, int]
+
+
 def _relative(root: Path, path: Path) -> str:
     return path.relative_to(root).as_posix()
+
+
+def _slugify_title(title: str) -> str:
+    slug = "-".join(_SLUG_TOKEN_PATTERN.findall(title.lower()))
+    if not slug:
+        msg = f"Could not derive a topic slug from title: {title!r}"
+        raise ValueError(msg)
+    return slug
+
+
+def _dedupe_preserve_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        normalized = value.strip()
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            result.append(normalized)
+    return result
+
+
+def _render_source_ref_lines(source_refs: list[str]) -> str:
+    if not source_refs:
+        return "- Add source refs as this topic is synthesized.\n"
+    return "".join(f"- `{source_ref}`\n" for source_ref in source_refs)
+
+
+def _render_topic_body(frontmatter: KnowledgePageFrontmatter, *, template: str) -> str:
+    source_ref_lines = _render_source_ref_lines(frontmatter.source_refs)
+    if template == "research-synthesis":
+        body = (
+            "## Summary\n\n"
+            "Draft the cross-source synthesis here.\n\n"
+            "## Source-Backed Findings\n\n"
+            "- Finding: TBD\n"
+            "  - Sources: TBD\n\n"
+            "## Open Questions\n\n"
+            "- TBD\n\n"
+            "## Source References\n\n"
+            f"{source_ref_lines}"
+        )
+    elif template == "issue-tracker":
+        body = (
+            "## Summary\n\n"
+            "Track related symptoms, root causes, and resolution status here.\n\n"
+            "## Issues\n\n"
+            "| Issue | Severity | Symptoms | Root Cause | Status | Source Refs |\n"
+            "| --- | --- | --- | --- | --- | --- |\n"
+            "| TBD | TBD | TBD | TBD | open | TBD |\n\n"
+            "## Source References\n\n"
+            f"{source_ref_lines}"
+        )
+    else:
+        body = (
+            "## Summary\n\n"
+            "Draft the maintained topic synthesis here.\n\n"
+            "## Notes\n\n"
+            "- TBD\n\n"
+            "## Source References\n\n"
+            f"{source_ref_lines}"
+        )
+    return f"---\n{render_frontmatter(frontmatter)}\n---\n\n# {frontmatter.title}\n\n{body}"
+
+
+def add_topic_page(
+    root: Path,
+    title: str,
+    *,
+    tags: list[str] | None = None,
+    source_refs: list[str] | None = None,
+    template: str = "default",
+) -> TopicScaffoldResult:
+    if template not in _TOPIC_TEMPLATES:
+        msg = f"Unknown topic template: {template}"
+        raise ValueError(msg)
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    slug = _slugify_title(title)
+    page_id = f"topic-{slug}"
+    page_path = layout.wiki_dir / "topics" / f"{slug}.md"
+    page_ref = _relative(root, page_path)
+    if page_path.exists():
+        msg = f"Topic page already exists: {page_ref}"
+        raise FileExistsError(msg)
+
+    pages, invalid_pages = _load_wiki_pages(root, layout)
+    if invalid_pages:
+        msg = f"Cannot add topic with invalid wiki pages present: {invalid_pages[0].path}"
+        raise ValueError(msg)
+    duplicate_path = next(
+        (page.path for page in pages if page.frontmatter.page_id == page_id),
+        None,
+    )
+    if duplicate_path is not None:
+        msg = f"Topic page_id already exists in {duplicate_path}: {page_id}"
+        raise FileExistsError(msg)
+
+    frontmatter = KnowledgePageFrontmatter(
+        kind="topic",
+        title=title,
+        page_id=page_id,
+        status="active",
+        review_state="draft",
+        source_refs=_dedupe_preserve_order(source_refs or []),
+        tags=_dedupe_preserve_order(tags or []),
+        confidence=0.0,
+    )
+    page_content = _render_topic_body(frontmatter, template=template)
+    write_text_atomic(page_path, page_content)
+    try:
+        parse_wiki_markdown(page_path)
+        rebuild_wiki_index(root)
+    except Exception:
+        page_path.unlink(missing_ok=True)
+        raise
+
+    return TopicScaffoldResult(
+        title=title,
+        page_id=page_id,
+        path=page_ref,
+        tags=frontmatter.tags,
+        source_refs=frontmatter.source_refs,
+        template=template,
+    )
+
+
+def rebuild_wiki_index(root: Path) -> WikiIndexRebuildResult:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    pages, invalid_pages = _load_wiki_pages(root, layout)
+    if invalid_pages:
+        msg = f"Cannot rebuild index with invalid wiki pages present: {invalid_pages[0].path}"
+        raise ValueError(msg)
+
+    entries = [
+        WikiIndexEntry(
+            kind=page.frontmatter.kind,
+            title=page.frontmatter.title,
+            page_id=page.frontmatter.page_id,
+            path=page.path,
+            status=page.frontmatter.status,
+            review_state=page.frontmatter.review_state,
+        )
+        for page in pages
+    ]
+    entries.sort(key=lambda entry: (entry.kind, entry.title.casefold(), entry.path))
+    content = _render_rebuilt_index(entries)
+    write_text_atomic(layout.index_file, content)
+    section_counts = Counter(entry.kind for entry in entries)
+    return WikiIndexRebuildResult(
+        path=_relative(root, layout.index_file),
+        page_count=len(entries),
+        sections={kind: section_counts[kind] for kind in _INDEX_KIND_ORDER if section_counts[kind]},
+    )
+
+
+def _render_rebuilt_index(entries: list[WikiIndexEntry]) -> str:
+    lines = [
+        "# Splendor Wiki Index",
+        "",
+        "This wiki is maintained by Splendor.",
+        "",
+        "## Navigation",
+        "",
+        "- `wiki/sources/` for deterministic source summary pages.",
+        "- `wiki/topics/` for maintained topic synthesis pages.",
+        "- `planning/` for milestones, tasks, decisions, and questions.",
+        "- `state/` for machine-readable queue, run, and manifest records.",
+    ]
+    for kind in _INDEX_KIND_ORDER:
+        section_entries = [entry for entry in entries if entry.kind == kind]
+        if not section_entries:
+            continue
+        lines.extend(["", f"## {_INDEX_SECTION_LABELS[kind]}", ""])
+        lines.extend(_index_bullet(entry) for entry in section_entries)
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _index_bullet(entry: WikiIndexEntry) -> str:
+    link = entry.path.removeprefix("wiki/")
+    return (
+        f"- [{entry.title}]({link}) (`{entry.page_id}`) "
+        f"status={entry.status} review={entry.review_state}"
+    )
 
 
 def load_sources(layout) -> list[SourceRecord]:
@@ -459,4 +682,12 @@ def render_wiki_suggest_json(result: WikiSuggestResult) -> str:
 
 
 def render_wiki_compile_contract_json(result: WikiCompileContract) -> str:
+    return json.dumps(asdict(result), indent=2)
+
+
+def render_topic_scaffold_json(result: TopicScaffoldResult) -> str:
+    return json.dumps(asdict(result), indent=2)
+
+
+def render_wiki_index_rebuild_json(result: WikiIndexRebuildResult) -> str:
     return json.dumps(asdict(result), indent=2)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,33 @@ def test_cli_add_source_capture_source_commit_flags_are_tri_state() -> None:
     assert no_capture_flag.capture_source_commit is False
 
 
+def test_cli_add_topic_parser_accepts_template_tags_source_refs_and_json() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(
+        [
+            "add-topic",
+            "Preprocessing Pipeline",
+            "--tags",
+            "preprocessing,audio",
+            "--tags",
+            "filter",
+            "--source-refs",
+            "src-a,src-b",
+            "--template",
+            "research-synthesis",
+            "--json",
+        ]
+    )
+
+    assert args.command == "add-topic"
+    assert args.title == "Preprocessing Pipeline"
+    assert args.tags == ["preprocessing,audio", "filter"]
+    assert args.source_refs == ["src-a,src-b"]
+    assert args.template == "research-synthesis"
+    assert args.json_output is True
+
+
 def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     parser = build_parser()
 
@@ -94,6 +121,16 @@ def test_cli_repo_refresh_parser_accepts_json_flag() -> None:
 
     assert args.command == "repo"
     assert args.repo_command == "refresh"
+    assert args.json_output is True
+
+
+def test_cli_wiki_rebuild_index_parser_accepts_json_flag() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["wiki", "rebuild-index", "--json"])
+
+    assert args.command == "wiki"
+    assert args.wiki_command == "rebuild-index"
     assert args.json_output is True
 
 

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -40,26 +40,32 @@ def write_wiki_page(
 
 def test_add_topic_scaffolds_valid_frontmatter_and_rebuilds_index(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
+    source_a = tmp_path / "source-a.md"
+    source_b = tmp_path / "source-b.md"
+    source_a.write_text("# Source A\n", encoding="utf-8")
+    source_b.write_text("# Source B\n", encoding="utf-8")
+    added_a = add_source(tmp_path, source_a)
+    added_b = add_source(tmp_path, source_b)
 
     result = add_topic_page(
         tmp_path,
         "Preprocessing Pipeline",
         tags=["preprocessing", "audio", "preprocessing"],
-        source_refs=["src-a", "src-b", "src-a"],
+        source_refs=[added_a.source_id, added_b.source_id, added_a.source_id],
         template="research-synthesis",
     )
 
     assert result.path == "wiki/topics/preprocessing-pipeline.md"
     assert result.page_id == "topic-preprocessing-pipeline"
     assert result.tags == ["preprocessing", "audio"]
-    assert result.source_refs == ["src-a", "src-b"]
+    assert result.source_refs == [added_a.source_id, added_b.source_id]
     page = parse_wiki_markdown(tmp_path / result.path)
     assert page.frontmatter.kind == "topic"
     assert page.frontmatter.title == "Preprocessing Pipeline"
     assert page.frontmatter.page_id == "topic-preprocessing-pipeline"
     assert page.frontmatter.status == "active"
     assert page.frontmatter.review_state == "draft"
-    assert page.frontmatter.source_refs == ["src-a", "src-b"]
+    assert page.frontmatter.source_refs == [added_a.source_id, added_b.source_id]
     assert "## Source-Backed Findings" in page.body
     index = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
     assert (
@@ -70,6 +76,9 @@ def test_add_topic_scaffolds_valid_frontmatter_and_rebuilds_index(tmp_path: Path
 
 def test_add_topic_cli_supports_issue_tracker_template_and_json(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
+    source = tmp_path / "quality.md"
+    source.write_text("# Quality\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
     capsys.readouterr()
 
     exit_code = main(
@@ -81,7 +90,7 @@ def test_add_topic_cli_supports_issue_tracker_template_and_json(tmp_path: Path, 
             "--tags",
             "audio,quality",
             "--source-refs",
-            "src-123",
+            added.source_id,
             "--template",
             "issue-tracker",
             "--json",
@@ -92,6 +101,7 @@ def test_add_topic_cli_supports_issue_tracker_template_and_json(tmp_path: Path, 
     payload = json.loads(capsys.readouterr().out)
     assert payload["path"] == "wiki/topics/audio-quality-issues.md"
     assert payload["page_id"] == "topic-audio-quality-issues"
+    assert payload["source_refs"] == [added.source_id]
     assert payload["template"] == "issue-tracker"
     page = parse_wiki_markdown(tmp_path / payload["path"])
     assert "| Issue | Severity | Symptoms | Root Cause | Status | Source Refs |" in page.body
@@ -109,6 +119,41 @@ def test_add_topic_rejects_duplicate_slug_without_mutating_index(tmp_path: Path,
         capsys.readouterr().out
     )
     assert (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8") == index_before
+
+
+def test_add_topic_rejects_unknown_source_ref_without_mutating_wiki(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    index_before = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "add-topic",
+            "Bogus Ref",
+            "--source-refs",
+            "src-missing",
+        ]
+    )
+
+    assert exit_code == 1
+    assert "Error: Unknown source ref for topic page: src-missing" in capsys.readouterr().out
+    assert not (tmp_path / "wiki" / "topics" / "bogus-ref.md").exists()
+    assert (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8") == index_before
+
+
+def test_add_topic_rejects_uninitialized_workspace_without_partial_writes(
+    tmp_path: Path, capsys
+) -> None:
+    exit_code = main(["--root", str(tmp_path), "add-topic", "No Init"])
+
+    assert exit_code == 1
+    assert (
+        "Error: Workspace is missing required wiki files: "
+        "wiki/index.md, wiki/log.md. Run `splendor init`."
+    ) in capsys.readouterr().out
+    assert not (tmp_path / "wiki" / "index.md").exists()
+    assert not (tmp_path / "wiki" / "topics" / "no-init.md").exists()
 
 
 def test_rebuild_wiki_index_includes_pages_in_deterministic_sections(tmp_path: Path) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -6,8 +6,10 @@ import yaml
 from splendor.cli import main
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
+from splendor.commands.wiki import add_topic_page, rebuild_wiki_index
 from splendor.schemas import KnowledgePageFrontmatter, MaintenanceReport
 from splendor.state.source_registry import load_source_record
+from splendor.utils.wiki import parse_wiki_markdown
 
 
 def write_wiki_page(
@@ -34,6 +36,134 @@ def write_wiki_page(
     path.parent.mkdir(parents=True, exist_ok=True)
     frontmatter_text = yaml.safe_dump(frontmatter.model_dump(mode="json"), sort_keys=False).strip()
     path.write_text(f"---\n{frontmatter_text}\n---\n\n{body}", encoding="utf-8")
+
+
+def test_add_topic_scaffolds_valid_frontmatter_and_rebuilds_index(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    result = add_topic_page(
+        tmp_path,
+        "Preprocessing Pipeline",
+        tags=["preprocessing", "audio", "preprocessing"],
+        source_refs=["src-a", "src-b", "src-a"],
+        template="research-synthesis",
+    )
+
+    assert result.path == "wiki/topics/preprocessing-pipeline.md"
+    assert result.page_id == "topic-preprocessing-pipeline"
+    assert result.tags == ["preprocessing", "audio"]
+    assert result.source_refs == ["src-a", "src-b"]
+    page = parse_wiki_markdown(tmp_path / result.path)
+    assert page.frontmatter.kind == "topic"
+    assert page.frontmatter.title == "Preprocessing Pipeline"
+    assert page.frontmatter.page_id == "topic-preprocessing-pipeline"
+    assert page.frontmatter.status == "active"
+    assert page.frontmatter.review_state == "draft"
+    assert page.frontmatter.source_refs == ["src-a", "src-b"]
+    assert "## Source-Backed Findings" in page.body
+    index = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+    assert (
+        "- [Preprocessing Pipeline](topics/preprocessing-pipeline.md) "
+        "(`topic-preprocessing-pipeline`) status=active review=draft"
+    ) in index
+
+
+def test_add_topic_cli_supports_issue_tracker_template_and_json(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "add-topic",
+            "Audio Quality Issues",
+            "--tags",
+            "audio,quality",
+            "--source-refs",
+            "src-123",
+            "--template",
+            "issue-tracker",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["path"] == "wiki/topics/audio-quality-issues.md"
+    assert payload["page_id"] == "topic-audio-quality-issues"
+    assert payload["template"] == "issue-tracker"
+    page = parse_wiki_markdown(tmp_path / payload["path"])
+    assert "| Issue | Severity | Symptoms | Root Cause | Status | Source Refs |" in page.body
+
+
+def test_add_topic_rejects_duplicate_slug_without_mutating_index(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    add_topic_page(tmp_path, "Preprocessing Pipeline")
+    index_before = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+
+    exit_code = main(["--root", str(tmp_path), "add-topic", "Preprocessing Pipeline"])
+
+    assert exit_code == 1
+    assert "Error: Topic page already exists: wiki/topics/preprocessing-pipeline.md" in (
+        capsys.readouterr().out
+    )
+    assert (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8") == index_before
+
+
+def test_rebuild_wiki_index_includes_pages_in_deterministic_sections(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "zeta.md",
+        kind="topic",
+        title="Zeta Topic",
+        page_id="topic-zeta",
+        review_state="draft",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "architecture" / "alpha.md",
+        kind="architecture",
+        title="Alpha Architecture",
+        page_id="architecture-alpha",
+        review_state="machine-generated",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "sources" / "src-a.md",
+        kind="source-summary",
+        title="Source A",
+        page_id="source-src-a",
+        review_state="machine-generated",
+        source_refs=["src-a"],
+    )
+    (tmp_path / "wiki" / "index.md").write_text("# Drifted\n", encoding="utf-8")
+
+    result = rebuild_wiki_index(tmp_path)
+    first_index = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+    second_result = rebuild_wiki_index(tmp_path)
+    second_index = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+
+    assert result.page_count == 3
+    assert result.sections == {"architecture": 1, "topic": 1, "source-summary": 1}
+    assert second_result == result
+    assert second_index == first_index
+    assert first_index.index("## Architecture") < first_index.index("## Topics")
+    assert first_index.index("## Topics") < first_index.index("## Sources")
+    assert "[Alpha Architecture](architecture/alpha.md)" in first_index
+    assert "[Zeta Topic](topics/zeta.md)" in first_index
+    assert "[Source A](sources/src-a.md)" in first_index
+
+
+def test_wiki_rebuild_index_cli_reports_invalid_frontmatter(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    bad_page = tmp_path / "wiki" / "topics" / "bad.md"
+    bad_page.write_text("---\nkind: topic\nbogus: true\n---\n\n# Bad\n", encoding="utf-8")
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "rebuild-index"])
+
+    assert exit_code == 1
+    assert "Error: Cannot rebuild index with invalid wiki pages present: wiki/topics/bad.md" in (
+        capsys.readouterr().out
+    )
 
 
 def test_add_source_queues_pending_ingest_for_cli_handoff(tmp_path: Path, capsys) -> None:

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -4,30 +4,31 @@ This wiki is maintained by Splendor.
 
 ## Navigation
 
-- `wiki/sources/` for source summary pages once ingestion starts.
+- `wiki/sources/` for deterministic source summary pages.
+- `wiki/topics/` for maintained topic synthesis pages.
 - `planning/` for milestones, tasks, decisions, and questions.
 - `state/` for machine-readable queue, run, and manifest records.
 
-## Sources
+## Architecture
 
-- [karpathy llm wiki pattern](sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md) (`src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac`)
-- [karpathy x llm knowledge bases](sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md) (`src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a`)
-- [llm research knowledge work notes](sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md) (`src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41`)
-- [lucas astorian llmwiki implementation](sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.md) (`src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd`)
-- [round 1 llm wiki implementation landscape](sources/src-6be68f3b5ee70bf209d78171363cbd857c72f331dbdd13ddc79fd2f7d8c188a6.md) (`src-6be68f3b5ee70bf209d78171363cbd857c72f331dbdd13ddc79fd2f7d8c188a6`)
-- [round 2 context engineering and repo memory](sources/src-a1af8da17b1e5f3c5616150339ba58f1832bc91fccf9a534c59063d3ca0173d4.md) (`src-a1af8da17b1e5f3c5616150339ba58f1832bc91fccf9a534c59063d3ca0173d4`)
-- [round 3 competitive feature map](sources/src-c2176196c8d0e5edd5f231021c55821d970230fada194b4a3d53b24abd77921b.md) (`src-c2176196c8d0e5edd5f231021c55821d970230fada194b4a3d53b24abd77921b`)
+- [Splendor as an LLM Wiki Compiler](architecture/splendor-as-llm-wiki-compiler.md) (`architecture-splendor-as-llm-wiki-compiler`) status=active review=machine-generated
 
 ## Concepts
 
-- [LLM Wiki Pattern](concepts/llm-wiki-pattern.md) (`concept-llm-wiki-pattern`)
+- [LLM Wiki Pattern](concepts/llm-wiki-pattern.md) (`concept-llm-wiki-pattern`) status=active review=machine-generated
 
 ## Topics
 
-- [LLM-Assisted Knowledge Work](topics/llm-assisted-knowledge-work.md) (`topic-llm-assisted-knowledge-work`)
-- [Agent Context Infrastructure](topics/agent-context-infrastructure.md) (`topic-agent-context-infrastructure`)
-- [LLM Wiki Tool Landscape](topics/llm-wiki-tool-landscape.md) (`topic-llm-wiki-tool-landscape`)
+- [Agent Context Infrastructure](topics/agent-context-infrastructure.md) (`topic-agent-context-infrastructure`) status=active review=machine-generated
+- [LLM Wiki Tool Landscape](topics/llm-wiki-tool-landscape.md) (`topic-llm-wiki-tool-landscape`) status=active review=machine-generated
+- [LLM-Assisted Knowledge Work](topics/llm-assisted-knowledge-work.md) (`topic-llm-assisted-knowledge-work`) status=active review=machine-generated
 
-## Architecture
+## Sources
 
-- [Splendor as an LLM Wiki Compiler](architecture/splendor-as-llm-wiki-compiler.md) (`architecture-splendor-as-llm-wiki-compiler`)
+- [karpathy llm wiki pattern](sources/src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac.md) (`src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac`) status=active review=machine-generated
+- [karpathy x llm knowledge bases](sources/src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a.md) (`src-3e2ae8bad71969d960fabb9ea0670dfb6db9f6c62d0484a445cf3ff5e2af6f1a`) status=active review=machine-generated
+- [llm research knowledge work notes](sources/src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41.md) (`src-9143c8df18710ac189ed8d1fa38a8df92509acadedaaf96ab40e189ab4877a41`) status=active review=machine-generated
+- [lucas astorian llmwiki implementation](sources/src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd.md) (`src-e7f25dbe0c913cb8938d30e2da9d2e4d03afbab29f519db40ea90b23e0113bfd`) status=active review=machine-generated
+- [round 1 llm wiki implementation landscape](sources/src-6be68f3b5ee70bf209d78171363cbd857c72f331dbdd13ddc79fd2f7d8c188a6.md) (`src-6be68f3b5ee70bf209d78171363cbd857c72f331dbdd13ddc79fd2f7d8c188a6`) status=active review=machine-generated
+- [round 2 context engineering and repo memory](sources/src-a1af8da17b1e5f3c5616150339ba58f1832bc91fccf9a534c59063d3ca0173d4.md) (`src-a1af8da17b1e5f3c5616150339ba58f1832bc91fccf9a534c59063d3ca0173d4`) status=active review=machine-generated
+- [round 3 competitive feature map](sources/src-c2176196c8d0e5edd5f231021c55821d970230fada194b4a3d53b24abd77921b.md) (`src-c2176196c8d0e5edd5f231021c55821d970230fada194b4a3d53b24abd77921b`) status=active review=machine-generated


### PR DESCRIPTION
## Summary

Implements M11-P2.1 for issue #55.

- add `splendor add-topic "Title"` with deterministic topic slugs/page IDs, schema-validated topic frontmatter, optional `--tags`, optional `--source-refs`, and JSON output
- add deterministic topic templates for `default`, `research-synthesis`, and `issue-tracker`
- add `splendor wiki rebuild-index` to regenerate `wiki/index.md` from validated wiki page frontmatter without mutating generated source-summary pages
- update README, quickstart, schema/product docs, roadmap state, and the committed wiki index for the new topic/index contract

## Scope notes

- Keeps source-summary generation separate from maintained synthesis pages.
- Leaves query/source lookup and agent-context improvements for M11-P3.1 / issue #56.
- Leaves source commit capture intent for the later source lifecycle follow-up / issue #61.
- Does not add SQLite, background workers, OCR, or mutating web UI behavior.

## Verification

- `uv run pytest`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`

Closes #55
