### PR TITLE
M13-P2.3 Source freshness preview

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M13-P2.1`
-- Last action taken: `M13-P2.1` is implemented; issue #70 design reset and roadmap realignment are complete.
+- Previous completed PR sub-slice: `M13-P2.2`
+- Last action taken: `M13-P2.2` is implemented; safe repo scan candidate discovery is complete.
 - Current planned slice: `M13-P2`
-- Current PR sub-slice: `M13-P2.2`
+- Current PR sub-slice: `M13-P2.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M13-P2`
-- Next planned PR sub-slice: `M13-P2.3`
+- Next planned PR sub-slice: `M13-P2.4`
 - Current blockers: none
 
 ## Planning Notation
@@ -193,6 +193,10 @@
   - [x] Make bare `splendor repo scan` a non-mutating candidate preview
   - [x] Add JSON/report output, class filters, config include/exclude patterns, and default classes
   - [x] Move registration to explicit `--apply` with class/all opt-in and large-set refusal
+- [x] Implement `M13-P2.3`: Source freshness / diff-since-ingest workflow
+  - [x] Add non-mutating `splendor source freshness` for curated source manifests
+  - [x] Report unchanged, changed, missing, and unsupported freshness states path-first
+  - [x] Add JSON output and explicit freshness report persistence
 
 ## Context Pointers
 

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -193,7 +193,7 @@
   - [x] Make bare `splendor repo scan` a non-mutating candidate preview
   - [x] Add JSON/report output, class filters, config include/exclude patterns, and default classes
   - [x] Move registration to explicit `--apply` with class/all opt-in and large-set refusal
-- [x] Implement `M13-P2.3`: Source freshness / diff-since-ingest workflow
+- [x] Implement `M13-P2.3`: Source freshness / manifest-drift workflow
   - [x] Add non-mutating `splendor source freshness` for curated source manifests
   - [x] Report unchanged, changed, missing, and unsupported freshness states path-first
   - [x] Add JSON output and explicit freshness report persistence
@@ -246,6 +246,6 @@
 - `M13-P1.1` Schema/docs/migration stabilization
 - `M13-P2.1` Issue #70 design reset and roadmap realignment
 - `M13-P2.2` Safe repo scan candidate discovery
-- `M13-P2.3` Source freshness / diff-since-ingest workflow
+- `M13-P2.3` Source freshness / manifest-drift workflow
 - `M13-P2.4` Agent handoff brief and suggest-next
 - `M13-P2.5` Source-summary policy and path-first UX

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ derived state. Registration requires `repo scan --apply` plus `--class ...` or `
 source files to their manifest checksums, reports unchanged/changed/missing/unsupported sources,
 and prints exact `source refresh`/`ingest --pending` next commands for stale paths. `--json` emits
 the same preview for machine handoff, and `--report PATH` writes only an explicit freshness report.
+Relative report paths use the current working directory.
 
 Text-bearing PDFs are supported through the ingest dispatch path. Parsed PDF text is written under
 `derived/parsed/`, linked from the source manifest, and used for the generated source-summary page.
@@ -231,7 +232,8 @@ writing manifests or derived state, `--json` emits the preview, and `--report PA
 explicit discovery report. Registration moved behind `--apply` plus `--class ...` or `--all`, with
 large candidate sets refused unless `--allow-large-apply` is passed after review.
 
-`M13-P2.3` adds `splendor source freshness`, a safe diff-since-ingest preview for curated sources.
-It reports path-first freshness state for workspace-backed manifests, includes manifest/current
-checksums, supports JSON/report output, and does not update manifests, wiki pages, derived
-artifacts, queue records, run records, or reports unless `--report PATH` is provided.
+`M13-P2.3` adds `splendor source freshness`, a safe manifest-drift preview for curated sources. It
+reports path-first freshness state for workspace-backed manifests, includes manifest/current
+checksums, separates historical source versions from actionable stale paths, supports JSON/report
+output, and does not update manifests, wiki pages, derived artifacts, queue records, run records, or
+reports unless `--report PATH` is provided.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Implemented today:
 - `splendor init`
 - `splendor add-source <path>`, `splendor add-source --glob "pattern"`, and
   `splendor add-source --dir path`
-- `splendor source list`, `splendor source lookup [query]`, and
+- `splendor source list`, `splendor source lookup [query]`, `splendor source freshness`, and
   `splendor source refresh <source-id|title|path>`
 - `splendor ingest <source-id>` and `splendor ingest --pending`
 - `splendor queue inspect [job-id]` and `splendor queue retry <job-id>`
@@ -143,6 +143,10 @@ Not implemented yet:
 
 `splendor repo scan` is safe by default: it previews candidates without writing manifests or
 derived state. Registration requires `repo scan --apply` plus `--class ...` or `--all`.
+`splendor source freshness` is also non-mutating by default: it compares workspace-backed curated
+source files to their manifest checksums, reports unchanged/changed/missing/unsupported sources,
+and prints exact `source refresh`/`ingest --pending` next commands for stale paths. `--json` emits
+the same preview for machine handoff, and `--report PATH` writes only an explicit freshness report.
 
 Text-bearing PDFs are supported through the ingest dispatch path. Parsed PDF text is written under
 `derived/parsed/`, linked from the source manifest, and used for the generated source-summary page.
@@ -163,12 +167,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M13-P2.1`
+- Previous completed PR sub-slice: `M13-P2.2`
 - Current planned slice: `M13-P2`
-- Current PR sub-slice: `M13-P2.2`
+- Current PR sub-slice: `M13-P2.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M13-P2`
-- Next planned PR sub-slice: `M13-P2.3`
+- Next planned PR sub-slice: `M13-P2.4`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -226,3 +230,8 @@ candidate reports, curated source manifests, source freshness, and higher-signal
 writing manifests or derived state, `--json` emits the preview, and `--report PATH` writes only an
 explicit discovery report. Registration moved behind `--apply` plus `--class ...` or `--all`, with
 large candidate sets refused unless `--allow-large-apply` is passed after review.
+
+`M13-P2.3` adds `splendor source freshness`, a safe diff-since-ingest preview for curated sources.
+It reports path-first freshness state for workspace-backed manifests, includes manifest/current
+checksums, supports JSON/report output, and does not update manifests, wiki pages, derived
+artifacts, queue records, run records, or reports unless `--report PATH` is provided.

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -78,7 +78,8 @@ The next implementation slices should document and then implement these contract
   large-candidate refusal.
 - `splendor source freshness` reports curated sources whose current canonical file content differs
   from the manifest checksum, prints path-first status with exact next commands, supports JSON and
