### PR TITLE
Fix pr-agent refresh workflow runs API call

### DIFF
--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -114,7 +114,7 @@ jobs:
 
             const recentDispatchCutoff = Date.now() - recentDispatchWindowMs;
             const { data: workflowRunsResponse } =
-              await github.rest.actions.listWorkflowRunsForWorkflow({
+              await github.rest.actions.listWorkflowRuns({
                 owner,
                 repo,
                 workflow_id: 'pr-agent-context-refresh.yml',


### PR DESCRIPTION
## Problem

Scheduled `pr-agent-context` refresh fanout currently calls `github.rest.actions.listWorkflowRunsForWorkflow`, which is not exposed by the Octokit client in `actions/github-script@v7`. That causes scheduled refreshes to fail before they can dispatch per-PR refresh runs.

## Change

Replace the unsupported `listWorkflowRunsForWorkflow` call with the supported `github.rest.actions.listWorkflowRuns` method while preserving the existing request parameters.

## Validation

- Confirmed `.github/workflows/pr-agent-context-refresh.yml` no longer contains `listWorkflowRunsForWorkflow`.
- Confirmed the workflow now calls `github.rest.actions.listWorkflowRuns({`.
- Repository pre-commit hooks passed for the commit.
