### PR TITLE
M13-P2.5: Source-summary policy and path-first UX

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M13-P2.3`
-- Last action taken: `M13-P2.3` is implemented; source freshness / manifest-drift preview is complete.
+- Previous completed PR sub-slice: `M13-P2.4`
+- Last action taken: `M13-P2.4` is implemented; agent handoff brief and suggest-next are complete.
 - Current planned slice: `M13-P2`
-- Current PR sub-slice: `M13-P2.4`
+- Current PR sub-slice: `M13-P2.5`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M13-P2`
-- Next planned PR sub-slice: `M13-P2.5`
+- Next planned slice: `M13-P3`
+- Next planned PR sub-slice: `M13-P3.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -201,6 +201,11 @@
   - [x] Add deterministic ranked next-action guidance from freshness, queue, review, planning, maintenance, and goal-match state
   - [x] Add read-only `splendor suggest-next [goal]` with JSON output for machine handoff
   - [x] Make `brief --agent-context` lead with suggested work before metadata lists
+- [x] Implement `M13-P2.5`: Source-summary policy and path-first UX
+  - [x] Prefer claim-bearing bounded excerpts for readable in-repo source summaries
+  - [x] Keep fuller extracts for external, copied, parsed PDF, and OCR-derived sources where useful
+  - [x] Make human CLI output lead with source paths/source refs before source IDs where practical
+  - [x] Clarify generated-state review policy in docs and ingest guidance
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Implemented today:
 - `splendor repair ingest <source-id>`
 - `splendor materialize-source <source-id>`
 - `splendor query "<question>"`, `splendor query --tag <tag>`,
-  `splendor query --source <source-id>`, and `splendor query "<question>" --json`
+  `splendor query --source <source-id|title|path>`, and `splendor query "<question>" --json`
 - `splendor file-answer --from-last-query --title "..."`
 - `splendor task|milestone|decision|question ...`
 - `splendor repo scan`
@@ -149,6 +149,13 @@ and prints exact `source refresh`/`ingest --pending` next commands for stale pat
 the same preview for machine handoff, and `--report PATH` writes only an explicit freshness report.
 Relative report paths use the current working directory.
 
+Generated source-summary pages are deterministic ingestion artifacts. For readable in-repo
+markdown/text/code sources, Splendor defaults to concise claim-bearing excerpts and path-first
+display; copied, external, parsed PDF, and OCR-derived sources keep fuller extracts by default
+because the generated artifact may be the clearest review surface. Queue/run records are
+mechanical provenance, while explicit reports should be committed only when they support the
+reviewed workspace update.
+
 Text-bearing PDFs are supported through the ingest dispatch path. Parsed PDF text is written under
 `derived/parsed/`, linked from the source manifest, and used for the generated source-summary page.
 Image sources and image-only PDFs can use explicitly configured sidecar-text OCR; extracted OCR text
@@ -168,12 +175,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M13-P2.3`
+- Previous completed PR sub-slice: `M13-P2.4`
 - Current planned slice: `M13-P2`
-- Current PR sub-slice: `M13-P2.4`
+- Current PR sub-slice: `M13-P2.5`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M13-P2`
-- Next planned PR sub-slice: `M13-P2.5`
+- Next planned slice: `M13-P3`
+- Next planned PR sub-slice: `M13-P3.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -43,6 +43,12 @@ users and agents can identify affected concept, entity, topic, architecture, or 
 rank immediate handoff work before manual review. Mutating compile/update workflow support remains
 planned.
 
+For readable in-repo sources, generated source-summary pages should stay compact and path-first:
+Splendor renders claim-bearing excerpts by default and keeps source paths visible before source IDs.
+Commit source summaries, manifests, queue/run state, and explicit reports when they are part of a
+reviewed workspace update; leave failed or exploratory local reports out unless the report itself
+is the artifact under review.
+
 Dogfood runs should record usability friction separately from knowledge gaps. Pay special attention
 to whether each command prints the next useful command, whether long source IDs need to be copied
 manually, whether query results show claim-bearing snippets, and whether the web UI exposes enough

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -85,6 +85,12 @@ The next implementation slices should document and then implement these contract
 - `splendor suggest-next [goal]` ranks work from source freshness, queue failures or pending work,
   missing synthesis, stale/contested/review-needed pages, active planning records, maintenance
   reports, and goal matches without mutating the workspace.
+- Source-summary rendering defaults readable in-repo sources to concise claim-bearing excerpts,
+  keeps fuller extracts for copied/external/transformed sources, and prints source paths before
+  source IDs in human-facing source-summary and CLI surfaces.
+- CLI guidance distinguishes reviewer-significant generated state from mechanical queue/run/report
+  churn so PR authors can explain what should be reviewed rather than asking reviewers to decode
+  every generated record equally.
 
 ## Roadmap Impact
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -159,6 +159,15 @@ This creates:
 - a run record under `state/runs/`
 - updated `wiki/index.md` and `wiki/log.md`
 