-  explicit report output, and does not mutate manifests or derived state by default.
+  explicit report output, separates historical source versions from actionable stale paths, and does
+  not mutate manifests or derived state by default.
 - `brief --agent-context` leads with actual project state, stale/contested/actionable items, and
   next actions before metadata.
 - A future `suggest-next` command ranks work from open tasks, stale sources, failed jobs, missing

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -76,8 +76,9 @@ The next implementation slices should document and then implement these contract
 - M13-P2.2 must update CLI help, README/quickstart guidance, and tests around the new preview
   default, the `--apply` compatibility path, JSON output, report persistence, class filters, and
   large-candidate refusal.
-- A freshness workflow reports curated sources whose current canonical file content differs from
-  the manifest checksum and prints exact next commands.
+- `splendor source freshness` reports curated sources whose current canonical file content differs
+  from the manifest checksum, prints path-first status with exact next commands, supports JSON and
+  explicit report output, and does not mutate manifests or derived state by default.
 - `brief --agent-context` leads with actual project state, stale/contested/actionable items, and
   next actions before metadata.
 - A future `suggest-next` command ranks work from open tasks, stale sources, failed jobs, missing

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -196,9 +196,11 @@ uv run splendor --root /tmp/demo-repo ingest --pending
 ```
 
 `source freshness` is a safe preview. By default it writes nothing and reports unchanged, changed,
-missing, and unsupported source freshness states for curated sources. Workspace-backed changed
-sources include manifest/current checksums and exact next commands; non-workspace sources are
-reported as unsupported for this preview.
+missing, historical, and unsupported source freshness states for curated sources. Workspace-backed
+changed sources include manifest/current checksums and exact next commands; older source versions
+for paths already covered by a current manifest are reported as historical. Non-workspace sources
+are reported as unsupported for this preview. Relative `--report` paths use the current working
+directory.
 
 Refresh does not override active ingest leases or dead-letter protections; use `queue retry` or
 `repair ingest` for those recovery cases.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -188,9 +188,17 @@ ingest through the same ledger used by `add-source`. It carries the manifest's
 capture keeps that behavior even if the previous version had no `source_commit` value:
 
 ```bash
+uv run splendor --root /tmp/demo-repo source freshness
+uv run splendor --root /tmp/demo-repo source freshness --json
+uv run splendor --root /tmp/demo-repo source freshness --report /tmp/demo-repo/reports/source-freshness.json
 uv run splendor --root /tmp/demo-repo source refresh product-note.md
 uv run splendor --root /tmp/demo-repo ingest --pending
 ```
+
+`source freshness` is a safe preview. By default it writes nothing and reports unchanged, changed,
+missing, and unsupported source freshness states for curated sources. Workspace-backed changed
+sources include manifest/current checksums and exact next commands; non-workspace sources are
+reported as unsupported for this preview.
 
 Refresh does not override active ingest leases or dead-letter protections; use `queue retry` or
 `repair ingest` for those recovery cases.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -160,10 +160,12 @@ Implemented fields:
 - `splendor source freshness` is a non-mutating preview over curated source manifests. It reports
   path-first freshness state for workspace-backed canonical source refs, including unchanged,
   changed, missing, and unsupported statuses, manifest/current checksums where available, source
-  IDs, titles, manifest paths, and exact next commands for changed sources.
+  IDs, titles, manifest paths, historical versions for paths covered by a current manifest, and
+  exact next commands for changed sources.
 - `splendor source freshness --json` emits the same preview for machine handoff. `--report PATH`
-  writes only an explicit freshness report JSON; the default command writes no source manifests,
-  wiki pages, derived artifacts, queue records, run records, or reports.
+  writes only an explicit freshness report JSON, with relative report paths resolved from the
+  current working directory; the default command writes no source manifests, wiki pages, derived
+  artifacts, queue records, run records, or reports.
 - Refresh uses the queue ledger directly, so active leases remain protected and dead-lettered jobs
   still require `splendor queue retry <job-id>` or `splendor repair ingest <source-id>`.
 - Text-bearing PDF sources are routed through source-type dispatch during ingest. The source

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -157,6 +157,13 @@ Implemented fields:
   compares current bytes to the manifest checksum, registers changed content as a new canonical
   source version, preserves `source_commit_capture` intent, and queues ingest through the same queue
   handoff used by `add-source`.
+- `splendor source freshness` is a non-mutating preview over curated source manifests. It reports
+  path-first freshness state for workspace-backed canonical source refs, including unchanged,
+  changed, missing, and unsupported statuses, manifest/current checksums where available, source
+  IDs, titles, manifest paths, and exact next commands for changed sources.
+- `splendor source freshness --json` emits the same preview for machine handoff. `--report PATH`
+  writes only an explicit freshness report JSON; the default command writes no source manifests,
+  wiki pages, derived artifacts, queue records, run records, or reports.
 - Refresh uses the queue ledger directly, so active leases remain protected and dead-lettered jobs
   still require `splendor queue retry <job-id>` or `splendor repair ingest <source-id>`.
 - Text-bearing PDF sources are routed through source-type dispatch during ingest. The source

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -773,7 +773,7 @@ freshness, contested knowledge, planning state, and next actions rather than mos
 - versioned schemas
 - issue #70 design response
 - safe repo discovery and curation controls
-- source freshness and diff-since-ingest reporting
+- source freshness and manifest-drift reporting
 - higher-signal agent handoff and next-action guidance
 - source-summary policy and path-first UX
 - release finalization after the redesign lands
@@ -786,7 +786,7 @@ freshness, contested knowledge, planning state, and next actions rather than mos
 ### Current PR sub-slices
 - `M13-P2.1` Docs-only design reset and roadmap realignment
 - `M13-P2.2` Safe repo scan candidate discovery
-- `M13-P2.3` Source freshness / diff-since-ingest workflow
+- `M13-P2.3` Source freshness / manifest-drift workflow
 - `M13-P2.4` Agent handoff brief and suggest-next
 - `M13-P2.5` Source-summary policy and path-first UX
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,17 +334,17 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M13-P2.1`
+- Previous completed PR sub-slice: `M13-P2.2`
 - Current planned slice: `M13-P2`
