### PR TITLE
M11-P3.1 Query/source lookup and agent-context improvements

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M11-P1.1`
-- Last action taken: `M11-P1.1` is implemented; source lifecycle refresh, bulk registration, and readable source lookup are available.
-- Current planned slice: `M11-P2`
-- Current PR sub-slice: `M11-P2.1`
+- Previous completed PR sub-slice: `M11-P2.1`
+- Last action taken: `M11-P2.1` is implemented; topic scaffolding, templates, and wiki index rebuild are available.
+- Current planned slice: `M11-P3`
+- Current PR sub-slice: `M11-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M11-P3`
-- Next planned PR sub-slice: `M11-P3.1`
+- Next planned slice: `M12-P1`
+- Next planned PR sub-slice: `M12-P1.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -162,6 +162,11 @@
   - [x] Add default, research-synthesis, and issue-tracker markdown templates
   - [x] Add `splendor wiki rebuild-index` from wiki page frontmatter
   - [x] Update docs, tests, and planning state for the topic/index contract
+- [x] Implement `M11-P3.1`: Query/source lookup and agent-context improvements
+  - [x] Add deterministic query filtering by wiki tag and source ID
+  - [x] Preserve saved-query and no-save behavior with explicit filter metadata
+  - [x] Add compact `splendor brief --agent-context` handoff output
+  - [x] Update docs, tests, and planning state for the query/context contract
 
 ## Context Pointers
 
@@ -204,3 +209,4 @@
 - `M11-P1.1` Source lifecycle, bulk registration, refresh, and readable source lookup
 - `M11-P2.1` Topic scaffolding, templates, and index rebuild
 - `M11-P3.1` Query/source lookup and agent-context improvements
+- `M12-P1.1` Rich-source dispatch and PDF path

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Implemented today:
 - `splendor queue inspect [job-id]` and `splendor queue retry <job-id>`
 - `splendor repair ingest <source-id>`
 - `splendor materialize-source <source-id>`
-- `splendor query "<question>"` and `splendor query "<question>" --json`
+- `splendor query "<question>"`, `splendor query --tag <tag>`,
+  `splendor query --source <source-id>`, and `splendor query "<question>" --json`
 - `splendor file-answer --from-last-query --title "..."`
 - `splendor task|milestone|decision|question ...`
 - `splendor repo scan`
@@ -128,7 +129,7 @@ Implemented today:
 - `splendor wiki suggest <source-id>`
 - `splendor wiki compile <source-id>` as a non-mutating review-gated contract description
 - `splendor wiki rebuild-index`
-- `splendor brief [goal]`
+- `splendor brief [goal]` and `splendor brief --agent-context [goal]`
 - `splendor serve` for a read-only local browse/search/status/planning/runtime UI
 - read-only web `/status`, `/sources/<source-id>`, `/planning`, `/runs`, and `/queue` views
 - `splendor lint` and `splendor health`
@@ -152,12 +153,12 @@ Not implemented yet:
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M11-P1.1`
-- Current planned slice: `M11-P2`
-- Current PR sub-slice: `M11-P2.1`
+- Previous completed PR sub-slice: `M11-P2.1`
+- Current planned slice: `M11-P3`
+- Current PR sub-slice: `M11-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M11-P3`
-- Next planned PR sub-slice: `M11-P3.1`
+- Next planned slice: `M12-P1`
+- Next planned PR sub-slice: `M12-P1.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -195,6 +196,7 @@ explicit dead-letter records, and stale-lease recovery.
 
 `M11-P1.1` is implemented: it adds deterministic bulk source registration, explicit source
 refresh through the existing ingest queue, and readable source lookup by title or path without
-changing canonical source IDs. The current PR sub-slice is `M11-P2.1`, which adds CLI-first topic
-scaffolding, deterministic templates, and wiki index rebuild support. After `M11-P2`, the next
-Milestone 11 work moves to query/source lookup and agent-context improvements.
+changing canonical source IDs. `M11-P2.1` is implemented: it adds CLI-first topic scaffolding,
+deterministic templates, and wiki index rebuild support. The current PR sub-slice is `M11-P3.1`,
+which adds query filters for tags/source refs and a compact agent-context handoff mode before the
+roadmap moves to richer source handling in `M12-P1`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -167,11 +167,17 @@ That writes a task markdown record under `planning/tasks/`.
 
 ```bash
 uv run splendor --root /tmp/demo-repo query "durable wiki"
+uv run splendor --root /tmp/demo-repo query "durable wiki" --tag architecture
+uv run splendor --root /tmp/demo-repo query --source <source-id>
 uv run splendor --root /tmp/demo-repo query "durable wiki" --json
+uv run splendor --root /tmp/demo-repo brief --agent-context "durable wiki" --json
 ```
 
-The query command searches maintained wiki pages and planning records. The JSON form is useful for
-agent or script integration.
+The query command searches maintained wiki pages and planning records. Tag filters apply to wiki
+frontmatter tags; source filters require a known canonical source ID and return records whose
+`source_refs` include that ID. The JSON form includes active filters and is useful for agent or
+script integration. `brief --agent-context` packages query matches, source refs, wiki status,
+active planning records, recent runs, and next actions for a new coding-agent thread.
 
 ## 7. Run deterministic checks
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -238,6 +238,26 @@ Task records now also reserve:
 Those fields let contradiction-review tasks carry explicit links back to the affected wiki pages
 and the ingest run that surfaced the conflict.
 