+Generated source-summary pages are reviewer-significant when they help explain a curated source,
+its provenance, or synthesis follow-up. Queue and run records are deterministic operational state;
+review them for broken references or surprising failures, but do not treat every timestamp-only
+record as hand-authored knowledge. Explicit reports under `reports/` should be committed only when
+they support the reviewed workspace update; failed or exploratory local reports can stay local.
+Readable in-repo markdown/text/code summaries default to concise excerpts, while external, copied,
+parsed PDF, and OCR-derived sources keep fuller extracts because the generated artifact may be the
+most convenient review surface.
+
 After ingest, use the source ID from the command output to inspect likely synthesis follow-up:
 
 ```bash

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -255,6 +255,12 @@ Current runtime behavior:
 - those pages persist `last_generated_at`
 - those pages persist structured provenance links back to the source manifest, ingest run, and
   source-content path actually read
+- readable workspace-backed text summaries default to a policy-driven `excerpt` extract that
+  prefers claim-bearing sections before falling back to a bounded opening excerpt
+- copied, external, parsed PDF, and OCR-derived sources keep fuller extracts by default because the
+  generated page or derived artifact is often the easiest local review surface
+- human-facing source-summary markdown renders source paths/source files before source IDs, while
+  frontmatter and state records keep canonical source IDs as the durable linkage contract
 - when contradiction review finds explicit conflicts, both involved source-summary pages switch to
   `review_state: contested`
 - contested pages persist structured contradiction annotations with linked review-task IDs and
@@ -291,6 +297,7 @@ Current implementation fields:
 - `filters`
   - `tags`
   - `source_id`
+  - `source_ids`
 - `summary`
 - `match_count`
 - `created_at`
@@ -298,6 +305,9 @@ Current implementation fields:
 
 Query matches preserve rank, score, class/kind, record identity, path, status/review state, snippet,
 source refs, generated run IDs, provenance links, contradiction counts, review task IDs, and tags.
+When a source filter is provided by readable path and multiple content-addressed source versions
+share that path, `source_id` stores the primary resolved source ID and `source_ids` stores every
+matching source ID used for the filter.
 `splendor query --no-save` preserves query output behavior but does not update this snapshot.
 
 ## Queue and run records

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M13-P2.3`
+- Previous completed PR sub-slice: `M13-P2.4`
 - Current planned slice: `M13-P2`
-- Current PR sub-slice: `M13-P2.4`
+- Current PR sub-slice: `M13-P2.5`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M13-P2`
-- Next planned PR sub-slice: `M13-P2.5`
+- Next planned slice: `M13-P3`
+- Next planned PR sub-slice: `M13-P3.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The current M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -810,6 +810,11 @@ freshness, contested knowledge, planning state, and next actions rather than mos
 are read-only and draw from source freshness, queue failures or pending work,
 stale/contested/review-needed pages, missing synthesis follow-up, active planning records, recent
 maintenance reports, and optional goal matches.
+
+`M13-P2.5` is in progress: generated source-summary pages stay deterministic while readable
+in-repo markdown/text/code sources default to concise, claim-bearing excerpts. Human CLI surfaces
+should lead with source paths or source refs before canonical source IDs, while persisted
+frontmatter, manifests, and run records continue to use canonical IDs for compatibility.
 
 ### Exit criteria
 - the product is stable enough for sustained real-world use

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -703,6 +703,9 @@ Recommended default behavior:
 Current implementation:
 
 - workspace-backed in-repo text sources default to `excerpt`
+- excerpt mode prefers claim-bearing sections such as `Core Claims`, `Design Implications`,
+  `Product Experience Notes`, and `Summary`; if no such section exists, it falls back to a bounded
+  opening excerpt
 - copied or external text sources default to `full`
 - text-bearing PDF sources are parsed through source-type dispatch, with extracted text written to
   `derived/parsed/<source-id>.txt` and linked from the source manifest via `derived_artifacts`
@@ -714,6 +717,8 @@ Current implementation:
 - projects may set either class to `none`, `excerpt`, or `full` through
   `sources.summarize_in_repo_extracts_as` and `sources.summarize_external_extracts_as`
 - when the mode is `none`, the `## Extract` section is omitted entirely
+- generated source-summary pages render the registered path/source file before the canonical source
+  ID so reviewers can inspect the readable source first
 
 ## 14.6 Wiki compile/update workflow
 
@@ -722,9 +727,9 @@ can be conservative and review-oriented:
 
 - `splendor wiki status` reports source counts, page counts, queue state, recent runs,
   machine-generated pages, stale pages, contested pages, orphan pages, and pages needing review
-- `splendor wiki suggest <source-id>` identifies concept, topic, architecture, comparison, or
+- `splendor wiki suggest <source-id|title|path>` identifies concept, topic, architecture, comparison, or
   overview pages likely affected by a source
-- `splendor wiki compile <source-id>` or an equivalent reviewed operation updates synthesis pages
+- `splendor wiki compile <source-id|title|path>` or an equivalent reviewed operation updates synthesis pages
   with auditable provenance and run state
 
 This workflow should start with text-native sources and deterministic page-impact suggestions. The
@@ -759,7 +764,8 @@ Current implementation:
   with valid knowledge-page frontmatter, optional tags/source refs, and deterministic markdown
   templates for default synthesis, research synthesis, and issue tracking.
 - `splendor ingest <source-id>` prints the generated source-summary page/run records and the next
-  `splendor wiki suggest <source-id>` command.
+  `splendor wiki suggest <source-id>` command, plus generated-state guidance for reviewing source
+  manifests, source-summary pages, queue records, run records, and explicit reports.
 - PDF ingest first uses deterministic local extraction for text-bearing PDFs. Image-only PDFs and
   image sources only enter OCR when `sources.ocr_enabled` is true; the current local provider reads
   adjacent sidecar text files named with `sources.ocr_sidecar_suffix` and writes normalized output
@@ -769,10 +775,10 @@ Current implementation:
 - `splendor wiki status` reports source, page, queue, run, review, contested, stale,
   machine-generated, invalid-page, actionable synthesis-review, and missing
   synthesis-follow-up counts, with optional JSON output.
-- `splendor wiki suggest <source-id>` deterministically ranks existing synthesis pages using source
+- `splendor wiki suggest <source-id|title|path>` deterministically ranks existing synthesis pages using source
   metadata, source-summary text, frontmatter source refs, tags, source refs, and page content, with
   optional JSON output.