-- Current PR sub-slice: `M13-P2.2`
+- Current PR sub-slice: `M13-P2.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M13-P2`
-- Next planned PR sub-slice: `M13-P2.3`
+- Next planned PR sub-slice: `M13-P2.4`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The current M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
 shifting agent-facing value toward freshness, contested knowledge, planning state, and next
-actions. The lifecycle marker means `M13-P2.2` is in progress on feature branches and merged once
+actions. The lifecycle marker means `M13-P2.3` is in progress on feature branches and merged once
 the same committed state is observed on `main`.
 
 ---

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -800,8 +800,10 @@ M13-P2 repo-discovery contracts:
 - `splendor.yaml` supports `sources.include_patterns`, `sources.exclude_patterns`, and
   `sources.repo_scan_default_classes`; the default class policy favors documentation/curated
   knowledge over all supported files.
-- A freshness workflow should report curated sources whose canonical file content differs from the
-  manifest checksum and should include source IDs, titles, paths, status, and exact next commands.
+- `splendor source freshness` reports curated sources whose canonical file content differs from the
+  manifest checksum and includes source IDs, titles, paths, freshness status, manifest/current
+  checksums where available, and exact next commands. The default command is non-mutating; `--json`
+  emits machine-readable output and `--report PATH` writes only an explicit freshness report.
 - `brief --agent-context` should lead with project state, stale/contested/actionable items, and
   next actions before metadata.
 - A future `suggest-next` command should rank work from open tasks, stale sources, failed jobs,

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -802,8 +802,9 @@ M13-P2 repo-discovery contracts:
   knowledge over all supported files.
 - `splendor source freshness` reports curated sources whose canonical file content differs from the
   manifest checksum and includes source IDs, titles, paths, freshness status, manifest/current
