### PR TITLE
M13-P2.1 Issue #70 design reset

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M12-P2.1`
-- Last action taken: `M12-P2.1` is implemented; OCR/image ingest path support is available.
-- Current planned slice: `M13-P1`
-- Current PR sub-slice: `M13-P1.1`
+- Previous completed PR sub-slice: `M13-P1.1`
+- Last action taken: `M13-P1.1` is implemented; source schema/docs/migration stabilization is complete.
+- Current planned slice: `M13-P2`
+- Current PR sub-slice: `M13-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M13-P2`
-- Next planned PR sub-slice: `M13-P2.1`
+- Next planned PR sub-slice: `M13-P2.2`
 - Current blockers: none
 
 ## Planning Notation
@@ -184,6 +184,11 @@
   - [x] Preserve legacy manifest compatibility when the intent field is absent
   - [x] Teach source refresh to carry capture intent without inferring from `source_commit`
   - [x] Update schema/product/quickstart docs and planning state
+- [x] Implement `M13-P2.1`: Issue #70 design reset and roadmap realignment
+  - [x] Add a docs-only design response for the first real agent-experience report
+  - [x] Reframe M13-P2 around discovery, curation, synthesis, freshness, and agent handoff
+  - [x] Document planned safe repo-scan, source-freshness, and suggest-next contracts
+  - [x] Update README, roadmap, product spec, quickstart, and static agent rules only
 
 ## Context Pointers
 
@@ -191,6 +196,7 @@
 - Delivery roadmap: `docs/splendor_mvp_to_v1_roadmap.md`
 - Source-resolution sequence (completed through SR-9): `docs/source_resolution_refactor_plan.md`
 - Schema summary: `docs/schema_contracts.md`
+- Issue #70 design response: `docs/issue_70_design_response.md`
 - CI and contributor automation: `docs/ci_and_repo_automation.md`
 
 ## Planned PR Queue
@@ -210,7 +216,8 @@
 - `M12-P1` Rich-source dispatch and PDF path
 - `M12-P2` OCR/image ingest path
 - `M13-P1` Schema/docs/migration stabilization
-- `M13-P2` Extension/performance/release finalization
+- `M13-P2` Issue #70 agent-usefulness redesign
+- `M13-P3` Extension/performance/release finalization
 
 ## PR Sub-slice Queue
 
@@ -229,4 +236,8 @@
 - `M12-P1.1` Rich-source dispatch and PDF path
 - `M12-P2.1` OCR/image ingest path
 - `M13-P1.1` Schema/docs/migration stabilization
-- `M13-P2.1` Extension/performance/release finalization
+- `M13-P2.1` Issue #70 design reset and roadmap realignment
+- `M13-P2.2` Safe repo scan candidate discovery
+- `M13-P2.3` Source freshness / diff-since-ingest workflow
+- `M13-P2.4` Agent handoff brief and suggest-next
+- `M13-P2.5` Source-summary policy and path-first UX

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,8 @@
 
 - Keep repository layout changes aligned with `src/splendor/layout.py`.
 - Use models in `src/splendor/schemas/` as the contract for persisted record shapes.
-- `state/manifests/sources/` is the canonical machine-readable source registry.
+- `state/manifests/sources/` is the default machine-readable source registry; non-default layouts
+  may override it with `layout.source_records_dir`.
 - Treat source discovery and source curation as separate concepts. Future discovery workflows must
   be non-mutating by default and should produce candidate reports before writing manifests.
 - Treat source manifests as intentional curated sources, not a dumping ground for every supported

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,12 @@
 - Keep repository layout changes aligned with `src/splendor/layout.py`.
 - Use models in `src/splendor/schemas/` as the contract for persisted record shapes.
 - `state/manifests/sources/` is the canonical machine-readable source registry.
+- Treat source discovery and source curation as separate concepts. Future discovery workflows must
+  be non-mutating by default and should produce candidate reports before writing manifests.
+- Treat source manifests as intentional curated sources, not a dumping ground for every supported
+  file discovered in a repository.
+- Broad repo registration must require explicit operator intent and must document the expected
+  manifest/wiki churn before implementation.
 - Prefer deterministic filesystem state over hidden caches or implicit runtime state.
 - Do not add SQLite, background workers, OCR flows, or web UI code unless the task explicitly calls for them.
 

--- a/README.md
+++ b/README.md
@@ -136,10 +136,14 @@ Implemented today:
 
 Not implemented yet:
 
+- safe-by-default non-mutating `repo scan` candidate discovery
 - mutating review-gated `splendor wiki compile`
 - heavyweight OCR/image extraction providers
 - mutating web UI actions such as add-source forms
 - changed-files-driven refresh suggestions
+
+Current `splendor repo scan` is broad and mutating. On real repositories, prefer curated
+`add-source` registration until the M13-P2 safe discovery redesign from issue #70 lands.
 
 Text-bearing PDFs are supported through the ingest dispatch path. Parsed PDF text is written under
 `derived/parsed/`, linked from the source manifest, and used for the generated source-summary page.
@@ -152,6 +156,7 @@ the source manifest, and kept separate from parsed PDF artifacts.
 - [docs/quickstart.md](docs/quickstart.md)
 - [docs/companion_repo_setup.md](docs/companion_repo_setup.md)
 - [docs/dogfooding.md](docs/dogfooding.md)
+- [docs/issue_70_design_response.md](docs/issue_70_design_response.md)
 - [docs/splendor_product_spec.md](docs/splendor_product_spec.md)
 - [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md)
 - [docs/schema_contracts.md](docs/schema_contracts.md)
@@ -159,12 +164,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M12-P2.1`
-- Current planned slice: `M13-P1`
-- Current PR sub-slice: `M13-P1.1`
+- Previous completed PR sub-slice: `M13-P1.1`
+- Current planned slice: `M13-P2`
+- Current PR sub-slice: `M13-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M13-P2`
-- Next planned PR sub-slice: `M13-P2.1`
+- Next planned PR sub-slice: `M13-P2.2`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -204,5 +209,16 @@ explicit dead-letter records, and stale-lease recovery.
 refresh through the existing ingest queue, and readable source lookup by title or path without
 changing canonical source IDs. `M11-P2.1` is implemented: it adds CLI-first topic scaffolding,
 deterministic templates, and wiki index rebuild support. `M11-P3.1` is implemented: it adds query
