### PR TITLE
M12-P1.1 Rich-source dispatch and PDF path

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M11-P2.1`
-- Last action taken: `M11-P2.1` is implemented; topic scaffolding, templates, and wiki index rebuild are available.
-- Current planned slice: `M11-P3`
-- Current PR sub-slice: `M11-P3.1`
+- Previous completed PR sub-slice: `M11-P3.1`
+- Last action taken: `M11-P3.1` is implemented; query/source lookup filters and compact agent-context handoff are available.
+- Current planned slice: `M12-P1`
+- Current PR sub-slice: `M12-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M12-P1`
-- Next planned PR sub-slice: `M12-P1.1`
+- Next planned slice: `M12-P2`
+- Next planned PR sub-slice: `M12-P2.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -167,6 +167,12 @@
   - [x] Preserve saved-query and no-save behavior with explicit filter metadata
   - [x] Add compact `splendor brief --agent-context` handoff output
   - [x] Update docs, tests, and planning state for the query/context contract
+- [x] Implement `M12-P1.1`: Rich-source dispatch and PDF path
+  - [x] Add source-type dispatch for ingestion while preserving text-native behavior
+  - [x] Add deterministic text-bearing PDF extraction without OCR/image processing
+  - [x] Persist parsed PDF text under `derived/parsed/`
+  - [x] Link parsed artifacts from source manifests via `derived_artifacts`
+  - [x] Update tests, docs, and planning state for the PDF dispatch contract
 
 ## Context Pointers
 
@@ -210,3 +216,4 @@
 - `M11-P2.1` Topic scaffolding, templates, and index rebuild
 - `M11-P3.1` Query/source lookup and agent-context improvements
 - `M12-P1.1` Rich-source dispatch and PDF path
+- `M12-P2.1` OCR/image ingest path

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The companion-repo guidance and sample agent instructions live in
 
 - A hosted service
 - A full web UI product beyond the local read-only inspection shell
-- An OCR or rich-media ingestion pipeline in the current MVP
+- An OCR or image-ingestion pipeline in the current MVP
 - A mandatory GitHub-only workflow
 
 ## Current MVP Surface
@@ -141,6 +141,10 @@ Not implemented yet:
 - mutating web UI actions such as add-source forms
 - changed-files-driven refresh suggestions
 
+Text-bearing PDFs are supported through the ingest dispatch path. Parsed PDF text is written under
+`derived/parsed/`, linked from the source manifest, and used for the generated source-summary page.
+Scanned/image-only PDFs still fail deterministically until the later OCR slice.
+
 ## Documentation
 
 - [docs/quickstart.md](docs/quickstart.md)
@@ -153,12 +157,12 @@ Not implemented yet:
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M11-P2.1`
-- Current planned slice: `M11-P3`
-- Current PR sub-slice: `M11-P3.1`
+- Previous completed PR sub-slice: `M11-P3.1`
+- Current planned slice: `M12-P1`
+- Current PR sub-slice: `M12-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M12-P1`
-- Next planned PR sub-slice: `M12-P1.1`
+- Next planned slice: `M12-P2`
+- Next planned PR sub-slice: `M12-P2.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -197,6 +201,6 @@ explicit dead-letter records, and stale-lease recovery.
 `M11-P1.1` is implemented: it adds deterministic bulk source registration, explicit source
 refresh through the existing ingest queue, and readable source lookup by title or path without
 changing canonical source IDs. `M11-P2.1` is implemented: it adds CLI-first topic scaffolding,
-deterministic templates, and wiki index rebuild support. The current PR sub-slice is `M11-P3.1`,
-which adds query filters for tags/source refs and a compact agent-context handoff mode before the
-roadmap moves to richer source handling in `M12-P1`.
+deterministic templates, and wiki index rebuild support. `M11-P3.1` is implemented: it adds query
+filters for tags/source refs and a compact agent-context handoff mode. The current PR sub-slice is
+`M12-P1.1`, which adds rich-source dispatch and the first deterministic text-bearing PDF path.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -92,6 +92,17 @@ records or generated `wiki/sources/src-...md` pages:
 uv run splendor --root /tmp/demo-repo source lookup product-note
 ```
 
+Text-bearing PDFs can be registered the same way as markdown or plain-text files:
+
+```bash
+uv run splendor --root /tmp/demo-repo add-source /tmp/demo-repo/research-note.pdf
+```
+
+During ingest, Splendor extracts PDF text locally, writes the parsed text artifact under
+`derived/parsed/`, links that artifact from the source manifest, and uses the extracted text for the
+generated source-summary page. Scanned or image-only PDFs fail with a deterministic message because
+OCR/image extraction is a later workflow.
+
 ## 4. Ingest the source
 
 Drain the pending ingest queue:

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -150,6 +150,16 @@ Implemented fields:
   source version, and queues ingest through the same queue handoff used by `add-source`.
 - Refresh uses the queue ledger directly, so active leases remain protected and dead-lettered jobs
   still require `splendor queue retry <job-id>` or `splendor repair ingest <source-id>`.
+- Text-bearing PDF sources are routed through source-type dispatch during ingest. The source
+  manifest keeps the same `source_ref`, `source_ref_kind`, and `storage_mode` contract as
+  text-native sources, while extracted text artifacts are recorded in `derived_artifacts`.
+
+### Derived artifacts
+
+`derived_artifacts` stores repo-relative paths to repairable machine-generated artifacts derived
+from the source. Current runtime support writes parsed text from text-bearing PDFs to
+`derived/parsed/<source-id>.txt`; lint and health validate that listed artifacts are repo-relative,
+remain under `derived/`, and exist on disk. OCR/image-derived artifacts are intentionally deferred.
 
 ### Recommended default policy
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M11-P2.1`
-- Current planned slice: `M11-P3`
-- Current PR sub-slice: `M11-P3.1`
+- Previous completed PR sub-slice: `M11-P3.1`
+- Current planned slice: `M12-P1`
+- Current PR sub-slice: `M12-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M12-P1`
-- Next planned PR sub-slice: `M12-P1.1`
+- Next planned slice: `M12-P2`
+- Next planned PR sub-slice: `M12-P2.1`
 
 `M10-P0.1` is implemented: the CLI-first wiki status and source-impact suggestion bridge is in
 place. `M10-P0.2` is implemented: project briefing and the non-mutating review-gated compile-loop
