### PR TITLE
M12-P2.1 OCR/image ingest path

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M11-P3.1`
-- Last action taken: `M11-P3.1` is implemented; query/source lookup filters and compact agent-context handoff are available.
-- Current planned slice: `M12-P1`
-- Current PR sub-slice: `M12-P1.1`
+- Previous completed PR sub-slice: `M12-P1.1`
+- Last action taken: `M12-P1.1` is implemented; rich-source dispatch and deterministic text-bearing PDF ingest are available.
+- Current planned slice: `M12-P2`
+- Current PR sub-slice: `M12-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M12-P2`
-- Next planned PR sub-slice: `M12-P2.1`
+- Next planned slice: `M13-P1`
+- Next planned PR sub-slice: `M13-P1.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -173,6 +173,12 @@
   - [x] Persist parsed PDF text under `derived/parsed/`
   - [x] Link parsed artifacts from source manifests via `derived_artifacts`
   - [x] Update tests, docs, and planning state for the PDF dispatch contract
+- [x] Implement `M12-P2.1`: OCR/image ingest path
+  - [x] Add explicitly configured image/OCR dispatch over the existing source resolver
+  - [x] Keep OCR output separate from parsed PDF text under `derived/ocr/`
+  - [x] Link OCR artifacts from source manifests via `derived_artifacts`
+  - [x] Preserve deterministic failures for unconfigured or unextractable OCR/image sources
+  - [x] Update tests, docs, and planning state for the OCR/image ingest contract
 
 ## Context Pointers
 
@@ -217,3 +223,4 @@
 - `M11-P3.1` Query/source lookup and agent-context improvements
 - `M12-P1.1` Rich-source dispatch and PDF path
 - `M12-P2.1` OCR/image ingest path
+- `M13-P1.1` Schema/docs/migration stabilization

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ Not implemented yet:
 Text-bearing PDFs are supported through the ingest dispatch path. Parsed PDF text is written under
 `derived/parsed/`, linked from the source manifest, and used for the generated source-summary page.
 Image sources and image-only PDFs can use explicitly configured sidecar-text OCR; extracted OCR text
-is written under `derived/ocr/`, linked from the source manifest, and kept separate from parsed PDF
-artifacts.
+is written under `derived/ocr/` with sidecar checksum metadata under `derived/metadata/`, linked from
+the source manifest, and kept separate from parsed PDF artifacts.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -137,13 +137,15 @@ Implemented today:
 Not implemented yet:
 
 - mutating review-gated `splendor wiki compile`
-- OCR and image extraction flows
+- heavyweight OCR/image extraction providers
 - mutating web UI actions such as add-source forms
 - changed-files-driven refresh suggestions
 
 Text-bearing PDFs are supported through the ingest dispatch path. Parsed PDF text is written under
 `derived/parsed/`, linked from the source manifest, and used for the generated source-summary page.
-Scanned/image-only PDFs still fail deterministically until the later OCR slice.
+Image sources and image-only PDFs can use explicitly configured sidecar-text OCR; extracted OCR text
+is written under `derived/ocr/`, linked from the source manifest, and kept separate from parsed PDF
+artifacts.
 
 ## Documentation
 
@@ -157,12 +159,12 @@ Scanned/image-only PDFs still fail deterministically until the later OCR slice.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M11-P3.1`
-- Current planned slice: `M12-P1`
-- Current PR sub-slice: `M12-P1.1`
+- Previous completed PR sub-slice: `M12-P1.1`
+- Current planned slice: `M12-P2`
+- Current PR sub-slice: `M12-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M12-P2`
-- Next planned PR sub-slice: `M12-P2.1`
+- Next planned slice: `M13-P1`
+- Next planned PR sub-slice: `M13-P1.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -100,8 +100,15 @@ uv run splendor --root /tmp/demo-repo add-source /tmp/demo-repo/research-note.pd
 
 During ingest, Splendor extracts PDF text locally, writes the parsed text artifact under
 `derived/parsed/`, links that artifact from the source manifest, and uses the extracted text for the
-generated source-summary page. Scanned or image-only PDFs fail with a deterministic message because
-OCR/image extraction is a later workflow.
+generated source-summary page.
+
+Image files and image-only PDFs require explicit OCR configuration. The current lightweight local
+provider is `sidecar-text`: set `sources.ocr_enabled: true`, keep
+`sources.ocr_provider: sidecar-text`, and place UTF-8 sidecar text next to the resolved source file
+using the configured suffix, default `.ocr.txt` (for example `diagram.png.ocr.txt`). Successful OCR
+ingest writes extracted text under `derived/ocr/` and links it from the source manifest. When OCR is
+not configured, the sidecar is missing, or extraction fails, ingest reports a deterministic one-line
+error and leaves text-native/PDF-text ingest behavior unchanged.
 
 ## 4. Ingest the source
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -106,9 +106,10 @@ Image files and image-only PDFs require explicit OCR configuration. The current 
 provider is `sidecar-text`: set `sources.ocr_enabled: true`, keep
 `sources.ocr_provider: sidecar-text`, and place UTF-8 sidecar text next to the resolved source file
 using the configured suffix, default `.ocr.txt` (for example `diagram.png.ocr.txt`). Successful OCR
-ingest writes extracted text under `derived/ocr/` and links it from the source manifest. When OCR is
-not configured, the sidecar is missing, or extraction fails, ingest reports a deterministic one-line
-error and leaves text-native/PDF-text ingest behavior unchanged.
+ingest writes extracted text under `derived/ocr/`, writes sidecar checksum metadata under
+`derived/metadata/`, and links both artifacts from the source manifest. When OCR is not configured,
+the sidecar is missing, or extraction fails, ingest reports a deterministic one-line error and
+leaves text-native/PDF-text ingest behavior unchanged.
 
 ## 4. Ingest the source
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -155,14 +155,16 @@ Implemented fields:
   text-native sources, while extracted text artifacts are recorded in `derived_artifacts`.
 - Image sources and image-only PDFs use the same source registration and resolver contract. OCR is
   optional and explicitly configured; successful OCR-derived text is recorded in
-  `derived_artifacts` without changing the canonical source identity.
+  `derived_artifacts` without changing the canonical source identity. Sidecar OCR inputs are
+  tracked through metadata artifacts so no-op ingest can detect sidecar checksum drift.
 
 ### Derived artifacts
 
 `derived_artifacts` stores repo-relative paths to repairable machine-generated artifacts derived
 from the source. Current runtime support writes parsed text from text-bearing PDFs to
-`derived/parsed/<source-id>.txt` and configured OCR text to `derived/ocr/<source-id>.txt`; lint and
-health validate that listed artifacts are repo-relative, remain under `derived/`, and exist on disk.
+`derived/parsed/<source-id>.txt`, configured OCR text to `derived/ocr/<source-id>.txt`, and OCR
+sidecar metadata to `derived/metadata/<source-id>.ocr.json`; lint and health validate that listed
+artifacts are repo-relative, remain under `derived/`, and exist on disk.
 
 ### Recommended default policy
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -153,13 +153,16 @@ Implemented fields:
 - Text-bearing PDF sources are routed through source-type dispatch during ingest. The source
   manifest keeps the same `source_ref`, `source_ref_kind`, and `storage_mode` contract as
   text-native sources, while extracted text artifacts are recorded in `derived_artifacts`.
+- Image sources and image-only PDFs use the same source registration and resolver contract. OCR is
+  optional and explicitly configured; successful OCR-derived text is recorded in
+  `derived_artifacts` without changing the canonical source identity.
 
 ### Derived artifacts
 
 `derived_artifacts` stores repo-relative paths to repairable machine-generated artifacts derived
 from the source. Current runtime support writes parsed text from text-bearing PDFs to