+## Query snapshots
+
+The latest saved query snapshot lives at `state/queries/last-query.json`.
+
+Current implementation fields:
+
+- `schema_version`
+- `query`
+- `filters`
+  - `tags`
+  - `source_id`
+- `summary`
+- `match_count`
+- `created_at`
+- `matches`
+
+Query matches preserve rank, score, class/kind, record identity, path, status/review state, snippet,
+source refs, generated run IDs, provenance links, contradiction counts, review task IDs, and tags.
+`splendor query --no-save` preserves query output behavior but does not update this snapshot.
+
 ## Queue and run records
 
 The runtime contracts are now used by deterministic single-source ingestion.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M11-P1.1`
-- Current planned slice: `M11-P2`
-- Current PR sub-slice: `M11-P2.1`
+- Previous completed PR sub-slice: `M11-P2.1`
+- Current planned slice: `M11-P3`
+- Current PR sub-slice: `M11-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M11-P3`
-- Next planned PR sub-slice: `M11-P3.1`
+- Next planned slice: `M12-P1`
+- Next planned PR sub-slice: `M12-P1.1`
 
 `M10-P0.1` is implemented: the CLI-first wiki status and source-impact suggestion bridge is in
 place. `M10-P0.2` is implemented: project briefing and the non-mutating review-gated compile-loop
@@ -697,9 +697,10 @@ project knowledge bases.
 
 `M11-P1.1` is implemented: it adds deterministic bulk registration through `add-source --glob`
 and `add-source --dir`, explicit source refresh via the existing ingest queue, and readable source
-lookup by title/path without changing canonical source IDs. `M11-P2.1` is in progress: it adds
+lookup by title/path without changing canonical source IDs. `M11-P2.1` is implemented: it adds
 CLI-first topic scaffolding, deterministic topic templates, and a frontmatter-driven wiki index
-rebuild. Broader query/source lookup and agent-context work remains planned for `M11-P3.1`.
+rebuild. `M11-P3.1` is in progress: it adds tag/source query filters and compact agent-context
+handoff output before the roadmap moves to rich-source dispatch in `M12-P1`.
 
 ---
 
@@ -740,6 +741,9 @@ feed the same source-impact and compile/update workflow used for markdown and te
 ### Planned PR slices
 - `M12-P1` Rich-source dispatch and PDF path
 - `M12-P2` OCR/image ingest path
+
+### Current PR sub-slices
+- `M12-P1.1` Rich-source dispatch and PDF path
 
 ---
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -691,8 +691,8 @@ Current implementation:
   including maintained synthesis pages and generated source-summary pages, without mutating the
   pages themselves.
 - `splendor query` prefers claim-bearing source-summary sections over generated metadata
-  boilerplate when selecting snippets, and text output points to `file-answer` when a saved query
-  has matches.
+  boilerplate when selecting snippets, supports tag/source filters, records those filters in JSON
+  and saved snapshots, and text output points to `file-answer` when a saved query has matches.
 - `splendor file-answer` prints the created page and a restrained review hint after filing.
 - Mutating `splendor wiki compile <source-id>` remains deferred to a later reviewed compile-loop
   slice.
@@ -814,6 +814,12 @@ pages, sections such as `Core Claims`, `Design Implications`, `Product Experienc
 source extract should outrank frontmatter-derived facts, provenance boilerplate, and generic
 machine-generated labels.
 
+Current query output includes any active deterministic filters. `splendor query --tag <tag>`
+restricts matches to wiki pages carrying all requested tags, and
+`splendor query --source <source-id>` validates the canonical source ID before returning wiki or
+planning records whose `source_refs` include that ID. Filter-only source lookup is allowed so
+agents can ask which pages reference a known source without inventing a search phrase.
+
 ### 17.3 Project briefing
 
 Splendor should support a briefing workflow for humans and agents entering an existing repository.
@@ -834,6 +840,9 @@ Current implementation:
 - `splendor brief [goal]` assembles a terminal-friendly and JSON project brief from deterministic
   query matches, wiki status, active planning records, recent sources/runs, latest lint/health
   reports, the last query snapshot, and likely next actions.
+- `splendor brief --agent-context [goal]` renders the same deterministic state as a compact
+  coding-agent handoff with relevant matches, source refs, wiki status, active planning records,
+  recent sources/runs, maintenance reports, warnings, and next actions.
 - Briefing is read-only and does not replace `splendor query`; query finds records, while briefing
   packages the surrounding project state needed to resume work.
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -9,7 +9,12 @@ from pathlib import Path
 
 from splendor import __version__
 from splendor.commands.add_source import add_source, expand_source_paths
