### PR TITLE
M13-P1.1 Schema/docs/migration stabilization

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M12-P1.1`
-- Last action taken: `M12-P1.1` is implemented; rich-source dispatch and deterministic text-bearing PDF ingest are available.
-- Current planned slice: `M12-P2`
-- Current PR sub-slice: `M12-P2.1`
+- Previous completed PR sub-slice: `M12-P2.1`
+- Last action taken: `M12-P2.1` is implemented; OCR/image ingest path support is available.
+- Current planned slice: `M13-P1`
+- Current PR sub-slice: `M13-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M13-P1`
-- Next planned PR sub-slice: `M13-P1.1`
+- Next planned slice: `M13-P2`
+- Next planned PR sub-slice: `M13-P2.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -179,6 +179,11 @@
   - [x] Link OCR artifacts from source manifests via `derived_artifacts`
   - [x] Preserve deterministic failures for unconfigured or unextractable OCR/image sources
   - [x] Update tests, docs, and planning state for the OCR/image ingest contract
+- [x] Implement `M13-P1.1`: Schema/docs/migration stabilization
+  - [x] Persist explicit source commit capture intent in source manifests
+  - [x] Preserve legacy manifest compatibility when the intent field is absent
+  - [x] Teach source refresh to carry capture intent without inferring from `source_commit`
+  - [x] Update schema/product/quickstart docs and planning state
 
 ## Context Pointers
 
@@ -224,3 +229,4 @@
 - `M12-P1.1` Rich-source dispatch and PDF path
 - `M12-P2.1` OCR/image ingest path
 - `M13-P1.1` Schema/docs/migration stabilization
+- `M13-P2.1` Extension/performance/release finalization

--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M12-P1.1`
-- Current planned slice: `M12-P2`
-- Current PR sub-slice: `M12-P2.1`
+- Previous completed PR sub-slice: `M12-P2.1`
+- Current planned slice: `M13-P1`
+- Current PR sub-slice: `M13-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M13-P1`
-- Next planned PR sub-slice: `M13-P1.1`
+- Next planned slice: `M13-P2`
+- Next planned PR sub-slice: `M13-P2.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -76,6 +76,9 @@ The command prints:
 
 For in-repo files, the current default storage mode is `none`, which means Splendor tracks the
 workspace file directly instead of copying it into `raw/sources/`.
+Commit provenance capture is also explicit in the manifest: `source_commit_capture: true` preserves
+an explicit `--capture-source-commit` request, `false` preserves `--no-capture-source-commit`, and
+`null` means future refreshes use `sources.capture_source_commit` from `splendor.yaml`.
 
 To register a batch, use a glob or direct directory scan. Both forms process files in deterministic
 path order and create pending ingest jobs for newly registered sources:
@@ -154,7 +157,9 @@ does not rewrite generated source-summary pages.
 
 When a tracked source file changes, refresh it by ID, title, or path. Refresh detects changed
 content, registers the current content as a new canonical source version when needed, and queues