-  checksums where available, and exact next commands. The default command is non-mutating; `--json`
-  emits machine-readable output and `--report PATH` writes only an explicit freshness report.
+  checksums where available, historical source-version status for paths already covered by a current
+  manifest, and exact next commands. The default command is non-mutating; `--json` emits
+  machine-readable output and `--report PATH` writes only an explicit freshness report.
 - `brief --agent-context` should lead with project state, stale/contested/actionable items, and
   next actions before metadata.
 - A future `suggest-next` command should rank work from open tasks, stale sources, failed jobs,

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -58,8 +58,11 @@ from splendor.commands.source import (
     list_sources,
     lookup_sources,
     refresh_source,
+    render_source_freshness_json,
     render_source_lookup_json,
     render_source_refresh_json,
+    scan_source_freshness,
+    write_source_freshness_report,
 )
 from splendor.commands.wiki import (
     add_topic_page,
@@ -214,6 +217,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     source_refresh_parser.set_defaults(handler=handle_source_refresh)
+    source_freshness_parser = source_subparsers.add_parser(
+        "freshness", help="Preview changed workspace-backed source content without mutating"
+    )
+    source_freshness_parser.add_argument(
+        "--report",
+        type=Path,
+        help="Write the freshness report JSON to this explicit path.",
+    )
+    source_freshness_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    source_freshness_parser.set_defaults(handler=handle_source_freshness)
 
     ingest_parser = subparsers.add_parser("ingest", help="Ingest registered sources into the wiki")
     ingest_parser.add_argument(
@@ -850,6 +868,53 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
     else:
         print(f"Refresh skipped: {result.message}")
         print(f"Next: splendor wiki suggest {result.refreshed.record.source_id}")
+    return 0
+
+
+def handle_source_freshness(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = scan_source_freshness(root)
+        if args.report is not None:
+            result = write_source_freshness_report(root, result, args.report)
+    except (FileNotFoundError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_source_freshness_json(root, result))
+        return 0
+
+    print("Source freshness preview")
+    print(
+        "Summary: "
+        f"total={result.total} "
+        f"unchanged={result.unchanged} "
+        f"changed={result.changed} "
+        f"missing={result.missing} "
+        f"unsupported={result.unsupported}"
+    )
+    if result.report_path is not None:
+        print(f"Report: {result.report_path}")
+    if not result.sources:
+        print("No source manifests found.")
+        return 0
+    for item in result.sources:
+        source = item.source
+        print(
+            f"- {item.canonical_path}: {item.status} "
+            f"title={source.title} source_id={source.source_id}"
+        )
+        print(f"  Manifest: {item.manifest_path}")
+        print(f"  Manifest checksum: {item.manifest_checksum}")
+        if item.current_checksum is not None:
+            print(f"  Current checksum: {item.current_checksum}")
+        print(f"  Message: {item.message}")
+        for command in item.next_commands:
+            print(f"  Next: {command}")
+    if result.changed or result.missing:
+        print("Next: splendor source refresh <path>")
+    else:
+        print("Next: splendor source lookup")
     return 0
 
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -879,7 +879,7 @@ def handle_source_freshness(args: argparse.Namespace) -> int:
     try:
         result = scan_source_freshness(root)
         if args.report is not None:
-            result = write_source_freshness_report(root, result, args.report.resolve())
+            result = write_source_freshness_report(root, result, args.report)
     except (FileNotFoundError, ValueError) as exc:
         return _print_error(exc)
 
@@ -915,11 +915,9 @@ def handle_source_freshness(args: argparse.Namespace) -> int:
         print(f"  Message: {item.message}")
         for command in item.next_commands:
             print(f"  Next: {command}")
-    if result.changed:
-        print("Next: splendor source refresh <path>")
-    elif result.missing:
+    if result.missing:
         print("Next: restore missing source files or inspect the listed source manifests")
-    else:
+    elif not result.changed:
         print("Next: splendor source lookup")
     return 0
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -223,7 +223,10 @@ def build_parser() -> argparse.ArgumentParser:
     source_freshness_parser.add_argument(
         "--report",
         type=Path,
-        help="Write the freshness report JSON to this explicit path.",
+        help=(
+            "Write the freshness report JSON to this explicit path. "
+            "Relative paths use the current working directory."
+        ),
     )
     source_freshness_parser.add_argument(
         "--json",
@@ -876,7 +879,7 @@ def handle_source_freshness(args: argparse.Namespace) -> int:
     try:
         result = scan_source_freshness(root)
         if args.report is not None:
-            result = write_source_freshness_report(root, result, args.report)
+            result = write_source_freshness_report(root, result, args.report.resolve())
     except (FileNotFoundError, ValueError) as exc:
         return _print_error(exc)
 
@@ -891,7 +894,8 @@ def handle_source_freshness(args: argparse.Namespace) -> int:
         f"unchanged={result.unchanged} "
         f"changed={result.changed} "
         f"missing={result.missing} "
-        f"unsupported={result.unsupported}"
+        f"unsupported={result.unsupported} "
+        f"historical={result.historical}"
     )
     if result.report_path is not None:
         print(f"Report: {result.report_path}")
@@ -911,8 +915,10 @@ def handle_source_freshness(args: argparse.Namespace) -> int:
         print(f"  Message: {item.message}")
         for command in item.next_commands:
             print(f"  Next: {command}")
-    if result.changed or result.missing:
+    if result.changed:
         print("Next: splendor source refresh <path>")
+    elif result.missing:
+        print("Next: restore missing source files or inspect the listed source manifests")
     else:
         print("Next: splendor source lookup")
     return 0

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -399,7 +400,7 @@ def _workspace_freshness_items(
                     current_checksum=current_checksum,
                     message="canonical workspace source differs from manifest checksum",
                     next_commands=[
-                        f"splendor source refresh {source_ref}",
+                        _source_refresh_command(source_ref),
                         "splendor ingest --pending",
                     ],
                 )
@@ -419,6 +420,10 @@ def _workspace_freshness_items(
             )
         )
     return items
+
+
+def _source_refresh_command(source_ref: str) -> str:
+    return f"splendor source refresh {shlex.quote(source_ref)}"
 
 
 def _freshness_payload(root: Path, item: SourceFreshnessItem) -> dict[str, object]:

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -242,7 +242,12 @@ def render_source_refresh_json(root: Path, result: SourceRefreshResult) -> str:
 def write_source_freshness_report(
     root: Path, result: SourceFreshnessResult, report_path: Path
 ) -> SourceFreshnessResult:
-    resolved_report_path = report_path if report_path.is_absolute() else root / report_path
+    expanded_report_path = report_path.expanduser()
+    resolved_report_path = (
+        expanded_report_path
+        if expanded_report_path.is_absolute()
+        else Path.cwd() / expanded_report_path
+    )
     resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
     result_with_report_path = replace(result, report_path=resolved_report_path.as_posix())
     resolved_report_path.write_text(
@@ -365,16 +370,33 @@ def _workspace_freshness_items(
             for result in results
         ]
 
+    layout = resolve_layout(root, load_config(root))
     current_checksum = sha256_file(source_path)
-    matching_source_ids = {
-        result.source.source_id for result in results if result.source.checksum == current_checksum
-    }
-    changed_candidate = None if matching_source_ids else max(results, key=_latest_source_sort_key)
+    latest_result = max(results, key=_latest_source_sort_key)
 
     items = []
     for result in results:
         source = result.source
-        if source.source_id in matching_source_ids:
+        if source.source_id != latest_result.source.source_id:
+            items.append(
+                SourceFreshnessItem(
+                    source=source,
+                    manifest_path=result.manifest_path,
+                    canonical_path=source_ref,
+                    status="historical",
+                    manifest_checksum=source.checksum,
+                    current_checksum=current_checksum,
+                    message=(
+                        "older source version for this workspace path; "
+                        "latest manifest is freshness target"
+                    ),
+                    next_commands=[],
+                )
+            )
+            continue
+
+        if source.checksum == current_checksum:
+            ingest_current = is_ingest_current(root, layout, source)
             items.append(
                 SourceFreshnessItem(
                     source=source,
@@ -383,25 +405,20 @@ def _workspace_freshness_items(
                     status="unchanged",
                     manifest_checksum=source.checksum,
                     current_checksum=current_checksum,
-                    message="canonical workspace source matches manifest checksum",
-                    next_commands=[f"splendor wiki suggest {source.source_id}"],
-                )
-            )
-            continue
-
-        if changed_candidate is not None and source.source_id == changed_candidate.source.source_id:
-            items.append(
-                SourceFreshnessItem(
-                    source=source,
-                    manifest_path=result.manifest_path,
-                    canonical_path=source_ref,
-                    status="changed",
-                    manifest_checksum=source.checksum,
-                    current_checksum=current_checksum,
-                    message="canonical workspace source differs from manifest checksum",
+                    message=(
+                        "canonical workspace source matches manifest checksum"
+                        if ingest_current
+                        else (
+                            "canonical workspace source matches manifest checksum "
+                            "but ingest is not current"
+                        )
+                    ),
                     next_commands=[
-                        _source_refresh_command(source_ref),
-                        "splendor ingest --pending",
+                        (
+                            f"splendor wiki suggest {source.source_id}"
+                            if ingest_current
+                            else _source_ingest_command(source.source_id)
+                        )
                     ],
                 )
             )
@@ -412,14 +429,21 @@ def _workspace_freshness_items(
                 source=source,
                 manifest_path=result.manifest_path,
                 canonical_path=source_ref,
-                status="historical",
+                status="changed",
                 manifest_checksum=source.checksum,
                 current_checksum=current_checksum,
-                message="older source version for this workspace path; current path is covered",
-                next_commands=[],
+                message="canonical workspace source differs from latest manifest checksum",
+                next_commands=[
+                    _source_refresh_command(source_ref),
+                    "splendor ingest --pending",
+                ],
             )
         )
     return items
+
+
+def _source_ingest_command(source_id: str) -> str:
+    return f"splendor ingest {shlex.quote(source_id)}"
 
 
 def _source_refresh_command(source_ref: str) -> str:

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -1,9 +1,9 @@
-"""Source lifecycle and lookup command helpers."""
+"""Source lifecycle, lookup, and freshness command helpers."""
 
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from splendor.commands.ingest import enqueue_ingest_job, is_ingest_current
@@ -42,6 +42,29 @@ class SourceRefreshResult:
     message: str
 
 
+@dataclass(frozen=True)
+class SourceFreshnessItem:
+    source: SourceRecord
+    manifest_path: Path
+    canonical_path: str
+    status: str
+    manifest_checksum: str
+    current_checksum: str | None
+    message: str
+    next_commands: list[str]
+
+
+@dataclass(frozen=True)
+class SourceFreshnessResult:
+    total: int
+    unchanged: int
+    changed: int
+    missing: int
+    unsupported: int
+    sources: list[SourceFreshnessItem]
+    report_path: str | None = None
+
+
 def list_sources(root: Path) -> list[SourceLookupResult]:
     layout = resolve_layout(root, load_config(root))
     results = [
@@ -49,6 +72,18 @@ def list_sources(root: Path) -> list[SourceLookupResult]:
         for path in sorted(layout.source_records_dir.glob("*.json"))
     ]
     return sorted(results, key=_lookup_sort_key)
+
+
+def scan_source_freshness(root: Path) -> SourceFreshnessResult:
+    items = [_freshness_item(root, result) for result in list_sources(root)]
+    return SourceFreshnessResult(
+        total=len(items),
+        unchanged=sum(1 for item in items if item.status == "unchanged"),
+        changed=sum(1 for item in items if item.status == "changed"),
+        missing=sum(1 for item in items if item.status == "missing"),
+        unsupported=sum(1 for item in items if item.status == "unsupported"),
+        sources=items,
+    )
 
 
 def lookup_sources(root: Path, query: str | None = None) -> list[SourceLookupResult]:
@@ -186,6 +221,38 @@ def render_source_refresh_json(root: Path, result: SourceRefreshResult) -> str:
     )
 
 
+def write_source_freshness_report(
+    root: Path, result: SourceFreshnessResult, report_path: Path
+) -> SourceFreshnessResult:
+    resolved_report_path = report_path if report_path.is_absolute() else root / report_path
+    resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        report_value = resolved_report_path.relative_to(root).as_posix()
+    except ValueError:
+        report_value = resolved_report_path.as_posix()
+    result_with_report_path = replace(result, report_path=report_value)
+    resolved_report_path.write_text(
+        render_source_freshness_json(root, result_with_report_path) + "\n",
+        encoding="utf-8",
+    )
+    return result_with_report_path
+
+
+def render_source_freshness_json(root: Path, result: SourceFreshnessResult) -> str:
+    return json.dumps(
+        {
+            "total": result.total,
+            "unchanged": result.unchanged,
+            "changed": result.changed,
+            "missing": result.missing,
+            "unsupported": result.unsupported,
+            "report_path": result.report_path,
+            "sources": [_freshness_payload(root, item) for item in result.sources],
+        },
+        indent=2,
+    )
+
+
 def _lookup_sort_key(result: SourceLookupResult) -> tuple[str, str, str]:
     return (
         result.source.title.casefold(),
@@ -222,6 +289,93 @@ def _refreshable_source_path(root: Path, source: SourceRecord) -> Path:
         "with `splendor add-source <path>` to create a refreshable source_ref."
     )
     raise ValueError(msg)
+
+
+def _freshness_item(root: Path, result: SourceLookupResult) -> SourceFreshnessItem:
+    source = result.source
+    canonical_path = canonical_source_ref(source)
+    if source.source_ref_kind != "workspace_path" or not source.source_ref:
+        return SourceFreshnessItem(
+            source=source,
+            manifest_path=result.manifest_path,
+            canonical_path=canonical_path,
+            status="unsupported",
+            manifest_checksum=source.checksum,
+            current_checksum=None,
+            message=(
+                "freshness preview supports only workspace-backed canonical source refs in this "
+                "release"
+            ),
+            next_commands=[],
+        )
+
+    source_path = resolve_workspace_path(root, source.source_ref, context="Workspace source")
+    if not source_path.exists():
+        return SourceFreshnessItem(
+            source=source,
+            manifest_path=result.manifest_path,
+            canonical_path=source.source_ref,
+            status="missing",
+            manifest_checksum=source.checksum,
+            current_checksum=None,
+            message="canonical workspace source file is missing",
+            next_commands=[],
+        )
+    if not source_path.is_file():
+        return SourceFreshnessItem(
+            source=source,
+            manifest_path=result.manifest_path,
+            canonical_path=source.source_ref,
+            status="unsupported",
+            manifest_checksum=source.checksum,
+            current_checksum=None,
+            message="canonical workspace source ref does not resolve to a file",
+            next_commands=[],
+        )
+
+    current_checksum = sha256_file(source_path)
+    if current_checksum == source.checksum:
+        return SourceFreshnessItem(
+            source=source,
+            manifest_path=result.manifest_path,
+            canonical_path=source.source_ref,
+            status="unchanged",
+            manifest_checksum=source.checksum,
+            current_checksum=current_checksum,
+            message="canonical workspace source matches manifest checksum",
+            next_commands=[f"splendor wiki suggest {source.source_id}"],
+        )
+
+    return SourceFreshnessItem(
+        source=source,
+        manifest_path=result.manifest_path,
+        canonical_path=source.source_ref,
+        status="changed",
+        manifest_checksum=source.checksum,
+        current_checksum=current_checksum,
+        message="canonical workspace source differs from manifest checksum",
+        next_commands=[
+            f"splendor source refresh {source.source_ref}",
+            "splendor ingest --pending",
+        ],
+    )
+
+
+def _freshness_payload(root: Path, item: SourceFreshnessItem) -> dict[str, object]:
+    source = item.source
+    return {
+        "path": item.canonical_path,
+        "status": item.status,
+        "source_id": source.source_id,
+        "title": source.title,
+        "source_ref": canonical_source_ref(source),
+        "source_ref_kind": source.source_ref_kind,
+        "manifest_checksum": item.manifest_checksum,
+        "current_checksum": item.current_checksum,
+        "manifest_path": item.manifest_path.relative_to(root).as_posix(),
+        "message": item.message,
+        "next_commands": item.next_commands,
+    }
 
 
 def _source_payload(root: Path, result: SourceLookupResult) -> dict[str, object]:

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -61,6 +61,7 @@ class SourceFreshnessResult:
     changed: int
     missing: int
     unsupported: int
+    historical: int
     sources: list[SourceFreshnessItem]
     report_path: str | None = None
 
@@ -75,13 +76,29 @@ def list_sources(root: Path) -> list[SourceLookupResult]:
 
 
 def scan_source_freshness(root: Path) -> SourceFreshnessResult:
-    items = [_freshness_item(root, result) for result in list_sources(root)]
+    lookup_results = list_sources(root)
+    workspace_groups: dict[str, list[SourceLookupResult]] = {}
+    items_by_source_id: dict[str, SourceFreshnessItem] = {}
+
+    for result in lookup_results:
+        source = result.source
+        if source.source_ref_kind == "workspace_path" and source.source_ref:
+            workspace_groups.setdefault(source.source_ref, []).append(result)
+            continue
+        items_by_source_id[source.source_id] = _freshness_item(root, result)
+
+    for grouped_results in workspace_groups.values():
+        for item in _workspace_freshness_items(root, grouped_results):
+            items_by_source_id[item.source.source_id] = item
+
+    items = [items_by_source_id[result.source.source_id] for result in lookup_results]
     return SourceFreshnessResult(
         total=len(items),
         unchanged=sum(1 for item in items if item.status == "unchanged"),
         changed=sum(1 for item in items if item.status == "changed"),
         missing=sum(1 for item in items if item.status == "missing"),
         unsupported=sum(1 for item in items if item.status == "unsupported"),
+        historical=sum(1 for item in items if item.status == "historical"),
         sources=items,
     )
 
@@ -226,11 +243,7 @@ def write_source_freshness_report(
 ) -> SourceFreshnessResult:
     resolved_report_path = report_path if report_path.is_absolute() else root / report_path
     resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        report_value = resolved_report_path.relative_to(root).as_posix()
-    except ValueError:
-        report_value = resolved_report_path.as_posix()
-    result_with_report_path = replace(result, report_path=report_value)
+    result_with_report_path = replace(result, report_path=resolved_report_path.as_posix())
     resolved_report_path.write_text(
         render_source_freshness_json(root, result_with_report_path) + "\n",
         encoding="utf-8",
@@ -246,6 +259,7 @@ def render_source_freshness_json(root: Path, result: SourceFreshnessResult) -> s
             "changed": result.changed,
             "missing": result.missing,
             "unsupported": result.unsupported,
+            "historical": result.historical,
             "report_path": result.report_path,
             "sources": [_freshness_payload(root, item) for item in result.sources],
         },
@@ -309,56 +323,102 @@ def _freshness_item(root: Path, result: SourceLookupResult) -> SourceFreshnessIt
             next_commands=[],
         )
 
-    source_path = resolve_workspace_path(root, source.source_ref, context="Workspace source")
+    return _workspace_freshness_items(root, [result])[0]
+
+
+def _workspace_freshness_items(
+    root: Path, results: list[SourceLookupResult]
+) -> list[SourceFreshnessItem]:
+    source_ref = results[0].source.source_ref
+    if source_ref is None:
+        msg = "Workspace freshness group is missing source_ref"
+        raise ValueError(msg)
+
+    source_path = resolve_workspace_path(root, source_ref, context="Workspace source")
     if not source_path.exists():
-        return SourceFreshnessItem(
-            source=source,
-            manifest_path=result.manifest_path,
-            canonical_path=source.source_ref,
-            status="missing",
-            manifest_checksum=source.checksum,
-            current_checksum=None,
-            message="canonical workspace source file is missing",
-            next_commands=[],
-        )
+        return [
+            SourceFreshnessItem(
+                source=result.source,
+                manifest_path=result.manifest_path,
+                canonical_path=source_ref,
+                status="missing",
+                manifest_checksum=result.source.checksum,
+                current_checksum=None,
+                message="canonical workspace source file is missing",
+                next_commands=[f"splendor source lookup {result.source.source_id}"],
+            )
+            for result in results
+        ]
     if not source_path.is_file():
-        return SourceFreshnessItem(
-            source=source,
-            manifest_path=result.manifest_path,
-            canonical_path=source.source_ref,
-            status="unsupported",
-            manifest_checksum=source.checksum,
-            current_checksum=None,
-            message="canonical workspace source ref does not resolve to a file",
-            next_commands=[],
-        )
+        return [
+            SourceFreshnessItem(
+                source=result.source,
+                manifest_path=result.manifest_path,
+                canonical_path=source_ref,
+                status="unsupported",
+                manifest_checksum=result.source.checksum,
+                current_checksum=None,
+                message="canonical workspace source ref does not resolve to a file",
+                next_commands=[],
+            )
+            for result in results
+        ]
 
     current_checksum = sha256_file(source_path)
-    if current_checksum == source.checksum:
-        return SourceFreshnessItem(
-            source=source,
-            manifest_path=result.manifest_path,
-            canonical_path=source.source_ref,
-            status="unchanged",
-            manifest_checksum=source.checksum,
-            current_checksum=current_checksum,
-            message="canonical workspace source matches manifest checksum",
-            next_commands=[f"splendor wiki suggest {source.source_id}"],
-        )
+    matching_source_ids = {
+        result.source.source_id for result in results if result.source.checksum == current_checksum
+    }
+    changed_candidate = None if matching_source_ids else max(results, key=_latest_source_sort_key)
 
-    return SourceFreshnessItem(
-        source=source,
-        manifest_path=result.manifest_path,
-        canonical_path=source.source_ref,
-        status="changed",
-        manifest_checksum=source.checksum,
-        current_checksum=current_checksum,
-        message="canonical workspace source differs from manifest checksum",
-        next_commands=[
-            f"splendor source refresh {source.source_ref}",
-            "splendor ingest --pending",
-        ],
-    )
+    items = []
+    for result in results:
+        source = result.source
+        if source.source_id in matching_source_ids:
+            items.append(
+                SourceFreshnessItem(
+                    source=source,
+                    manifest_path=result.manifest_path,
+                    canonical_path=source_ref,
+                    status="unchanged",
+                    manifest_checksum=source.checksum,
+                    current_checksum=current_checksum,
+                    message="canonical workspace source matches manifest checksum",
+                    next_commands=[f"splendor wiki suggest {source.source_id}"],
+                )
+            )
+            continue
+
+        if changed_candidate is not None and source.source_id == changed_candidate.source.source_id:
+            items.append(
+                SourceFreshnessItem(
+                    source=source,
+                    manifest_path=result.manifest_path,
+                    canonical_path=source_ref,
+                    status="changed",
+                    manifest_checksum=source.checksum,
+                    current_checksum=current_checksum,
+                    message="canonical workspace source differs from manifest checksum",
+                    next_commands=[
+                        f"splendor source refresh {source_ref}",
+                        "splendor ingest --pending",
+                    ],
+                )
+            )
+            continue
+
+        items.append(
+            SourceFreshnessItem(
+                source=source,
+                manifest_path=result.manifest_path,
+                canonical_path=source_ref,
+                status="historical",
+                manifest_checksum=source.checksum,
+                current_checksum=current_checksum,
+                message="older source version for this workspace path; current path is covered",
+                next_commands=[],
+            )
+        )
+    return items
 
 
 def _freshness_payload(root: Path, item: SourceFreshnessItem) -> dict[str, object]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -737,6 +737,7 @@ def test_cli_source_freshness_reports_changed_workspace_sources_without_mutating
     assert "Current checksum:" in out
     assert "Next: splendor source refresh brief.md" in out
     assert "Next: splendor ingest --pending" in out
+    assert "Next: splendor source refresh <path>" not in out
     assert manifest_path.read_text(encoding="utf-8") == before_manifest
     assert len(list((tmp_path / "state" / "manifests" / "sources").glob("*.json"))) == 1
     assert not list((tmp_path / "reports").glob("**/*.json"))
@@ -802,11 +803,34 @@ def test_cli_source_freshness_json_reports_unchanged_missing_and_unsupported(
         assert statuses["missing.md"]["next_commands"] == [
             f"splendor source lookup {statuses['missing.md']['source_id']}"
         ]
+        assert statuses["unchanged.md"]["next_commands"] == [
+            f"splendor ingest {statuses['unchanged.md']['source_id']}"
+        ]
         assert statuses[external.resolve().as_posix()]["status"] == "unsupported"
         assert statuses[external.resolve().as_posix()]["next_commands"] == []
     finally:
         external.unlink(missing_ok=True)
         external_dir.rmdir()
+
+
+def test_cli_source_freshness_suggests_wiki_work_only_after_current_ingest(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nCurrent.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "freshness", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    item = payload["sources"][0]
+    assert item["status"] == "unchanged"
+    assert item["next_commands"] == [f"splendor wiki suggest {source_id}"]
 
 
 def test_cli_source_freshness_marks_old_versions_historical_when_current_manifest_exists(
@@ -837,6 +861,41 @@ def test_cli_source_freshness_marks_old_versions_historical_when_current_manifes
     assert statuses[original_id]["status"] == "historical"
     assert statuses[original_id]["next_commands"] == []
     assert statuses[refreshed_id]["status"] == "unchanged"
+
+
+def test_cli_source_freshness_targets_latest_manifest_when_file_reverts(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    original_text = "# Brief\n\nOriginal.\n"
+    source.write_text(original_text, encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    refreshed_id = next(
+        path.stem
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if path.stem != original_id
+    )
+    source.write_text(original_text, encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "freshness", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["changed"] == 1
+    assert payload["unchanged"] == 0
+    assert payload["historical"] == 1
+    statuses = {source["source_id"]: source for source in payload["sources"]}
+    assert statuses[original_id]["status"] == "historical"
+    assert statuses[refreshed_id]["status"] == "changed"
+    assert statuses[refreshed_id]["next_commands"] == [
+        "splendor source refresh brief.md",
+        "splendor ingest --pending",
+    ]
 
 
 def test_cli_source_freshness_report_writes_only_explicit_report(tmp_path: Path, capsys) -> None:
@@ -887,6 +946,40 @@ def test_cli_source_freshness_report_writes_only_explicit_report(tmp_path: Path,
     )
     assert not list((tmp_path / "wiki").glob("sources/*.md"))
     assert not list((tmp_path / "state" / "runs").glob("*.json"))
+
+
+def test_cli_source_freshness_relative_report_uses_current_working_directory(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    root = tmp_path / "workspace"
+    cwd = tmp_path / "caller"
+    root.mkdir()
+    cwd.mkdir()
+    main(["--root", str(root), "init"])
+    source = root / "brief.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(root), "add-source", str(source)])
+    monkeypatch.chdir(cwd)
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(root),
+            "source",
+            "freshness",
+            "--report",
+            "reports/source-freshness.json",
+            "--json",
+        ]
+    )
+
+    expected_report = cwd / "reports" / "source-freshness.json"
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["report_path"] == expected_report.as_posix()
+    assert expected_report.exists()
+    assert not (root / "reports" / "source-freshness.json").exists()
 
 
 def test_cli_source_refresh_preserves_active_lease_protection(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -742,6 +742,28 @@ def test_cli_source_freshness_reports_changed_workspace_sources_without_mutating
     assert not list((tmp_path / "reports").glob("**/*.json"))
 
 
+def test_cli_source_freshness_quotes_changed_source_path_next_command(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief with spaces.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "freshness", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    item = payload["sources"][0]
+    assert item["status"] == "changed"
+    assert item["next_commands"] == [
+        "splendor source refresh 'brief with spaces.md'",
+        "splendor ingest --pending",
+    ]
+
+
 def test_cli_source_freshness_json_reports_unchanged_missing_and_unsupported(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,6 +94,9 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
 
     lookup = parser.parse_args(["source", "lookup", "brief", "--json"])
     refresh = parser.parse_args(["source", "refresh", "docs/brief.md", "--json"])
+    freshness = parser.parse_args(
+        ["source", "freshness", "--report", "reports/freshness.json", "--json"]
+    )
 
     assert lookup.command == "source"
     assert lookup.source_command == "lookup"
@@ -102,6 +105,9 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     assert refresh.source_command == "refresh"
     assert refresh.query == "docs/brief.md"
     assert refresh.json_output is True
+    assert freshness.source_command == "freshness"
+    assert freshness.report == Path("reports/freshness.json")
+    assert freshness.json_output is True
 
 
 def test_cli_query_parser_accepts_filters_and_no_question() -> None:
@@ -705,6 +711,127 @@ def test_cli_source_refresh_by_path_uses_latest_matching_source_ref(tmp_path: Pa
     out = capsys.readouterr().out
     assert "ambiguous" not in out
     assert "No source content change detected" in out
+
+
+def test_cli_source_freshness_reports_changed_workspace_sources_without_mutating(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source_id = manifest_path.stem
+    before_manifest = manifest_path.read_text(encoding="utf-8")
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "freshness"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Source freshness preview" in out
+    assert "changed=1" in out
+    assert f"- brief.md: changed title=brief source_id={source_id}" in out
+    assert "Manifest checksum:" in out
+    assert "Current checksum:" in out
+    assert "Next: splendor source refresh brief.md" in out
+    assert "Next: splendor ingest --pending" in out
+    assert manifest_path.read_text(encoding="utf-8") == before_manifest
+    assert len(list((tmp_path / "state" / "manifests" / "sources").glob("*.json"))) == 1
+    assert not list((tmp_path / "reports").glob("**/*.json"))
+
+
+def test_cli_source_freshness_json_reports_unchanged_missing_and_unsupported(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    unchanged = tmp_path / "unchanged.md"
+    missing = tmp_path / "missing.md"
+    external_dir = tmp_path.parent / f"{tmp_path.name}-external"
+    external_dir.mkdir()
+    external = external_dir / "outside.md"
+    unchanged.write_text("# Unchanged\n", encoding="utf-8")
+    missing.write_text("# Missing\n", encoding="utf-8")
+    external.write_text("# Outside\n", encoding="utf-8")
+    try:
+        main(["--root", str(tmp_path), "add-source", str(unchanged)])
+        main(["--root", str(tmp_path), "add-source", str(missing)])
+        main(["--root", str(tmp_path), "add-source", str(external)])
+        missing.unlink()
+        capsys.readouterr()
+
+        exit_code = main(["--root", str(tmp_path), "source", "freshness", "--json"])
+
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["total"] == 3
+        assert payload["unchanged"] == 1
+        assert payload["missing"] == 1
+        assert payload["unsupported"] == 1
+        statuses = {source["path"]: source for source in payload["sources"]}
+        assert statuses["unchanged.md"]["status"] == "unchanged"
+        assert (
+            statuses["unchanged.md"]["current_checksum"]
+            == statuses["unchanged.md"]["manifest_checksum"]
+        )
+        assert statuses["missing.md"]["status"] == "missing"
+        assert statuses["missing.md"]["current_checksum"] is None
+        assert statuses[external.resolve().as_posix()]["status"] == "unsupported"
+        assert statuses[external.resolve().as_posix()]["next_commands"] == []
+    finally:
+        external.unlink(missing_ok=True)
+        external_dir.rmdir()
+
+
+def test_cli_source_freshness_report_writes_only_explicit_report(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    manifest_paths_before = sorted(
+        path.relative_to(tmp_path).as_posix()
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+    )
+    queue_paths_before = sorted(
+        path.relative_to(tmp_path).as_posix()
+        for path in (tmp_path / "state" / "queue").glob("*.json")
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "source",
+            "freshness",
+            "--report",
+            "reports/source-freshness.json",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["report_path"] == "reports/source-freshness.json"
+    report_payload = json.loads((tmp_path / "reports" / "source-freshness.json").read_text())
+    assert report_payload["unchanged"] == 1
+    assert (
+        sorted(
+            path.relative_to(tmp_path).as_posix()
+            for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        )
+        == manifest_paths_before
+    )
+    assert (
+        sorted(
+            path.relative_to(tmp_path).as_posix()
+            for path in (tmp_path / "state" / "queue").glob("*.json")
+        )
+        == queue_paths_before
+    )
+    assert not list((tmp_path / "wiki").glob("sources/*.md"))
+    assert not list((tmp_path / "state" / "runs").glob("*.json"))
 
 
 def test_cli_source_refresh_preserves_active_lease_protection(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -777,11 +777,44 @@ def test_cli_source_freshness_json_reports_unchanged_missing_and_unsupported(
         )
         assert statuses["missing.md"]["status"] == "missing"
         assert statuses["missing.md"]["current_checksum"] is None
+        assert statuses["missing.md"]["next_commands"] == [
+            f"splendor source lookup {statuses['missing.md']['source_id']}"
+        ]
         assert statuses[external.resolve().as_posix()]["status"] == "unsupported"
         assert statuses[external.resolve().as_posix()]["next_commands"] == []
     finally:
         external.unlink(missing_ok=True)
         external_dir.rmdir()
+
+
+def test_cli_source_freshness_marks_old_versions_historical_when_current_manifest_exists(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    refreshed_id = next(
+        path.stem
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if path.stem != original_id
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "freshness", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["changed"] == 0
+    assert payload["unchanged"] == 1
+    assert payload["historical"] == 1
+    statuses = {source["source_id"]: source for source in payload["sources"]}
+    assert statuses[original_id]["status"] == "historical"
+    assert statuses[original_id]["next_commands"] == []
+    assert statuses[refreshed_id]["status"] == "unchanged"
 
 
 def test_cli_source_freshness_report_writes_only_explicit_report(tmp_path: Path, capsys) -> None:
@@ -806,14 +839,14 @@ def test_cli_source_freshness_report_writes_only_explicit_report(tmp_path: Path,
             "source",
             "freshness",
             "--report",
-            "reports/source-freshness.json",
+            str(tmp_path / "reports" / "source-freshness.json"),
             "--json",
         ]
     )
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["report_path"] == "reports/source-freshness.json"
+    assert payload["report_path"] == (tmp_path / "reports" / "source-freshness.json").as_posix()
     report_payload = json.loads((tmp_path / "reports" / "source-freshness.json").read_text())
     assert report_payload["unchanged"] == 1
     assert (


### PR DESCRIPTION
## Summary

Implements M13-P2.3 under the M13-P2 Issue #70 redesign by adding a safe source freshness preview for curated sources.

Changes:
- Add `splendor source freshness` as a non-mutating manifest-drift preview over source manifests.
- Report workspace-backed curated sources as unchanged, changed, missing, historical, or unsupported with path-first human output.
- Group workspace manifests by canonical path so older content-addressed versions do not stay actionable-stale forever when a current manifest already matches.
- Include source IDs, titles, canonical refs, manifest/current checksums where available, manifest paths, and exact shell-quoted next commands for actionable stale sources.
- Add machine-readable `--json` output and explicit `--report PATH` persistence aligned with `repo scan --report` path semantics.
- Update quickstart/schema/product docs, issue #70 design response, README, and synchronized planning-state lines for M13-P2.3.

## Validation

- `uv run pytest`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`

Refs #70
Refs #72