### PR TITLE
M13-P2.4 Agent handoff next actions

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M13-P2.2`
-- Last action taken: `M13-P2.2` is implemented; safe repo scan candidate discovery is complete.
+- Previous completed PR sub-slice: `M13-P2.3`
+- Last action taken: `M13-P2.3` is implemented; source freshness / manifest-drift preview is complete.
 - Current planned slice: `M13-P2`
-- Current PR sub-slice: `M13-P2.3`
+- Current PR sub-slice: `M13-P2.4`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M13-P2`
-- Next planned PR sub-slice: `M13-P2.4`
+- Next planned PR sub-slice: `M13-P2.5`
 - Current blockers: none
 
 ## Planning Notation
@@ -197,6 +197,10 @@
   - [x] Add non-mutating `splendor source freshness` for curated source manifests
   - [x] Report unchanged, changed, missing, and unsupported freshness states path-first
   - [x] Add JSON output and explicit freshness report persistence
+- [x] Implement `M13-P2.4`: Agent handoff brief and suggest-next
+  - [x] Add deterministic ranked next-action guidance from freshness, queue, review, planning, maintenance, and goal-match state
+  - [x] Add read-only `splendor suggest-next [goal]` with JSON output for machine handoff
+  - [x] Make `brief --agent-context` lead with suggested work before metadata lists
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -168,12 +168,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M13-P2.2`
+- Previous completed PR sub-slice: `M13-P2.3`
 - Current planned slice: `M13-P2`
-- Current PR sub-slice: `M13-P2.3`
+- Current PR sub-slice: `M13-P2.4`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M13-P2`
-- Next planned PR sub-slice: `M13-P2.4`
+- Next planned PR sub-slice: `M13-P2.5`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -237,3 +237,10 @@ reports path-first freshness state for workspace-backed manifests, includes mani
 checksums, separates historical source versions from actionable stale paths, supports JSON/report
 output, and does not update manifests, wiki pages, derived artifacts, queue records, run records, or
 reports unless `--report PATH` is provided.
+
+`M13-P2.4` adds a ranked handoff surface for agents. `splendor suggest-next [goal]` is read-only
+and ranks deterministic next actions from source freshness, queue failures or pending ingest work,
+stale/contested/review-needed pages, missing synthesis follow-up, active planning records, recent
+maintenance reports, and query matches for the optional goal. `brief --agent-context` now leads
+with the same suggested work before the lower-level metadata lists. Use `--json` on either command
+for machine handoff.

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -38,9 +38,10 @@ source-summary key facts during ingest.
 
 Ingest currently creates deterministic source summaries and run/provenance state. The `M10-P0`
 bridge adds `splendor wiki status`, `splendor wiki suggest <source-id>`, `splendor brief [goal]`,
-and a non-mutating `splendor wiki compile <source-id>` contract so users and agents can identify
-affected concept, entity, topic, architecture, or glossary pages before manual review. Mutating
-compile/update workflow support remains planned.
+`splendor suggest-next [goal]`, and a non-mutating `splendor wiki compile <source-id>` contract so
+users and agents can identify affected concept, entity, topic, architecture, or glossary pages and
+rank immediate handoff work before manual review. Mutating compile/update workflow support remains
+planned.
 
 Dogfood runs should record usability friction separately from knowledge gaps. Pay special attention
 to whether each command prints the next useful command, whether long source IDs need to be copied

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -81,9 +81,10 @@ The next implementation slices should document and then implement these contract
   explicit report output, separates historical source versions from actionable stale paths, and does
   not mutate manifests or derived state by default.
 - `brief --agent-context` leads with actual project state, stale/contested/actionable items, and
-  next actions before metadata.
-- A future `suggest-next` command ranks work from open tasks, stale sources, failed jobs, missing
-  synthesis, and contradictions.
+  ranked next actions before metadata.
+- `splendor suggest-next [goal]` ranks work from source freshness, queue failures or pending work,
+  missing synthesis, stale/contested/review-needed pages, active planning records, maintenance
+  reports, and goal matches without mutating the workspace.
 
 ## Roadmap Impact
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -231,13 +231,17 @@ uv run splendor --root /tmp/demo-repo query "durable wiki" --tag architecture
 uv run splendor --root /tmp/demo-repo query --source <source-id>
 uv run splendor --root /tmp/demo-repo query "durable wiki" --json
 uv run splendor --root /tmp/demo-repo brief --agent-context "durable wiki" --json
+uv run splendor --root /tmp/demo-repo suggest-next "durable wiki" --json
 ```
 
 The query command searches maintained wiki pages and planning records. Tag filters apply to wiki
 frontmatter tags; source filters require a known canonical source ID and return records whose
 `source_refs` include that ID. The JSON form includes active filters and is useful for agent or
 script integration. `brief --agent-context` packages query matches, source refs, wiki status,
-active planning records, recent runs, and next actions for a new coding-agent thread.
+active planning records, recent runs, and ranked next actions for a new coding-agent thread.
+`suggest-next` is the smaller handoff primitive when the agent needs only what to do next: it ranks
+source freshness, queue work, stale or contested pages, missing synthesis follow-up, active
+planning records, maintenance reports, and goal matches without mutating the workspace.
 
 ## 7. Run deterministic checks
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -168,6 +168,14 @@ Implemented fields:
   artifacts, queue records, run records, or reports.
 - Refresh uses the queue ledger directly, so active leases remain protected and dead-lettered jobs
   still require `splendor queue retry <job-id>` or `splendor repair ingest <source-id>`.
+- `splendor suggest-next [goal]` is a read-only handoff view over existing deterministic state. It
+  does not create planning records, queue jobs, manifests, wiki pages, run records, or reports.
+  Human output is path-first where possible; `--json` emits ranked action objects with category,
+  priority, title, reason, command, path, source ID/source ref, and planning/page record IDs when
+  available.
+- Suggested actions are derived from source freshness, queue operator state, invalid/stale/
+  contested/review-needed wiki pages, ingested sources missing maintained synthesis follow-up,
+  active planning records, recent lint/health reports, and optional goal query matches.
 - Text-bearing PDF sources are routed through source-type dispatch during ingest. The source
   manifest keeps the same `source_ref`, `source_ref_kind`, and `storage_mode` contract as
   text-native sources, while extracted text artifacts are recorded in `derived_artifacts`.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,17 +334,17 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M13-P2.2`
+- Previous completed PR sub-slice: `M13-P2.3`
 - Current planned slice: `M13-P2`