-filters for tags/source refs and a compact agent-context handoff mode. The current PR sub-slice is
-`M12-P1.1`, which adds rich-source dispatch and the first deterministic text-bearing PDF path.
+filters for tags/source refs and a compact agent-context handoff mode.
+
+`M12-P1.1`, `M12-P2.1`, and `M13-P1.1` are implemented. The current M13-P2 work responds to the
+first real agent-experience report in issue #70 by redesigning repo discovery around safe
+candidate reports, curated source manifests, source freshness, and higher-signal agent handoffs.
+
+`M13-P2.1` is a docs/planning-only reset:
+
+- [x] record the accepted Issue #70 design response
+- [x] realign the roadmap around safe discovery, curation, freshness, and agent handoff
+- [x] document planned interfaces for `repo scan`, freshness, `brief --agent-context`, and
+  `suggest-next`
+- [x] avoid Python, schema, test, and runtime behavior changes

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -44,7 +44,8 @@ curated project knowledge."
 The design distinction is:
 
 - **Discovery** finds candidate files and reports them without changing source manifests.
-- **Curation** explicitly accepts sources into `state/manifests/sources/`.
+- **Curation** explicitly accepts sources into the configured source-record registry, which defaults
+  to `state/manifests/sources/` and is controlled by `layout.source_records_dir`.
 - **Synthesis** creates or updates maintained wiki pages only when the result adds cross-source
   value, review context, contradiction handling, or handoff value.
 
@@ -56,8 +57,15 @@ rather than assumed to be the primary value.
 
 The next implementation slices should document and then implement these contracts:
 