-ingest through the same ledger used by `add-source`:
+ingest through the same ledger used by `add-source`. It carries the manifest's
+`source_commit_capture` intent forward, so a source that was explicitly opted in or out of commit
+capture keeps that behavior even if the previous version had no `source_commit` value:
 
 ```bash
 uv run splendor --root /tmp/demo-repo source refresh product-note.md

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -79,6 +79,8 @@ workspace file directly instead of copying it into `raw/sources/`.
 Commit provenance capture is also explicit in the manifest: `source_commit_capture: true` preserves
 an explicit `--capture-source-commit` request, `false` preserves `--no-capture-source-commit`, and
 `null` means future refreshes use `sources.capture_source_commit` from `splendor.yaml`.
+Older manifests that predate this field still preserve positive capture intent when they already
+contain a `source_commit`.
 
 To register a batch, use a glob or direct directory scan. Both forms process files in deterministic
 path order and create pending ingest jobs for newly registered sources:

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -40,6 +40,7 @@ Current implementation fields:
 - `storage_mode`
 - `storage_path`
 - `materialized_at`
+- `source_commit_capture`
 - `source_commit`
 - `source_class`
 - `source_labels`
@@ -117,6 +118,11 @@ Implemented fields:
   - Symlink-backed sources use `raw/sources/<source_id>/<filename>`.
 - `materialized_at`
   - Timestamp indicating when `storage_path` was created or last refreshed.
+- `source_commit_capture`
+  - Nullable persisted intent for git provenance capture:
+    - `true` means commit capture was explicitly requested for registration and refresh
+    - `false` means commit capture was explicitly disabled
+    - `null` means use the workspace `sources.capture_source_commit` default
 - `source_commit`
   - Optional git commit SHA captured for clean tracked workspace files.
 - `source_class`
@@ -147,7 +153,8 @@ Implemented fields:
   generated `wiki/sources/src-...md` pages.
 - `splendor source refresh <source-id|title|path>` resolves the tracked workspace or external path,
   compares current bytes to the manifest checksum, registers changed content as a new canonical
-  source version, and queues ingest through the same queue handoff used by `add-source`.
+  source version, preserves `source_commit_capture` intent, and queues ingest through the same queue
+  handoff used by `add-source`.
 - Refresh uses the queue ledger directly, so active leases remain protected and dead-lettered jobs
   still require `splendor queue retry <job-id>` or `splendor repair ingest <source-id>`.
 - Text-bearing PDF sources are routed through source-type dispatch during ingest. The source
@@ -186,7 +193,8 @@ Splendor currently supports both:
 
 1. legacy manifests that only have `path` and are treated as copied-source records at read time
 2. new manifests that write `source_ref`, `source_ref_kind`, `storage_mode`, `storage_path`,
-   `materialized_at`, `source_commit`, and optional repo-scan classification fields
+   `materialized_at`, `source_commit_capture`, `source_commit`, and optional repo-scan
+   classification fields
 
 In this release:
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -123,6 +123,8 @@ Implemented fields:
     - `true` means commit capture was explicitly requested for registration and refresh
     - `false` means commit capture was explicitly disabled
     - `null` means use the workspace `sources.capture_source_commit` default
+  - Legacy manifests without this field preserve positive capture intent when `source_commit` is
+    already populated.
 - `source_commit`
   - Optional git commit SHA captured for clean tracked workspace files.
 - `source_class`

--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -137,6 +137,7 @@ New fields to add:
 - `storage_mode`
 - `storage_path`
 - `materialized_at`
+- `source_commit_capture`
 - `source_commit`
 
 Compatibility plan:
@@ -185,6 +186,14 @@ Optional repo-relative path, usually under `raw/sources/`, used when a source is
 ### `materialized_at`
 
 Timestamp capturing when the storage artifact was created or refreshed.
+
+### `source_commit_capture`
+
+Nullable intent flag controlling whether refresh should attempt source commit capture again:
+
+- `true`: capture was explicitly requested, even if no commit was available at registration time
+- `false`: capture was explicitly disabled
+- `null`: use the current workspace `sources.capture_source_commit` default
 
 ### `source_commit`
 

--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -195,6 +195,9 @@ Nullable intent flag controlling whether refresh should attempt source commit ca
 - `false`: capture was explicitly disabled
 - `null`: use the current workspace `sources.capture_source_commit` default
 
+Legacy manifests without this field preserve positive capture intent when `source_commit` is
+already populated.
+
 ### `source_commit`
 
 Optional git commit SHA captured for clean tracked workspace files when stronger repo-native

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M12-P1.1`
-- Current planned slice: `M12-P2`
-- Current PR sub-slice: `M12-P2.1`
+- Previous completed PR sub-slice: `M12-P2.1`
+- Current planned slice: `M13-P1`
+- Current PR sub-slice: `M13-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M13-P1`
-- Next planned PR sub-slice: `M13-P1.1`
+- Next planned slice: `M13-P2`
+- Next planned PR sub-slice: `M13-P2.1`
 
 `M10-P0.1` is implemented: the CLI-first wiki status and source-impact suggestion bridge is in
 place. `M10-P0.2` is implemented: project briefing and the non-mutating review-gated compile-loop

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -352,6 +352,7 @@ Suggested fields:
 - `last_run_id`
 - `review_state`
 - `materialized_at` (optional)
+- `source_commit_capture` (optional nullable)
 - `source_commit` (optional)
 
 Field meanings:
@@ -372,6 +373,10 @@ Field meanings:
   - Optional path to the materialized artifact under `raw/sources/` when one exists.
   - Pointer-backed sources use `raw/sources/<source_id>/pointer.json`.
   - Symlink-backed sources use `raw/sources/<source_id>/<filename>`.