@@ -699,7 +699,7 @@ project knowledge bases.
 and `add-source --dir`, explicit source refresh via the existing ingest queue, and readable source
 lookup by title/path without changing canonical source IDs. `M11-P2.1` is implemented: it adds
 CLI-first topic scaffolding, deterministic topic templates, and a frontmatter-driven wiki index
-rebuild. `M11-P3.1` is in progress: it adds tag/source query filters and compact agent-context
+rebuild. `M11-P3.1` is implemented: it adds tag/source query filters and compact agent-context
 handoff output before the roadmap moves to rich-source dispatch in `M12-P1`.
 
 ---
@@ -744,6 +744,15 @@ feed the same source-impact and compile/update workflow used for markdown and te
 
 ### Current PR sub-slices
 - `M12-P1.1` Rich-source dispatch and PDF path
+- `M12-P2.1` OCR/image ingest path
+
+### Milestone 12 status
+
+`M12-P1.1` is in progress: it introduces source-type dispatch for ingestion and routes
+text-bearing PDFs through deterministic local extraction. Parsed PDF text is stored under
+`derived/parsed/`, linked from source manifests through `derived_artifacts`, and used by the same
+source-summary/query path as text-native sources. OCR and image-only PDFs remain deferred to
+`M12-P2.1`.
 
 ---
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -628,6 +628,8 @@ Current implementation:
 
 - workspace-backed in-repo text sources default to `excerpt`
 - copied or external text sources default to `full`
+- text-bearing PDF sources are parsed through source-type dispatch, with extracted text written to
+  `derived/parsed/<source-id>.txt` and linked from the source manifest via `derived_artifacts`
 - projects may set either class to `none`, `excerpt`, or `full` through
   `sources.summarize_in_repo_extracts_as` and `sources.summarize_external_extracts_as`
 - when the mode is `none`, the `## Extract` section is omitted entirely
@@ -677,6 +679,8 @@ Current implementation:
   templates for default synthesis, research synthesis, and issue tracking.
 - `splendor ingest <source-id>` prints the generated source-summary page/run records and the next
   `splendor wiki suggest <source-id>` command.
+- PDF ingest is limited to deterministic local extraction for text-bearing PDFs. Image-only or
+  otherwise unextractable PDFs fail with a deterministic error and do not invoke OCR.
 - `splendor ingest --pending` prints the next `wiki suggest` command when exactly one source was
   ingested, or points back to `wiki status` for batch follow-up.
 - `splendor wiki status` reports source, page, queue, run, review, contested, stale,
@@ -698,7 +702,6 @@ Current implementation:
   slice.
 
 Later optional support:
-- PDF
 - image-based sources
 - OCR-derived flows
 - audio/transcript flows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "fastapi>=0.115,<1.0",
   "markdown>=3.7,<4.0",
   "pydantic>=2.8,<3.0",
+  "pypdf>=5.0,<7.0",
   "pyyaml>=6.0.2,<7.0.0",
   "uvicorn>=0.34,<1.0",
 ]

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -130,6 +130,43 @@ def _load_source_records(
                 check_name="source-storage",
             )
             continue
+        for artifact_ref in source.derived_artifacts:
+            try:
+                artifact_path = resolve_workspace_path(
+                    root, artifact_ref, context="Source derived artifact"
+                )
+            except ValueError as exc:
+                _append_issue(
+                    issues,
+                    code="invalid-source-derived-artifact",
+                    message=str(exc),
+                    path=manifest_relpath,
+                    record_id=source_id,
+                    check_name="source-derived-artifacts",
+                )
+                continue
+            try:
+                artifact_path.relative_to(layout.derived_dir.resolve())
+            except ValueError:
+                _append_issue(
+                    issues,
+                    code="invalid-source-derived-artifact",
+                    message=f"Source derived artifact is outside derived/: {artifact_ref}",
+                    path=manifest_relpath,
+                    record_id=source_id,
+                    check_name="source-derived-artifacts",
+                )
+                continue
+            if not artifact_path.is_file():
+                _append_issue(
+                    issues,
+                    code="missing-source-derived-artifact",
+                    message=f"Source derived artifact does not exist: {artifact_ref}",
+                    path=manifest_relpath,
+                    record_id=source_id,
+                    check_name="source-derived-artifacts",
+                )
+                continue
         records[source_id] = (manifest_path, source)
 
     return records, invalid_ids, checked_count

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from splendor import __version__
 from splendor.config import load_config