-- `splendor repo scan` defaults to a non-mutating candidate preview.
-- Mutating registration from scan requires `--apply`.
+- `splendor repo scan` defaults to a non-mutating candidate preview. Non-mutating means stdout
+  output only by default: no source manifests, wiki pages, derived artifacts, queue records, run
+  records, or reports are written.
+- `repo scan --json` emits the same preview as machine-readable JSON to stdout. Persisting a
+  discovery report requires an explicit output flag such as `--report PATH`, and that flag writes
+  only the report, not source manifests.
+- Mutating registration from scan requires `--apply`. This is an intentional safety-breaking
+  change from the current mutating default: the old behavior moves behind `--apply`, and the bare
+  command should clearly say that it is preview-only and print the exact apply command.
 - Broad registration requires explicit class/all opt-in and should refuse huge candidate sets
   without confirmation flags.
 - `repo scan` supports class filtering, such as `--class documentation`, `--class code`, and
@@ -65,6 +73,9 @@ The next implementation slices should document and then implement these contract
 - `splendor.yaml` supports planned `sources.include_patterns` and `sources.exclude_patterns`.
 - Scan candidate output includes paths, classes, labels, ignore reasons, and whether a source is
   already curated.
+- M13-P2.2 must update CLI help, README/quickstart guidance, and tests around the new preview
+  default, the `--apply` compatibility path, JSON output, report persistence, class filters, and
+  large-candidate refusal.
 - A freshness workflow reports curated sources whose current canonical file content differs from
   the manifest checksum and prints exact next commands.
 - `brief --agent-context` leads with actual project state, stale/contested/actionable items, and

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -1,0 +1,82 @@
+# Issue 70 Design Response
+
+## Status
+
+Issue #70 is the first real external agent-experience report for Splendor. It is a product signal,
+not just a bug report. The accepted direction is the middle-ground redesign:
+
+- keep Splendor local-first, file-based, and git-native
+- split source discovery, source curation, and synthesis into separate workflow stages
+- make broad repo discovery safe before it can create manifest or wiki churn
+- focus agent-facing value on freshness, contested knowledge, planning state, and next actions
+
+This note is a planning contract for the M13-P2 implementation sequence. It does not describe
+current runtime behavior where noted as planned.
+
+## What Went Wrong
+
+`splendor repo scan` registered thousands of files in a real companion repository. The command
+treated every supported file as a source, including generated YAML, tests, source files, and
+configuration. That destroyed the value of the curated source set and created a diff dominated by
+manifest noise.
+
+The report also challenged the product's value proposition for agents. Agents already read files,
+grep, inspect git history, and open issues quickly. Splendor is useful only when it answers
+questions the source files alone do not answer:
+
+- what knowledge is stale
+- what sources contradict each other
+- what review tasks are open
+- what changed since the last ingest
+- what the next highest-value action is
+- what a new agent should know before continuing work
+
+The current agent handoff is also too metadata-heavy. A useful brief should front-load project
+state, stale or contested knowledge, open review work, and next actions before listing source and
+schema details.
+
+## Accepted Redesign
+
+Splendor remains a durable project knowledge system, but its center of gravity shifts from
+"generate a maintained wiki for everything" to "maintain an agent context/control layer over
+curated project knowledge."
+
+The design distinction is:
+
+- **Discovery** finds candidate files and reports them without changing source manifests.
+- **Curation** explicitly accepts sources into `state/manifests/sources/`.
+- **Synthesis** creates or updates maintained wiki pages only when the result adds cross-source
+  value, review context, contradiction handling, or handoff value.
+
+Source-summary pages remain useful for opaque, transformed, external, PDF, OCR, or otherwise
+hard-to-read sources. For readable in-repo markdown and code, summaries should become policy-driven
+rather than assumed to be the primary value.
+
+## Planned Interface Direction
+
+The next implementation slices should document and then implement these contracts:
+
+- `splendor repo scan` defaults to a non-mutating candidate preview.
+- Mutating registration from scan requires `--apply`.
+- Broad registration requires explicit class/all opt-in and should refuse huge candidate sets
+  without confirmation flags.
+- `repo scan` supports class filtering, such as `--class documentation`, `--class code`, and
+  `--class configuration`.
+- `splendor.yaml` supports planned `sources.include_patterns` and `sources.exclude_patterns`.
+- Scan candidate output includes paths, classes, labels, ignore reasons, and whether a source is
+  already curated.
+- A freshness workflow reports curated sources whose current canonical file content differs from
+  the manifest checksum and prints exact next commands.
+- `brief --agent-context` leads with actual project state, stale/contested/actionable items, and
+  next actions before metadata.
+- A future `suggest-next` command ranks work from open tasks, stale sources, failed jobs, missing
+  synthesis, and contradictions.
+
+## Roadmap Impact
+
+M13-P2 now owns the Issue #70 agent-usefulness redesign. Release finalization moves behind that
+work because Splendor is not v1-ready while a reasonable agent can accidentally register thousands
+of files from a broad scan.
+
+Issue #70 remains open as the parent product-feedback issue until the implementation slices
+substantially address the scan safety, freshness, handoff, and path-first UX gaps.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -90,6 +90,14 @@ uv run splendor --root /tmp/demo-repo add-source --glob "docs/*.md"
 uv run splendor --root /tmp/demo-repo add-source --dir docs
 ```
 
+For real repositories, prefer curated `add-source`, `--glob`, or `--dir` registration over broad
+repo discovery. Current `splendor repo scan` is broad and mutating: it registers supported files it
+finds under the workspace. Issue #70 showed that this can create thousands of manifests in repos
+with generated configs, tests, or large code trees. M13-P2 redesign work will make repo scan safe by
+default with non-mutating candidate reports, filters, and explicit apply semantics. Until then, use
+`repo scan` only for small demo repositories or deliberate bulk registration runs whose diff you
+intend to review.
+
 Readable source lookup maps titles and paths back to canonical source IDs without renaming source
 records or generated `wiki/sources/src-...md` pages:
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,21 +334,18 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M12-P2.1`
-- Current planned slice: `M13-P1`
-- Current PR sub-slice: `M13-P1.1`
+- Previous completed PR sub-slice: `M13-P1.1`
+- Current planned slice: `M13-P2`
+- Current PR sub-slice: `M13-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M13-P2`
-- Next planned PR sub-slice: `M13-P2.1`
+- Next planned PR sub-slice: `M13-P2.2`
 