-from splendor.commands.brief import build_project_brief, render_project_brief_json
+from splendor.commands.brief import (
+    ProjectBrief,
+    build_project_brief,
+    render_agent_context_json,
+    render_project_brief_json,
+)
 from splendor.commands.file_answer import (
     default_answer_page_id,
     file_answer_from_last_query,
@@ -68,6 +73,7 @@ from splendor.layout import resolve_layout
 from splendor.schemas import (
     DecisionRecord,
     MilestoneRecord,
+    QueryFilterSnapshot,
     QueryMatchSnapshot,
     QuerySnapshot,
     QuestionRecord,
@@ -334,7 +340,19 @@ def build_parser() -> argparse.ArgumentParser:
     health_parser.set_defaults(handler=handle_health)
 
     query_parser = subparsers.add_parser("query", help="Query maintained wiki and planning records")
-    query_parser.add_argument("question", nargs="+", help="Question or search phrase.")
+    query_parser.add_argument("question", nargs="*", help="Question or search phrase.")
+    query_parser.add_argument(
+        "--tag",
+        action="append",
+        default=[],
+        dest="tags",
+        help="Restrict wiki results to pages with this tag. May be repeated.",
+    )
+    query_parser.add_argument(
+        "--source",
+        dest="source_id",
+        help="Restrict results to records referencing this source ID.",
+    )
     query_parser.add_argument(
         "--json",
         action="store_true",
@@ -357,6 +375,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         dest="json_output",
         help="Emit machine-readable JSON output.",
+    )
+    brief_parser.add_argument(
+        "--agent-context",
+        action="store_true",
+        help="Emit a compact coding-agent handoff over brief state.",
     )
     brief_parser.set_defaults(handler=handle_brief)
 
@@ -1140,8 +1163,13 @@ def handle_health(args: argparse.Namespace) -> int:
 def handle_query(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     try:
-        result = run_query(root, " ".join(args.question))
-    except ValueError as exc:
+        result = run_query(
+            root,
+            " ".join(args.question),
+            tags=args.tags,
+            source_id=args.source_id,
+        )
+    except (OSError, ValueError) as exc:
         return _print_error(exc)
 
     if not args.no_save:
@@ -1149,6 +1177,10 @@ def handle_query(args: argparse.Namespace) -> int:
             layout = resolve_layout(root, load_config(root))
             snapshot = QuerySnapshot(
                 query=result.query,
+                filters=QueryFilterSnapshot(
+                    tags=result.filters.tags,
+                    source_id=result.filters.source_id,
+                ),
                 summary=result.summary,
                 match_count=result.match_count,
                 created_at=utc_now_iso(),
@@ -1182,6 +1214,10 @@ def handle_query(args: argparse.Namespace) -> int:
     if args.json_output:
         payload = {
             "query": result.query,
+            "filters": {
+                "tags": result.filters.tags,
+                "source_id": result.filters.source_id,
+            },
             "summary": result.summary,
             "match_count": result.match_count,
             "matches": [
@@ -1213,6 +1249,12 @@ def handle_query(args: argparse.Namespace) -> int:
         return 0
 
     print(f"Query: {result.query}")
+    if result.filters.active:
+        print(
+            "Filters: "
+            f"tags={', '.join(result.filters.tags) if result.filters.tags else '-'} "
+            f"source={result.filters.source_id or '-'}"
+        )
     print(f"Summary: {result.summary}")
     print("Matches:")
     for match in result.matches:
@@ -1249,7 +1291,14 @@ def handle_brief(args: argparse.Namespace) -> int:
         return _print_error(exc)
 
     if args.json_output:
-        print(render_project_brief_json(result))
+        if args.agent_context:
+            print(render_agent_context_json(result))
+        else:
+            print(render_project_brief_json(result))
+        return 0
+
+    if args.agent_context:
+        _print_agent_context(result)
         return 0
 
     print("Project brief")
@@ -1297,6 +1346,48 @@ def handle_brief(args: argparse.Namespace) -> int:
     for action in result.next_actions:
         print(f"- {action}")
     return 0
+
+
+def _print_agent_context(result: ProjectBrief) -> None:
+    print("Agent context")
+    print(f"Goal: {result.goal or '-'}")
+    print(
+        "Wiki status: "
+        f"sources={result.status.source_total} "
+        f"pages={result.status.page_total} "
+        f"queue_pending={result.status.queue_status_counts.get('pending', 0)} "
+        f"review_needed={result.status.review_needed_pages}"
+    )
+    if result.matches:
+        print("Relevant matches:")
+        for match in result.matches:
+            source_refs = ", ".join(match.source_refs) if match.source_refs else "-"
+            print(f"- {match.path} [{match.kind}] score={match.score} sources={source_refs}")
+            if match.snippet:
+                print(f"  {match.snippet}")
+    if result.planning_items:
+        print("Active planning:")
+        for item in result.planning_items:
+            print(f"- {item.record_id} [{item.kind}/{item.status}] {item.title}")
+    if result.recent_sources:
+        print("Recent sources:")
+        for source in result.recent_sources:
+            print(f"- {source.source_id} [{source.status}/{source.review_state}] {source.title}")
+    if result.recent_runs:
+        print("Recent runs:")
+        for run in result.recent_runs:
+            finished = run.finished_at or "-"
+            print(f"- {run.run_id} {run.status} finished={finished}")
+    if result.last_query is not None:
+        print(f"Last query: {result.last_query.query} ({result.last_query.match_count} matches)")
+    if result.warnings:
+        print("Warnings:")
+        for warning in result.warnings:
+            subject = warning.path or warning.area
+            print(f"- {subject}: {warning.message}")
+    print("Next actions:")
+    for action in result.next_actions:
+        print(f"- {action}")
 
 
 def handle_serve(args: argparse.Namespace) -> int:

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -344,6 +344,4 @@ def _agent_context_source_refs(brief: ProjectBrief) -> list[str]:
     refs: set[str] = set()
     for match in brief.matches:
         refs.update(match.source_refs)
-    for source in brief.recent_sources:
-        refs.add(source.source_id)
     return sorted(refs)

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -308,3 +308,42 @@ def render_project_brief_json(brief: ProjectBrief) -> str:
         },
         indent=2,
     )
+
+
+def render_agent_context_json(brief: ProjectBrief) -> str:
+    return json.dumps(
+        {
+            "agent_context": True,
+            "goal": brief.goal,
+            "query_summary": brief.query_summary,
+            "wiki_status": {
+                "source_total": brief.status.source_total,
+                "page_total": brief.status.page_total,
+                "queue_status_counts": brief.status.queue_status_counts,
+                "review_needed_pages": brief.status.review_needed_pages,
+                "machine_generated_pages": brief.status.machine_generated_pages,
+                "contested_pages": brief.status.contested_pages,
+                "stale_pages": brief.status.stale_pages,
+                "sources_missing_synthesis": brief.status.sources_missing_synthesis,
+            },
+            "matches": [asdict(match) for match in brief.matches],
+            "source_refs": _agent_context_source_refs(brief),
+            "active_planning": [asdict(item) for item in brief.planning_items],
+            "recent_sources": [asdict(source) for source in brief.recent_sources],
+            "recent_runs": [asdict(run) for run in brief.recent_runs],
+            "latest_reports": [asdict(report) for report in brief.latest_reports],
+            "last_query": asdict(brief.last_query) if brief.last_query else None,
+            "warnings": [asdict(warning) for warning in brief.warnings],
+            "next_actions": brief.next_actions,
+        },
+        indent=2,
+    )
+
+
+def _agent_context_source_refs(brief: ProjectBrief) -> list[str]:
+    refs: set[str] = set()
+    for match in brief.matches:
+        refs.update(match.source_refs)
+    for source in brief.recent_sources:
+        refs.add(source.source_id)
+    return sorted(refs)

--- a/src/splendor/commands/file_answer.py
+++ b/src/splendor/commands/file_answer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from splendor.commands.planning import UpdateQuestionAnswerResult
 from splendor.config import load_config
 from splendor.layout import resolve_layout
-from splendor.schemas import KnowledgePageFrontmatter, QueryMatchSnapshot
+from splendor.schemas import KnowledgePageFrontmatter, QueryFilterSnapshot, QueryMatchSnapshot
 from splendor.state.query_snapshot import last_query_path_for, load_query_snapshot
 from splendor.utils.fs import ensure_directory
 from splendor.utils.planning import slugify, validate_record_id
@@ -63,6 +63,7 @@ def file_answer_from_last_query(
         page_id=answer_page_id,
         page_ref=page_ref,
         query=snapshot.query,
+        filters=snapshot.filters,
         summary=snapshot.summary,
         matches=snapshot.matches,
     )
@@ -72,9 +73,10 @@ def file_answer_from_last_query(
         bullet=f"- [{title}](topics/{page_path.name}) (`{answer_page_id}`)",
     )
     question_fragment = f" for question `{linked_question_id}`" if linked_question_id else ""
+    query_label = _query_context_label(snapshot.query, snapshot.filters)
     log_content = append_log_entry(
         layout.log_file.read_text(encoding="utf-8"),
-        f"- Filed answer `{answer_page_id}` from query `{snapshot.query}`{question_fragment}.",
+        f"- Filed answer `{answer_page_id}` from query `{query_label}`{question_fragment}.",
     )
     ensure_directory(page_path.parent)
     apply_wiki_updates(
@@ -101,6 +103,7 @@ def _render_answer_page(
     page_id: str,
     page_ref: str,
     query: str,
+    filters: QueryFilterSnapshot,
     summary: str,
     matches: list[QueryMatchSnapshot],
 ) -> str:
@@ -120,7 +123,7 @@ def _render_answer_page(
         f"---\n{render_frontmatter(frontmatter)}\n---\n\n"
         f"# {title}\n\n"
         "## Query\n\n"
-        f"{query}\n\n"
+        f"{_render_query_context(query, filters)}\n\n"
         "## Summary\n\n"
         f"{summary}\n\n"
         "## Ranked Matches\n\n"
@@ -128,6 +131,26 @@ def _render_answer_page(
         "## Provenance\n\n"
         f"{_render_provenance(matches, page_ref=page_ref)}\n"
     )
+
+
+def _render_query_context(query: str, filters: QueryFilterSnapshot) -> str:
+    lines = [f"Query: {query or '-'}"]
+    if filters.tags:
+        lines.append(f"Tags: {', '.join(filters.tags)}")
+    if filters.source_id is not None:
+        lines.append(f"Source ID: {filters.source_id}")
+    return "\n".join(lines)
+
+
+def _query_context_label(query: str, filters: QueryFilterSnapshot) -> str:
+    if query:
+        return query
+    parts: list[str] = []
+    if filters.tags:
+        parts.append("tags " + ", ".join(filters.tags))
+    if filters.source_id is not None:
+        parts.append(f"source {filters.source_id}")
+    return "; ".join(parts) or "-"
 
 
 def _dedupe_refs(matches: list[QueryMatchSnapshot]) -> list[str]:

--- a/src/splendor/commands/query.py
+++ b/src/splendor/commands/query.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from splendor.config import load_config
 from splendor.layout import ResolvedLayout, resolve_layout
 from splendor.schemas import ProvenanceLink
+from splendor.state.source_registry import load_source_record, manifest_path_for
 from splendor.utils.planning import (
     iter_planning_paths,
     parse_planning_document,
@@ -56,6 +57,16 @@ class QueryValidationError(ValueError):
 
 
 @dataclass(frozen=True)
+class QueryFilters:
+    tags: list[str]
+    source_id: str | None = None
+
+    @property
+    def active(self) -> bool:
+        return bool(self.tags or self.source_id)
+
+
+@dataclass(frozen=True)
 class QueryMatch:
     rank: int
     score: int
@@ -79,6 +90,7 @@ class QueryMatch:
 @dataclass(frozen=True)
 class QueryResult:
     query: str
+    filters: QueryFilters
     summary: str
     matches: list[QueryMatch]
 
@@ -117,24 +129,40 @@ class _ScoredDocument:
     snippet: str
 
 
-def run_query(root: Path, question: str) -> QueryResult:
+def run_query(
+    root: Path,
+    question: str,
+    *,
+    tags: list[str] | None = None,
+    source_id: str | None = None,
+) -> QueryResult:
     normalized_query = question.strip()
-    query_tokens = _query_tokens(normalized_query)
-    if not query_tokens:
+    filters = _normalize_filters(root, tags=tags or [], source_id=source_id)
+    query_tokens = _query_tokens(normalized_query) if normalized_query else []
+    if normalized_query and not query_tokens:
+        raise QueryValidationError("Query must contain at least one ASCII letter or number")
+    if not query_tokens and not filters.active:
         raise QueryValidationError("Query must contain at least one ASCII letter or number")
 
     layout = resolve_layout(root, load_config(root))
     documents = [*_iter_wiki_documents(root, layout), *_iter_planning_documents(root, layout)]
     scored_documents: list[_ScoredDocument] = []
     for document in documents:
-        score = _score_document(document, query_tokens)
+        if not _matches_filters(document, filters):
+            continue
+        score = _score_document(document, query_tokens) if query_tokens else _filter_score(document)
         if score <= 0:
             continue
+        snippet = (
+            _best_snippet(document.snippet_source, query_tokens)
+            if query_tokens
+            else _default_snippet(document.snippet_source)
+        )
         scored_documents.append(
             _ScoredDocument(
                 score=score,
                 document=document,
-                snippet=_best_snippet(document.snippet_source, query_tokens),
+                snippet=snippet,
             )
         )
 
@@ -169,8 +197,67 @@ def run_query(root: Path, question: str) -> QueryResult:
             f'Found {len(matches)} matching records. Best match: "{best.title}" ({best.path}).'
         )
     else:
-        summary = f'No matches found for "{normalized_query}".'
-    return QueryResult(query=normalized_query, summary=summary, matches=matches)
+        query_label = normalized_query or _filter_summary(filters)
+        summary = f'No matches found for "{query_label}".'
+    return QueryResult(query=normalized_query, filters=filters, summary=summary, matches=matches)
+
+
+def _normalize_filters(root: Path, *, tags: list[str], source_id: str | None) -> QueryFilters:
+    normalized_tags = _normalize_tags(tags)
+    normalized_source_id = source_id.strip() if source_id is not None else None
+    if normalized_source_id:
+        manifest_path = manifest_path_for(root, normalized_source_id)
+        if not manifest_path.exists():
+            msg = f"Unknown source ID: {normalized_source_id}"
+            raise FileNotFoundError(msg)
+        source = load_source_record(manifest_path)
+        if source.source_id != normalized_source_id:
+            msg = f"Source manifest ID does not match requested source: {normalized_source_id}"
+            raise ValueError(msg)
+    return QueryFilters(tags=normalized_tags, source_id=normalized_source_id)
+
+
+def _normalize_tags(tags: list[str]) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for tag in tags:
+        value = tag.strip()
+        if not value:
+            continue
+        key = value.casefold()
+        if key in seen:
+            continue
+        normalized.append(value)
+        seen.add(key)
+    return normalized
+
+
+def _matches_filters(document: _QueryDocument, filters: QueryFilters) -> bool:
+    if filters.source_id is not None and filters.source_id not in document.source_refs:
+        return False
+    if filters.tags:
+        document_tags = {tag.casefold() for tag in document.tags}
+        if not all(tag.casefold() in document_tags for tag in filters.tags):
+            return False
+    return True
+
+
+def _filter_score(document: _QueryDocument) -> int:
+    score = 1
+    if document.document_class == "wiki":
+        score += 2
+    if document.kind == "source-summary":
+        score += 1
+    return score
+
+
+def _filter_summary(filters: QueryFilters) -> str:
+    parts: list[str] = []
+    if filters.tags:
+        parts.append("tags " + ", ".join(filters.tags))
+    if filters.source_id is not None:
+        parts.append(f"source {filters.source_id}")
+    return "; ".join(parts) or "filters"
 
 
 def _iter_wiki_documents(root: Path, layout: ResolvedLayout) -> list[_QueryDocument]:
@@ -314,6 +401,19 @@ def _best_snippet(text: str, query_tokens: list[str]) -> str:
     if _candidate_score(best, query_tokens) <= 0:
         best = paragraphs[0] if paragraphs else lines[0]
     collapsed = _WHITESPACE_PATTERN.sub(" ", _strip_candidate_heading(best)).strip()
+    if len(collapsed) <= 240:
+        return collapsed
+    return collapsed[:237].rstrip() + "..."
+
+
+def _default_snippet(text: str) -> str:
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n").strip()
+    if not normalized:
+        return ""
+    candidates = _unique_in_order([*_candidate_segments(normalized), *_snippet_lines(normalized)])
+    if not candidates:
+        return ""
+    collapsed = _WHITESPACE_PATTERN.sub(" ", _strip_candidate_heading(candidates[0])).strip()
     if len(collapsed) <= 240:
         return collapsed
     return collapsed[:237].rstrip() + "..."

--- a/src/splendor/schemas/__init__.py
+++ b/src/splendor/schemas/__init__.py
@@ -9,7 +9,7 @@ from splendor.schemas.planning import (
     TaskRecord,
 )
 from splendor.schemas.provenance import ProvenanceLink
-from splendor.schemas.query import QueryMatchSnapshot, QuerySnapshot
+from splendor.schemas.query import QueryFilterSnapshot, QueryMatchSnapshot, QuerySnapshot
 from splendor.schemas.runtime import QueueItemRecord, RunRecord
 from splendor.schemas.source import SourceRecord
 from splendor.schemas.source_pointer import SourcePointerArtifact
@@ -37,6 +37,7 @@ __all__ = [
     "PageReviewState",
     "ProvenanceLink",
     "ProvenanceRole",
+    "QueryFilterSnapshot",
     "QueryMatchSnapshot",
     "QuerySnapshot",
     "QuestionRecord",

--- a/src/splendor/schemas/query.py
+++ b/src/splendor/schemas/query.py
@@ -8,6 +8,11 @@ from splendor.schemas.common import StrictRecord
 from splendor.schemas.provenance import ProvenanceLink
 
 
+class QueryFilterSnapshot(StrictRecord):
+    tags: list[str] = Field(default_factory=list)
+    source_id: str | None = None
+
+
 class QueryMatchSnapshot(StrictRecord):
     rank: int
     score: int
@@ -30,6 +35,7 @@ class QueryMatchSnapshot(StrictRecord):
 
 class QuerySnapshot(StrictRecord):
     query: str
+    filters: QueryFilterSnapshot = Field(default_factory=QueryFilterSnapshot)
     summary: str
     match_count: int
     created_at: str

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,6 +104,31 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     assert refresh.json_output is True
 
 
+def test_cli_query_parser_accepts_filters_and_no_question() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(
+        ["query", "--tag", "preprocessing", "--tag", "audio", "--source", "src-123", "--json"]
+    )
+
+    assert args.command == "query"
+    assert args.question == []
+    assert args.tags == ["preprocessing", "audio"]
+    assert args.source_id == "src-123"
+    assert args.json_output is True
+
+
+def test_cli_brief_parser_accepts_agent_context() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["brief", "--agent-context", "query", "handoff", "--json"])
+
+    assert args.command == "brief"
+    assert args.agent_context is True
+    assert args.goal == ["query", "handoff"]
+    assert args.json_output is True
+
+
 def test_cli_repo_scan_parser_accepts_json_flag() -> None:
     parser = build_parser()
 
@@ -1191,6 +1216,8 @@ def write_queryable_wiki_page(
     title: str,
     page_id: str,
     body: str,
+    source_refs: list[str] | None = None,
+    tags: list[str] | None = None,
     contradictions: list[dict] | None = None,
 ) -> None:
     frontmatter = KnowledgePageFrontmatter(
@@ -1198,7 +1225,9 @@ def write_queryable_wiki_page(
         title=title,
         page_id=page_id,
         status="active",
+        source_refs=source_refs or [],
         confidence=0.8,
+        tags=tags or [],
         contradictions=contradictions or [],
     )
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -1251,6 +1280,62 @@ def test_cli_query_command_supports_json_output(tmp_path: Path, capsys) -> None:
     assert payload["matches"][0]["contradiction_count"] == 0
     assert payload["matches"][0]["review_task_ids"] == []
     assert payload["matches"][0]["tags"] == []
+
+
+def test_cli_query_command_json_reports_active_filters(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "brief.md"])
+    source_id = load_source_record(
+        next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    ).source_id
+    write_queryable_wiki_page(
+        tmp_path / "wiki" / "topics" / "preprocessing.md",
+        title="Preprocessing pipeline",
+        page_id="topic-preprocessing-pipeline",
+        source_refs=[source_id],
+        tags=["preprocessing"],
+        body="Preprocessing pipeline notes.",
+    )
+    write_queryable_wiki_page(
+        tmp_path / "wiki" / "topics" / "deployment.md",
+        title="Deployment pipeline",
+        page_id="topic-deployment-pipeline",
+        tags=["deployment"],
+        body="Deployment pipeline notes.",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "query",
+            "--tag",
+            "preprocessing",
+            "--source",
+            source_id,
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["query"] == ""
+    assert payload["filters"] == {"tags": ["preprocessing"], "source_id": source_id}
+    assert payload["match_count"] == 1
+    assert payload["matches"][0]["path"] == "wiki/topics/preprocessing.md"
+
+
+def test_cli_query_command_rejects_unknown_source_filter(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "query", "--source", "src-missing", "brief"])
+
+    assert exit_code == 1
+    assert capsys.readouterr().out == "Error: Unknown source ID: src-missing\n"
 
 
 def test_cli_query_command_persists_last_query_snapshot(tmp_path: Path, capsys) -> None:

--- a/tests/test_file_answer.py
+++ b/tests/test_file_answer.py
@@ -6,7 +6,12 @@ from splendor.commands.file_answer import default_answer_page_id, file_answer_fr
 from splendor.commands.init import initialize_workspace
 from splendor.config import load_config
 from splendor.layout import resolve_layout
-from splendor.schemas import KnowledgePageFrontmatter, QueryMatchSnapshot, QuerySnapshot
+from splendor.schemas import (
+    KnowledgePageFrontmatter,
+    QueryFilterSnapshot,
+    QueryMatchSnapshot,
+    QuerySnapshot,
+)
 from splendor.state.query_snapshot import last_query_path_for, write_query_snapshot
 from splendor.utils.wiki import render_frontmatter
 
@@ -106,3 +111,41 @@ def test_file_answer_from_last_query_dedupes_source_refs(tmp_path: Path) -> None
 
     page = result.page_path.read_text(encoding="utf-8")
     assert "source_refs:\n- src-1\n- src-2\n- src-3\n" in page
+
+
+def test_file_answer_from_filter_only_query_renders_filter_context(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    write_query_snapshot(
+        last_query_path_for(layout),
+        QuerySnapshot(
+            query="",
+            filters=QueryFilterSnapshot(tags=["preprocessing"], source_id="src-1"),
+            summary='Found 1 matching records. Best match: "Preprocessing" (wiki/topics/pre.md).',
+            match_count=1,
+            created_at="2026-05-01T10:00:00+00:00",
+            matches=[
+                QueryMatchSnapshot(
+                    rank=1,
+                    score=3,
+                    document_class="wiki",
+                    kind="topic",
+                    record_id="topic-preprocessing",
+                    title="Preprocessing",
+                    path="wiki/topics/pre.md",
+                    status="active",
+                    snippet="Preprocessing evidence.",
+                    source_refs=["src-1"],
+                    generated_by_run_ids=[],
+                    tags=["preprocessing"],
+                )
+            ],
+        ),
+    )
+
+    result = file_answer_from_last_query(tmp_path, title="Preprocessing Answer", page_id=None)
+
+    page = result.page_path.read_text(encoding="utf-8")
+    log = layout.log_file.read_text(encoding="utf-8")
+    assert "## Query\n\nQuery: -\nTags: preprocessing\nSource ID: src-1\n\n" in page
+    assert "from query `tags preprocessing; source src-1`" in log

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import yaml
 
+from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.planning import create_question, create_task
 from splendor.commands.query import run_query
@@ -76,6 +77,67 @@ def test_run_query_returns_ranked_matches_from_wiki_and_planning(tmp_path: Path)
     assert wiki_match.provenance_links == []
     assert wiki_match.contradiction_count == 0
     assert wiki_match.review_task_ids == []
+
+
+def test_run_query_filters_by_wiki_tag(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "preprocessing.md",
+        title="Preprocessing pipeline",
+        page_id="topic-preprocessing-pipeline",
+        tags=["preprocessing", "audio"],
+        body="Lowpass filter notes for the preprocessing pipeline.",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "deployment.md",
+        title="Deployment pipeline",
+        page_id="topic-deployment-pipeline",
+        tags=["deployment"],
+        body="Deployment pipeline notes mention preprocessing only as background.",
+    )
+
+    result = run_query(tmp_path, "pipeline", tags=["preprocessing"])
+
+    assert result.filters.tags == ["preprocessing"]
+    assert [match.path for match in result.matches] == ["wiki/topics/preprocessing.md"]
+
+
+def test_run_query_filters_by_source_ref_and_allows_filter_only_lookup(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "briefing.md",
+        title="Briefing notes",
+        page_id="topic-briefing-notes",
+        source_refs=[added.source_id],
+        body="Briefing notes carry source-backed context.",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "other.md",
+        title="Other notes",
+        page_id="topic-other-notes",
+        body="Other notes do not reference the source.",
+    )
+
+    result = run_query(tmp_path, "", source_id=added.source_id)
+
+    assert result.query == ""
+    assert result.filters.source_id == added.source_id
+    assert result.match_count == 1
+    assert result.matches[0].path == "wiki/topics/briefing.md"
+
+
+def test_run_query_rejects_unknown_source_filter(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+
+    try:
+        run_query(tmp_path, "briefing", source_id="src-missing")
+    except FileNotFoundError as exc:
+        assert str(exc) == "Unknown source ID: src-missing"
+    else:
+        raise AssertionError("Expected unknown source filter failure")
 
 
 def test_run_query_excludes_index_and_log(tmp_path: Path) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -716,6 +716,75 @@ def test_brief_json_output_is_available_without_goal(tmp_path: Path, capsys) -> 
     assert "next_actions" in payload
 
 
+def test_brief_agent_context_json_packages_handoff_state(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "briefing.md"
+    source.write_text(
+        "# Briefing\n\nAgent context should include source-backed handoff state.",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "agent-context.md",
+        kind="topic",
+        title="Agent context",
+        page_id="topic-agent-context",
+        source_refs=[added.source_id],
+        body="Agent context packages query matches and planning state.",
+    )
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "create",
+            "Continue agent context",
+            "--id",
+            "task-agent-context",
+            "--status",
+            "in_progress",
+        ]
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "agent",
+            "context",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["agent_context"] is True
+    assert payload["goal"] == "agent context"
+    assert payload["wiki_status"]["source_total"] == 1
+    assert payload["source_refs"] == [added.source_id]
+    assert any(match["path"] == "wiki/topics/agent-context.md" for match in payload["matches"])
+    assert payload["active_planning"][0]["record_id"] == "task-agent-context"
+    assert payload["recent_runs"][0]["source_ids"] == [added.source_id]
+    assert payload["next_actions"]
+
+
+def test_brief_agent_context_text_output_is_compact(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "brief", "--agent-context"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Agent context" in out
+    assert "Wiki status:" in out
+    assert "Next actions:" in out
+
+
 def test_brief_skips_invalid_query_matches_without_failing(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
     bad_page = tmp_path / "wiki" / "topics" / "bad.md"

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -719,12 +719,16 @@ def test_brief_json_output_is_available_without_goal(tmp_path: Path, capsys) -> 
 def test_brief_agent_context_json_packages_handoff_state(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "briefing.md"
+    unrelated_source = tmp_path / "unrelated.md"
     source.write_text(
         "# Briefing\n\nAgent context should include source-backed handoff state.",
         encoding="utf-8",
     )
+    unrelated_source.write_text("# Unrelated\n\nRecent but irrelevant source.", encoding="utf-8")
     added = add_source(tmp_path, source)
+    unrelated = add_source(tmp_path, unrelated_source)
     main(["--root", str(tmp_path), "ingest", added.source_id])
+    main(["--root", str(tmp_path), "ingest", unrelated.source_id])
     write_wiki_page(
         tmp_path / "wiki" / "topics" / "agent-context.md",
         kind="topic",
@@ -764,11 +768,12 @@ def test_brief_agent_context_json_packages_handoff_state(tmp_path: Path, capsys)
     payload = json.loads(capsys.readouterr().out)
     assert payload["agent_context"] is True
     assert payload["goal"] == "agent context"
-    assert payload["wiki_status"]["source_total"] == 1
+    assert payload["wiki_status"]["source_total"] == 2
     assert payload["source_refs"] == [added.source_id]
+    assert unrelated.source_id not in payload["source_refs"]
     assert any(match["path"] == "wiki/topics/agent-context.md" for match in payload["matches"])
     assert payload["active_planning"][0]["record_id"] == "task-agent-context"
-    assert payload["recent_runs"][0]["source_ids"] == [added.source_id]
+    assert any(run["source_ids"] == [added.source_id] for run in payload["recent_runs"])
     assert payload["next_actions"]
 
 


### PR DESCRIPTION
## Summary

Implements M11-P3.1 for issue #56.

- add deterministic `splendor query --tag <tag>` filtering over wiki frontmatter tags and `splendor query --source <source-id>` filtering over `source_refs`
- allow filter-only source lookups while preserving existing full-text query behavior and `--no-save`
- validate source-filter IDs against source manifests with deterministic one-line CLI errors
- include active query filters in JSON output and saved query snapshots
- add compact `splendor brief --agent-context [goal]` text/JSON output for coding-agent handoff context
- update schema/product docs, quickstart, README, roadmap, and planning state for M11-P3.1 and next M12-P1.1 work

## Scope notes

- Keeps query deterministic over filesystem markdown/frontmatter and planning records.
- Keeps source IDs and page IDs stable.
- Keeps source-summary pages as generated artifacts separate from maintained synthesis pages.
- Leaves source commit capture intent (#61), optimization/scaling work (#30, #37), OCR/image handling, SQLite/vector search, hidden caches, background workers, and mutating web UI behavior out of scope.

## Verification

- `uv run pytest`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`

Closes #56