+from splendor.ingest_dispatch import dispatch_source_content
 from splendor.layout import resolve_layout
 from splendor.schemas import (
     KnowledgePageFrontmatter,
@@ -58,25 +59,6 @@ from splendor.utils.wiki import (
     update_index_content,
 )
 
-SUPPORTED_SOURCE_TYPES = {
-    "md",
-    "txt",
-    "json",
-    "yaml",
-    "yml",
-    "py",
-    "js",
-    "ts",
-    "tsx",
-    "rs",
-    "go",
-    "java",
-    "c",
-    "cpp",
-    "h",
-    "hpp",
-    "sh",
-}
 _MARKDOWN_HEADING_PATTERN = re.compile(r"^(?P<level>#{1,6})\s+(?P<title>.+?)\s*#*\s*$")
 _CLAIM_SECTION_HEADINGS = {
     "core claims",
@@ -180,7 +162,7 @@ def _rendered_extract(text: str, mode: SummaryMode) -> str | None:
 def _build_summary(source: SourceRecord, source_text: str) -> str:
     path_fragment = canonical_source_ref(source)
     content_summary = _build_content_summary(source_text)
-    if source.source_type in {"md", "txt"} and content_summary is not None:
+    if source.source_type in {"md", "txt", "pdf"} and content_summary is not None:
         return f"{content_summary} registered from `{path_fragment}`."
     return (
         f"This page records deterministic ingestion output for source `{source.source_id}`, "
@@ -329,6 +311,7 @@ def _source_provenance_links(
     run_id: str,
     page_id: str,
     page_ref: str,
+    derived_artifacts: list[str],
     existing_links: list[ProvenanceLink],
 ) -> list[ProvenanceLink]:
     return dedupe_provenance_links(
@@ -336,6 +319,10 @@ def _source_provenance_links(
             *existing_links,
             make_provenance_link(page_id=page_id, path_ref=page_ref, role="generated-page"),
             make_provenance_link(run_id=run_id, source_id=source_id, role="output"),
+            *[
+                make_provenance_link(source_id=source_id, path_ref=artifact, role="output")
+                for artifact in derived_artifacts
+            ],
         ]
     )
 
@@ -362,6 +349,7 @@ def _run_success_provenance_links(
     page_id: str,
     page_ref: str,
     run_id: str,
+    derived_artifacts: list[str],
 ) -> list[ProvenanceLink]:
     return dedupe_provenance_links(
         [
@@ -372,6 +360,10 @@ def _run_success_provenance_links(
             ),
             make_provenance_link(page_id=page_id, path_ref=page_ref, role="generated-page"),
             make_provenance_link(run_id=run_id, page_id=page_id, role="output"),
+            *[
+                make_provenance_link(source_id=source_id, path_ref=artifact, role="output")
+                for artifact in derived_artifacts
+            ],
         ]
     )
 
@@ -578,6 +570,7 @@ def _commit_success(
         wiki_payload.page_path,
         layout.index_file,
         layout.log_file,
+        *[path for path, _content in wiki_payload.extra_writes],
     ]
     previous_content: dict[Path, str | None] = {}
     for path in tracked_paths:
@@ -752,15 +745,14 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
         )
         write_run_record(run_path, run)
 
-        if source.source_type not in SUPPORTED_SOURCE_TYPES:
-            msg = f"Unsupported source type for ingestion: {source.source_type}"
-            raise ValueError(msg)
-
-        try:
-            source_text = resolved_source.resolved_path.read_text(encoding="utf-8")
-        except UnicodeDecodeError as exc:
-            msg = f"Source file is not valid UTF-8 text: {resolved_source.resolved_path}"
-            raise ValueError(msg) from exc
+        dispatched_content = dispatch_source_content(source, resolved_source, layout=layout)
+        source_text = dispatched_content.text
+        derived_artifact_ref = (
+            _relative_to_root(root, dispatched_content.derived_artifact_path)
+            if dispatched_content.derived_artifact_path is not None
+            else None
+        )
+        derived_artifacts = [derived_artifact_ref] if derived_artifact_ref is not None else []
 
         extract_mode = _summary_mode_for(config, source)
         page_path = _page_path_for(layout.wiki_sources_dir, source.source_id)
@@ -792,6 +784,11 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
                 f"- Registered path: `{registered_path}`",
                 f"- Source file: `{resolved_source.resolved_ref}`",
             ]
+            + (
+                [f"- Parsed artifact: `{derived_artifact_ref}`"]
+                if derived_artifact_ref is not None
+                else []
+            )
         )
         key_facts = [
             f"Source ID: `{source.source_id}`",
@@ -805,6 +802,11 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
         provenance_lines = [
             f"Manifest: `{_relative_to_root(root, manifest_path)}`",
             f"{resolved_source.content_origin_label}: `{resolved_source.resolved_ref}`",
+            *(
+                [f"Parsed artifact: `{derived_artifact_ref}`"]
+                if derived_artifact_ref is not None
+                else []
+            ),
             f"Run ID: `{run_id}`",
             f"Pipeline version: `{__version__}`",
         ]
@@ -861,11 +863,13 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
                 "last_run_id": run_id,
                 "generated_by_run_ids": sorted(set([*source.generated_by_run_ids, run_id])),
                 "linked_pages": sorted(set([*source.linked_pages, page_relpath])),
+                "derived_artifacts": sorted(set([*source.derived_artifacts, *derived_artifacts])),
                 "provenance_links": _source_provenance_links(
                     source_id=source.source_id,
                     run_id=run_id,
                     page_id=source.source_id,
                     page_ref=page_relpath,
+                    derived_artifacts=derived_artifacts,
                     existing_links=source.provenance_links,
                 ),
             }
@@ -878,6 +882,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
                     page_relpath,
                     _relative_to_root(root, layout.index_file),
                     _relative_to_root(root, layout.log_file),
+                    *derived_artifacts,
                     *[
                         _relative_to_root(root, path)
                         for path, _content in contradiction_review.page_updates
@@ -899,6 +904,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
                     page_id=source.source_id,
                     page_ref=page_relpath,
                     run_id=run_id,
+                    derived_artifacts=derived_artifacts,
                 ),
             }
         )