-`derived/parsed/<source-id>.txt`; lint and health validate that listed artifacts are repo-relative,
-remain under `derived/`, and exist on disk. OCR/image-derived artifacts are intentionally deferred.
+`derived/parsed/<source-id>.txt` and configured OCR text to `derived/ocr/<source-id>.txt`; lint and
+health validate that listed artifacts are repo-relative, remain under `derived/`, and exist on disk.
 
 ### Recommended default policy
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M11-P3.1`
-- Current planned slice: `M12-P1`
-- Current PR sub-slice: `M12-P1.1`
+- Previous completed PR sub-slice: `M12-P1.1`
+- Current planned slice: `M12-P2`
+- Current PR sub-slice: `M12-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M12-P2`
-- Next planned PR sub-slice: `M12-P2.1`
+- Next planned slice: `M13-P1`
+- Next planned PR sub-slice: `M13-P1.1`
 
 `M10-P0.1` is implemented: the CLI-first wiki status and source-impact suggestion bridge is in
 place. `M10-P0.2` is implemented: project briefing and the non-mutating review-gated compile-loop
@@ -748,11 +748,16 @@ feed the same source-impact and compile/update workflow used for markdown and te
 
 ### Milestone 12 status
 
-`M12-P1.1` is in progress: it introduces source-type dispatch for ingestion and routes
+`M12-P1.1` is implemented: it introduced source-type dispatch for ingestion and routes
 text-bearing PDFs through deterministic local extraction. Parsed PDF text is stored under
 `derived/parsed/`, linked from source manifests through `derived_artifacts`, and used by the same
-source-summary/query path as text-native sources. OCR and image-only PDFs remain deferred to
-`M12-P2.1`.
+source-summary/query path as text-native sources.
+
+`M12-P2.1` is in progress: it adds explicitly configured image/OCR dispatch using a deterministic
+sidecar-text provider. OCR-derived text is stored separately under `derived/ocr/`, linked from
+source manifests through `derived_artifacts`, and used by the same generated source-summary/query
+path when extraction succeeds. Unconfigured or unextractable OCR/image sources fail
+deterministically without destabilizing text-native or text-bearing PDF ingest.
 
 ---
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -756,7 +756,8 @@ source-summary/query path as text-native sources.
 `M12-P2.1` is in progress: it adds explicitly configured image/OCR dispatch using a deterministic
 sidecar-text provider. OCR-derived text is stored separately under `derived/ocr/`, linked from
 source manifests through `derived_artifacts`, and used by the same generated source-summary/query
-path when extraction succeeds. Unconfigured or unextractable OCR/image sources fail
+path when extraction succeeds. Sidecar checksum metadata is stored under `derived/metadata/` so
+no-op ingest can detect OCR input drift. Unconfigured or unextractable OCR/image sources fail
 deterministically without destabilizing text-native or text-bearing PDF ingest.
 
 ---

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -630,6 +630,9 @@ Current implementation:
 - copied or external text sources default to `full`
 - text-bearing PDF sources are parsed through source-type dispatch, with extracted text written to
   `derived/parsed/<source-id>.txt` and linked from the source manifest via `derived_artifacts`
+- image sources and image-only PDFs may use explicitly configured OCR through the deterministic
+  `sidecar-text` provider, with extracted text written separately to
+  `derived/ocr/<source-id>.txt` and linked from the source manifest via `derived_artifacts`
 - projects may set either class to `none`, `excerpt`, or `full` through
   `sources.summarize_in_repo_extracts_as` and `sources.summarize_external_extracts_as`
 - when the mode is `none`, the `## Extract` section is omitted entirely
@@ -679,8 +682,10 @@ Current implementation:
   templates for default synthesis, research synthesis, and issue tracking.
 - `splendor ingest <source-id>` prints the generated source-summary page/run records and the next
   `splendor wiki suggest <source-id>` command.
-- PDF ingest is limited to deterministic local extraction for text-bearing PDFs. Image-only or
-  otherwise unextractable PDFs fail with a deterministic error and do not invoke OCR.
+- PDF ingest first uses deterministic local extraction for text-bearing PDFs. Image-only PDFs and
+  image sources only enter OCR when `sources.ocr_enabled` is true; the current local provider reads
+  adjacent sidecar text files named with `sources.ocr_sidecar_suffix` and writes normalized output
+  under `derived/ocr/`.
 - `splendor ingest --pending` prints the next `wiki suggest` command when exactly one source was
   ingested, or points back to `wiki status` for batch follow-up.
 - `splendor wiki status` reports source, page, queue, run, review, contested, stale,
@@ -702,8 +707,8 @@ Current implementation:
   slice.
 
 Later optional support:
-- image-based sources
-- OCR-derived flows
+- additional OCR providers
+- image captioning or metadata extraction
 - audio/transcript flows
 
 ## 14.7 OCR/LLM-assisted extraction
@@ -715,6 +720,11 @@ For harder formats, ingestion may optionally invoke:
 - summary generation
 
 These outputs should be stored as **derived artifacts**, not mixed directly into raw source files.
+Current OCR support is explicitly configured and local: `sources.ocr_enabled: true` with
+`sources.ocr_provider: sidecar-text` reads UTF-8 sidecar text next to the resolved source artifact
+using `sources.ocr_sidecar_suffix` and records the resulting artifact under `derived/ocr/`.
+Unconfigured, missing-sidecar, invalid UTF-8, and empty OCR text cases fail with deterministic
+one-line ingest errors.
 
 ## 15. Idempotency and Atomicity
 
@@ -1062,6 +1072,12 @@ Likely configuration domains:
 - planning schema conventions
 - GitHub integration toggles
 - policy rules
+
+Current OCR-related source settings:
+- `sources.ocr_enabled`: opt-in OCR/image extraction toggle, default `false`
+- `sources.ocr_provider`: OCR provider name, currently `sidecar-text`
+- `sources.ocr_sidecar_suffix`: sidecar suffix appended to the resolved source path, default
+  `.ocr.txt`
 
 ## 28. Minimum Opinionated Core
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -632,7 +632,9 @@ Current implementation:
   `derived/parsed/<source-id>.txt` and linked from the source manifest via `derived_artifacts`
 - image sources and image-only PDFs may use explicitly configured OCR through the deterministic
   `sidecar-text` provider, with extracted text written separately to
-  `derived/ocr/<source-id>.txt` and linked from the source manifest via `derived_artifacts`
+  `derived/ocr/<source-id>.txt`, sidecar checksum metadata written to
+  `derived/metadata/<source-id>.ocr.json`, and both artifacts linked from the source manifest via
+  `derived_artifacts`
 - projects may set either class to `none`, `excerpt`, or `full` through
   `sources.summarize_in_repo_extracts_as` and `sources.summarize_external_extracts_as`
 - when the mode is `none`, the `## Extract` section is omitted entirely
@@ -685,7 +687,7 @@ Current implementation:
 - PDF ingest first uses deterministic local extraction for text-bearing PDFs. Image-only PDFs and
   image sources only enter OCR when `sources.ocr_enabled` is true; the current local provider reads
   adjacent sidecar text files named with `sources.ocr_sidecar_suffix` and writes normalized output
-  under `derived/ocr/`.
+  under `derived/ocr/` plus sidecar checksum metadata under `derived/metadata/`.
 - `splendor ingest --pending` prints the next `wiki suggest` command when exactly one source was
   ingested, or points back to `wiki status` for batch follow-up.
 - `splendor wiki status` reports source, page, queue, run, review, contested, stale,