-- `splendor wiki compile <source-id>` exposes the review-gated compile-loop contract, validates the
+- `splendor wiki compile <source-id|title|path>` exposes the review-gated compile-loop contract, validates the
   source, and reports that it does not mutate synthesis pages yet.
 - `splendor wiki rebuild-index` rewrites `wiki/index.md` from validated wiki page frontmatter,
   including maintained synthesis pages and generated source-summary pages, without mutating the
@@ -936,9 +942,11 @@ machine-generated labels.
 
 Current query output includes any active deterministic filters. `splendor query --tag <tag>`
 restricts matches to wiki pages carrying all requested tags, and
-`splendor query --source <source-id>` validates the canonical source ID before returning wiki or
-planning records whose `source_refs` include that ID. Filter-only source lookup is allowed so
-agents can ask which pages reference a known source without inventing a search phrase.
+`splendor query --source <source-id|title|path>` resolves the source filter to canonical source
+IDs before returning wiki or planning records whose `source_refs` intersect those IDs. Exact
+readable path filters include all known content-addressed versions for that path until stable
+logical source identities exist. Filter-only source lookup is allowed so agents can ask which pages
+reference a known source without inventing a search phrase.
 
 ### 17.3 Project briefing
 
@@ -1256,7 +1264,8 @@ These are not blockers to the spec, but should remain visible:
 5. how aggressively to auto-update central synthesis pages
 6. exact level of provenance granularity at the paragraph/claim level
 7. whether a companion-repo linking model needs a first-class schema element
-8. exact generated source-summary policy for readable in-repo markdown and code files
+8. post-v1 refinements to generated source-summary policy for readable in-repo markdown and code
+   files, after the v1 default of concise claim-bearing excerpts has been exercised in real repos
 
 ## 31. Summary Product Statement
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -305,7 +305,9 @@ def build_parser() -> argparse.ArgumentParser:
     wiki_suggest_parser = wiki_subparsers.add_parser(
         "suggest", help="Suggest synthesis pages affected by a source"
     )