-`M10-P0.1` is implemented: the CLI-first wiki status and source-impact suggestion bridge is in
-place. `M10-P0.2` is implemented: project briefing and the non-mutating review-gated compile-loop
-contract are available. `M10-P0.3` is implemented: it polishes the visible dogfood workflow with
-restrained next-action hints, claim-bearing snippets, and read-only web status/source-detail
-surfaces. The current PR sub-slice is `M9-P2.1`, under parent slice `M9-P2`, which returns to
-read-only planning and runtime inspection pages for the local web UI. The lifecycle marker means
-`M9-P2.1` is in progress on feature branches and merged once the same committed state is observed
-on `main`.
+`M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The current M13-P2 sequence
+responds to issue #70 by making source discovery safe, keeping source manifests curated, and
+shifting agent-facing value toward freshness, contested knowledge, planning state, and next
+actions. The lifecycle marker means `M13-P2.1` is in progress on feature branches and merged once
+the same committed state is observed on `main`.
 
 ---
 
@@ -753,7 +750,7 @@ text-bearing PDFs through deterministic local extraction. Parsed PDF text is sto
 `derived/parsed/`, linked from source manifests through `derived_artifacts`, and used by the same
 source-summary/query path as text-native sources.
 
-`M12-P2.1` is in progress: it adds explicitly configured image/OCR dispatch using a deterministic
+`M12-P2.1` is implemented: it adds explicitly configured image/OCR dispatch using a deterministic
 sidecar-text provider. OCR-derived text is stored separately under `derived/ocr/`, linked from
 source manifests through `derived_artifacts`, and used by the same generated source-summary/query
 path when extraction succeeds. Sidecar checksum metadata is stored under `derived/metadata/` so
@@ -762,27 +759,45 @@ deterministically without destabilizing text-native or text-bearing PDF ingest.
 
 ---
 
-## Milestone 13 — v1 stabilization and release
+## Milestone 13 — v1 stabilization, agent usefulness, and release
 
 ### Goal
-Publish a coherent, documented v1 that feels like a complete product.
+Publish a coherent v1 only after the first real agent-experience feedback is addressed: broad repo
+discovery must be safe, source manifests must stay curated, and agent handoffs must summarize
+freshness, contested knowledge, planning state, and next actions rather than mostly metadata.
 
 ### Scope
 - contract hardening
 - docs and examples
 - migration notes
 - versioned schemas
-- extension points
-- performance polish
-- one or two real-world showcase repos
+- issue #70 design response
+- safe repo discovery and curation controls
+- source freshness and diff-since-ingest reporting
+- higher-signal agent handoff and next-action guidance
+- source-summary policy and path-first UX
+- release finalization after the redesign lands
 
 ### Planned PR slices
 - `M13-P1` Schema/docs/migration stabilization
-- `M13-P2` Extension/performance/release finalization
+- `M13-P2` Issue #70 agent-usefulness redesign
+- `M13-P3` Extension/performance/release finalization
+
+### Current PR sub-slices
+- `M13-P2.1` Docs-only design reset and roadmap realignment
+- `M13-P2.2` Safe repo scan candidate discovery
+- `M13-P2.3` Source freshness / diff-since-ingest workflow
+- `M13-P2.4` Agent handoff brief and suggest-next
+- `M13-P2.5` Source-summary policy and path-first UX
 
 ### Deliverables
 - v1 schema versions
 - migration documentation for earlier repos
+- issue #70 design response
+- safe repo scan candidate reports
+- curated source registration guidance
+- freshness reporting for changed curated sources
+- actionable agent handoff and next-action surfaces
 - end-to-end tutorials
 - reference example repos
 - stable CLI docs
@@ -794,6 +809,8 @@ Publish a coherent, documented v1 that feels like a complete product.
 - the product is stable enough for sustained real-world use
 - the architecture is coherent
 - the CLI, file contracts, and workflow model are documented and dependable
+- broad discovery cannot accidentally create large manifest/wiki churn
+- generated artifacts add value beyond readable source files
 - the difference between core and optional features is very clear
 
 ---

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -79,7 +79,9 @@ reports may classify and rank them, but candidates are not part of the durable s
 the user accepts them.
 
 **Curated sources** are immutable source artifacts that represent the project’s evidence base and
-are recorded in `state/manifests/sources/`.
+are recorded in the configured source-record registry. The default registry path is
+`state/manifests/sources/`; non-default layouts use `layout.source_records_dir` in
+`splendor.yaml`.
 
 Examples:
 - markdown notes
@@ -116,6 +118,25 @@ Examples:
 - already-curated candidate markers
 
 Discovery reports are not source manifests. They help users and agents decide what to curate.
+Planned `splendor repo scan` behavior is:
+
+- default output is a human-readable stdout preview only
+- `--json` emits a machine-readable preview to stdout
+- persistent report files are written only when the operator passes an explicit report path such as
+  `--report PATH`
+- preview/report generation must not write source manifests, wiki pages, derived artifacts, queue
+  records, or run records
+- mutating source registration is allowed only through an explicit apply path
+
+The minimum planned candidate fields are:
+- `path`: workspace-root-relative POSIX path or external reference
+- `class`: candidate class such as `documentation`, `code`, or `configuration`
+- `labels`: deterministic labels assigned during classification
+- `status`: `included`, `excluded`, or `already_curated`
+- `ignore_reason`: explanation when a candidate is skipped
+- `matched_include_patterns` and `matched_exclude_patterns`
+- `source_id` and `title` when the candidate is already curated
+- `next_command`: exact follow-up command for registration, inspection, or exclusion
 
 ### 4.3 Derived Extraction Artifacts
 
@@ -767,6 +788,9 @@ Planned M13-P2 contracts:
 
 - `splendor repo scan` should default to a non-mutating candidate preview that writes no source
   manifests unless the user passes an explicit apply flag.
+- This preview default is an intentional safety-breaking CLI change. The previous mutating behavior
+  moves to `repo scan --apply`; the bare command should say that it is preview-only and print the
+  exact apply command.
 - Repo scan should support class filters, include/exclude patterns from `splendor.yaml`, and guard
   against large candidate sets before registration.
 - Broad registration should require explicit all/classes opt-in and should refuse huge candidate
@@ -1159,9 +1183,18 @@ Current source settings:
   `.ocr.txt`
 
 Planned source-discovery settings:
-- `sources.include_patterns`: optional glob patterns that define repo-scan candidate inclusion
-- `sources.exclude_patterns`: optional glob patterns that skip generated/noisy paths
-- `sources.repo_scan_default_classes`: class policy for non-mutating candidate discovery
+- `sources.include_patterns`: optional workspace-root-relative POSIX glob patterns that define
+  repo-scan candidate inclusion
+- `sources.exclude_patterns`: optional workspace-root-relative POSIX glob patterns that skip
+  generated/noisy paths; exclude matches win over include matches
+- `sources.repo_scan_default_classes`: class policy for non-mutating candidate discovery, applied
+  after include/exclude filtering
+
+Repo scan should skip Git-ignored files, Splendor state/output directories, dependency directories,
+build artifacts, and other generated paths by default unless a future explicit override flag
+documents the extra churn. Class filters narrow the already-filtered candidate set; they should not
+override excludes. The default class policy should bias toward documentation and curated knowledge
+over all supported files.
 
 ## 28. Minimum Opinionated Core
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -2,20 +2,29 @@
 
 ## 1. Overview
 
-**Splendor** is a local-first, git-native, schema-driven knowledge compiler for code-and-research repositories. It turns a software project and its surrounding research materials into a maintained, queryable, reviewable project wiki composed primarily of markdown files, with structured provenance, planning objects, and incremental LLM-assisted synthesis.
+**Splendor** is a local-first, git-native, schema-driven agent context system for
+code-and-research repositories. It maintains curated project knowledge, provenance, planning
+objects, freshness signals, and reviewable synthesis in markdown and structured sidecars so humans
+and agents can decide what is trustworthy, stale, contested, and actionable.
 
 The product is inspired by the LLM Wiki pattern: a persistent wiki that is continuously updated as new source material arrives, instead of re-deriving knowledge from raw documents at query time. In Splendor, that pattern is adapted specifically for software projects that require substantial research, domain knowledge, technical decision tracking, and project planning. The uploaded concept note emphasizes the persistent wiki as the central compounding artifact, with raw sources remaining immutable and the LLM maintaining the synthesized layer. fileciteturn0file0L6-L18 fileciteturn0file0L35-L43
+
+Issue #70 clarified that this wiki layer must not become a noisy mirror of files agents can already
+read directly. Splendor should distinguish discovery from curation, keep source manifests
+intentional, and generate synthesis when it adds cross-source value, freshness context,
+contradiction handling, or handoff value.
 
 ## 2. Product Goals
 
 ### Core goals
 
-1. **Maintain a persistent project wiki in git**
-   - The wiki lives either inside the code repository or in a companion repository.
-   - The wiki is primarily markdown and optimized for GitHub readability and reviewability.
+1. **Maintain curated project context in git**
+   - The knowledge workspace lives either inside the code repository or in a companion repository.
+   - The durable state is markdown and schema-bound sidecars optimized for GitHub readability and
+     reviewability.
 
 2. **Support incremental source ingestion**
-   - New sources are added to the repository and processed into structured wiki updates.
+   - Curated sources are added to the repository and processed into structured knowledge updates.
    - Existing wiki pages are updated rather than recreated from scratch.
 
 3. **Treat provenance as a first-class concern**
@@ -51,6 +60,7 @@ Splendor is built around a few principles:
 - **Local-first authoring and ingestion**
 - **Git-native collaboration and review**
 - **Persistent knowledge over stateless retrieval**
+- **Curated source intent over broad file mirroring**
 - **Structured provenance over opaque synthesis**
 - **Deterministic maintenance where rules suffice**
 - **LLMs for semantic work, not for every operation**
@@ -58,11 +68,18 @@ Splendor is built around a few principles:
 
 ## 4. Core Conceptual Model
 
-Splendor has five conceptual layers.
+Splendor has seven conceptual layers.
 
-### 4.1 Sources
+### 4.1 Source Candidates and Curated Sources
 
-Immutable source artifacts that represent the project’s evidence base.
+Splendor distinguishes files it discovers from sources the user intentionally curates.
+
+**Source candidates** are files or external references found by discovery workflows. Candidate
+reports may classify and rank them, but candidates are not part of the durable source registry until
+the user accepts them.
+
+**Curated sources** are immutable source artifacts that represent the project’s evidence base and
+are recorded in `state/manifests/sources/`.
 
 Examples:
 - markdown notes
@@ -75,7 +92,8 @@ Examples:
 - design docs
 - code files or code snapshots
 
-The source layer is append-oriented. Sources are not mutated by LLM workflows.
+The source layer is append-oriented. Sources are not mutated by LLM workflows. Discovery must not
+create large manifest or wiki churn unless the user explicitly applies a curated selection.
 
 Splendor now defaults to workspace-backed registration for in-repo files and materialized copies
 for external local files. Materialization under `raw/sources/` remains useful for external and
@@ -87,7 +105,19 @@ already live inside git. The source model therefore distinguishes between:
 - any optional **materialized snapshot or pointer artifact** Splendor creates for provenance,
   portability, or repairability
 
-### 4.2 Derived Extraction Artifacts
+### 4.2 Discovery Reports
+
+Machine-readable reports produced by non-mutating discovery workflows.
+
+Examples:
+- repo scan candidate reports
+- include/exclude match summaries
+- candidate class counts
+- already-curated candidate markers
+
+Discovery reports are not source manifests. They help users and agents decide what to curate.
+
+### 4.3 Derived Extraction Artifacts
 
 Machine-generated extraction outputs derived from raw sources.
 
@@ -102,7 +132,7 @@ Examples:
 
 These are repairable intermediates, not the wiki itself.
 
-### 4.3 Knowledge Pages
+### 4.4 Knowledge Pages
 
 Maintained markdown pages that form the project wiki.
 
@@ -118,12 +148,30 @@ Examples:
 These pages are incrementally updated as new sources arrive.
 
 Source-summary pages are ingestion artifacts, not the full compounding synthesis layer. They make a
-registered source searchable, reviewable, and traceable to an ingest run. Concept, topic,
+curated source searchable, reviewable, and traceable to an ingest run. Concept, topic,
 comparison, architecture, and overview pages are the maintained synthesis layer where Splendor
 turns source evidence into project knowledge. Product workflows should keep that distinction
 explicit instead of implying that source-summary generation alone completes wiki maintenance.
 
-### 4.4 Operational Ledger
+Future public concepts should name this distinction directly:
+- **Generated source-summary artifact**: a per-source page or sidecar produced by ingest, useful
+  when the source is opaque, transformed, external, PDF/OCR-derived, or otherwise hard to inspect
+  directly.
+- **Maintained synthesis page**: a curated wiki page that compounds evidence across sources,
+  decisions, tasks, contradictions, and project history.
+
+### 4.5 Freshness State
+
+Computed state that compares curated source manifests, canonical source paths, generated artifacts,
+and wiki pages.
+
+Freshness answers:
+- which curated sources changed since their manifest checksum
+- which ingests or source summaries are stale
+- which synthesis pages need follow-up
+- which exact command should move the project state forward
+
+### 4.6 Operational Ledger
 
 Durable operational records that track what happened.
 
@@ -139,7 +187,7 @@ Examples:
 
 This layer exists to support idempotency, trust, debugging, and recovery.
 
-### 4.5 Planning Objects
+### 4.7 Planning Objects
 
 Structured project-management artifacts rendered as markdown and queryable through the CLI/UI.
 
@@ -715,6 +763,24 @@ Current implementation:
 - Mutating `splendor wiki compile <source-id>` remains deferred to a later reviewed compile-loop
   slice.
 
+Planned M13-P2 contracts:
+
+- `splendor repo scan` should default to a non-mutating candidate preview that writes no source
+  manifests unless the user passes an explicit apply flag.
+- Repo scan should support class filters, include/exclude patterns from `splendor.yaml`, and guard
+  against large candidate sets before registration.
+- Broad registration should require explicit all/classes opt-in and should refuse huge candidate
+  sets unless the operator passes documented confirmation flags.
+- `splendor.yaml` should add planned `sources.include_patterns`, `sources.exclude_patterns`, and a
+  repo-scan default class policy that favors documentation/curated knowledge over all supported
+  files.
+- A freshness workflow should report curated sources whose canonical file content differs from the
+  manifest checksum and should include source IDs, titles, paths, status, and exact next commands.
+- `brief --agent-context` should lead with project state, stale/contested/actionable items, and
+  next actions before metadata.
+- A future `suggest-next` command should rank work from open tasks, stale sources, failed jobs,
+  missing synthesis, and contradictions.
+
 Later optional support:
 - additional OCR providers
 - image captioning or metadata extraction
@@ -1092,6 +1158,11 @@ Current source settings:
 - `sources.ocr_sidecar_suffix`: sidecar suffix appended to the resolved source path, default
   `.ocr.txt`
 
+Planned source-discovery settings:
+- `sources.include_patterns`: optional glob patterns that define repo-scan candidate inclusion
+- `sources.exclude_patterns`: optional glob patterns that skip generated/noisy paths
+- `sources.repo_scan_default_classes`: class policy for non-mutating candidate discovery
+
 ## 28. Minimum Opinionated Core
 
 The smallest opinionated core should be:
@@ -1117,7 +1188,7 @@ The smallest opinionated core should be:
 Splendor should be considered successful at the product-spec level if it can do the following reliably:
 
 1. initialize a repo or subdirectory as a Splendor wiki
-2. add a source and create stable source metadata
+2. curate a source and create stable source metadata
 3. ingest a source and create a stable source-summary page
 4. identify or update affected synthesis pages through a reviewable compile/update path
 5. avoid duplicate accidental re-ingestion
@@ -1130,6 +1201,8 @@ Splendor should be considered successful at the product-spec level if it can do 
 11. lint the repo deterministically
 12. operate locally without GitHub
 13. optionally integrate with GitHub Actions for maintenance
+14. preview repo discovery without mutating manifests or wiki pages
+15. report stale curated sources and actionable next commands
 
 ## 30. Open Design Questions
 
@@ -1142,7 +1215,9 @@ These are not blockers to the spec, but should remain visible:
 5. how aggressively to auto-update central synthesis pages
 6. exact level of provenance granularity at the paragraph/claim level
 7. whether a companion-repo linking model needs a first-class schema element
+8. exact generated source-summary policy for readable in-repo markdown and code files
 
 ## 31. Summary Product Statement
 
-**Splendor turns a code repo and its research materials into a maintained, queryable, reviewable project wiki — with provenance, tasks, decisions, and incremental LLM-assisted synthesis.**
+**Splendor turns curated project sources, planning state, and review signals into an agent-ready
+context layer with provenance, freshness, contradictions, next actions, and reviewable synthesis.**


### PR DESCRIPTION
## Summary

- Add a docs-only Issue #70 design response that accepts the Option 3 middle-ground direction: keep Splendor file-based while separating discovery, curation, and synthesis.
- Realign M13-P2 around safe repo scan candidate discovery, source freshness, higher-signal agent handoff, and source-summary/path-first UX.
- Update planning state, README guidance, quickstart warnings, product concepts, roadmap slices, and durable AGENTS.md design rules.

## Scope

This is a documentation/planning PR only. It does not change Python code, schemas, tests, CLI behavior, repo-scan behavior, or runtime workflows.

## Validation

- `uv run splendor lint`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `git diff --check`

Not run: `uv run pytest` because this PR is docs/planning-only per the requested test plan.

Refs #70