@@ -925,6 +931,17 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
                 index_content=index_content,
                 log_content=log_content,
                 extra_writes=[
+                    *(
+                        [
+                            (
+                                dispatched_content.derived_artifact_path,
+                                dispatched_content.derived_artifact_content,
+                            )
+                        ]
+                        if dispatched_content.derived_artifact_path is not None
+                        and dispatched_content.derived_artifact_content is not None
+                        else []
+                    ),
                     *contradiction_review.page_updates,
                     *[
                         (update.task_path, update.content)

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -361,7 +361,12 @@ def _run_success_provenance_links(
             make_provenance_link(page_id=page_id, path_ref=page_ref, role="generated-page"),
             make_provenance_link(run_id=run_id, page_id=page_id, role="output"),
             *[
-                make_provenance_link(source_id=source_id, path_ref=artifact, role="output")
+                make_provenance_link(
+                    run_id=run_id,
+                    source_id=source_id,
+                    path_ref=artifact,
+                    role="output",
+                )
                 for artifact in derived_artifacts
             ],
         ]
@@ -418,6 +423,14 @@ def _is_no_op(root: Path, layout, source: SourceRecord) -> bool:
     run_path = layout.runs_dir / f"{source.last_run_id}.json"
     if not run_path.exists():
         return False
+
+    for artifact_ref in source.derived_artifacts:
+        try:
+            artifact_path = resolve_workspace_path(root, artifact_ref, context="Derived artifact")
+        except ValueError:
+            return False
+        if not artifact_path.is_file():
+            return False
 
     run = load_run_record(run_path)
     return run.status == "succeeded" and run.pipeline_version == __version__

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -393,6 +393,8 @@ def _run_reference_integrity_checks(
     for manifest in inventory.source_manifests:
         if manifest.record is None:
             continue
+        checked_count += len(manifest.record.derived_artifacts)
+        issues.extend(_derived_artifact_issues(root, layout, manifest))
         checked_count += len(manifest.record.linked_pages)
         issues.extend(_linked_page_issues(root, manifest, wiki_by_path))
         checked_count += len(manifest.record.provenance_links)
@@ -413,6 +415,53 @@ def _run_reference_integrity_checks(
     issues.extend(planning_state_issues)
 
     return _LintCheckResult(checked_count=checked_count, issues=issues)
+
+
+def _derived_artifact_issues(
+    root: Path, layout: ResolvedLayout, manifest: _SourceInventory
+) -> list[MaintenanceIssue]:
+    if manifest.record is None:
+        return []
+    issues: list[MaintenanceIssue] = []
+    manifest_relpath = workspace_relative_path(root, manifest.manifest_path)
+    for artifact_ref in manifest.record.derived_artifacts:
+        try:
+            artifact_path = resolve_workspace_path(root, artifact_ref, context="Derived artifact")
+        except ValueError as exc:
+            issues.append(
+                MaintenanceIssue(
+                    code="invalid-source-derived-artifact",
+                    message=str(exc),
+                    path=manifest_relpath,
+                    record_id=manifest.record.source_id,
+                    check_name="source-derived-artifacts",
+                )
+            )
+            continue
+        try:
+            artifact_path.relative_to(layout.derived_dir.resolve())
+        except ValueError:
+            issues.append(
+                MaintenanceIssue(
+                    code="invalid-source-derived-artifact",
+                    message=f"Source derived artifact is outside derived/: {artifact_ref}",
+                    path=manifest_relpath,
+                    record_id=manifest.record.source_id,
+                    check_name="source-derived-artifacts",
+                )
+            )
+            continue
+        if not artifact_path.is_file():
+            issues.append(
+                MaintenanceIssue(
+                    code="missing-source-derived-artifact",
+                    message=f"Source derived artifact does not exist: {artifact_ref}",
+                    path=manifest_relpath,
+                    record_id=manifest.record.source_id,
+                    check_name="source-derived-artifacts",
+                )
+            )
+    return issues
 
 
 def _planning_state_issues(root: Path) -> tuple[int, list[MaintenanceIssue]]:

--- a/src/splendor/commands/repo_scan.py
+++ b/src/splendor/commands/repo_scan.py
@@ -7,8 +7,8 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from splendor.commands.ingest import SUPPORTED_SOURCE_TYPES
 from splendor.config import load_config
+from splendor.ingest_dispatch import SUPPORTED_SOURCE_TYPES
 from splendor.layout import resolve_layout
 from splendor.schemas.types import SourceClass
 from splendor.state.source_registry import register_source

--- a/src/splendor/commands/repo_scan.py
+++ b/src/splendor/commands/repo_scan.py
@@ -13,8 +13,9 @@ from splendor.layout import resolve_layout
 from splendor.schemas.types import SourceClass
 from splendor.state.source_registry import register_source
 
-_CODE_EXTENSIONS = SUPPORTED_SOURCE_TYPES - {"json", "md", "txt", "yaml", "yml"}
 _CONFIG_EXTENSIONS = {"json", "yaml", "yml"}
+_DOCUMENTATION_EXTENSIONS = {"md", "pdf", "txt"}
+_CODE_EXTENSIONS = SUPPORTED_SOURCE_TYPES - _CONFIG_EXTENSIONS - _DOCUMENTATION_EXTENSIONS
 _IGNORED_TOP_LEVEL_DIRS = {
     ".git",
     ".pytest_cache",
@@ -173,7 +174,7 @@ def _ignored_top_level_dirs(root: Path, layout) -> set[str]:
 
 def _classify_path(path: Path, relative_path: str) -> SourceClass:
     suffix = path.suffix.lstrip(".")
-    if suffix in {"md", "txt"}:
+    if suffix in _DOCUMENTATION_EXTENSIONS:
         return "documentation"
     if suffix in _CONFIG_EXTENSIONS or relative_path.startswith(".github/workflows/"):
         return "configuration"

--- a/src/splendor/ingest_dispatch.py
+++ b/src/splendor/ingest_dispatch.py
@@ -1,0 +1,101 @@
+"""Source-type dispatch for ingestion content extraction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from pypdf import PdfReader
+
+from splendor.layout import ResolvedLayout
+from splendor.schemas import SourceRecord
+from splendor.state.source_resolver import ResolvedSource
+
+TEXT_SOURCE_TYPES = {
+    "md",
+    "txt",
+    "json",
+    "yaml",
+    "yml",
+    "py",
+    "js",
+    "ts",
+    "tsx",
+    "rs",
+    "go",
+    "java",
+    "c",
+    "cpp",
+    "h",
+    "hpp",
+    "sh",
+}
+SUPPORTED_SOURCE_TYPES = {*TEXT_SOURCE_TYPES, "pdf"}
+
+
+@dataclass(frozen=True)
+class DispatchedSourceContent:
+    text: str
+    derived_artifact_path: Path | None = None
+    derived_artifact_content: str | None = None
+
+
+def dispatch_source_content(
+    source: SourceRecord,
+    resolved_source: ResolvedSource,
+    *,
+    layout: ResolvedLayout,
+) -> DispatchedSourceContent:
+    if source.source_type in TEXT_SOURCE_TYPES:
+        return _read_text_source(resolved_source.resolved_path)
+    if source.source_type == "pdf":
+        return _extract_pdf_source(source, resolved_source, layout=layout)
+
+    msg = f"Unsupported source type for ingestion: {source.source_type}"
+    raise ValueError(msg)
+
+
+def _read_text_source(path: Path) -> DispatchedSourceContent:
+    try:
+        return DispatchedSourceContent(text=path.read_text(encoding="utf-8"))
+    except UnicodeDecodeError as exc:
+        msg = f"Source file is not valid UTF-8 text: {path}"
+        raise ValueError(msg) from exc
+
+
+def _extract_pdf_source(
+    source: SourceRecord,
+    resolved_source: ResolvedSource,
+    *,
+    layout: ResolvedLayout,
+) -> DispatchedSourceContent:
+    try:
+        reader = PdfReader(str(resolved_source.resolved_path))
+        page_texts = [page.extract_text() or "" for page in reader.pages]
+    except Exception as exc:
+        msg = f"PDF text extraction failed for {resolved_source.resolved_ref}: {exc}"
+        raise ValueError(msg) from exc
+
+    extracted_text = _normalize_pdf_text(page_texts)
+    if not extracted_text:
+        msg = (
+            "PDF source has no extractable text; OCR/image extraction is not supported: "
+            f"{resolved_source.resolved_ref}"
+        )
+        raise ValueError(msg)
+
+    artifact_content = f"{extracted_text}\n"
+    return DispatchedSourceContent(
+        text=extracted_text,
+        derived_artifact_path=layout.derived_parsed_dir / f"{source.source_id}.txt",
+        derived_artifact_content=artifact_content,
+    )
+
+
+def _normalize_pdf_text(page_texts: list[str]) -> str:
+    normalized_pages = []
+    for page_text in page_texts:
+        normalized = page_text.replace("\r\n", "\n").replace("\r", "\n").strip()
+        if normalized:
+            normalized_pages.append(normalized)
+    return "\n\n".join(normalized_pages).strip()

--- a/src/splendor/ingest_dispatch.py
+++ b/src/splendor/ingest_dispatch.py
@@ -73,7 +73,7 @@ def _extract_pdf_source(
         reader = PdfReader(str(resolved_source.resolved_path))
         page_texts = [page.extract_text() or "" for page in reader.pages]
     except Exception as exc:
-        msg = f"PDF text extraction failed for {resolved_source.resolved_ref}: {exc}"
+        msg = f"PDF text extraction failed for {resolved_source.resolved_ref}"
         raise ValueError(msg) from exc
 
     extracted_text = _normalize_pdf_text(page_texts)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+"""Shared pytest helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pypdf import PdfReader
+
+
+def write_text_pdf(path: Path, lines: list[str]) -> None:
+    content_lines = []
+    for index, line in enumerate(lines):
+        if index > 0:
+            content_lines.append("0 -18 Td")
+        content_lines.append(f"({_escape_pdf_text(line)}) Tj")
+    content = "\n".join(["BT", "/F1 12 Tf", "72 720 Td", *content_lines, "ET", ""]).encode()
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            b"/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>"
+        ),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        b"<< /Length " + str(len(content)).encode() + b" >>\nstream\n" + content + b"endstream",
+    ]
+    data = _build_pdf(objects)
+    path.write_bytes(data)
+    assert PdfReader(str(path)).pages[0].extract_text()
+
+
+def _escape_pdf_text(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+
+def _build_pdf(objects: list[bytes]) -> bytes:
+    chunks = [b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"]
+    offsets = [0]
+    for index, payload in enumerate(objects, start=1):
+        offsets.append(sum(len(chunk) for chunk in chunks))
+        chunks.append(f"{index} 0 obj\n".encode())
+        chunks.append(payload)
+        chunks.append(b"\nendobj\n")
+
+    xref_offset = sum(len(chunk) for chunk in chunks)
+    chunks.append(f"xref\n0 {len(objects) + 1}\n".encode())
+    chunks.append(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        chunks.append(f"{offset:010d} 00000 n \n".encode())
+    chunks.append(
+        (
+            f"trailer\n<< /Root 1 0 R /Size {len(objects) + 1} >>\n"
+            f"startxref\n{xref_offset}\n%%EOF\n"
+        ).encode()
+    )
+    return b"".join(chunks)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -29,6 +29,22 @@ def test_run_health_checks_returns_no_issues_for_initialized_workspace(tmp_path:
     assert result.issues == []
 
 
+def test_run_health_checks_reports_missing_source_derived_artifact(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={"derived_artifacts": ["derived/parsed/missing.txt"]}
+    )
+    write_source_record(added.manifest_path, source_record)
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["missing-source-derived-artifact"]
+    assert result.issues[0].path == added.manifest_path.relative_to(tmp_path).as_posix()
+
+
 def test_run_health_checks_reports_invalid_queue_and_run_records(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     (tmp_path / "state" / "queue" / "ingest-bad.json").write_text("{bad json}\n", encoding="utf-8")

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pypdf import PdfReader, PdfWriter
+from pypdf.generic import DecodedStreamObject, DictionaryObject, NameObject
 
 import splendor.utils.contradictions as contradictions_module
 from splendor.commands.add_source import add_source
@@ -65,6 +67,35 @@ def rewrite_symlink(root: Path, source_id: str, target: Path) -> Path:
     symlink_path.parent.mkdir(parents=True, exist_ok=True)
     symlink_path.symlink_to(target)
     return symlink_path
+
+
+def write_text_pdf(path: Path, lines: list[str]) -> None:
+    writer = PdfWriter()
+    page = writer.add_blank_page(width=612, height=792)
+    font = DictionaryObject(
+        {
+            NameObject("/Type"): NameObject("/Font"),
+            NameObject("/Subtype"): NameObject("/Type1"),
+            NameObject("/BaseFont"): NameObject("/Helvetica"),
+        }
+    )
+    font_ref = writer._add_object(font)
+    page[NameObject("/Resources")] = DictionaryObject(
+        {NameObject("/Font"): DictionaryObject({NameObject("/F1"): font_ref})}
+    )
+    text_ops = ["BT", "/F1 12 Tf", "72 720 Td"]
+    for index, line in enumerate(lines):
+        if index > 0:
+            text_ops.append("0 -18 Td")
+        escaped = line.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+        text_ops.append(f"({escaped}) Tj")
+    text_ops.append("ET")
+    stream = DecodedStreamObject()
+    stream.set_data(("\n".join(text_ops) + "\n").encode("utf-8"))
+    page[NameObject("/Contents")] = writer._add_object(stream)
+    with path.open("wb") as handle:
+        writer.write(handle)
+    assert PdfReader(str(path)).pages[0].extract_text()
 
 
 def test_ingest_source_happy_path(tmp_path: Path) -> None:
@@ -209,6 +240,66 @@ def test_ingest_source_rejects_unsupported_type(tmp_path: Path) -> None:
     assert run_record.page_ids == []
     assert run_record.output_refs == []
     assert not (tmp_path / "wiki" / "sources" / f"{added.source_id}.md").exists()
+
+
+def test_ingest_source_pdf_writes_parsed_artifact_and_links_manifest(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "dispatch.pdf"
+    write_text_pdf(
+        source,
+        [
+            "Splendor PDF dispatch claim",
+            "Text-bearing PDF extraction works.",
+        ],
+    )
+    added = add_source(tmp_path, source)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    frontmatter, body = parse_frontmatter(result.page_path)
+    assert frontmatter.tags == ["source-summary", "pdf"]
+    assert "Parsed artifact: `derived/parsed/" in body
+    assert "Splendor PDF dispatch claim" in body
+    assert "Text-bearing PDF extraction works." in body
+
+    parsed_artifact = tmp_path / "derived" / "parsed" / f"{added.source_id}.txt"
+    assert parsed_artifact.read_text(encoding="utf-8") == (
+        "Splendor PDF dispatch claim\nText-bearing PDF extraction works.\n"
+    )
+
+    source_record = load_source_record(added.manifest_path)
+    artifact_ref = parsed_artifact.relative_to(tmp_path).as_posix()
+    assert source_record.source_ref == "dispatch.pdf"
+    assert source_record.storage_mode == "none"
+    assert source_record.derived_artifacts == [artifact_ref]
+    assert any(link.path_ref == artifact_ref for link in source_record.provenance_links)
+
+    run_record = load_run_record(result.run_path)
+    assert artifact_ref in run_record.output_refs
+    assert any(link.path_ref == artifact_ref for link in run_record.provenance_links)
+
+
+def test_ingest_source_pdf_without_text_fails_without_ocr(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "scan.pdf"
+    writer = PdfWriter()
+    writer.add_blank_page(width=612, height=792)
+    with source.open("wb") as handle:
+        writer.write(handle)
+    added = add_source(tmp_path, source)
+
+    with pytest.raises(ValueError, match="OCR/image extraction is not supported"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.derived_artifacts == []
+    assert not (tmp_path / "derived" / "parsed" / f"{added.source_id}.txt").exists()
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.status == "failed"
+    assert "OCR/image extraction is not supported" in (queue_record.last_error or "")
 
 
 def test_ingest_source_rejects_invalid_utf8_text(tmp_path: Path) -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import pytest
 import yaml
-from pypdf import PdfReader, PdfWriter
-from pypdf.generic import DecodedStreamObject, DictionaryObject, NameObject
+from pypdf import PdfWriter
 
 import splendor.utils.contradictions as contradictions_module
+from conftest import write_text_pdf
 from splendor.commands.add_source import add_source
 from splendor.commands.ingest import (
     drain_pending_ingest_jobs,
@@ -67,35 +67,6 @@ def rewrite_symlink(root: Path, source_id: str, target: Path) -> Path:
     symlink_path.parent.mkdir(parents=True, exist_ok=True)
     symlink_path.symlink_to(target)
     return symlink_path
-
-
-def write_text_pdf(path: Path, lines: list[str]) -> None:
-    writer = PdfWriter()
-    page = writer.add_blank_page(width=612, height=792)
-    font = DictionaryObject(
-        {
-            NameObject("/Type"): NameObject("/Font"),
-            NameObject("/Subtype"): NameObject("/Type1"),
-            NameObject("/BaseFont"): NameObject("/Helvetica"),
-        }
-    )
-    font_ref = writer._add_object(font)
-    page[NameObject("/Resources")] = DictionaryObject(
-        {NameObject("/Font"): DictionaryObject({NameObject("/F1"): font_ref})}
-    )
-    text_ops = ["BT", "/F1 12 Tf", "72 720 Td"]
-    for index, line in enumerate(lines):
-        if index > 0:
-            text_ops.append("0 -18 Td")
-        escaped = line.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
-        text_ops.append(f"({escaped}) Tj")
-    text_ops.append("ET")
-    stream = DecodedStreamObject()
-    stream.set_data(("\n".join(text_ops) + "\n").encode("utf-8"))
-    page[NameObject("/Contents")] = writer._add_object(stream)
-    with path.open("wb") as handle:
-        writer.write(handle)
-    assert PdfReader(str(path)).pages[0].extract_text()
 
 
 def test_ingest_source_happy_path(tmp_path: Path) -> None:
@@ -277,7 +248,30 @@ def test_ingest_source_pdf_writes_parsed_artifact_and_links_manifest(tmp_path: P
 
     run_record = load_run_record(result.run_path)
     assert artifact_ref in run_record.output_refs
-    assert any(link.path_ref == artifact_ref for link in run_record.provenance_links)
+    assert any(
+        link.path_ref == artifact_ref
+        and link.source_id == added.source_id
+        and link.run_id == result.run_id
+        and link.role == "output"
+        for link in run_record.provenance_links
+    )
+
+
+def test_ingest_source_pdf_recreates_missing_parsed_artifact(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "dispatch.pdf"
+    write_text_pdf(source, ["Splendor PDF dispatch claim"])
+    added = add_source(tmp_path, source)
+
+    first = ingest_source(tmp_path, added.source_id)
+    parsed_artifact = tmp_path / "derived" / "parsed" / f"{added.source_id}.txt"
+    parsed_artifact.unlink()
+
+    second = ingest_source(tmp_path, added.source_id)
+
+    assert first.no_op is False
+    assert second.no_op is False
+    assert parsed_artifact.read_text(encoding="utf-8") == "Splendor PDF dispatch claim\n"
 
 
 def test_ingest_source_pdf_without_text_fails_without_ocr(tmp_path: Path) -> None:
@@ -300,6 +294,20 @@ def test_ingest_source_pdf_without_text_fails_without_ocr(tmp_path: Path) -> Non
     queue_record = load_queue_item(queue_path)
     assert queue_record.status == "failed"
     assert "OCR/image extraction is not supported" in (queue_record.last_error or "")
+
+
+def test_ingest_source_malformed_pdf_uses_stable_error(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "broken.pdf"
+    source.write_bytes(b"%PDF-1.4\nnot a valid pdf\n")
+    added = add_source(tmp_path, source)
+
+    with pytest.raises(ValueError, match="^PDF text extraction failed for broken.pdf$"):
+        ingest_source(tmp_path, added.source_id)
+
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.last_error == "PDF text extraction failed for broken.pdf"
 
 
 def test_ingest_source_rejects_invalid_utf8_text(tmp_path: Path) -> None:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -231,6 +231,22 @@ def test_run_lint_checks_reports_invalid_source_manifest(tmp_path: Path) -> None
     assert str(tmp_path) not in result.issues[0].message
 
 
+def test_run_lint_checks_reports_missing_source_derived_artifact(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={"derived_artifacts": ["derived/parsed/missing.txt"]}
+    )
+    write_source_record(added.manifest_path, source_record)
+
+    result = _run_lint(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["missing-source-derived-artifact"]
+    assert result.issues[0].path == added.manifest_path.relative_to(tmp_path).as_posix()
+
+
 def test_run_lint_checks_reports_missing_wiki_refs_and_related_pages(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     _write_wiki_page(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,9 +2,8 @@ import json
 from pathlib import Path
 
 import yaml
-from pypdf import PdfWriter
-from pypdf.generic import DecodedStreamObject, DictionaryObject, NameObject
 
+from conftest import write_text_pdf
 from splendor.commands.add_source import add_source
 from splendor.commands.ingest import ingest_source
 from splendor.commands.init import initialize_workspace
@@ -12,28 +11,6 @@ from splendor.commands.planning import create_question, create_task
 from splendor.commands.query import run_query
 from splendor.schemas import KnowledgePageFrontmatter
 from splendor.state.query_snapshot import load_query_snapshot
-
-
-def write_text_pdf(path: Path, text: str) -> None:
-    writer = PdfWriter()
-    page = writer.add_blank_page(width=612, height=792)
-    font = DictionaryObject(
-        {
-            NameObject("/Type"): NameObject("/Font"),
-            NameObject("/Subtype"): NameObject("/Type1"),
-            NameObject("/BaseFont"): NameObject("/Helvetica"),
-        }
-    )
-    font_ref = writer._add_object(font)
-    page[NameObject("/Resources")] = DictionaryObject(
-        {NameObject("/Font"): DictionaryObject({NameObject("/F1"): font_ref})}
-    )
-    stream = DecodedStreamObject()
-    escaped = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
-    stream.set_data(f"BT\n/F1 12 Tf\n72 720 Td\n({escaped}) Tj\nET\n".encode())
-    page[NameObject("/Contents")] = writer._add_object(stream)
-    with path.open("wb") as handle:
-        writer.write(handle)
 
 
 def write_wiki_page(
@@ -157,7 +134,7 @@ def test_run_query_filters_by_source_ref_and_allows_filter_only_lookup(tmp_path:
 def test_run_query_finds_extracted_pdf_source_summary_text(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "dispatch.pdf"
-    write_text_pdf(source, "Extracted PDF dispatch evidence")
+    write_text_pdf(source, ["Extracted PDF dispatch evidence"])
     added = add_source(tmp_path, source)
     ingest_source(tmp_path, added.source_id)
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,13 +2,38 @@ import json
 from pathlib import Path
 
 import yaml
+from pypdf import PdfWriter
+from pypdf.generic import DecodedStreamObject, DictionaryObject, NameObject
 
 from splendor.commands.add_source import add_source
+from splendor.commands.ingest import ingest_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.planning import create_question, create_task
 from splendor.commands.query import run_query
 from splendor.schemas import KnowledgePageFrontmatter
 from splendor.state.query_snapshot import load_query_snapshot
+
+
+def write_text_pdf(path: Path, text: str) -> None:
+    writer = PdfWriter()
+    page = writer.add_blank_page(width=612, height=792)
+    font = DictionaryObject(
+        {
+            NameObject("/Type"): NameObject("/Font"),
+            NameObject("/Subtype"): NameObject("/Type1"),
+            NameObject("/BaseFont"): NameObject("/Helvetica"),
+        }
+    )
+    font_ref = writer._add_object(font)
+    page[NameObject("/Resources")] = DictionaryObject(
+        {NameObject("/Font"): DictionaryObject({NameObject("/F1"): font_ref})}
+    )
+    stream = DecodedStreamObject()
+    escaped = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+    stream.set_data(f"BT\n/F1 12 Tf\n72 720 Td\n({escaped}) Tj\nET\n".encode())
+    page[NameObject("/Contents")] = writer._add_object(stream)
+    with path.open("wb") as handle:
+        writer.write(handle)
 
 
 def write_wiki_page(
@@ -127,6 +152,21 @@ def test_run_query_filters_by_source_ref_and_allows_filter_only_lookup(tmp_path:
     assert result.filters.source_id == added.source_id
     assert result.match_count == 1
     assert result.matches[0].path == "wiki/topics/briefing.md"
+
+
+def test_run_query_finds_extracted_pdf_source_summary_text(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "dispatch.pdf"
+    write_text_pdf(source, "Extracted PDF dispatch evidence")
+    added = add_source(tmp_path, source)
+    ingest_source(tmp_path, added.source_id)
+
+    result = run_query(tmp_path, "dispatch evidence", source_id=added.source_id)
+
+    assert result.match_count == 1
+    assert result.matches[0].kind == "source-summary"
+    assert result.matches[0].source_refs == [added.source_id]
+    assert "Extracted PDF dispatch evidence" in result.matches[0].snippet
 
 
 def test_run_query_rejects_unknown_source_filter(tmp_path: Path) -> None:

--- a/tests/test_repo_scan.py
+++ b/tests/test_repo_scan.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+from conftest import write_text_pdf
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.repo_scan import render_repo_scan_json, scan_repo
@@ -23,6 +24,7 @@ def test_repo_scan_registers_and_classifies_supported_workspace_files(tmp_path: 
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir()
     (docs_dir / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    write_text_pdf(docs_dir / "research.pdf", ["Research PDF"])
     src_dir = tmp_path / "src"
     src_dir.mkdir()
     (src_dir / "main.py").write_text("print('hi')\n", encoding="utf-8")
@@ -35,12 +37,12 @@ def test_repo_scan_registers_and_classifies_supported_workspace_files(tmp_path: 
 
     result = scan_repo(tmp_path)
 
-    assert result.scanned == 6
-    assert result.registered == 6
+    assert result.scanned == 7
+    assert result.registered == 7
     assert result.already_registered == 0
     assert result.class_counts == {
         "code": 2,
-        "documentation": 3,
+        "documentation": 4,
         "configuration": 1,
         "other": 0,
     }
@@ -48,6 +50,7 @@ def test_repo_scan_registers_and_classifies_supported_workspace_files(tmp_path: 
     assert touched["AGENTS.md"].source_labels == ["agent-instructions"]
     assert touched["README.md"].source_class == "documentation"
     assert touched["docs/guide.md"].source_class == "documentation"
+    assert touched["docs/research.pdf"].source_class == "documentation"
     assert touched["src/main.py"].source_class == "code"
     assert touched["tests/test_main.py"].source_labels == ["test"]
     assert touched[".github/workflows/ci.yml"].source_class == "configuration"

--- a/uv.lock
+++ b/uv.lock
@@ -423,6 +423,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/3f/9f2167401c2e94833ca3b69535bad89e533b5de75fefe4197a2c224baec2/pypdf-6.10.2.tar.gz", hash = "sha256:7d09ce108eff6bf67465d461b6ef352dcb8d84f7a91befc02f904455c6eea11d", size = 5315679, upload-time = "2026-04-15T16:37:36.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/d6/1d5c60cc17bbdf37c1552d9c03862fc6d32c5836732a0415b2d637edc2d0/pypdf-6.10.2-py3-none-any.whl", hash = "sha256:aa53be9826655b51c96741e5d7983ca224d898ac0a77896e64636810517624aa", size = 336308, upload-time = "2026-04-15T16:37:34.851Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -545,6 +554,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "markdown" },
     { name = "pydantic" },
+    { name = "pypdf" },
     { name = "pyyaml" },
     { name = "uvicorn" },
 ]
@@ -565,6 +575,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115,<1.0" },
     { name = "markdown", specifier = ">=3.7,<4.0" },
     { name = "pydantic", specifier = ">=2.8,<3.0" },
+    { name = "pypdf", specifier = ">=5.0,<7.0" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
     { name = "uvicorn", specifier = ">=0.34,<1.0" },
 ]


### PR DESCRIPTION
## Summary

Implements M12-P1.1 as the first rich-source ingestion slice.

- Add source-type dispatch for ingestion and move the supported source-type registry out of the ingest command.
- Add deterministic local extraction for text-bearing PDF sources using `pypdf`.
- Persist parsed PDF text under `derived/parsed/{source-id}.txt`, link it from source manifests via `derived_artifacts`, and include it in run/source provenance and output refs.
- Preserve existing markdown/plain-text behavior and keep PDFs on the existing `source_ref` plus `storage_mode` model.
- Add lint and health validation for manifest `derived_artifacts` links.
- Update planning/docs for M12-P1.1 and set the next concrete PR to M12-P2.1.

## Scope boundaries

- No OCR or image extraction.
- No vector search, SQLite, background workers, hidden caches, or mutating web UI behavior.
- Image-only or otherwise unextractable PDFs fail deterministically with an OCR-deferred message.

## Tests

- `uv run pytest`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`

Closes #64.