+- `source_commit_capture`
+  - Optional nullable capture intent persisted separately from `source_commit`. `true` preserves an
+    explicit capture request across refreshes, `false` preserves an explicit opt-out, and `null`
+    means refresh uses the workspace `sources.capture_source_commit` default.
 - `source_commit`
   - Optional git commit SHA captured for clean tracked workspace files when the project wants
     stronger repo-native provenance.
@@ -1077,7 +1082,9 @@ Likely configuration domains:
 - GitHub integration toggles
 - policy rules
 
-Current OCR-related source settings:
+Current source settings:
+- `sources.capture_source_commit`: default git commit capture policy for workspace sources when a
+  source manifest has `source_commit_capture: null`, default `true`
 - `sources.ocr_enabled`: opt-in OCR/image extraction toggle, default `false`
 - `sources.ocr_provider`: OCR provider name, currently `sidecar-text`
 - `sources.ocr_sidecar_suffix`: sidecar suffix appended to the resolved source path, default

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -377,6 +377,8 @@ Field meanings:
   - Optional nullable capture intent persisted separately from `source_commit`. `true` preserves an
     explicit capture request across refreshes, `false` preserves an explicit opt-out, and `null`
     means refresh uses the workspace `sources.capture_source_commit` default.
+  - Legacy manifests without this field preserve positive capture intent when `source_commit` is
+    already populated.
 - `source_commit`
   - Optional git commit SHA captured for clean tracked workspace files when the project wants
     stronger repo-native provenance.

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -59,6 +59,14 @@ def lookup_sources(root: Path, query: str | None = None) -> list[SourceLookupRes
     return [result for result in results if _matches_source(result.source, needle)]
 
 
+def source_commit_capture_intent(source: SourceRecord) -> bool | None:
+    if source.source_commit_capture is not None:
+        return source.source_commit_capture
+    if source.source_commit is not None:
+        return True
+    return None
+
+
 def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
     matches = lookup_sources(root, source_query)
     exact_matches = [
@@ -85,7 +93,7 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
             root,
             current_path,
             storage_mode=requested.storage_mode,
-            capture_source_commit=requested.source_commit_capture,
+            capture_source_commit=source_commit_capture_intent(requested),
             source_class=requested.source_class,
             source_labels=requested.source_labels,
             discovered_by=requested.discovered_by,

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -85,7 +85,7 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
             root,
             current_path,
             storage_mode=requested.storage_mode,
-            capture_source_commit=requested.source_commit is not None,
+            capture_source_commit=requested.source_commit_capture,
             source_class=requested.source_class,
             source_labels=requested.source_labels,
             discovered_by=requested.discovered_by,

--- a/src/splendor/schemas/source.py
+++ b/src/splendor/schemas/source.py
@@ -48,6 +48,7 @@ class SourceRecord(StrictRecord):
     storage_mode: StorageMode | None = None
     storage_path: str | None = None
     materialized_at: str | None = None
+    source_commit_capture: bool | None = None
     source_commit: str | None = None
     source_class: SourceClass | None = None
     source_labels: list[str] = Field(default_factory=list)

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -543,6 +543,7 @@ def register_source(
             stored_path.relative_to(root).as_posix() if stored_path is not None else None
         ),
         materialized_at=(added_at if stored_path is not None else None),
+        source_commit_capture=capture_source_commit,
         source_commit=source_commit,
         source_class=source_class,
         source_labels=sorted(source_labels or []),

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -484,23 +484,21 @@ def register_source(
         existing_stored_path, existing_storage_mode, existing_source_ref = (
             _validated_existing_registration(root=root, layout=layout, existing=existing)
         )
+        updated_fields: dict[str, object] = {}
+        if capture_source_commit is not None:
+            updated_fields["source_commit_capture"] = capture_source_commit
         if refresh_existing_metadata and existing.source_ref_kind == "workspace_path":
-            updated = SourceRecord.model_validate(
-                existing.model_dump(mode="json")
-                | {
-                    "source_class": source_class
-                    if source_class is not None
-                    else existing.source_class,
-                    "source_labels": sorted(
-                        source_labels if source_labels is not None else existing.source_labels
-                    ),
-                    "discovered_by": (
-                        existing.discovered_by
-                        if existing.discovered_by is not None
-                        else discovered_by
-                    ),
-                }
-            )
+            updated_fields |= {
+                "source_class": source_class if source_class is not None else existing.source_class,
+                "source_labels": sorted(
+                    source_labels if source_labels is not None else existing.source_labels
+                ),
+                "discovered_by": (
+                    existing.discovered_by if existing.discovered_by is not None else discovered_by
+                ),
+            }
+        if updated_fields:
+            updated = SourceRecord.model_validate(existing.model_dump(mode="json") | updated_fields)
             if updated != existing:
                 write_source_record(manifest_path, updated)
                 existing = updated

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -62,6 +62,7 @@ def test_add_source_registers_workspace_file_without_copy_by_default(tmp_path: P
     assert manifest.storage_mode == "none"
     assert manifest.storage_path is None
     assert manifest.materialized_at is None
+    assert manifest.source_commit_capture is None
     assert manifest.source_class is None
     assert manifest.source_labels == []
     assert manifest.discovered_by is None
@@ -504,7 +505,28 @@ def test_add_source_captures_head_for_clean_tracked_workspace_file(tmp_path: Pat
     result = add_source(tmp_path, source)
 
     manifest = load_source_record(result.manifest_path)
+    assert manifest.source_commit_capture is None
     assert manifest.source_commit == head
+
+
+def test_add_source_persists_explicit_commit_capture_intent(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    disabled_source = tmp_path / "disabled.md"
+    source.write_text("# note\n", encoding="utf-8")
+    disabled_source.write_text("# disabled\n", encoding="utf-8")
+
+    requested = add_source(tmp_path, source, capture_source_commit=True)
+    disabled = add_source(
+        tmp_path,
+        disabled_source,
+        capture_source_commit=False,
+    )
+
+    requested_manifest = load_source_record(requested.manifest_path)
+    disabled_manifest = load_source_record(disabled.manifest_path)
+    assert requested_manifest.source_commit_capture is True
+    assert disabled_manifest.source_commit_capture is False
 
 
 def test_add_source_leaves_source_commit_null_for_untracked_workspace_file(tmp_path: Path) -> None:

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -529,6 +529,37 @@ def test_add_source_persists_explicit_commit_capture_intent(tmp_path: Path) -> N
     assert disabled_manifest.source_commit_capture is False
 
 
+def test_add_source_updates_existing_commit_capture_intent(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+
+    first = add_source(tmp_path, source)
+    unchanged = add_source(tmp_path, source)
+    assert unchanged.already_registered is True
+    assert load_source_record(first.manifest_path).source_commit_capture is None
+
+    enabled = add_source(tmp_path, source, capture_source_commit=True)
+    assert enabled.already_registered is True
+    assert load_source_record(first.manifest_path).source_commit_capture is True
+
+    disabled = add_source(tmp_path, source, capture_source_commit=False)
+    assert load_source_record(first.manifest_path).source_commit_capture is False
+    assert disabled.already_registered is True
+
+
+def test_add_source_keeps_existing_commit_capture_intent_without_flag(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+
+    first = add_source(tmp_path, source)
+    repeat = add_source(tmp_path, source)
+
+    assert repeat.already_registered is True
+    assert load_source_record(first.manifest_path).source_commit_capture is None
+
+
 def test_add_source_leaves_source_commit_null_for_untracked_workspace_file(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     init_git_repo(tmp_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ from splendor import __version__
 from splendor.cli import build_parser, main
 from splendor.commands.ingest import enqueue_ingest_job
 from splendor.commands.source import refresh_source
-from splendor.config import load_config
+from splendor.config import load_config, write_config
 from splendor.layout import resolve_layout
 from splendor.schemas import KnowledgePageFrontmatter, MaintenanceIssue, MaintenanceReport
 from splendor.state.query_snapshot import last_query_path_for, load_query_snapshot
@@ -565,6 +565,43 @@ def test_cli_source_refresh_uses_config_default_for_legacy_commit_capture_intent
         if path != manifest_path
     ]
     assert refreshed_records[0].source_commit_capture is None
+    assert refreshed_records[0].source_commit == "legacy-new"
+
+
+def test_cli_source_refresh_preserves_legacy_positive_commit_capture_intent(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    config = load_config(tmp_path)
+    config.sources.capture_source_commit = False
+    write_config(tmp_path, config)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    manifest_payload = load_source_record(manifest_path).model_dump(mode="json")
+    manifest_payload.pop("source_commit_capture")
+    manifest_payload["source_commit"] = "legacy-old"
+    manifest_path.write_text(
+        json.dumps(manifest_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "splendor.state.source_registry.captured_source_commit",
+        lambda *_args, **_kwargs: "legacy-new",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+
+    assert exit_code == 0
+    refreshed_records = [
+        load_source_record(path)
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if path != manifest_path
+    ]
+    assert refreshed_records[0].source_commit_capture is True
     assert refreshed_records[0].source_commit == "legacy-new"
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -480,6 +480,9 @@ def test_cli_source_refresh_preserves_no_commit_capture_intent(
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", "--no-capture-source-commit", str(source)])
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    manifest = load_source_record(manifest_path)
+    assert manifest.source_commit_capture is False
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
 
     def fail_if_called(*_args, **_kwargs):
@@ -491,6 +494,12 @@ def test_cli_source_refresh_preserves_no_commit_capture_intent(
     exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
 
     assert exit_code == 0
+    refreshed_records = [
+        load_source_record(path)
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if path != manifest_path
+    ]
+    assert refreshed_records[0].source_commit_capture is False
 
 
 def test_cli_source_refresh_preserves_positive_commit_capture_intent(
@@ -502,7 +511,10 @@ def test_cli_source_refresh_preserves_positive_commit_capture_intent(
     main(["--root", str(tmp_path), "add-source", str(source)])
     manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
     manifest = load_source_record(manifest_path)
-    write_source_record(manifest_path, manifest.model_copy(update={"source_commit": "old"}))
+    write_source_record(
+        manifest_path,
+        manifest.model_copy(update={"source_commit_capture": True, "source_commit": None}),
+    )
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
     monkeypatch.setattr(
         "splendor.state.source_registry.captured_source_commit",
@@ -518,7 +530,42 @@ def test_cli_source_refresh_preserves_positive_commit_capture_intent(
         for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
         if path != manifest_path
     ]
+    assert refreshed_records[0].source_commit_capture is True
     assert refreshed_records[0].source_commit == "new"
+
+
+def test_cli_source_refresh_uses_config_default_for_legacy_commit_capture_intent(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    manifest_payload = load_source_record(manifest_path).model_dump(mode="json")
+    manifest_payload.pop("source_commit_capture")
+    manifest_payload["source_commit"] = None
+    manifest_path.write_text(
+        json.dumps(manifest_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "splendor.state.source_registry.captured_source_commit",
+        lambda *_args, **_kwargs: "legacy-new",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+
+    assert exit_code == 0
+    refreshed_records = [
+        load_source_record(path)
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if path != manifest_path
+    ]
+    assert refreshed_records[0].source_commit_capture is None
+    assert refreshed_records[0].source_commit == "legacy-new"
 
 
 def test_cli_source_refresh_supports_original_path_legacy_manifest(tmp_path: Path, capsys) -> None:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -25,6 +25,7 @@ def test_source_record_validation_accepts_valid_payload() -> None:
     )
 
     assert record.kind == "source"
+    assert record.source_commit_capture is None
 
 
 def test_source_record_validation_accepts_valid_expanded_payload() -> None:
@@ -41,6 +42,7 @@ def test_source_record_validation_accepts_valid_expanded_payload() -> None:
         storage_mode="none",
         storage_path=None,
         materialized_at="2026-04-10T15:01:00+00:00",
+        source_commit_capture=True,
         source_commit="abc123",
         source_class="documentation",
         source_labels=["agent-instructions"],
@@ -60,6 +62,7 @@ def test_source_record_validation_accepts_valid_expanded_payload() -> None:
 
     assert record.source_ref == "docs/spec.md"
     assert record.storage_mode == "none"
+    assert record.source_commit_capture is True
     assert record.source_class == "documentation"
     assert record.source_labels == ["agent-instructions"]
     assert record.discovered_by == "repo_scan"


### PR DESCRIPTION
## Summary

- Adds `source_commit_capture` to source manifests as nullable persisted commit-capture intent.
- Writes explicit add-source capture intent while preserving `null` for config-default behavior.
- Teaches `splendor source refresh` to carry capture intent instead of inferring from whether `source_commit` exists.
- Documents the schema/config/refresh contract and advances planning state to `M13-P1.1`.

## Issue

Closes #61.

## Validation

- `uv run pytest`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`

## Notes

Legacy manifests without `source_commit_capture` remain valid and continue to use the workspace `sources.capture_source_commit` default during refresh. This PR does not add remote fetch workflows, databases, background workers, vector search, or mutating web UI behavior.