-- Current PR sub-slice: `M13-P2.3`
+- Current PR sub-slice: `M13-P2.4`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M13-P2`
-- Next planned PR sub-slice: `M13-P2.4`
+- Next planned PR sub-slice: `M13-P2.5`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The current M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
 shifting agent-facing value toward freshness, contested knowledge, planning state, and next
-actions. The lifecycle marker means `M13-P2.3` is in progress on feature branches and merged once
+actions. The lifecycle marker means `M13-P2.4` is in progress on feature branches and merged once
 the same committed state is observed on `main`.
 
 ---
@@ -804,6 +804,12 @@ freshness, contested knowledge, planning state, and next actions rather than mos
 - provider/backend docs
 - GitHub optional integration docs
 - roadmap for post-v1 search/index accelerators
+
+`M13-P2.4` is implemented: `brief --agent-context` now leads with ranked suggested work, and
+`splendor suggest-next [goal]` exposes the same deterministic action model directly. Suggestions
+are read-only and draw from source freshness, queue failures or pending work,
+stale/contested/review-needed pages, missing synthesis follow-up, active planning records, recent
+maintenance reports, and optional goal matches.
 
 ### Exit criteria
 - the product is stable enough for sustained real-world use

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -805,10 +805,11 @@ M13-P2 repo-discovery contracts:
   checksums where available, historical source-version status for paths already covered by a current
   manifest, and exact next commands. The default command is non-mutating; `--json` emits
   machine-readable output and `--report PATH` writes only an explicit freshness report.
-- `brief --agent-context` should lead with project state, stale/contested/actionable items, and
+- `brief --agent-context` leads with project state, stale/contested/actionable items, and ranked
   next actions before metadata.
-- A future `suggest-next` command should rank work from open tasks, stale sources, failed jobs,
-  missing synthesis, and contradictions.
+- `splendor suggest-next [goal]` ranks work from open tasks, stale sources, failed jobs, missing
+  synthesis, contested/review-needed pages, maintenance reports, and goal matches. `--json` emits a
+  machine-readable handoff payload.
 
 Later optional support:
 - additional OCR providers
@@ -961,7 +962,11 @@ Current implementation:
   reports, the last query snapshot, and likely next actions.
 - `splendor brief --agent-context [goal]` renders the same deterministic state as a compact
   coding-agent handoff with relevant matches, source refs, wiki status, active planning records,
-  recent sources/runs, maintenance reports, warnings, and next actions.
+  recent sources/runs, maintenance reports, warnings, and ranked suggested actions.
+- `splendor suggest-next [goal]` renders the ranked action subset directly. It is read-only and
+  deterministic, and ranks source freshness, queue failures or pending work, stale/contested or
+  review-needed pages, missing synthesis follow-up, active planning records, recent maintenance
+  reports, and query matches for the optional goal.
 - Briefing is read-only and does not replace `splendor query`; query finds records, while briefing
   packages the surrounding project state needed to resume work.
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -12,8 +12,10 @@ from splendor.commands.add_source import add_source, expand_source_paths
 from splendor.commands.brief import (
     ProjectBrief,
     build_project_brief,
+    build_suggest_next,
     render_agent_context_json,
     render_project_brief_json,
+    render_suggest_next_json,
 )
 from splendor.commands.file_answer import (
     default_answer_page_id,
@@ -408,6 +410,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit a compact coding-agent handoff over brief state.",
     )
     brief_parser.set_defaults(handler=handle_brief)
+
+    suggest_next_parser = subparsers.add_parser(
+        "suggest-next", help="Rank deterministic next actions for agent handoff"
+    )
+    suggest_next_parser.add_argument("goal", nargs="*", help="Optional goal or search phrase.")
+    suggest_next_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    suggest_next_parser.set_defaults(handler=handle_suggest_next)
 
     serve_parser = subparsers.add_parser("serve", help="Run the read-only local web UI")
     serve_parser.add_argument(
@@ -1476,6 +1490,14 @@ def handle_brief(args: argparse.Namespace) -> int:
 def _print_agent_context(result: ProjectBrief) -> None:
     print("Agent context")
     print(f"Goal: {result.goal or '-'}")
+    if result.suggested_actions:
+        print("Suggested next:")
+        for action in result.suggested_actions[:5]:
+            subject = action.path or action.source_ref or action.record_id or "-"
+            command = f" command={action.command}" if action.command else ""
+            print(
+                f"- [{action.priority}/{action.category}] {action.title} target={subject}{command}"
+            )
     print(
         "Wiki status: "
         f"sources={result.status.source_total} "
@@ -1513,6 +1535,40 @@ def _print_agent_context(result: ProjectBrief) -> None:
     print("Next actions:")
     for action in result.next_actions:
         print(f"- {action}")
+
+
+def handle_suggest_next(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    goal = " ".join(args.goal).strip() or None
+    try:
+        result = build_suggest_next(root, goal)
+    except (OSError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_suggest_next_json(result))
+        return 0
+
+    print("Suggested next actions")
+    print(f"Goal: {result.goal or '-'}")
+    print(
+        "State: "
+        f"changed_sources={result.freshness.changed} "
+        f"missing_sources={result.freshness.missing} "
+        f"queue={result.queue.total} "
+        f"review_needed={result.status.review_needed_pages} "
+        f"contested={result.status.contested_pages} "
+        f"stale={result.status.stale_pages}"
+    )
+    for action in result.actions:
+        target = action.path or action.source_ref or action.record_id or "-"
+        command = f" command={action.command}" if action.command else ""
+        print(
+            f"{action.rank}. [{action.priority}/{action.category}] {action.title} "
+            f"target={target}{command}"
+        )
+        print(f"   Reason: {action.reason}")
+    return 0
 
 
 def handle_serve(args: argparse.Namespace) -> int:

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -1493,7 +1493,7 @@ def _print_agent_context(result: ProjectBrief) -> None:
     if result.suggested_actions:
         print("Suggested next:")
         for action in result.suggested_actions[:5]:
-            subject = action.path or action.source_ref or action.record_id or "-"
+            subject = _suggested_action_target(action)
             command = f" command={action.command}" if action.command else ""
             print(
                 f"- [{action.priority}/{action.category}] {action.title} target={subject}{command}"
@@ -1561,7 +1561,7 @@ def handle_suggest_next(args: argparse.Namespace) -> int:
         f"stale={result.status.stale_pages}"
     )
     for action in result.actions:
-        target = action.path or action.source_ref or action.record_id or "-"
+        target = _suggested_action_target(action)
         command = f" command={action.command}" if action.command else ""
         print(
             f"{action.rank}. [{action.priority}/{action.category}] {action.title} "
@@ -1569,6 +1569,10 @@ def handle_suggest_next(args: argparse.Namespace) -> int:
         )
         print(f"   Reason: {action.reason}")
     return 0
+
+
+def _suggested_action_target(action) -> str:
+    return action.source_ref or action.path or action.record_id or "-"
 
 
 def handle_serve(args: argparse.Namespace) -> int:

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import json
 import shlex
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 
 from splendor.config import load_config
 from splendor.layout import resolve_layout
-from splendor.schemas import MaintenanceReport, QuerySnapshot
+from splendor.schemas import MaintenanceReport, QuerySnapshot, SourceRecord
 from splendor.state.query_snapshot import last_query_path_for
 from splendor.state.source_compat import canonical_source_ref
 from splendor.utils.planning import (
@@ -24,12 +24,14 @@ from .query import QueryMatch, QueryValidationError, run_query
 from .queue import QueueInspectResult, inspect_queue
 from .source import SourceFreshnessResult, scan_source_freshness
 from .wiki import (
-    _SYNTHESIS_KINDS,
+    SYNTHESIS_KINDS,
+    InvalidWikiPageSnapshot,
     RecentRunSnapshot,
+    WikiPageSnapshot,
     WikiStatus,
-    _load_wiki_pages,
     build_wiki_status,
     load_sources,
+    load_wiki_pages,
 )
 
 _BRIEF_MATCH_LIMIT = 5
@@ -37,6 +39,31 @@ _BRIEF_PLANNING_LIMIT = 8
 _BRIEF_SOURCE_LIMIT = 5
 _BRIEF_REPORT_COMMANDS = ("lint", "health")
 _SUGGESTION_LIMIT = 8
+_SUGGESTION_CATEGORY_LIMITS = {
+    "source-freshness": 3,
+    "queue": 3,
+    "wiki-validation": 2,
+    "goal-match": 3,
+    "planning": 2,
+    "synthesis": 2,
+    "wiki-review": 2,
+    "maintenance": 2,
+    "query": 1,
+    "orientation": 1,
+}
+_SUGGESTION_CATEGORY_ORDER = {
+    "source-freshness": 0,
+    "queue": 1,
+    "wiki-validation": 2,
+    "goal-match": 3,
+    "planning": 4,
+    "synthesis": 5,
+    "wiki-review": 6,
+    "maintenance": 7,
+    "query": 8,
+    "orientation": 9,
+}
+_SUGGESTION_PRIORITY_ORDER = {"high": 0, "medium": 1, "low": 2}
 _PLANNING_STATUSES = {
     "task": {"todo", "in_progress", "blocked"},
     "milestone": {"planned", "active"},
@@ -130,6 +157,27 @@ class SuggestNextResult:
 
 
 @dataclass(frozen=True)
+class BriefStateSnapshot:
+    root: Path
+    goal: str | None
+    query_summary: str | None
+    layout: object
+    status: WikiStatus
+    queue: QueueInspectResult
+    freshness: SourceFreshnessResult
+    matches: list[BriefMatch]
+    planning_items: list[BriefPlanningItem]
+    recent_sources: list[BriefSourceItem]
+    recent_runs: list[RecentRunSnapshot]
+    latest_reports: list[BriefReportSnapshot]
+    last_query: BriefLastQuery | None
+    warnings: list[BriefWarning]
+    sources_by_id: dict[str, SourceRecord]
+    wiki_pages: list[WikiPageSnapshot]
+    invalid_wiki_pages: list[InvalidWikiPageSnapshot]
+
+
+@dataclass(frozen=True)
 class ProjectBrief:
     goal: str | None
     query_summary: str | None
@@ -146,11 +194,56 @@ class ProjectBrief:
 
 
 def build_project_brief(root: Path, goal: str | None) -> ProjectBrief:
+    snapshot = _collect_brief_state(root, goal)
+    suggested_actions = _ranked_suggestions(snapshot)
+    next_actions = _next_actions(
+        status=snapshot.status,
+        matches=snapshot.matches,
+        planning_items=snapshot.planning_items,
+        warnings=snapshot.warnings,
+        suggested_actions=suggested_actions,
+    )
+    return ProjectBrief(
+        goal=snapshot.goal,
+        query_summary=snapshot.query_summary,
+        status=snapshot.status,
+        matches=snapshot.matches,
+        planning_items=snapshot.planning_items,
+        recent_sources=snapshot.recent_sources,
+        recent_runs=snapshot.recent_runs,
+        latest_reports=snapshot.latest_reports,
+        last_query=snapshot.last_query,
+        warnings=snapshot.warnings,
+        suggested_actions=suggested_actions,
+        next_actions=next_actions,
+    )
+
+
+def build_suggest_next(root: Path, goal: str | None = None) -> SuggestNextResult:
+    snapshot = _collect_brief_state(root, goal)
+    actions = _ranked_suggestions(snapshot)
+    return SuggestNextResult(
+        goal=snapshot.goal,
+        actions=actions,
+        status=snapshot.status,
+        queue=snapshot.queue,
+        freshness=snapshot.freshness,
+        matches=snapshot.matches,
+        planning_items=snapshot.planning_items,
+        latest_reports=snapshot.latest_reports,
+        warnings=snapshot.warnings,
+    )
+
+
+def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
     config = load_config(root)
     layout = resolve_layout(root, config)
     status = build_wiki_status(root)
+    queue = inspect_queue(root)
+    freshness = scan_source_freshness(root)
     normalized_goal = goal.strip() if goal is not None else ""
     query_summary: str | None = None
+    query_warning: BriefWarning | None = None
     matches: list[BriefMatch] = []
     if normalized_goal:
         try:
@@ -158,27 +251,29 @@ def build_project_brief(root: Path, goal: str | None) -> ProjectBrief:
         except (QueryValidationError, OSError, ValueError) as exc:
             query_result = None
             query_summary = f"Query skipped: {_brief_error(exc)}"
+            query_warning = BriefWarning(area="query", path=None, message=query_summary)
         if query_result is not None:
             query_summary = query_result.summary
             matches = [_brief_match(match) for match in query_result.matches[:_BRIEF_MATCH_LIMIT]]
 
     planning_items, warnings = _active_planning_items(root, layout)
-    recent_sources = _recent_sources(root, layout)
+    if query_warning is not None:
+        warnings.insert(0, query_warning)
+    sources = load_sources(layout)
+    sources_by_id = {source.source_id: source for source in sources}
+    wiki_pages, invalid_wiki_pages = load_wiki_pages(root, layout)
+    recent_sources = _recent_sources(sources)
     recent_runs = status.recent_runs
     latest_reports = _latest_reports(root, layout)
     last_query = _last_query(layout)
-    suggested_actions = build_suggest_next(root, normalized_goal or None).actions
-    next_actions = _next_actions(
-        status=status,
-        matches=matches,
-        planning_items=planning_items,
-        warnings=warnings,
-        suggested_actions=suggested_actions,
-    )
-    return ProjectBrief(
+    return BriefStateSnapshot(
+        root=root,
         goal=normalized_goal or None,
         query_summary=query_summary,
+        layout=layout,
         status=status,
+        queue=queue,
+        freshness=freshness,
         matches=matches,
         planning_items=planning_items,
         recent_sources=recent_sources,
@@ -186,54 +281,9 @@ def build_project_brief(root: Path, goal: str | None) -> ProjectBrief:
         latest_reports=latest_reports,
         last_query=last_query,
         warnings=warnings,
-        suggested_actions=suggested_actions,
-        next_actions=next_actions,
-    )
-
-
-def build_suggest_next(root: Path, goal: str | None = None) -> SuggestNextResult:
-    config = load_config(root)
-    layout = resolve_layout(root, config)
-    status = build_wiki_status(root)
-    queue = inspect_queue(root)
-    freshness = scan_source_freshness(root)
-    normalized_goal = goal.strip() if goal is not None else ""
-    matches: list[BriefMatch] = []
-    warnings: list[BriefWarning] = []
-    if normalized_goal:
-        try:
-            query_result = run_query(root, normalized_goal)
-        except (QueryValidationError, OSError, ValueError) as exc:
-            warnings.append(
-                BriefWarning(area="query", path=None, message=f"Query skipped: {_brief_error(exc)}")
-            )
-        else:
-            matches = [_brief_match(match) for match in query_result.matches[:_BRIEF_MATCH_LIMIT]]
-
-    planning_items, planning_warnings = _active_planning_items(root, layout)
-    warnings.extend(planning_warnings)
-    latest_reports = _latest_reports(root, layout)
-    actions = _ranked_suggestions(
-        root=root,
-        layout=layout,
-        status=status,
-        queue=queue,
-        freshness=freshness,
-        matches=matches,
-        planning_items=planning_items,
-        latest_reports=latest_reports,
-        warnings=warnings,
-    )
-    return SuggestNextResult(
-        goal=normalized_goal or None,
-        actions=actions[:_SUGGESTION_LIMIT],
-        status=status,
-        queue=queue,
-        freshness=freshness,
-        matches=matches,
-        planning_items=planning_items,
-        latest_reports=latest_reports,
-        warnings=warnings,
+        sources_by_id=sources_by_id,
+        wiki_pages=wiki_pages,
+        invalid_wiki_pages=invalid_wiki_pages,
     )
 
 
@@ -293,8 +343,8 @@ def _active_planning_items(
     return items[:_BRIEF_PLANNING_LIMIT], warnings
 
 
-def _recent_sources(root: Path, layout) -> list[BriefSourceItem]:
-    sources = sorted(load_sources(layout), key=lambda source: (source.added_at, source.source_id))
+def _recent_sources(sources: list[SourceRecord]) -> list[BriefSourceItem]:
+    sources = sorted(sources, key=lambda source: (source.added_at, source.source_id))
     return [
         BriefSourceItem(
             source_id=source.source_id,
@@ -380,28 +430,13 @@ def _next_actions(
     return actions
 
 
-def _ranked_suggestions(
-    *,
-    root: Path,
-    layout,
-    status: WikiStatus,
-    queue: QueueInspectResult,
-    freshness: SourceFreshnessResult,
-    matches: list[BriefMatch],
-    planning_items: list[BriefPlanningItem],
-    latest_reports: list[BriefReportSnapshot],
-    warnings: list[BriefWarning],
-) -> list[SuggestedAction]:
-    sources_by_id = {source.source_id: source for source in load_sources(layout)}
+def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
     actions: list[SuggestedAction] = []
-    rank = 0
 
     def add(priority: str, category: str, title: str, reason: str, command: str | None, **kwargs):
-        nonlocal rank
-        rank += 1
         actions.append(
             SuggestedAction(
-                rank=rank,
+                rank=0,
                 priority=priority,
                 category=category,
                 title=title,
@@ -411,7 +446,7 @@ def _ranked_suggestions(
             )
         )
 
-    for item in freshness.sources:
+    for item in snapshot.freshness.sources:
         source = item.source
         if item.status == "changed":
             add(
@@ -436,8 +471,8 @@ def _ranked_suggestions(
                 source_ref=canonical_source_ref(source),
             )
 
-    for item in queue.items:
-        source = sources_by_id.get(item.source_id or "")
+    for item in snapshot.queue.items:
+        source = snapshot.sources_by_id.get(item.source_id or "")
         source_ref = canonical_source_ref(source) if source is not None else None
         if item.operator_state in {"pending", "failed_due", "expired_leased"}:
             add(
@@ -478,11 +513,11 @@ def _ranked_suggestions(
                 source_ref=source_ref,
             )
 
-    for page in _review_page_actions(root, layout):
+    for page in _review_page_actions(snapshot.wiki_pages, snapshot.invalid_wiki_pages):
         add(**page)
 
-    for source_id in _sources_missing_synthesis(root, layout, sources_by_id):
-        source = sources_by_id[source_id]
+    for source_id in _sources_missing_synthesis(snapshot.wiki_pages, snapshot.sources_by_id):
+        source = snapshot.sources_by_id[source_id]
         source_ref = canonical_source_ref(source)
         add(
             "medium",
@@ -495,7 +530,7 @@ def _ranked_suggestions(
             source_ref=source_ref,
         )
 
-    for report in latest_reports:
+    for report in snapshot.latest_reports:
         if report.status != "passed" or report.issue_count:
             add(
                 "medium",
@@ -507,7 +542,7 @@ def _ranked_suggestions(
                 path=report.path,
             )
 
-    for match in matches[:3]:
+    for match in snapshot.matches[:3]:
         add(
             "medium",
             "goal-match",
@@ -518,7 +553,7 @@ def _ranked_suggestions(
             record_id=match.record_id,
         )
 
-    for item in planning_items:
+    for item in snapshot.planning_items:
         command = f"splendor task list --status {item.status}" if item.kind == "task" else None
         add(
             "low",
@@ -530,7 +565,7 @@ def _ranked_suggestions(
             record_id=item.record_id,
         )
 
-    for warning in warnings:
+    for warning in snapshot.warnings:
         add(
             "low",
             warning.area,
@@ -549,15 +584,40 @@ def _ranked_suggestions(
             "splendor brief --agent-context",
         )
 
-    return actions
+    return _finalize_suggestions(actions)
 
 
 def _first_command(commands: list[str]) -> str | None:
     return commands[0] if commands else None
 
 
-def _review_page_actions(root: Path, layout) -> list[dict[str, object]]:
-    pages, invalid_pages = _load_wiki_pages(root, layout)
+def _finalize_suggestions(actions: list[SuggestedAction]) -> list[SuggestedAction]:
+    by_category: dict[str, int] = {}
+    capped: list[tuple[int, SuggestedAction]] = []
+    for sequence, action in enumerate(actions):
+        current_count = by_category.get(action.category, 0)
+        category_limit = _SUGGESTION_CATEGORY_LIMITS.get(action.category, 1)
+        if current_count >= category_limit:
+            continue
+        by_category[action.category] = current_count + 1
+        capped.append((sequence, action))
+
+    capped.sort(
+        key=lambda item: (
+            _SUGGESTION_CATEGORY_ORDER.get(item[1].category, 99),
+            _SUGGESTION_PRIORITY_ORDER.get(item[1].priority, 99),
+            item[0],
+        )
+    )
+    return [
+        replace(action, rank=rank)
+        for rank, (_sequence, action) in enumerate(capped[:_SUGGESTION_LIMIT], start=1)
+    ]
+
+
+def _review_page_actions(
+    pages: list[WikiPageSnapshot], invalid_pages: list[InvalidWikiPageSnapshot]
+) -> list[dict[str, object]]:
     actions: list[dict[str, object]] = []
     for invalid in invalid_pages:
         actions.append(
@@ -574,7 +634,7 @@ def _review_page_actions(root: Path, layout) -> list[dict[str, object]]:
         state = page.frontmatter.review_state
         if state not in {"contested", "stale", "draft", "machine-generated"}:
             continue
-        if page.frontmatter.kind not in _SYNTHESIS_KINDS and state != "contested":
+        if page.frontmatter.kind not in SYNTHESIS_KINDS and state != "contested":
             continue
         priority = "high" if state in {"contested", "stale"} else "medium"
         actions.append(
@@ -594,15 +654,16 @@ def _review_page_actions(root: Path, layout) -> list[dict[str, object]]:
     return actions
 
 
-def _sources_missing_synthesis(root: Path, layout, sources_by_id) -> list[str]:
-    pages, _invalid_pages = _load_wiki_pages(root, layout)
+def _sources_missing_synthesis(
+    pages: list[WikiPageSnapshot], sources_by_id: dict[str, SourceRecord]
+) -> list[str]:
     synthesis_source_ids = {
         source_ref
         for page in pages
-        if page.frontmatter.kind in _SYNTHESIS_KINDS
+        if page.frontmatter.kind in SYNTHESIS_KINDS
         for source_ref in page.frontmatter.source_refs
     }
-    synthesis_pages = [page for page in pages if page.frontmatter.kind in _SYNTHESIS_KINDS]
+    synthesis_pages = [page for page in pages if page.frontmatter.kind in SYNTHESIS_KINDS]
     source_ids = []
     for source_id, source in sources_by_id.items():
         if source.status != "ingested":

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -20,9 +21,13 @@ from splendor.utils.planning import (
 
 from .planning import model_for_planning_kind
 from .query import QueryMatch, QueryValidationError, run_query
+from .queue import QueueInspectResult, inspect_queue
+from .source import SourceFreshnessResult, scan_source_freshness
 from .wiki import (
+    _SYNTHESIS_KINDS,
     RecentRunSnapshot,
     WikiStatus,
+    _load_wiki_pages,
     build_wiki_status,
     load_sources,
 )
@@ -31,6 +36,7 @@ _BRIEF_MATCH_LIMIT = 5
 _BRIEF_PLANNING_LIMIT = 8
 _BRIEF_SOURCE_LIMIT = 5
 _BRIEF_REPORT_COMMANDS = ("lint", "health")
+_SUGGESTION_LIMIT = 8
 _PLANNING_STATUSES = {
     "task": {"todo", "in_progress", "blocked"},
     "milestone": {"planned", "active"},
@@ -97,6 +103,33 @@ class BriefLastQuery:
 
 
 @dataclass(frozen=True)
+class SuggestedAction:
+    rank: int
+    category: str
+    priority: str
+    title: str
+    reason: str
+    command: str | None
+    path: str | None = None
+    source_id: str | None = None
+    source_ref: str | None = None
+    record_id: str | None = None
+
+
+@dataclass(frozen=True)
+class SuggestNextResult:
+    goal: str | None
+    actions: list[SuggestedAction]
+    status: WikiStatus
+    queue: QueueInspectResult
+    freshness: SourceFreshnessResult
+    matches: list[BriefMatch]
+    planning_items: list[BriefPlanningItem]
+    latest_reports: list[BriefReportSnapshot]
+    warnings: list[BriefWarning]
+
+
+@dataclass(frozen=True)
 class ProjectBrief:
     goal: str | None
     query_summary: str | None
@@ -108,6 +141,7 @@ class ProjectBrief:
     latest_reports: list[BriefReportSnapshot]
     last_query: BriefLastQuery | None
     warnings: list[BriefWarning]
+    suggested_actions: list[SuggestedAction]
     next_actions: list[str]
 
 
@@ -133,11 +167,13 @@ def build_project_brief(root: Path, goal: str | None) -> ProjectBrief:
     recent_runs = status.recent_runs
     latest_reports = _latest_reports(root, layout)
     last_query = _last_query(layout)
+    suggested_actions = build_suggest_next(root, normalized_goal or None).actions
     next_actions = _next_actions(
         status=status,
         matches=matches,
         planning_items=planning_items,
         warnings=warnings,
+        suggested_actions=suggested_actions,
     )
     return ProjectBrief(
         goal=normalized_goal or None,
@@ -150,7 +186,54 @@ def build_project_brief(root: Path, goal: str | None) -> ProjectBrief:
         latest_reports=latest_reports,
         last_query=last_query,
         warnings=warnings,
+        suggested_actions=suggested_actions,
         next_actions=next_actions,
+    )
+
+
+def build_suggest_next(root: Path, goal: str | None = None) -> SuggestNextResult:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    status = build_wiki_status(root)
+    queue = inspect_queue(root)
+    freshness = scan_source_freshness(root)
+    normalized_goal = goal.strip() if goal is not None else ""
+    matches: list[BriefMatch] = []
+    warnings: list[BriefWarning] = []
+    if normalized_goal:
+        try:
+            query_result = run_query(root, normalized_goal)
+        except (QueryValidationError, OSError, ValueError) as exc:
+            warnings.append(
+                BriefWarning(area="query", path=None, message=f"Query skipped: {_brief_error(exc)}")
+            )
+        else:
+            matches = [_brief_match(match) for match in query_result.matches[:_BRIEF_MATCH_LIMIT]]
+
+    planning_items, planning_warnings = _active_planning_items(root, layout)
+    warnings.extend(planning_warnings)
+    latest_reports = _latest_reports(root, layout)
+    actions = _ranked_suggestions(
+        root=root,
+        layout=layout,
+        status=status,
+        queue=queue,
+        freshness=freshness,
+        matches=matches,
+        planning_items=planning_items,
+        latest_reports=latest_reports,
+        warnings=warnings,
+    )
+    return SuggestNextResult(
+        goal=normalized_goal or None,
+        actions=actions[:_SUGGESTION_LIMIT],
+        status=status,
+        queue=queue,
+        freshness=freshness,
+        matches=matches,
+        planning_items=planning_items,
+        latest_reports=latest_reports,
+        warnings=warnings,
     )
 
 
@@ -264,8 +347,14 @@ def _next_actions(
     matches: list[BriefMatch],
     planning_items: list[BriefPlanningItem],
     warnings: list[BriefWarning],
+    suggested_actions: list[SuggestedAction],
 ) -> list[str]:
     actions: list[str] = []
+    if suggested_actions:
+        actions.extend(
+            f"{action.title}" + (f" (`{action.command}`)" if action.command is not None else "")
+            for action in suggested_actions[:5]
+        )
     if status.queue_status_counts.get("pending", 0):
         actions.append("Run `splendor ingest --pending` to drain pending source ingests.")
     if status.invalid_pages:
@@ -291,6 +380,277 @@ def _next_actions(
     return actions
 
 
+def _ranked_suggestions(
+    *,
+    root: Path,
+    layout,
+    status: WikiStatus,
+    queue: QueueInspectResult,
+    freshness: SourceFreshnessResult,
+    matches: list[BriefMatch],
+    planning_items: list[BriefPlanningItem],
+    latest_reports: list[BriefReportSnapshot],
+    warnings: list[BriefWarning],
+) -> list[SuggestedAction]:
+    sources_by_id = {source.source_id: source for source in load_sources(layout)}
+    actions: list[SuggestedAction] = []
+    rank = 0
+
+    def add(priority: str, category: str, title: str, reason: str, command: str | None, **kwargs):
+        nonlocal rank
+        rank += 1
+        actions.append(
+            SuggestedAction(
+                rank=rank,
+                priority=priority,
+                category=category,
+                title=title,
+                reason=reason,
+                command=command,
+                **kwargs,
+            )
+        )
+
+    for item in freshness.sources:
+        source = item.source
+        if item.status == "changed":
+            add(
+                "high",
+                "source-freshness",
+                f"Refresh changed source {item.canonical_path}",
+                "The workspace file differs from the latest curated source manifest.",
+                _first_command(item.next_commands),
+                path=item.canonical_path,
+                source_id=source.source_id,
+                source_ref=canonical_source_ref(source),
+            )
+        elif item.status == "missing":
+            add(
+                "high",
+                "source-freshness",
+                f"Resolve missing source {item.canonical_path}",
+                "A curated workspace source path no longer exists.",
+                _first_command(item.next_commands),
+                path=item.canonical_path,
+                source_id=source.source_id,
+                source_ref=canonical_source_ref(source),
+            )
+
+    for item in queue.items:
+        source = sources_by_id.get(item.source_id or "")
+        source_ref = canonical_source_ref(source) if source is not None else None
+        if item.operator_state in {"pending", "failed_due", "expired_leased"}:
+            add(
+                "high",
+                "queue",
+                f"Drain ingest queue job {item.job_id}",
+                f"Queue job is actionable now: {item.operator_state}.",
+                "splendor ingest --pending",
+                path=item.record_path.as_posix(),
+                source_id=item.source_id,
+                source_ref=source_ref,
+            )
+        elif item.operator_state == "dead_letter":
+            command = (
+                f"splendor repair ingest {shlex.quote(item.source_id)}"
+                if item.source_id
+                else f"splendor queue retry {shlex.quote(item.job_id)}"
+            )
+            add(
+                "high",
+                "queue",
+                f"Repair dead-letter queue job {item.job_id}",
+                item.last_error or "Queue job reached dead-letter state.",
+                command,
+                path=item.record_path.as_posix(),
+                source_id=item.source_id,
+                source_ref=source_ref,
+            )
+        elif item.operator_state == "failed_backoff":
+            add(
+                "medium",
+                "queue",
+                f"Review backoff queue job {item.job_id}",
+                "Queue job failed and is waiting for its next retry window.",
+                f"splendor queue inspect {shlex.quote(item.job_id)}",
+                path=item.record_path.as_posix(),
+                source_id=item.source_id,
+                source_ref=source_ref,
+            )
+
+    for page in _review_page_actions(root, layout):
+        add(**page)
+
+    for source_id in _sources_missing_synthesis(root, layout, sources_by_id):
+        source = sources_by_id[source_id]
+        source_ref = canonical_source_ref(source)
+        add(
+            "medium",
+            "synthesis",
+            f"Review synthesis follow-up for {source_ref}",
+            "The source is ingested but has no maintained synthesis-page follow-up.",
+            f"splendor wiki suggest {shlex.quote(source_id)}",
+            path=source_ref,
+            source_id=source_id,
+            source_ref=source_ref,
+        )
+
+    for report in latest_reports:
+        if report.status != "passed" or report.issue_count:
+            add(
+                "medium",
+                "maintenance",
+                f"Review latest {report.command} report",
+                f"Latest {report.command} report status is {report.status} with "
+                f"{report.issue_count} issue(s).",
+                f"splendor {report.command}",
+                path=report.path,
+            )
+
+    for match in matches[:3]:
+        add(
+            "medium",
+            "goal-match",
+            f"Open goal match {match.path}",
+            f"Matched the stated goal with score {match.score}.",
+            None,
+            path=match.path,
+            record_id=match.record_id,
+        )
+
+    for item in planning_items:
+        command = f"splendor task list --status {item.status}" if item.kind == "task" else None
+        add(
+            "low",
+            "planning",
+            f"Continue {item.kind} {item.record_id}",
+            f"Planning record is active with status {item.status}.",
+            command,
+            path=item.path,
+            record_id=item.record_id,
+        )
+
+    for warning in warnings:
+        add(
+            "low",
+            warning.area,
+            f"Fix skipped {warning.area} record",
+            warning.message,
+            None,
+            path=warning.path,
+        )
+
+    if not actions:
+        add(
+            "low",
+            "orientation",
+            "Add or query project context",
+            "No stale, queued, contested, or active planning work was found.",
+            "splendor brief --agent-context",
+        )
+
+    return actions
+
+
+def _first_command(commands: list[str]) -> str | None:
+    return commands[0] if commands else None
+
+
+def _review_page_actions(root: Path, layout) -> list[dict[str, object]]:
+    pages, invalid_pages = _load_wiki_pages(root, layout)
+    actions: list[dict[str, object]] = []
+    for invalid in invalid_pages:
+        actions.append(
+            {
+                "priority": "high",
+                "category": "wiki-validation",
+                "title": f"Fix invalid wiki page {invalid.path}",
+                "reason": invalid.error,
+                "command": "splendor lint",
+                "path": invalid.path,
+            }
+        )
+    for page in pages:
+        state = page.frontmatter.review_state
+        if state not in {"contested", "stale", "draft", "machine-generated"}:
+            continue
+        if page.frontmatter.kind not in _SYNTHESIS_KINDS and state != "contested":
+            continue
+        priority = "high" if state in {"contested", "stale"} else "medium"
+        actions.append(
+            {
+                "priority": priority,
+                "category": "wiki-review",
+                "title": f"Review {state} page {page.path}",
+                "reason": (
+                    f"Page `{page.frontmatter.title}` is {state}; verify current source-backed "
+                    "synthesis before relying on it."
+                ),
+                "command": None,
+                "path": page.path,
+                "record_id": page.frontmatter.page_id,
+            }
+        )
+    return actions
+
+
+def _sources_missing_synthesis(root: Path, layout, sources_by_id) -> list[str]:
+    pages, _invalid_pages = _load_wiki_pages(root, layout)
+    synthesis_source_ids = {
+        source_ref
+        for page in pages
+        if page.frontmatter.kind in _SYNTHESIS_KINDS
+        for source_ref in page.frontmatter.source_refs
+    }
+    synthesis_pages = [page for page in pages if page.frontmatter.kind in _SYNTHESIS_KINDS]
+    source_ids = []
+    for source_id, source in sources_by_id.items():
+        if source.status != "ingested":
+            continue
+        source_ref = canonical_source_ref(source)
+        if source_id in synthesis_source_ids:
+            continue
+        if any(source_ref in page.body for page in synthesis_pages):
+            continue
+        source_ids.append(source_id)
+    return sorted(source_ids, key=lambda source_id: canonical_source_ref(sources_by_id[source_id]))
+
+
+def render_suggest_next_json(result: SuggestNextResult) -> str:
+    return json.dumps(
+        {
+            "goal": result.goal,
+            "actions": [asdict(action) for action in result.actions],
+            "status": {
+                "source_total": result.status.source_total,
+                "page_total": result.status.page_total,
+                "queue_status_counts": result.status.queue_status_counts,
+                "review_needed_pages": result.status.review_needed_pages,
+                "contested_pages": result.status.contested_pages,
+                "stale_pages": result.status.stale_pages,
+                "sources_missing_synthesis": result.status.sources_missing_synthesis,
+                "invalid_pages": result.status.invalid_pages,
+            },
+            "freshness": {
+                "total": result.freshness.total,
+                "changed": result.freshness.changed,
+                "missing": result.freshness.missing,
+                "unsupported": result.freshness.unsupported,
+                "historical": result.freshness.historical,
+            },
+            "queue": {
+                "total": result.queue.total,
+                "status_counts": result.queue.status_counts,
+            },
+            "matches": [asdict(match) for match in result.matches],
+            "planning_items": [asdict(item) for item in result.planning_items],
+            "latest_reports": [asdict(report) for report in result.latest_reports],
+            "warnings": [asdict(warning) for warning in result.warnings],
+        },
+        indent=2,
+    )
+
+
 def render_project_brief_json(brief: ProjectBrief) -> str:
     return json.dumps(
         {
@@ -304,6 +664,7 @@ def render_project_brief_json(brief: ProjectBrief) -> str:
             "latest_reports": [asdict(report) for report in brief.latest_reports],
             "last_query": asdict(brief.last_query) if brief.last_query else None,
             "warnings": [asdict(warning) for warning in brief.warnings],
+            "suggested_actions": [asdict(action) for action in brief.suggested_actions],
             "next_actions": brief.next_actions,
         },
         indent=2,
@@ -328,6 +689,7 @@ def render_agent_context_json(brief: ProjectBrief) -> str:
             },
             "matches": [asdict(match) for match in brief.matches],
             "source_refs": _agent_context_source_refs(brief),
+            "suggested_actions": [asdict(action) for action in brief.suggested_actions],
             "active_planning": [asdict(item) for item in brief.planning_items],
             "recent_sources": [asdict(source) for source in brief.recent_sources],
             "recent_runs": [asdict(run) for run in brief.recent_runs],

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -17,7 +17,7 @@ from splendor.state.source_registry import load_source_record
 from splendor.utils.fs import write_text_atomic
 from splendor.utils.wiki import parse_wiki_markdown, render_frontmatter
 
-_SYNTHESIS_KINDS = {"architecture", "concept", "entity", "glossary", "topic"}
+SYNTHESIS_KINDS = {"architecture", "concept", "entity", "glossary", "topic"}
 _REVIEW_NEEDED_STATES = {"draft", "machine-generated", "contested", "stale"}
 _TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]{1,}")
 _SLUG_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
@@ -270,7 +270,7 @@ def add_topic_page(
         msg = f"Topic page already exists: {page_ref}"
         raise FileExistsError(msg)
 
-    pages, invalid_pages = _load_wiki_pages(root, layout)
+    pages, invalid_pages = load_wiki_pages(root, layout)
     if invalid_pages:
         msg = f"Cannot add topic with invalid wiki pages present: {invalid_pages[0].path}"
         raise ValueError(msg)
@@ -314,7 +314,7 @@ def add_topic_page(
 def rebuild_wiki_index(root: Path) -> WikiIndexRebuildResult:
     config = load_config(root)
     layout = resolve_layout(root, config)
-    pages, invalid_pages = _load_wiki_pages(root, layout)
+    pages, invalid_pages = load_wiki_pages(root, layout)
     if invalid_pages:
         msg = f"Cannot rebuild index with invalid wiki pages present: {invalid_pages[0].path}"
         raise ValueError(msg)
@@ -392,7 +392,7 @@ def _load_runs(layout) -> list[RunRecord]:
     return records
 
 
-def _load_wiki_pages(
+def load_wiki_pages(
     root: Path, layout
 ) -> tuple[list[WikiPageSnapshot], list[InvalidWikiPageSnapshot]]:
     pages: list[WikiPageSnapshot] = []
@@ -442,7 +442,7 @@ def build_wiki_status(root: Path) -> WikiStatus:
     config = load_config(root)
     layout = resolve_layout(root, config)
     sources = load_sources(layout)
-    pages, invalid_pages = _load_wiki_pages(root, layout)
+    pages, invalid_pages = load_wiki_pages(root, layout)
     queue_records = _load_queue(layout)
     runs = _load_runs(layout)
 
@@ -457,17 +457,17 @@ def build_wiki_status(root: Path) -> WikiStatus:
     review_needed_synthesis_pages = sum(
         1
         for page in pages
-        if page.frontmatter.kind in _SYNTHESIS_KINDS
+        if page.frontmatter.kind in SYNTHESIS_KINDS
         and page.frontmatter.review_state in _REVIEW_NEEDED_STATES
     )
 
     synthesis_source_ids = {
         source_ref
         for page in pages
-        if page.frontmatter.kind in _SYNTHESIS_KINDS
+        if page.frontmatter.kind in SYNTHESIS_KINDS
         for source_ref in page.frontmatter.source_refs
     }
-    synthesis_pages = [page for page in pages if page.frontmatter.kind in _SYNTHESIS_KINDS]
+    synthesis_pages = [page for page in pages if page.frontmatter.kind in SYNTHESIS_KINDS]
     ingested_source_ids = {
         source.source_id
         for source in sources
@@ -613,13 +613,13 @@ def suggest_source_pages(root: Path, source_id: str) -> WikiSuggestResult:
         raise FileNotFoundError(msg)
 
     source = load_source_record(manifest_path)
-    pages, _invalid_pages = _load_wiki_pages(root, layout)
+    pages, _invalid_pages = load_wiki_pages(root, layout)
     summaries = _source_summary_pages(pages, source_id)
     source_terms = _source_terms(source, summaries)
     suggestions = [
         suggestion
         for page in pages
-        if page.frontmatter.kind in _SYNTHESIS_KINDS
+        if page.frontmatter.kind in SYNTHESIS_KINDS
         for suggestion in [_score_page(source=source, page=page, source_terms=source_terms)]
         if suggestion is not None
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,6 +135,16 @@ def test_cli_brief_parser_accepts_agent_context() -> None:
     assert args.json_output is True
 
 
+def test_cli_suggest_next_parser_accepts_goal_and_json() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["suggest-next", "agent", "handoff", "--json"])
+
+    assert args.command == "suggest-next"
+    assert args.goal == ["agent", "handoff"]
+    assert args.json_output is True
+
+
 def test_cli_repo_scan_parser_accepts_preview_apply_and_report_flags() -> None:
     parser = build_parser()
 

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -776,6 +776,13 @@ def test_brief_agent_context_json_packages_handoff_state(tmp_path: Path, capsys)
     assert payload["source_refs"] == [added.source_id]
     assert unrelated.source_id not in payload["source_refs"]
     assert any(match["path"] == "wiki/topics/agent-context.md" for match in payload["matches"])
+    assert payload["suggested_actions"]
+    assert payload["suggested_actions"][0]["category"] in {
+        "goal-match",
+        "planning",
+        "synthesis",
+        "wiki-review",
+    }
     assert payload["active_planning"][0]["record_id"] == "task-agent-context"
     assert any(run["source_ids"] == [added.source_id] for run in payload["recent_runs"])
     assert payload["next_actions"]
@@ -790,8 +797,58 @@ def test_brief_agent_context_text_output_is_compact(tmp_path: Path, capsys) -> N
     assert exit_code == 0
     out = capsys.readouterr().out
     assert "Agent context" in out
+    assert "Suggested next:" in out
     assert "Wiki status:" in out
     assert "Next actions:" in out
+
+
+def test_suggest_next_json_ranks_changed_sources_before_review_work(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "handoff.md"
+    source.write_text("# Handoff\n\nOriginal briefing state.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "handoff.md",
+        kind="topic",
+        title="Handoff",
+        page_id="topic-handoff",
+        review_state="contested",
+        source_refs=[added.source_id],
+        body="Handoff work has contested notes.",
+    )
+    source.write_text("# Handoff\n\nUpdated briefing state.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "suggest-next", "handoff", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    actions = payload["actions"]
+    assert actions[0]["category"] == "source-freshness"
+    assert actions[0]["path"] == "handoff.md"
+    assert actions[0]["source_id"] == added.source_id
+    assert actions[0]["command"] == "splendor source refresh handoff.md"
+    assert any(action["category"] == "wiki-review" for action in actions)
+    assert payload["freshness"]["changed"] == 1
+
+
+def test_suggest_next_text_reports_pending_queue_path_first(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "pending.md"
+    source.write_text("# Pending\n\nNeeds ingest.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "pending.md"])
+    added = load_source_record(next((tmp_path / "state" / "manifests" / "sources").glob("*.json")))
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "suggest-next"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Suggested next actions" in out
+    assert "Drain ingest queue job" in out
+    assert "command=splendor ingest --pending" in out
+    assert added.source_id in out
 
 
 def test_brief_skips_invalid_query_matches_without_failing(tmp_path: Path, capsys) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -847,8 +847,55 @@ def test_suggest_next_text_reports_pending_queue_path_first(tmp_path: Path, caps
     out = capsys.readouterr().out
     assert "Suggested next actions" in out
     assert "Drain ingest queue job" in out
+    assert "target=pending.md" in out
     assert "command=splendor ingest --pending" in out
     assert added.source_id in out
+
+
+def test_suggest_next_caps_review_noise_and_preserves_goal_work(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    for index in range(10):
+        write_wiki_page(
+            tmp_path / "wiki" / "topics" / f"generated-{index}.md",
+            kind="topic",
+            title=f"Generated {index}",
+            page_id=f"topic-generated-{index}",
+            review_state="machine-generated",
+            body="Generated review noise.",
+        )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "handoff.md",
+        kind="topic",
+        title="Handoff",
+        page_id="topic-handoff",
+        review_state="human-reviewed",
+        body="Handoff work should stay visible in suggest-next results.",
+    )
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "create",
+            "Continue handoff",
+            "--id",
+            "task-handoff",
+            "--status",
+            "in_progress",
+        ]
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "suggest-next", "handoff", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    actions = payload["actions"]
+    categories = [action["category"] for action in actions]
+    assert categories.count("wiki-review") == 2
+    assert "goal-match" in categories
+    assert "planning" in categories
+    assert categories.index("goal-match") < categories.index("wiki-review")
 
 
 def test_brief_skips_invalid_query_matches_without_failing(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Implements M13-P2.4 under the M13-P2 Issue #70/#72 agent-usefulness redesign by making handoffs lead with actionable project state.

Changes:
- Add read-only `splendor suggest-next [goal]` with human and JSON output for deterministic agent handoff.
- Rank next actions from existing state: source freshness, queue operator state, invalid/stale/contested/review-needed wiki pages, missing synthesis follow-up, active planning records, recent lint/health reports, and optional goal matches.
- Make `brief --agent-context` lead with ranked suggested work before lower-level metadata lists while preserving the existing brief JSON shape and next-action compatibility.
- Keep output path-first/source-ref-first where possible and avoid mutating manifests, queue records, wiki pages, run records, planning records, or reports.
- Update README, quickstart, product/spec/schema docs, dogfooding guidance, Issue #70 response, roadmap, and synchronized planning-state lines for M13-P2.4.

## Validation

- `uv run pytest`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run splendor suggest-next "M13-P2.4 agent handoff" --json`

Refs #70
Refs #72