@@ -722,9 +724,11 @@ For harder formats, ingestion may optionally invoke:
 These outputs should be stored as **derived artifacts**, not mixed directly into raw source files.
 Current OCR support is explicitly configured and local: `sources.ocr_enabled: true` with
 `sources.ocr_provider: sidecar-text` reads UTF-8 sidecar text next to the resolved source artifact
-using `sources.ocr_sidecar_suffix` and records the resulting artifact under `derived/ocr/`.
-Unconfigured, missing-sidecar, invalid UTF-8, and empty OCR text cases fail with deterministic
-one-line ingest errors.
+using `sources.ocr_sidecar_suffix`, records the resulting artifact under `derived/ocr/`, and records
+sidecar ref/checksum metadata under `derived/metadata/` so sidecar changes invalidate no-op ingest.
+For copied external sources, sidecar lookup first checks next to the stored source artifact and then
+next to the original local source path. Unconfigured, missing-sidecar, invalid UTF-8, and empty OCR
+text cases fail with deterministic one-line ingest errors.
 
 ## 15. Idempotency and Atomicity
 

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -492,7 +492,7 @@ def _is_no_op(root: Path, layout, source: SourceRecord) -> bool:
             return False
 
     run = load_run_record(run_path)
-    if not _ocr_metadata_is_current(root, source):
+    if not _ocr_metadata_is_current(root, layout, source):
         return False
     return run.status == "succeeded" and run.pipeline_version == __version__
 
@@ -501,12 +501,10 @@ def is_ingest_current(root: Path, layout, source: SourceRecord) -> bool:
     return _is_no_op(root, layout, source)
 
 
-def _ocr_metadata_is_current(root: Path, source: SourceRecord) -> bool:
-    metadata_refs = [
-        artifact_ref
-        for artifact_ref in source.derived_artifacts
-        if artifact_ref.startswith("derived/metadata/") and artifact_ref.endswith(".ocr.json")
-    ]
+def _ocr_metadata_is_current(root: Path, layout, source: SourceRecord) -> bool:
+    metadata_refs = _ocr_metadata_artifact_refs(root, layout, source)
+    if metadata_refs is None:
+        return False
     if not metadata_refs:
         return True
 
@@ -536,6 +534,24 @@ def _ocr_metadata_is_current(root: Path, source: SourceRecord) -> bool:
         if sha256_file(sidecar_path) != sidecar_checksum:
             return False
     return True
+
+
+def _ocr_metadata_artifact_refs(root: Path, layout, source: SourceRecord) -> list[str] | None:
+    metadata_root = layout.derived_metadata_dir.resolve()
+    metadata_refs: list[str] = []
+    for artifact_ref in source.derived_artifacts:
+        if not artifact_ref.endswith(".ocr.json"):
+            continue
+        try:
+            artifact_path = resolve_workspace_path(root, artifact_ref, context="OCR metadata")
+        except ValueError:
+            return None
+        try:
+            artifact_path.resolve().relative_to(metadata_root)
+        except ValueError:
+            continue
+        metadata_refs.append(artifact_ref)
+    return metadata_refs
 
 
 def _validate_workspace_files(layout) -> None:

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from dataclasses import dataclass
@@ -49,6 +50,7 @@ from splendor.utils.contradictions import (
     snapshot_from_rendered_page,
 )
 from splendor.utils.fs import write_text_atomic
+from splendor.utils.hashing import sha256_file
 from splendor.utils.provenance import dedupe_provenance_links, make_provenance_link
 from splendor.utils.time import parse_aware_timestamp_or_none, utc_now_iso
 from splendor.utils.wiki import (
@@ -262,6 +264,26 @@ def _content_origin_kind(storage_mode: str) -> str:
     return "workspace_path"
 
 
+def _workspace_relative_ref_or_none(root: Path, path_ref: str | None) -> str | None:
+    if path_ref is None:
+        return None
+    path = Path(path_ref)
+    if path.is_absolute():
+        try:
+            return path.resolve().relative_to(root.resolve()).as_posix()
+        except ValueError:
+            return None
+    if ".." in path.parts:
+        return None
+    return path.as_posix()
+
+
+def _input_artifact_note(path_ref: str | None, checksum: str | None) -> str | None:
+    if path_ref is None or checksum is None:
+        return None
+    return f"OCR sidecar: {path_ref} sha256={checksum}"
+
+
 def _best_available_source_ref(source: SourceRecord) -> str:
     if effective_storage_mode(source) == "none":
         return canonical_source_ref(source)
@@ -294,6 +316,7 @@ def _page_provenance_links(
     run_id: str,
     manifest_ref: str,
     resolved_ref: str,
+    input_artifact_ref: str | None = None,
 ) -> list[ProvenanceLink]:
     return dedupe_provenance_links(
         [
@@ -304,6 +327,11 @@ def _page_provenance_links(
             ),
             make_provenance_link(run_id=run_id, role="generated-from"),
             make_provenance_link(path_ref=resolved_ref, role="input"),
+            *(
+                [make_provenance_link(path_ref=input_artifact_ref, role="input")]
+                if input_artifact_ref is not None
+                else []
+            ),
         ]
     )
 
@@ -335,11 +363,35 @@ def _run_input_provenance_links(
     source_id: str,
     manifest_ref: str,
     resolved_ref: str,
+    input_artifact_ref: str | None = None,
+    input_artifact_note: str | None = None,
 ) -> list[ProvenanceLink]:
     return dedupe_provenance_links(
         [
             make_provenance_link(source_id=source_id, path_ref=manifest_ref, role="input"),
             make_provenance_link(source_id=source_id, path_ref=resolved_ref, role="input"),
+            *(
+                [
+                    make_provenance_link(
+                        source_id=source_id,
+                        path_ref=input_artifact_ref,
+                        role="input",
+                    )
+                ]
+                if input_artifact_ref is not None
+                else []
+            ),
+            *(
+                [
+                    make_provenance_link(
+                        source_id=source_id,
+                        role="input",
+                        note=input_artifact_note,
+                    )
+                ]
+                if input_artifact_note is not None
+                else []
+            ),
         ]
     )
 
@@ -353,6 +405,8 @@ def _run_success_provenance_links(
     page_ref: str,
     run_id: str,
     derived_artifacts: list[str],
+    input_artifact_ref: str | None = None,
+    input_artifact_note: str | None = None,
 ) -> list[ProvenanceLink]:
     return dedupe_provenance_links(
         [
@@ -360,6 +414,8 @@ def _run_success_provenance_links(
                 source_id=source_id,
                 manifest_ref=manifest_ref,
                 resolved_ref=resolved_ref,
+                input_artifact_ref=input_artifact_ref,
+                input_artifact_note=input_artifact_note,
             ),
             make_provenance_link(page_id=page_id, path_ref=page_ref, role="generated-page"),
             make_provenance_link(run_id=run_id, page_id=page_id, role="output"),
@@ -436,11 +492,50 @@ def _is_no_op(root: Path, layout, source: SourceRecord) -> bool:
             return False
 
     run = load_run_record(run_path)
+    if not _ocr_metadata_is_current(root, source):
+        return False
     return run.status == "succeeded" and run.pipeline_version == __version__
 
 
 def is_ingest_current(root: Path, layout, source: SourceRecord) -> bool:
     return _is_no_op(root, layout, source)
+
+
+def _ocr_metadata_is_current(root: Path, source: SourceRecord) -> bool:
+    metadata_refs = [
+        artifact_ref
+        for artifact_ref in source.derived_artifacts
+        if artifact_ref.startswith("derived/metadata/") and artifact_ref.endswith(".ocr.json")
+    ]
+    if not metadata_refs:
+        return True
+
+    for metadata_ref in metadata_refs:
+        try:
+            metadata_path = resolve_workspace_path(root, metadata_ref, context="OCR metadata")
+        except ValueError:
+            return False
+        if not metadata_path.is_file():
+            return False
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return False
+        sidecar_ref = metadata.get("sidecar_ref")
+        sidecar_checksum = metadata.get("sidecar_checksum")
+        if not isinstance(sidecar_ref, str) or not isinstance(sidecar_checksum, str):
+            return False
+        sidecar_path = Path(sidecar_ref).expanduser()
+        if not sidecar_path.is_absolute():
+            try:
+                sidecar_path = resolve_workspace_path(root, sidecar_ref, context="OCR sidecar")
+            except ValueError:
+                return False
+        if not sidecar_path.is_file():
+            return False
+        if sha256_file(sidecar_path) != sidecar_checksum:
+            return False
+    return True
 
 
 def _validate_workspace_files(layout) -> None:
@@ -773,7 +868,40 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
             if dispatched_content.derived_artifact_path is not None
             else None
         )
-        derived_artifacts = [derived_artifact_ref] if derived_artifact_ref is not None else []
+        metadata_artifact_ref = (
+            _relative_to_root(root, dispatched_content.metadata_artifact_path)
+            if dispatched_content.metadata_artifact_path is not None
+            else None
+        )
+        derived_artifacts = [
+            artifact_ref
+            for artifact_ref in [derived_artifact_ref, metadata_artifact_ref]
+            if artifact_ref is not None
+        ]
+        input_artifact_ref = _workspace_relative_ref_or_none(
+            root, dispatched_content.input_artifact_ref
+        )
+        input_artifact_note = _input_artifact_note(
+            dispatched_content.input_artifact_ref,
+            dispatched_content.input_artifact_checksum,
+        )
+        run = run.model_copy(
+            update={
+                "input_refs": [
+                    _relative_to_root(root, manifest_path),
+                    resolved_source.resolved_ref,
+                    *([input_artifact_ref] if input_artifact_ref is not None else []),
+                ],
+                "provenance_links": _run_input_provenance_links(
+                    source_id=source.source_id,
+                    manifest_ref=_relative_to_root(root, manifest_path),
+                    resolved_ref=resolved_source.resolved_ref,
+                    input_artifact_ref=input_artifact_ref,
+                    input_artifact_note=input_artifact_note,
+                ),
+            }
+        )
+        write_run_record(run_path, run)
 
         extract_mode = _summary_mode_for(config, source)
         page_path = _page_path_for(layout.wiki_sources_dir, source.source_id)
@@ -796,6 +924,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
                 run_id=run_id,
                 manifest_ref=_relative_to_root(root, manifest_path),
                 resolved_ref=resolved_source.resolved_ref,
+                input_artifact_ref=input_artifact_ref,
             ),
         )
         source_section = "\n".join(
@@ -826,6 +955,16 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
             *(
                 [f"{dispatched_content.derived_artifact_label}: `{derived_artifact_ref}`"]
                 if derived_artifact_ref is not None
+                else []
+            ),
+            *(
+                [f"OCR metadata artifact: `{metadata_artifact_ref}`"]
+                if metadata_artifact_ref is not None
+                else []
+            ),
+            *(
+                [f"OCR sidecar: `{dispatched_content.input_artifact_ref}`"]
+                if dispatched_content.input_artifact_ref is not None
                 else []
             ),
             f"Run ID: `{run_id}`",
@@ -926,6 +1065,8 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
                     page_ref=page_relpath,
                     run_id=run_id,
                     derived_artifacts=derived_artifacts,
+                    input_artifact_ref=input_artifact_ref,
+                    input_artifact_note=input_artifact_note,
                 ),
             }
         )