-    wiki_suggest_parser.add_argument("source_id", help="Registered source identifier to inspect")
+    wiki_suggest_parser.add_argument(
+        "source_id", help="Registered source ID, title, or path to inspect"
+    )
     wiki_suggest_parser.add_argument(
         "--json",
         action="store_true",
@@ -316,7 +318,9 @@ def build_parser() -> argparse.ArgumentParser:
     wiki_compile_parser = wiki_subparsers.add_parser(
         "compile", help="Describe the review-gated synthesis compile contract for a source"
     )
-    wiki_compile_parser.add_argument("source_id", help="Registered source identifier to inspect")
+    wiki_compile_parser.add_argument(
+        "source_id", help="Registered source ID, title, or path to inspect"
+    )
     wiki_compile_parser.add_argument(
         "--json",
         action="store_true",
@@ -379,7 +383,7 @@ def build_parser() -> argparse.ArgumentParser:
     query_parser.add_argument(
         "--source",
         dest="source_id",
-        help="Restrict results to records referencing this source ID.",
+        help="Restrict results to records referencing this source ID, title, or path.",
     )
     query_parser.add_argument(
         "--json",
@@ -732,7 +736,7 @@ def handle_add_source(args: argparse.Namespace) -> int:
 
             results.append(result)
             action = "already registered" if result.already_registered else "registered"
-            print(f"- {result.source_id} ({action}) {result.source_ref}")
+            print(f"- {result.source_ref}: {action} source_id={result.source_id}")
             if result.already_registered:
                 continue
             try:
@@ -772,9 +776,9 @@ def handle_add_source(args: argparse.Namespace) -> int:
     except (FileNotFoundError, IsADirectoryError, ValueError) as exc:
         return _print_error(exc)
     action = "Already registered" if result.already_registered else "Registered"
+    print(f"Source ref: {result.source_ref}")
     print(f"{action} source {result.source_id}")
     print(f"Manifest: {result.manifest_path}")
-    print(f"Source ref: {result.source_ref}")
     print(f"Storage mode: {result.storage_mode}")
     if result.stored_path is not None:
         print(f"Storage artifact: {result.stored_path}")
@@ -870,14 +874,16 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
         return 0
 
     if result.changed:
-        print(f"Detected changed source content for {result.requested.source_id}")
+        print(f"Detected changed source content for {canonical_source_ref(result.requested)}")
+        print(f"Requested source ID: {result.requested.source_id}")
         if result.refreshed.record.source_id != result.requested.source_id:
             if result.refreshed.already_registered:
-                print(f"Matched existing source version {result.refreshed.record.source_id}")
+                print(f"Matched existing source version: {result.refreshed.record.source_id}")
             else:
-                print(f"Registered refreshed source {result.refreshed.record.source_id}")
+                print(f"Registered refreshed source ID: {result.refreshed.record.source_id}")
     else:
-        print(f"No source content change detected for {result.requested.source_id}")
+        print(f"No source content change detected for {canonical_source_ref(result.requested)}")
+        print(f"Source ID: {result.requested.source_id}")
     print(f"Source ref: {result.refreshed.source_ref}")
     if result.queued and result.queue_path is not None:
         print(f"Queued ingest: {result.queue_path}")
@@ -976,14 +982,18 @@ def handle_ingest(args: argparse.Namespace) -> int:
         print(f"Page: {result.page_path}")
         return 0
 
-    print(f"Ingested source {result.source_id}")
-    print(f"Source ref: {result.canonical_ref}")
+    print(f"Ingested source: {result.canonical_ref}")
+    print(f"Source ID: {result.source_id}")
     print(f"Canonical content: {result.content_origin_kind.replace('_', ' ')}")
     print(f"Run: {result.run_id}")
     print(f"Page: {result.page_path}")
     print(f"Queue record: {result.queue_path}")
     print(f"Run record: {result.run_path}")
     print(f"Next: splendor wiki suggest {result.source_id}")
+    print(
+        "Generated state: review source-summary, source manifest, queue, and run changes; "
+        "commit explicit reports only when they support the reviewed workspace update."
+    )
     return 0
 
 
@@ -1111,8 +1121,8 @@ def _print_source_lookup_results(results: list[SourceLookupResult]) -> None:
     for result in results:
         source = result.source
         print(
-            f"- {source.source_id} [{source.status}] {source.title} "
-            f"ref={canonical_source_ref(source)}"
+            f"- {canonical_source_ref(source)} [{source.status}] {source.title} "
+            f"source_id={source.source_id} ref={canonical_source_ref(source)}"
         )
         print(f"  Manifest: {result.manifest_path}")
     print("Next: splendor source refresh <source-id|title|path>")
@@ -1183,9 +1193,11 @@ def handle_wiki_suggest(args: argparse.Namespace) -> int:
         print(render_wiki_suggest_json(result))
         return 0
 
-    print(f"Source: {result.source_id}")
-    print(f"Title: {result.source_title}")
     print(f"Source ref: {result.source_ref}")
+    print(f"Source ID: {result.source_id}")
+    if len(result.source_ids) > 1:
+        print(f"Resolved source IDs: {', '.join(result.source_ids)}")
+    print(f"Title: {result.source_title}")
     print(f"Status: {result.source_status}")
     if not result.suggestions:
         print("No likely synthesis-page matches found")
@@ -1208,9 +1220,9 @@ def handle_wiki_compile(args: argparse.Namespace) -> int:
         print(render_wiki_compile_contract_json(result))
         return 0
 
-    print(f"Source: {result.source_id}")
-    print(f"Title: {result.source_title}")
     print(f"Source ref: {result.source_ref}")
+    print(f"Source ID: {result.source_id}")
+    print(f"Title: {result.source_title}")
     print(f"Status: {result.source_status}")
     print("Compile contract: review-gated synthesis maintenance")
     print("Mutates wiki: no")
@@ -1319,6 +1331,7 @@ def handle_query(args: argparse.Namespace) -> int:
                 filters=QueryFilterSnapshot(
                     tags=result.filters.tags,
                     source_id=result.filters.source_id,
+                    source_ids=result.filters.source_ids or [],
                 ),
                 summary=result.summary,
                 match_count=result.match_count,
@@ -1356,6 +1369,7 @@ def handle_query(args: argparse.Namespace) -> int:
             "filters": {
                 "tags": result.filters.tags,
                 "source_id": result.filters.source_id,
+                "source_ids": result.filters.source_ids or [],
             },
             "summary": result.summary,
             "match_count": result.match_count,
@@ -1393,6 +1407,11 @@ def handle_query(args: argparse.Namespace) -> int:
             "Filters: "
             f"tags={', '.join(result.filters.tags) if result.filters.tags else '-'} "
             f"source={result.filters.source_id or '-'}"
+            + (
+                f" resolved={', '.join(result.filters.source_ids)}"
+                if result.filters.source_ids and len(result.filters.source_ids) > 1
+                else ""
+            )
         )
     print(f"Summary: {result.summary}")
     print("Matches:")
@@ -1464,7 +1483,10 @@ def handle_brief(args: argparse.Namespace) -> int:
     if result.recent_sources:
         print("Recent sources:")
         for source in result.recent_sources:
-            print(f"- {source.source_id} [{source.status}] {source.title}")
+            print(
+                f"- {source.source_ref} [{source.status}] {source.title} "
+                f"source_id={source.source_id}"
+            )
     if result.recent_runs:
         print("Recent runs:")
         for run in result.recent_runs:
@@ -1519,7 +1541,10 @@ def _print_agent_context(result: ProjectBrief) -> None:
     if result.recent_sources:
         print("Recent sources:")
         for source in result.recent_sources:
-            print(f"- {source.source_id} [{source.status}/{source.review_state}] {source.title}")
+            print(
+                f"- {source.source_ref} [{source.status}/{source.review_state}] "
+                f"{source.title} source_id={source.source_id}"
+            )
     if result.recent_runs:
         print("Recent runs:")
         for run in result.recent_runs:

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -70,7 +70,11 @@ _CLAIM_SECTION_HEADINGS = {
     "key facts",
     "claims",
     "findings",
+    "product experience notes",
+    "summary",
 }
+_EXCERPT_CHAR_LIMIT = 1600
+_EXCERPT_LINE_LIMIT = 36
 
 
 @dataclass(frozen=True)
@@ -125,6 +129,10 @@ def _page_path_for(layout_root: Path, source_id: str) -> Path:
 
 
 def _build_extract(text: str) -> str:
+    claim_excerpt = _build_claim_excerpt(text)
+    if claim_excerpt:
+        return claim_excerpt
+
     lines = text.splitlines()
     start_index = 0
     for index, line in enumerate(lines):
@@ -134,14 +142,53 @@ def _build_extract(text: str) -> str:
 
     extract_lines: list[str] = []
     char_count = 0
-    for line in lines[start_index : start_index + 80]:
+    for line in lines[start_index : start_index + _EXCERPT_LINE_LIMIT]:
         projected_count = char_count + len(line) + 1
-        if projected_count > 4000 and extract_lines:
+        if projected_count > _EXCERPT_CHAR_LIMIT and extract_lines:
             break
         extract_lines.append(line)
         char_count = projected_count
 
     return "\n".join(extract_lines).rstrip()
+
+
+def _build_claim_excerpt(text: str) -> str | None:
+    lines = text.splitlines()
+    excerpt_lines: list[str] = []
+    active = False
+    in_fence = False
+    char_count = 0
+    for raw_line in lines:
+        line = raw_line.strip()
+        if line.startswith("```") or line.startswith("~~~"):
+            if active:
+                break
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        heading_match = _MARKDOWN_HEADING_PATTERN.match(line)
+        if heading_match:
+            heading = _strip_markdown_inline(heading_match.group("title")).lower()
+            if active and excerpt_lines:
+                break
+            active = heading in _CLAIM_SECTION_HEADINGS
+            if active:
+                excerpt_lines.append(raw_line)
+                char_count += len(raw_line) + 1
+            continue
+        if not active:
+            continue
+        projected_count = char_count + len(raw_line) + 1
+        if projected_count > _EXCERPT_CHAR_LIMIT and excerpt_lines:
+            break
+        excerpt_lines.append(raw_line)
+        char_count = projected_count
+        if len(excerpt_lines) >= _EXCERPT_LINE_LIMIT:
+            break
+
+    excerpt = "\n".join(excerpt_lines).strip()
+    return excerpt or None
 
 
 def _summary_mode_for(config, source: SourceRecord) -> SummaryMode:
@@ -159,6 +206,14 @@ def _rendered_extract(text: str, mode: SummaryMode) -> str | None:
     if mode == "excerpt":
         return _build_extract(text)
     return text
+
+
+def _extract_policy_note(mode: SummaryMode) -> str:
+    if mode == "none":
+        return "Extract policy: `none` (source text omitted from this generated page)"
+    if mode == "excerpt":
+        return "Extract policy: `excerpt` (claim-bearing section or bounded opening excerpt)"
+    return "Extract policy: `full` (full resolved text rendered for local review)"
 
 
 def _build_summary(source: SourceRecord, source_text: str) -> str:
@@ -945,10 +1000,11 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
         )
         source_section = "\n".join(
             [
-                f"- Source ID: `{source.source_id}`",
-                f"- Source type: `{source.source_type}`",
                 f"- Registered path: `{registered_path}`",
                 f"- Source file: `{resolved_source.resolved_ref}`",
+                f"- Source ID: `{source.source_id}`",
+                f"- Source type: `{source.source_type}`",
+                f"- {_extract_policy_note(extract_mode)}",
             ]
             + (
                 [f"- {dispatched_content.derived_artifact_label}: `{derived_artifact_ref}`"]

--- a/src/splendor/commands/query.py
+++ b/src/splendor/commands/query.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+from splendor.commands.source import resolve_source_query_matches
 from splendor.config import load_config
 from splendor.layout import ResolvedLayout, resolve_layout
 from splendor.schemas import ProvenanceLink
@@ -60,10 +61,11 @@ class QueryValidationError(ValueError):
 class QueryFilters:
     tags: list[str]
     source_id: str | None = None
+    source_ids: list[str] | None = None
 
     @property
     def active(self) -> bool:
-        return bool(self.tags or self.source_id)
+        return bool(self.tags or self.source_id or self.source_ids)
 
 
 @dataclass(frozen=True)
@@ -205,16 +207,25 @@ def run_query(
 def _normalize_filters(root: Path, *, tags: list[str], source_id: str | None) -> QueryFilters:
     normalized_tags = _normalize_tags(tags)
     normalized_source_id = source_id.strip() if source_id is not None else None
+    normalized_source_ids: list[str] | None = None
     if normalized_source_id:
-        manifest_path = manifest_path_for(root, normalized_source_id)
-        if not manifest_path.exists():
-            msg = f"Unknown source ID: {normalized_source_id}"
-            raise FileNotFoundError(msg)
-        source = load_source_record(manifest_path)
-        if source.source_id != normalized_source_id:
-            msg = f"Source manifest ID does not match requested source: {normalized_source_id}"
-            raise ValueError(msg)
-    return QueryFilters(tags=normalized_tags, source_id=normalized_source_id)
+        resolved_sources = resolve_source_query_matches(root, normalized_source_id)
+        normalized_source_ids = [match.source.source_id for match in resolved_sources]
+        normalized_source_id = normalized_source_ids[0]
+        for resolved_source_id in normalized_source_ids:
+            manifest_path = manifest_path_for(root, resolved_source_id)
+            if not manifest_path.exists():
+                msg = f"Unknown source ID: {resolved_source_id}"
+                raise FileNotFoundError(msg)
+            source = load_source_record(manifest_path)
+            if source.source_id != resolved_source_id:
+                msg = f"Source manifest ID does not match requested source: {resolved_source_id}"
+                raise ValueError(msg)
+    return QueryFilters(
+        tags=normalized_tags,
+        source_id=normalized_source_id,
+        source_ids=normalized_source_ids,
+    )
 
 
 def _normalize_tags(tags: list[str]) -> list[str]:
@@ -233,7 +244,9 @@ def _normalize_tags(tags: list[str]) -> list[str]:
 
 
 def _matches_filters(document: _QueryDocument, filters: QueryFilters) -> bool:
-    if filters.source_id is not None and filters.source_id not in document.source_refs:
+    if filters.source_ids is not None and not set(filters.source_ids).intersection(
+        document.source_refs
+    ):
         return False
     if filters.tags:
         document_tags = {tag.casefold() for tag in document.tags}

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -112,6 +112,59 @@ def lookup_sources(root: Path, query: str | None = None) -> list[SourceLookupRes
     return [result for result in results if _matches_source(result.source, needle)]
 
 
+def resolve_source_query(root: Path, query: str) -> SourceLookupResult:
+    return _select_source_query_candidate(root, query)
+
+
+def resolve_source_query_matches(root: Path, query: str) -> list[SourceLookupResult]:
+    matches = lookup_sources(root, query)
+    if not matches:
+        label = "source ID" if query.startswith("src-") else "source"
+        msg = f"Unknown {label}: {query}"
+        raise FileNotFoundError(msg)
+
+    exact_id_matches = [match for match in matches if match.source.source_id == query]
+    if exact_id_matches:
+        return exact_id_matches
+
+    exact_ref_matches = [
+        match
+        for match in matches
+        if canonical_source_ref(match.source) == query
+        or (match.source.original_path is not None and match.source.original_path == query)
+    ]
+    if exact_ref_matches:
+        return sorted(exact_ref_matches, key=_latest_source_sort_key, reverse=True)
+
+    exact_matches = [
+        match for match in matches if match.source.title.casefold() == query.casefold()
+    ]
+    if exact_matches:
+        refs = {canonical_source_ref(match.source) for match in exact_matches}
+        if len(refs) == 1:
+            return sorted(exact_matches, key=_latest_source_sort_key, reverse=True)
+
+    return [_select_source_query_candidate(root, query)]
+
+
+def _select_source_query_candidate(root: Path, query: str) -> SourceLookupResult:
+    matches = lookup_sources(root, query)
+    exact_matches = [
+        match
+        for match in matches
+        if match.source.source_id == query
+        or match.source.title.casefold() == query.casefold()
+        or canonical_source_ref(match.source) == query
+        or (match.source.original_path is not None and match.source.original_path == query)
+    ]
+    candidates = exact_matches or matches
+    if not candidates:
+        label = "source ID" if query.startswith("src-") else "source"
+        msg = f"Unknown {label}: {query}"
+        raise FileNotFoundError(msg)
+    return _select_refresh_candidate(query, candidates)
+
+
 def source_commit_capture_intent(source: SourceRecord) -> bool | None:
     if source.source_commit_capture is not None:
         return source.source_commit_capture
@@ -121,20 +174,7 @@ def source_commit_capture_intent(source: SourceRecord) -> bool | None:
 
 
 def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
-    matches = lookup_sources(root, source_query)
-    exact_matches = [
-        match
-        for match in matches
-        if match.source.source_id == source_query
-        or match.source.title.casefold() == source_query.casefold()
-        or canonical_source_ref(match.source) == source_query
-        or (match.source.original_path is not None and match.source.original_path == source_query)
-    ]
-    candidates = exact_matches or matches
-    if not candidates:
-        msg = f"Unknown source: {source_query}"
-        raise FileNotFoundError(msg)
-    requested_match = _select_refresh_candidate(source_query, candidates)
+    requested_match = resolve_source_query(root, source_query)
 
     requested = requested_match.source
     current_path = _refreshable_source_path(root, requested)

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -8,6 +8,7 @@ from collections import Counter
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+from splendor.commands.source import resolve_source_query, resolve_source_query_matches
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord, SourceRecord
@@ -115,6 +116,7 @@ class WikiSuggestion:
 @dataclass(frozen=True)
 class WikiSuggestResult:
     source_id: str
+    source_ids: list[str]
     source_title: str
     source_ref: str
     source_status: str
@@ -604,28 +606,56 @@ def _score_page(
     )
 
 
+def _score_page_for_sources(
+    *,
+    sources: list[SourceRecord],
+    page: WikiPageSnapshot,
+    source_terms: set[str],
+) -> WikiSuggestion | None:
+    scored = [
+        suggestion
+        for source in sources
+        for suggestion in [_score_page(source=source, page=page, source_terms=source_terms)]
+        if suggestion is not None
+    ]
+    if not scored:
+        return None
+    best = max(scored, key=lambda suggestion: (suggestion.score, -len(suggestion.reasons)))
+    reasons = sorted({reason for suggestion in scored for reason in suggestion.reasons})
+    return WikiSuggestion(
+        path=best.path,
+        page_id=best.page_id,
+        title=best.title,
+        kind=best.kind,
+        score=max(suggestion.score for suggestion in scored),
+        reasons=reasons,
+    )
+
+
 def suggest_source_pages(root: Path, source_id: str) -> WikiSuggestResult:
     config = load_config(root)
     layout = resolve_layout(root, config)
-    manifest_path = layout.source_records_dir / f"{source_id}.json"
-    if not manifest_path.exists():
-        msg = f"Unknown source ID: {source_id}"
-        raise FileNotFoundError(msg)
-
-    source = load_source_record(manifest_path)
+    source_matches = resolve_source_query_matches(root, source_id)
+    sources = [match.source for match in source_matches]
+    source = sources[0]
     pages, _invalid_pages = load_wiki_pages(root, layout)
-    summaries = _source_summary_pages(pages, source_id)
-    source_terms = _source_terms(source, summaries)
+    source_terms: set[str] = set()
+    for matched_source in sources:
+        summaries = _source_summary_pages(pages, matched_source.source_id)
+        source_terms.update(_source_terms(matched_source, summaries))
     suggestions = [
         suggestion
         for page in pages
         if page.frontmatter.kind in SYNTHESIS_KINDS
-        for suggestion in [_score_page(source=source, page=page, source_terms=source_terms)]
+        for suggestion in [
+            _score_page_for_sources(sources=sources, page=page, source_terms=source_terms)
+        ]
         if suggestion is not None
     ]
     suggestions.sort(key=lambda suggestion: (-suggestion.score, suggestion.path))
     return WikiSuggestResult(
         source_id=source.source_id,
+        source_ids=[matched_source.source_id for matched_source in sources],
         source_title=source.title,
         source_ref=canonical_source_ref(source),
         source_status=source.status,
@@ -634,14 +664,7 @@ def suggest_source_pages(root: Path, source_id: str) -> WikiSuggestResult:
 
 
 def describe_wiki_compile_contract(root: Path, source_id: str) -> WikiCompileContract:
-    config = load_config(root)
-    layout = resolve_layout(root, config)
-    manifest_path = layout.source_records_dir / f"{source_id}.json"
-    if not manifest_path.exists():
-        msg = f"Unknown source ID: {source_id}"
-        raise FileNotFoundError(msg)
-
-    source = load_source_record(manifest_path)
+    source = resolve_source_query(root, source_id).source
     return WikiCompileContract(
         source_id=source.source_id,
         source_title=source.title,
@@ -695,6 +718,7 @@ def render_wiki_suggest_json(result: WikiSuggestResult) -> str:
     return json.dumps(
         {
             "source_id": result.source_id,
+            "source_ids": result.source_ids,
             "source_title": result.source_title,
             "source_ref": result.source_ref,
             "source_status": result.source_status,

--- a/src/splendor/schemas/query.py
+++ b/src/splendor/schemas/query.py
@@ -11,6 +11,7 @@ from splendor.schemas.provenance import ProvenanceLink
 class QueryFilterSnapshot(StrictRecord):
     tags: list[str] = Field(default_factory=list)
     source_id: str | None = None
+    source_ids: list[str] = Field(default_factory=list)
 
 
 class QueryMatchSnapshot(StrictRecord):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -375,6 +375,7 @@ def test_cli_source_lookup_maps_readable_path_to_source_id(tmp_path: Path, capsy
     assert "Sources: 1" in out
     assert "Audio Quality Feedback" in out or "audio quality feedback" in out
     assert "docs/audio-quality-feedback.md" in out
+    assert out.index("docs/audio-quality-feedback.md") < out.index("source_id=src-")
 
 
 def test_cli_source_list_reports_registered_sources(tmp_path: Path, capsys) -> None:
@@ -475,11 +476,12 @@ def test_cli_source_refresh_registers_changed_workspace_source_and_queues_it(
 
     assert exit_code == 0
     out = capsys.readouterr().out
-    assert f"Detected changed source content for {original_id}" in out
+    assert "Detected changed source content for brief.md" in out
+    assert f"Requested source ID: {original_id}" in out
     manifests = sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
     assert len(manifests) == 2
     refreshed_id = [path.stem for path in manifests if path.stem != original_id][0]
-    assert f"Registered refreshed source {refreshed_id}" in out
+    assert f"Registered refreshed source ID: {refreshed_id}" in out
     assert (tmp_path / "state" / "queue" / f"ingest-{refreshed_id}.json").exists()
 
 
@@ -498,7 +500,7 @@ def test_cli_source_refresh_reports_existing_version_match(tmp_path: Path, capsy
 
     assert exit_code == 0
     out = capsys.readouterr().out
-    assert f"Matched existing source version {original_id}" in out
+    assert f"Matched existing source version: {original_id}" in out
     assert f"Registered refreshed source {original_id}" not in out
 
 
@@ -1749,7 +1751,11 @@ def test_cli_query_command_json_reports_active_filters(tmp_path: Path, capsys) -
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["query"] == ""
-    assert payload["filters"] == {"tags": ["preprocessing"], "source_id": source_id}
+    assert payload["filters"] == {
+        "tags": ["preprocessing"],
+        "source_id": source_id,
+        "source_ids": [source_id],
+    }
     assert payload["match_count"] == 1
     assert payload["matches"][0]["path"] == "wiki/topics/preprocessing.md"
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -46,6 +46,11 @@ def update_summary_modes(
     write_config(root, config)
 
 
+def extract_rendered_extract_section(body: str) -> str:
+    after_heading = body.split("## Extract\n\n", maxsplit=1)[1]
+    return after_heading.split("\n\n## ", maxsplit=1)[0]
+
+
 def enable_sidecar_ocr(root: Path, *, suffix: str = ".ocr.txt") -> None:
     config = load_config(root)
     config.sources.ocr_enabled = True
@@ -1212,6 +1217,33 @@ def test_ingest_source_workspace_backed_default_uses_excerpt(tmp_path: Path) -> 
     assert "## Extract" in body
     assert "line 10" in body
     assert "line 119" not in body
+    assert "Extract policy: `excerpt`" in body
+
+
+def test_ingest_source_excerpt_prefers_claim_bearing_section(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text(
+        "# Brief\n\n"
+        + "\n".join(f"opening filler {i}" for i in range(60))
+        + "\n\n## Product Experience Notes\n\n"
+        "- Path-first output should be visible before source IDs.\n"
+        "- Generated summaries should stay compact for readable repo files.\n"
+        "\n## Later Detail\n\n"
+        "This late section should not enter the bounded excerpt.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    body = result.page_path.read_text(encoding="utf-8")
+    extract = extract_rendered_extract_section(body)
+    assert "## Product Experience Notes" in extract
+    assert "Path-first output should be visible before source IDs." in extract
+    assert "opening filler 50" not in extract
+    assert "This late section should not enter the bounded excerpt." not in extract
 
 
 def test_ingest_source_markdown_summary_uses_heading_and_paragraph(tmp_path: Path) -> None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -138,6 +138,62 @@ def test_run_query_filters_by_source_ref_and_allows_filter_only_lookup(tmp_path:
     assert result.matches[0].path == "wiki/topics/briefing.md"
 
 
+def test_run_query_source_filter_accepts_readable_source_path(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    source = docs / "brief.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "briefing.md",
+        title="Briefing",
+        page_id="topic-briefing",
+        body="Planning brief uses source refs.",
+        source_refs=[added.source_id],
+    )
+
+    result = run_query(tmp_path, "", source_id="docs/brief.md")
+
+    assert result.filters.source_id == added.source_id
+    assert result.matches[0].path == "wiki/topics/briefing.md"
+
+
+def test_run_query_source_path_filter_matches_all_versions_for_that_path(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "docs" / "brief.md"
+    source.parent.mkdir()
+    source.write_text("# Brief\n\nOriginal source version.\n", encoding="utf-8")
+    original = add_source(tmp_path, source)
+    source.write_text("# Brief\n\nUpdated source version.\n", encoding="utf-8")
+    updated = add_source(tmp_path, source)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "original.md",
+        title="Original",
+        page_id="topic-original",
+        body="Original synthesis page.",
+        source_refs=[original.source_id],
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "updated.md",
+        title="Updated",
+        page_id="topic-updated",
+        body="Updated synthesis page.",
+        source_refs=[updated.source_id],
+    )
+
+    result = run_query(tmp_path, "", source_id="docs/brief.md")
+
+    assert result.filters.source_id in {updated.source_id, original.source_id}
+    assert set(result.filters.source_ids or []) == {updated.source_id, original.source_id}
+    assert {match.path for match in result.matches} == {
+        "wiki/topics/original.md",
+        "wiki/topics/updated.md",
+    }
+
+
 def test_run_query_finds_extracted_pdf_source_summary_text(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "dispatch.pdf"

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -456,12 +456,55 @@ def test_wiki_suggest_text_output_reports_top_suggestion(tmp_path: Path, capsys)
     )
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "wiki", "suggest", added.source_id])
+    exit_code = main(["--root", str(tmp_path), "wiki", "suggest", "wiki-maintenance.md"])
 
     assert exit_code == 0
     out = capsys.readouterr().out
+    assert "Source ref: wiki-maintenance.md" in out
+    assert f"Source ID: {added.source_id}" in out
     assert "Suggested pages:" in out
     assert "wiki/topics/wiki-maintenance.md" in out
+
+
+def test_wiki_suggest_path_includes_all_versions_for_that_path(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "docs" / "wiki-maintenance.md"
+    source.parent.mkdir()
+    source.write_text("# Wiki maintenance\n\nOriginal source version.\n", encoding="utf-8")
+    original = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", original.source_id])
+    source.write_text("# Wiki maintenance\n\nUpdated source version.\n", encoding="utf-8")
+    updated = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", updated.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "original.md",
+        kind="topic",
+        title="Original maintenance",
+        page_id="topic-original-maintenance",
+        source_refs=[original.source_id],
+        body="Original source-impact suggestions.",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "updated.md",
+        kind="topic",
+        title="Updated maintenance",
+        page_id="topic-updated-maintenance",
+        source_refs=[updated.source_id],
+        body="Updated source-impact suggestions.",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "suggest", "docs/wiki-maintenance.md"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    resolved_line = next(
+        line for line in out.splitlines() if line.startswith("Resolved source IDs:")
+    )
+    assert updated.source_id in resolved_line
+    assert original.source_id in resolved_line
+    assert "wiki/topics/original.md" in out
+    assert "wiki/topics/updated.md" in out
 
 
 def test_wiki_suggest_reports_unknown_source(tmp_path: Path, capsys) -> None:
@@ -605,7 +648,8 @@ def test_wiki_compile_text_reports_review_gated_contract_without_mutating(
 
     assert exit_code == 0
     out = capsys.readouterr().out
-    assert f"Source: {added.source_id}" in out
+    assert "Source ref: compile-contract.md" in out
+    assert f"Source ID: {added.source_id}" in out
     assert "Compile contract" in out
     assert "Mutates wiki: no" in out
     assert "Next steps:" in out


### PR DESCRIPTION
## Planning notation

- Concrete PR sub-slice: `M13-P2.5`
- Parent milestone slice: `M13-P2` Issue #70/#72 agent-usefulness redesign
- Plan source: `.agent-plan.md`, README "What Comes Next", and `docs/splendor_mvp_to_v1_roadmap.md`

## Summary

Implements the M13-P2.5 source-summary policy and path-first UX slice.

Changes:
- Make excerpt-mode generated source summaries prefer claim-bearing sections such as `Core Claims`, `Design Implications`, `Product Experience Notes`, and `Summary` before falling back to a bounded opening excerpt.
- Keep the configured generated-summary policy deterministic and read-only during ingest while preserving full extracts for copied/external/transformed sources.
- Render source-summary source sections path-first/source-file-first before canonical source IDs and include the extract policy used for the page.
- Make human CLI source displays more path-first/source-ref-first for add-source, source lookup/list, source refresh, ingest, wiki suggest/compile, and brief recent-source output.
- Allow `splendor query --source`, `splendor wiki suggest`, and `splendor wiki compile` to accept source IDs, titles, or readable paths while continuing to persist canonical source IDs.
- For query/suggest path aliases, exact readable paths now resolve across all known content-addressed source versions for that path until stable logical source identities exist.
- Clarify generated-state review policy in README, quickstart, schema/product docs, dogfooding guidance, and the Issue #70 design response.
- Advance synchronized planning-state lines to `M13-P2.5` with `M13-P3.1` as the conservative next release-finalization/hardening sub-slice.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest` (`500 passed`)
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

Note: `uv` was not on the shell `PATH` in this Codex session, so validation used the installed binary at `/Users/shaypalachy/.local/bin/uv`.

## Follow-ups intentionally deferred

- Stable logical source identities
- Supersedes/superseded_by source lifecycle semantics
- Pruning old generated state
- Full workspace refresh command
- `splendor pr-summary`

Refs #70
Refs #72