@@ -961,6 +1102,17 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
                         ]
                         if dispatched_content.derived_artifact_path is not None
                         and dispatched_content.derived_artifact_content is not None
+                        else []
+                    ),
+                    *(
+                        [
+                            (
+                                dispatched_content.metadata_artifact_path,
+                                dispatched_content.metadata_artifact_content,
+                            )
+                        ]
+                        if dispatched_content.metadata_artifact_path is not None
+                        and dispatched_content.metadata_artifact_content is not None
                         else []
                     ),
                     *contradiction_review.page_updates,

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from splendor import __version__
 from splendor.config import load_config
-from splendor.ingest_dispatch import dispatch_source_content
+from splendor.ingest_dispatch import IMAGE_SOURCE_TYPES, dispatch_source_content
 from splendor.layout import resolve_layout
 from splendor.schemas import (
     KnowledgePageFrontmatter,
@@ -162,7 +162,10 @@ def _rendered_extract(text: str, mode: SummaryMode) -> str | None:
 def _build_summary(source: SourceRecord, source_text: str) -> str:
     path_fragment = canonical_source_ref(source)
     content_summary = _build_content_summary(source_text)
-    if source.source_type in {"md", "txt", "pdf"} and content_summary is not None:
+    if (
+        source.source_type in {"md", "txt", "pdf", *IMAGE_SOURCE_TYPES}
+        and content_summary is not None
+    ):
         return f"{content_summary} registered from `{path_fragment}`."
     return (
         f"This page records deterministic ingestion output for source `{source.source_id}`, "
@@ -758,7 +761,12 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
         )
         write_run_record(run_path, run)
 
-        dispatched_content = dispatch_source_content(source, resolved_source, layout=layout)
+        dispatched_content = dispatch_source_content(
+            source,
+            resolved_source,
+            layout=layout,
+            config=config,
+        )
         source_text = dispatched_content.text
         derived_artifact_ref = (
             _relative_to_root(root, dispatched_content.derived_artifact_path)
@@ -798,7 +806,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
                 f"- Source file: `{resolved_source.resolved_ref}`",
             ]
             + (
-                [f"- Parsed artifact: `{derived_artifact_ref}`"]
+                [f"- {dispatched_content.derived_artifact_label}: `{derived_artifact_ref}`"]
                 if derived_artifact_ref is not None
                 else []
             )
@@ -816,7 +824,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
             f"Manifest: `{_relative_to_root(root, manifest_path)}`",
             f"{resolved_source.content_origin_label}: `{resolved_source.resolved_ref}`",
             *(
-                [f"Parsed artifact: `{derived_artifact_ref}`"]
+                [f"{dispatched_content.derived_artifact_label}: `{derived_artifact_ref}`"]
                 if derived_artifact_ref is not None
                 else []
             ),

--- a/src/splendor/commands/repo_scan.py
+++ b/src/splendor/commands/repo_scan.py
@@ -8,14 +8,16 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from splendor.config import load_config
-from splendor.ingest_dispatch import SUPPORTED_SOURCE_TYPES
+from splendor.ingest_dispatch import IMAGE_SOURCE_TYPES, SUPPORTED_SOURCE_TYPES
 from splendor.layout import resolve_layout
 from splendor.schemas.types import SourceClass
 from splendor.state.source_registry import register_source
 
 _CONFIG_EXTENSIONS = {"json", "yaml", "yml"}
 _DOCUMENTATION_EXTENSIONS = {"md", "pdf", "txt"}
-_CODE_EXTENSIONS = SUPPORTED_SOURCE_TYPES - _CONFIG_EXTENSIONS - _DOCUMENTATION_EXTENSIONS
+_CODE_EXTENSIONS = (
+    SUPPORTED_SOURCE_TYPES - _CONFIG_EXTENSIONS - _DOCUMENTATION_EXTENSIONS - IMAGE_SOURCE_TYPES
+)
 _IGNORED_TOP_LEVEL_DIRS = {
     ".git",
     ".pytest_cache",

--- a/src/splendor/config.py
+++ b/src/splendor/config.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field
@@ -43,7 +43,7 @@ class SourcesConfig(BaseModel):
     summarize_in_repo_extracts_as: SummaryMode = "excerpt"
     summarize_external_extracts_as: SummaryMode = "full"
     ocr_enabled: bool = False
-    ocr_provider: Literal["sidecar-text"] = "sidecar-text"
+    ocr_provider: str = "sidecar-text"
     ocr_sidecar_suffix: str = ".ocr.txt"
 
 

--- a/src/splendor/config.py
+++ b/src/splendor/config.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field
@@ -42,6 +42,9 @@ class SourcesConfig(BaseModel):
     capture_source_commit: bool = True
     summarize_in_repo_extracts_as: SummaryMode = "excerpt"
     summarize_external_extracts_as: SummaryMode = "full"
+    ocr_enabled: bool = False
+    ocr_provider: Literal["sidecar-text"] = "sidecar-text"
+    ocr_sidecar_suffix: str = ".ocr.txt"
 
 
 class ContradictionsReviewConfig(BaseModel):

--- a/src/splendor/ingest_dispatch.py
+++ b/src/splendor/ingest_dispatch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -10,6 +11,7 @@ from pypdf import PdfReader
 from splendor.layout import ResolvedLayout
 from splendor.schemas import SourceRecord
 from splendor.state.source_resolver import ResolvedSource
+from splendor.utils.hashing import sha256_file
 
 TEXT_SOURCE_TYPES = {
     "md",
@@ -40,6 +42,11 @@ class DispatchedSourceContent:
     derived_artifact_path: Path | None = None
     derived_artifact_content: str | None = None
     derived_artifact_label: str = "Parsed artifact"
+    metadata_artifact_path: Path | None = None
+    metadata_artifact_content: str | None = None
+    input_artifact_path: Path | None = None
+    input_artifact_ref: str | None = None
+    input_artifact_checksum: str | None = None
 
 
 def dispatch_source_content(
@@ -117,10 +124,12 @@ def _extract_ocr_source(
         msg = f"OCR provider is not supported: {config.sources.ocr_provider}"
         raise ValueError(msg)
 
-    sidecar_path = _ocr_sidecar_path(
-        resolved_source.resolved_path,
+    sidecar_path = _resolve_ocr_sidecar_path(
+        source,
+        resolved_source,
         sidecar_suffix=config.sources.ocr_sidecar_suffix,
     )
+    sidecar_ref = _path_ref_for_sidecar(layout.root, sidecar_path)
     if not sidecar_path.is_file():
         msg = f"OCR sidecar text is missing for {resolved_source.resolved_ref}: {sidecar_path.name}"
         raise ValueError(msg)
@@ -136,17 +145,74 @@ def _extract_ocr_source(
         msg = f"OCR sidecar text is empty for {resolved_source.resolved_ref}: {sidecar_path.name}"
         raise ValueError(msg)
 
+    sidecar_checksum = sha256_file(sidecar_path)
+    metadata_content = _ocr_metadata_content(
+        source=source,
+        resolved_source=resolved_source,
+        sidecar_ref=sidecar_ref,
+        sidecar_checksum=sidecar_checksum,
+        provider=config.sources.ocr_provider,
+        sidecar_suffix=config.sources.ocr_sidecar_suffix,
+    )
     return DispatchedSourceContent(
         text=extracted_text,
         derived_artifact_path=layout.derived_ocr_dir / f"{source.source_id}.txt",
         derived_artifact_content=f"{extracted_text}\n",
         derived_artifact_label="OCR artifact",
+        metadata_artifact_path=layout.derived_metadata_dir / f"{source.source_id}.ocr.json",
+        metadata_artifact_content=metadata_content,
+        input_artifact_path=sidecar_path,
+        input_artifact_ref=sidecar_ref,
+        input_artifact_checksum=sidecar_checksum,
     )
-
-
-def _ocr_sidecar_path(path: Path, *, sidecar_suffix: str) -> Path:
-    return Path(f"{path}{sidecar_suffix}")
 
 
 def _normalize_ocr_text(text: str) -> str:
     return text.replace("\r\n", "\n").replace("\r", "\n").strip()
+
+
+def _resolve_ocr_sidecar_path(
+    source: SourceRecord,
+    resolved_source: ResolvedSource,
+    *,
+    sidecar_suffix: str,
+) -> Path:
+    candidates = [Path(f"{resolved_source.resolved_path}{sidecar_suffix}")]
+    if source.source_ref_kind == "external_path" and source.source_ref:
+        source_ref_path = Path(source.source_ref).expanduser()
+        if source_ref_path.is_absolute():
+            candidates.append(Path(f"{source_ref_path}{sidecar_suffix}"))
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return candidates[0]
+
+
+def _path_ref_for_sidecar(root: Path, sidecar_path: Path) -> str:
+    resolved = sidecar_path.expanduser().resolve()
+    try:
+        return resolved.relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def _ocr_metadata_content(
+    *,
+    source: SourceRecord,
+    resolved_source: ResolvedSource,
+    sidecar_ref: str,
+    sidecar_checksum: str,
+    provider: str,
+    sidecar_suffix: str,
+) -> str:
+    payload = {
+        "kind": "ocr_metadata",
+        "source_id": source.source_id,
+        "provider": provider,
+        "sidecar_suffix": sidecar_suffix,
+        "sidecar_ref": sidecar_ref,
+        "sidecar_checksum": sidecar_checksum,
+        "resolved_source_ref": resolved_source.resolved_ref,
+    }
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"

--- a/src/splendor/ingest_dispatch.py
+++ b/src/splendor/ingest_dispatch.py
@@ -30,7 +30,8 @@ TEXT_SOURCE_TYPES = {
     "hpp",
     "sh",
 }
-SUPPORTED_SOURCE_TYPES = {*TEXT_SOURCE_TYPES, "pdf"}
+IMAGE_SOURCE_TYPES = {"png", "jpg", "jpeg", "tif", "tiff", "bmp", "webp"}
+SUPPORTED_SOURCE_TYPES = {*TEXT_SOURCE_TYPES, "pdf", *IMAGE_SOURCE_TYPES}
 
 
 @dataclass(frozen=True)
@@ -38,6 +39,7 @@ class DispatchedSourceContent:
     text: str
     derived_artifact_path: Path | None = None
     derived_artifact_content: str | None = None
+    derived_artifact_label: str = "Parsed artifact"
 
 
 def dispatch_source_content(
@@ -45,11 +47,14 @@ def dispatch_source_content(
     resolved_source: ResolvedSource,
     *,
     layout: ResolvedLayout,
+    config,
 ) -> DispatchedSourceContent:
     if source.source_type in TEXT_SOURCE_TYPES:
         return _read_text_source(resolved_source.resolved_path)
     if source.source_type == "pdf":
-        return _extract_pdf_source(source, resolved_source, layout=layout)
+        return _extract_pdf_source(source, resolved_source, layout=layout, config=config)
+    if source.source_type in IMAGE_SOURCE_TYPES:
+        return _extract_ocr_source(source, resolved_source, layout=layout, config=config)
 
     msg = f"Unsupported source type for ingestion: {source.source_type}"
     raise ValueError(msg)
@@ -68,6 +73,7 @@ def _extract_pdf_source(
     resolved_source: ResolvedSource,
     *,
     layout: ResolvedLayout,
+    config,
 ) -> DispatchedSourceContent:
     try:
         reader = PdfReader(str(resolved_source.resolved_path))
@@ -78,11 +84,7 @@ def _extract_pdf_source(
 
     extracted_text = _normalize_pdf_text(page_texts)
     if not extracted_text:
-        msg = (
-            "PDF source has no extractable text; OCR/image extraction is not supported: "
-            f"{resolved_source.resolved_ref}"
-        )
-        raise ValueError(msg)
+        return _extract_ocr_source(source, resolved_source, layout=layout, config=config)
 
     artifact_content = f"{extracted_text}\n"
     return DispatchedSourceContent(
@@ -99,3 +101,52 @@ def _normalize_pdf_text(page_texts: list[str]) -> str:
         if normalized:
             normalized_pages.append(normalized)
     return "\n\n".join(normalized_pages).strip()
+
+
+def _extract_ocr_source(
+    source: SourceRecord,
+    resolved_source: ResolvedSource,
+    *,
+    layout: ResolvedLayout,
+    config,
+) -> DispatchedSourceContent:
+    if not config.sources.ocr_enabled:
+        msg = f"OCR/image extraction is not configured: {resolved_source.resolved_ref}"
+        raise ValueError(msg)
+    if config.sources.ocr_provider != "sidecar-text":
+        msg = f"OCR provider is not supported: {config.sources.ocr_provider}"
+        raise ValueError(msg)
+
+    sidecar_path = _ocr_sidecar_path(
+        resolved_source.resolved_path,
+        sidecar_suffix=config.sources.ocr_sidecar_suffix,
+    )
+    if not sidecar_path.is_file():
+        msg = f"OCR sidecar text is missing for {resolved_source.resolved_ref}: {sidecar_path.name}"
+        raise ValueError(msg)
+
+    try:
+        ocr_text = sidecar_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        msg = f"OCR sidecar text is not valid UTF-8: {sidecar_path.name}"
+        raise ValueError(msg) from exc
+
+    extracted_text = _normalize_ocr_text(ocr_text)
+    if not extracted_text:
+        msg = f"OCR sidecar text is empty for {resolved_source.resolved_ref}: {sidecar_path.name}"
+        raise ValueError(msg)
+
+    return DispatchedSourceContent(
+        text=extracted_text,
+        derived_artifact_path=layout.derived_ocr_dir / f"{source.source_id}.txt",
+        derived_artifact_content=f"{extracted_text}\n",
+        derived_artifact_label="OCR artifact",
+    )
+
+
+def _ocr_sidecar_path(path: Path, *, sidecar_suffix: str) -> Path:
+    return Path(f"{path}{sidecar_suffix}")
+
+
+def _normalize_ocr_text(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n").strip()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -45,6 +45,24 @@ def test_run_health_checks_reports_missing_source_derived_artifact(tmp_path: Pat
     assert result.issues[0].path == added.manifest_path.relative_to(tmp_path).as_posix()
 
 
+def test_run_health_checks_accepts_ocr_derived_artifact_links(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "diagram.png"
+    source.write_bytes(b"\x89PNG\r\n\x1a\n")
+    added = add_source(tmp_path, source)
+    artifact = tmp_path / "derived" / "ocr" / f"{added.source_id}.txt"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text("Extracted OCR text\n", encoding="utf-8")
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={"derived_artifacts": [artifact.relative_to(tmp_path).as_posix()]}
+    )
+    write_source_record(added.manifest_path, source_record)
+
+    result = _run_health(tmp_path)
+
+    assert result.issues == []
+
+
 def test_run_health_checks_reports_invalid_queue_and_run_records(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     (tmp_path / "state" / "queue" / "ingest-bad.json").write_text("{bad json}\n", encoding="utf-8")

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -396,6 +396,48 @@ def test_ingest_source_image_fails_when_configured_ocr_sidecar_missing(tmp_path:
     )
 
 
+def test_ingest_source_image_fails_when_ocr_sidecar_is_invalid_utf8(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    enable_sidecar_ocr(tmp_path)
+    source = tmp_path / "diagram.png"
+    source.write_bytes(b"\x89PNG\r\n\x1a\n")
+    Path(f"{source}.ocr.txt").write_bytes(b"\xff\xfe\xfa")
+    added = add_source(tmp_path, source)
+
+    with pytest.raises(ValueError, match="^OCR sidecar text is not valid UTF-8"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.derived_artifacts == []
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.status == "failed"
+    assert queue_record.last_error == "OCR sidecar text is not valid UTF-8: diagram.png.ocr.txt"
+
+
+def test_ingest_source_image_fails_when_ocr_sidecar_is_empty(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    enable_sidecar_ocr(tmp_path)
+    source = tmp_path / "diagram.png"
+    source.write_bytes(b"\x89PNG\r\n\x1a\n")
+    Path(f"{source}.ocr.txt").write_text("  \n\t\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    with pytest.raises(ValueError, match="^OCR sidecar text is empty for diagram.png"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.derived_artifacts == []
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.status == "failed"
+    assert (
+        queue_record.last_error == "OCR sidecar text is empty for diagram.png: diagram.png.ocr.txt"
+    )
+
+
 def test_ingest_source_image_only_pdf_can_use_configured_ocr_sidecar(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     enable_sidecar_ocr(tmp_path)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -46,6 +46,14 @@ def update_summary_modes(
     write_config(root, config)
 
 
+def enable_sidecar_ocr(root: Path, *, suffix: str = ".ocr.txt") -> None:
+    config = load_config(root)
+    config.sources.ocr_enabled = True
+    config.sources.ocr_provider = "sidecar-text"
+    config.sources.ocr_sidecar_suffix = suffix
+    write_config(root, config)
+
+
 def rewrite_pointer(
     root: Path,
     source_id: str,
@@ -283,7 +291,7 @@ def test_ingest_source_pdf_without_text_fails_without_ocr(tmp_path: Path) -> Non
         writer.write(handle)
     added = add_source(tmp_path, source)
 
-    with pytest.raises(ValueError, match="OCR/image extraction is not supported"):
+    with pytest.raises(ValueError, match="OCR/image extraction is not configured"):
         ingest_source(tmp_path, added.source_id)
 
     source_record = load_source_record(added.manifest_path)
@@ -293,7 +301,114 @@ def test_ingest_source_pdf_without_text_fails_without_ocr(tmp_path: Path) -> Non
     queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
     queue_record = load_queue_item(queue_path)
     assert queue_record.status == "failed"
-    assert "OCR/image extraction is not supported" in (queue_record.last_error or "")
+    assert "OCR/image extraction is not configured" in (queue_record.last_error or "")
+
+
+def test_ingest_source_image_requires_configured_ocr(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "diagram.png"
+    source.write_bytes(b"\x89PNG\r\n\x1a\n")
+    added = add_source(tmp_path, source)
+
+    with pytest.raises(ValueError, match="^OCR/image extraction is not configured: diagram.png$"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.derived_artifacts == []
+    assert not (tmp_path / "derived" / "ocr" / f"{added.source_id}.txt").exists()
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.status == "failed"
+    assert queue_record.last_error == "OCR/image extraction is not configured: diagram.png"
+
+
+def test_ingest_source_image_writes_ocr_artifact_and_links_manifest(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    enable_sidecar_ocr(tmp_path)
+    source = tmp_path / "diagram.png"
+    source.write_bytes(b"\x89PNG\r\n\x1a\n")
+    Path(f"{source}.ocr.txt").write_text(
+        "# Diagram Notes\n\nOCR claim from image source.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    frontmatter, body = parse_frontmatter(result.page_path)
+    assert frontmatter.tags == ["source-summary", "png"]
+    assert "OCR artifact: `derived/ocr/" in body
+    assert "OCR claim from image source." in body
+    assert "Parsed artifact:" not in body
+
+    ocr_artifact = tmp_path / "derived" / "ocr" / f"{added.source_id}.txt"
+    assert ocr_artifact.read_text(encoding="utf-8") == (
+        "# Diagram Notes\n\nOCR claim from image source.\n"
+    )
+
+    source_record = load_source_record(added.manifest_path)
+    artifact_ref = ocr_artifact.relative_to(tmp_path).as_posix()
+    assert source_record.source_ref == "diagram.png"
+    assert source_record.storage_mode == "none"
+    assert source_record.derived_artifacts == [artifact_ref]
+    assert any(link.path_ref == artifact_ref for link in source_record.provenance_links)
+
+    run_record = load_run_record(result.run_path)
+    assert artifact_ref in run_record.output_refs
+    assert any(
+        link.path_ref == artifact_ref
+        and link.source_id == added.source_id
+        and link.run_id == result.run_id
+        and link.role == "output"
+        for link in run_record.provenance_links
+    )
+
+
+def test_ingest_source_image_fails_when_configured_ocr_sidecar_missing(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    enable_sidecar_ocr(tmp_path)
+    source = tmp_path / "diagram.png"
+    source.write_bytes(b"\x89PNG\r\n\x1a\n")
+    added = add_source(tmp_path, source)
+
+    with pytest.raises(ValueError, match="^OCR sidecar text is missing for diagram.png"):
+        ingest_source(tmp_path, added.source_id)
+
+    source_record = load_source_record(added.manifest_path)
+    assert source_record.status == "failed"
+    assert source_record.derived_artifacts == []
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
+    queue_record = load_queue_item(queue_path)
+    assert queue_record.status == "failed"
+    assert (
+        queue_record.last_error
+        == "OCR sidecar text is missing for diagram.png: diagram.png.ocr.txt"
+    )
+
+
+def test_ingest_source_image_only_pdf_can_use_configured_ocr_sidecar(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    enable_sidecar_ocr(tmp_path)
+    source = tmp_path / "scan.pdf"
+    writer = PdfWriter()
+    writer.add_blank_page(width=612, height=792)
+    with source.open("wb") as handle:
+        writer.write(handle)
+    Path(f"{source}.ocr.txt").write_text("OCR text from scanned PDF.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    frontmatter, body = parse_frontmatter(result.page_path)
+    assert frontmatter.tags == ["source-summary", "pdf"]
+    assert "OCR artifact: `derived/ocr/" in body
+    assert "Parsed artifact:" not in body
+    assert "OCR text from scanned PDF." in body
+    assert (tmp_path / "derived" / "ocr" / f"{added.source_id}.txt").is_file()
+    assert not (tmp_path / "derived" / "parsed" / f"{added.source_id}.txt").exists()
 
 
 def test_ingest_source_malformed_pdf_uses_stable_error(tmp_path: Path) -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -484,6 +484,35 @@ def test_ingest_source_ocr_sidecar_change_forces_reingest(tmp_path: Path) -> Non
     assert metadata["sidecar_ref"] == "diagram.png.ocr.txt"
 
 
+def test_ingest_source_ocr_sidecar_change_forces_reingest_with_custom_metadata_dir(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.layout.derived_metadata_dir = "custom-derived/metadata"
+    config.sources.ocr_enabled = True
+    config.sources.ocr_provider = "sidecar-text"
+    write_config(tmp_path, config)
+    source = tmp_path / "diagram.png"
+    sidecar = Path(f"{source}.ocr.txt")
+    source.write_bytes(b"\x89PNG\r\n\x1a\n")
+    sidecar.write_text("Initial OCR text.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    first = ingest_source(tmp_path, added.source_id)
+    sidecar.write_text("Updated OCR text.\n", encoding="utf-8")
+    second = ingest_source(tmp_path, added.source_id)
+
+    assert first.no_op is False
+    assert second.no_op is False
+    metadata_artifact = tmp_path / "custom-derived" / "metadata" / f"{added.source_id}.ocr.json"
+    assert metadata_artifact.is_file()
+    manifest = load_source_record(added.manifest_path)
+    assert metadata_artifact.relative_to(tmp_path).as_posix() in manifest.derived_artifacts
+    ocr_artifact = tmp_path / "derived" / "ocr" / f"{added.source_id}.txt"
+    assert ocr_artifact.read_text(encoding="utf-8") == "Updated OCR text.\n"
+
+
 def test_ingest_source_external_image_uses_original_sidecar_for_copied_source(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -344,19 +344,27 @@ def test_ingest_source_image_writes_ocr_artifact_and_links_manifest(tmp_path: Pa
     assert "Parsed artifact:" not in body
 
     ocr_artifact = tmp_path / "derived" / "ocr" / f"{added.source_id}.txt"
+    metadata_artifact = tmp_path / "derived" / "metadata" / f"{added.source_id}.ocr.json"
     assert ocr_artifact.read_text(encoding="utf-8") == (
         "# Diagram Notes\n\nOCR claim from image source.\n"
     )
+    metadata = json.loads(metadata_artifact.read_text(encoding="utf-8"))
+    assert metadata["kind"] == "ocr_metadata"
+    assert metadata["sidecar_ref"] == "diagram.png.ocr.txt"
+    assert metadata["sidecar_checksum"]
 
     source_record = load_source_record(added.manifest_path)
     artifact_ref = ocr_artifact.relative_to(tmp_path).as_posix()
+    metadata_ref = metadata_artifact.relative_to(tmp_path).as_posix()
     assert source_record.source_ref == "diagram.png"
     assert source_record.storage_mode == "none"
-    assert source_record.derived_artifacts == [artifact_ref]
+    assert source_record.derived_artifacts == sorted([artifact_ref, metadata_ref])
     assert any(link.path_ref == artifact_ref for link in source_record.provenance_links)
 
     run_record = load_run_record(result.run_path)
+    assert "diagram.png.ocr.txt" in run_record.input_refs
     assert artifact_ref in run_record.output_refs
+    assert metadata_ref in run_record.output_refs
     assert any(
         link.path_ref == artifact_ref
         and link.source_id == added.source_id
@@ -409,6 +417,67 @@ def test_ingest_source_image_only_pdf_can_use_configured_ocr_sidecar(tmp_path: P
     assert "OCR text from scanned PDF." in body
     assert (tmp_path / "derived" / "ocr" / f"{added.source_id}.txt").is_file()
     assert not (tmp_path / "derived" / "parsed" / f"{added.source_id}.txt").exists()
+
+
+def test_ingest_source_ocr_sidecar_change_forces_reingest(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    enable_sidecar_ocr(tmp_path)
+    source = tmp_path / "diagram.png"
+    sidecar = Path(f"{source}.ocr.txt")
+    source.write_bytes(b"\x89PNG\r\n\x1a\n")
+    sidecar.write_text("Initial OCR text.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    first = ingest_source(tmp_path, added.source_id)
+    sidecar.write_text("Updated OCR text.\n", encoding="utf-8")
+    second = ingest_source(tmp_path, added.source_id)
+
+    assert first.no_op is False
+    assert second.no_op is False
+    assert first.run_id != second.run_id
+    ocr_artifact = tmp_path / "derived" / "ocr" / f"{added.source_id}.txt"
+    assert ocr_artifact.read_text(encoding="utf-8") == "Updated OCR text.\n"
+    metadata_artifact = tmp_path / "derived" / "metadata" / f"{added.source_id}.ocr.json"
+    metadata = json.loads(metadata_artifact.read_text(encoding="utf-8"))
+    assert metadata["sidecar_ref"] == "diagram.png.ocr.txt"
+
+
+def test_ingest_source_external_image_uses_original_sidecar_for_copied_source(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    enable_sidecar_ocr(tmp_path)
+    external_dir = tmp_path.parent / f"{tmp_path.name}-external-ocr"
+    external_dir.mkdir()
+    source = external_dir / "diagram.png"
+    sidecar = Path(f"{source}.ocr.txt")
+    source.write_bytes(b"\x89PNG\r\n\x1a\n")
+    sidecar.write_text("External OCR text.\n", encoding="utf-8")
+
+    try:
+        added = add_source(tmp_path, source)
+        result = ingest_source(tmp_path, added.source_id)
+    finally:
+        source.unlink(missing_ok=True)
+        sidecar.unlink(missing_ok=True)
+        external_dir.rmdir()
+
+    assert result.page_path is not None
+    ocr_artifact = tmp_path / "derived" / "ocr" / f"{added.source_id}.txt"
+    assert ocr_artifact.read_text(encoding="utf-8") == "External OCR text.\n"
+    metadata_artifact = tmp_path / "derived" / "metadata" / f"{added.source_id}.ocr.json"
+    metadata = json.loads(metadata_artifact.read_text(encoding="utf-8"))
+    assert metadata["sidecar_ref"] == str(sidecar.resolve())
+
+    run_record = load_run_record(result.run_path)
+    assert str(sidecar.resolve()) not in run_record.input_refs
+    assert any(
+        link.role == "input"
+        and link.path_ref is None
+        and link.note is not None
+        and str(sidecar.resolve()) in link.note
+        for link in run_record.provenance_links
+    )
 
 
 def test_ingest_source_malformed_pdf_uses_stable_error(tmp_path: Path) -> None:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -247,6 +247,24 @@ def test_run_lint_checks_reports_missing_source_derived_artifact(tmp_path: Path)
     assert result.issues[0].path == added.manifest_path.relative_to(tmp_path).as_posix()
 
 
+def test_run_lint_checks_accepts_ocr_derived_artifact_links(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "diagram.png"
+    source.write_bytes(b"\x89PNG\r\n\x1a\n")
+    added = add_source(tmp_path, source)
+    artifact = tmp_path / "derived" / "ocr" / f"{added.source_id}.txt"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text("Extracted OCR text\n", encoding="utf-8")
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={"derived_artifacts": [artifact.relative_to(tmp_path).as_posix()]}
+    )
+    write_source_record(added.manifest_path, source_record)
+
+    result = _run_lint(tmp_path)
+
+    assert result.issues == []
+
+
 def test_run_lint_checks_reports_missing_wiki_refs_and_related_pages(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     _write_wiki_page(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -9,8 +9,15 @@ from splendor.commands.ingest import ingest_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.planning import create_question, create_task
 from splendor.commands.query import run_query
+from splendor.config import load_config, write_config
 from splendor.schemas import KnowledgePageFrontmatter
 from splendor.state.query_snapshot import load_query_snapshot
+
+
+def enable_sidecar_ocr(root: Path) -> None:
+    config = load_config(root)
+    config.sources.ocr_enabled = True
+    write_config(root, config)
 
 
 def write_wiki_page(
@@ -144,6 +151,23 @@ def test_run_query_finds_extracted_pdf_source_summary_text(tmp_path: Path) -> No
     assert result.matches[0].kind == "source-summary"
     assert result.matches[0].source_refs == [added.source_id]
     assert "Extracted PDF dispatch evidence" in result.matches[0].snippet
+
+
+def test_run_query_finds_extracted_ocr_source_summary_text(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    enable_sidecar_ocr(tmp_path)
+    source = tmp_path / "diagram.png"
+    source.write_bytes(b"\x89PNG\r\n\x1a\n")
+    Path(f"{source}.ocr.txt").write_text("Extracted OCR diagram evidence\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    ingest_source(tmp_path, added.source_id)
+
+    result = run_query(tmp_path, "diagram evidence", source_id=added.source_id)
+
+    assert result.match_count == 1
+    assert result.matches[0].kind == "source-summary"
+    assert result.matches[0].source_refs == [added.source_id]
+    assert "Extracted OCR diagram evidence" in result.matches[0].snippet
 
 
 def test_run_query_rejects_unknown_source_filter(tmp_path: Path) -> None:

--- a/tests/test_repo_scan.py
+++ b/tests/test_repo_scan.py
@@ -66,6 +66,24 @@ def test_repo_scan_registers_and_classifies_supported_workspace_files(tmp_path: 
     assert manifest_by_ref["src/main.py"].source_class == "code"
 
 
+def test_repo_scan_classifies_image_sources_as_other(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    (tmp_path / "diagram.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    result = scan_repo(tmp_path)
+
+    assert result.scanned == 1
+    assert result.class_counts == {
+        "code": 0,
+        "documentation": 0,
+        "configuration": 0,
+        "other": 1,
+    }
+    assert result.touched_sources[0].path == "diagram.png"
+    assert result.touched_sources[0].source_class == "other"
+
+
 def test_repo_scan_ignores_managed_and_transient_directories(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     _remove_workspace_config(tmp_path)

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -7,6 +7,7 @@ from splendor.cli import main
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.wiki import add_topic_page, rebuild_wiki_index
+from splendor.config import load_config, write_config
 from splendor.schemas import KnowledgePageFrontmatter, MaintenanceReport
 from splendor.state.source_registry import load_source_record
 from splendor.utils.wiki import parse_wiki_markdown
@@ -718,6 +719,9 @@ def test_brief_json_output_is_available_without_goal(tmp_path: Path, capsys) -> 
 
 def test_brief_agent_context_json_packages_handoff_state(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    write_config(tmp_path, config)
     source = tmp_path / "briefing.md"
     unrelated_source = tmp_path / "unrelated.md"
     source.write_text(


### PR DESCRIPTION
## Summary

Implements the M12-P2.1 OCR/image ingest path on top of the M12-P1.1 rich-source dispatch work.

- adds optional image/OCR dispatch for common image source types and image-only PDFs
- keeps deterministic text-bearing PDF extraction under `derived/parsed/` and writes OCR-derived text separately under `derived/ocr/`
- introduces explicit OCR source config using the lightweight `sidecar-text` provider without adding heavyweight mandatory OCR dependencies
- tracks OCR sidecar ref/checksum metadata under `derived/metadata/` so sidecar changes invalidate no-op ingest
- supports copied external image/PDF sources by checking sidecars next to the stored artifact and then next to the original local source path
- links OCR text and metadata artifacts through source manifest `derived_artifacts`, run output refs, and provenance links
- preserves deterministic failures for unconfigured OCR, missing sidecar text, invalid UTF-8, empty OCR text, and unsupported source types
- updates docs and planning state from M12-P1.1 to M12-P2.1, with M13-P1.1 next

## Tracking

Closes #66.

## Validation

- `uv run pytest`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`

## Notes

The current OCR provider is intentionally local and deterministic: when `sources.ocr_enabled: true`, `sidecar-text` reads UTF-8 text next to the resolved source artifact using `sources.ocr_sidecar_suffix`, stores normalized output in `derived/ocr/`, and stores sidecar ref/checksum metadata in `derived/metadata/`. Additional OCR engines remain follow-up provider work rather than required runtime dependencies.