### PR TITLE
M13-P3.1: Release hardening and v1 readiness

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M13-P2.4`
-- Last action taken: `M13-P2.4` is implemented; agent handoff brief and suggest-next are complete.
-- Current planned slice: `M13-P2`
-- Current PR sub-slice: `M13-P2.5`
+- Previous completed PR sub-slice: `M13-P2.5`
+- Last action taken: `M13-P2.5` is implemented; source-summary policy and path-first UX are complete.
+- Current planned slice: `M13-P3`
+- Current PR sub-slice: `M13-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M13-P3`
-- Next planned PR sub-slice: `M13-P3.1`
+- Next planned PR sub-slice: `M13-P3.2`
 - Current blockers: none
 
 ## Planning Notation
@@ -206,6 +206,11 @@
   - [x] Keep fuller extracts for external, copied, parsed PDF, and OCR-derived sources where useful
   - [x] Make human CLI output lead with source paths/source refs before source IDs where practical
   - [x] Clarify generated-state review policy in docs and ingest guidance
+- [x] Implement `M13-P3.1`: Release hardening and v1 readiness
+  - [x] Reconcile README, quickstart, schema/product docs, roadmap, automation docs, and dogfooding guidance with current behavior
+  - [x] Document v1 release-readiness checks and generated-state review expectations
+  - [x] Audit issues #30, #37, #41-#47, #70, and #72 for completed work, remaining follow-ups, and post-v1 boundaries
+  - [x] Keep stable logical source identities, supersession lifecycle, full workspace refresh, pruning, and PR-summary support deferred beyond this PR
 
 ## Context Pointers
 
@@ -258,3 +263,5 @@
 - `M13-P2.3` Source freshness / manifest-drift workflow
 - `M13-P2.4` Agent handoff brief and suggest-next
 - `M13-P2.5` Source-summary policy and path-first UX
+- `M13-P3.1` Release hardening and v1 readiness
+- `M13-P3.2` Final release checklist and post-v1 handoff

--- a/README.md
+++ b/README.md
@@ -60,9 +60,8 @@ Splendor keeps a durable project wiki in git.
 EOF
 
 uv run splendor --root /tmp/demo-repo add-source /tmp/demo-repo/product-note.md
-# Copy the printed src-... identifier from the command output.
-
-uv run splendor --root /tmp/demo-repo ingest <source-id>
+uv run splendor --root /tmp/demo-repo ingest --pending
+uv run splendor --root /tmp/demo-repo source lookup product-note
 uv run splendor --root /tmp/demo-repo task create "Publish MVP docs" --priority high --source-ref <source-id>
 uv run splendor --root /tmp/demo-repo query "durable wiki"
 uv run splendor --root /tmp/demo-repo lint
@@ -102,7 +101,7 @@ The companion-repo guidance and sample agent instructions live in
 
 - A hosted service
 - A full web UI product beyond the local read-only inspection shell
-- An OCR or image-ingestion pipeline in the current MVP
+- A heavyweight OCR or image-ingestion platform
 - A mandatory GitHub-only workflow
 
 ## Current MVP Surface
@@ -139,7 +138,9 @@ Not implemented yet:
 - mutating review-gated `splendor wiki compile`
 - heavyweight OCR/image extraction providers
 - mutating web UI actions such as add-source forms
-- changed-files-driven refresh suggestions
+- stable logical source identities and supersession-aware pruning
+- one-command full workspace refresh for changed sources
+- PR-oriented generated-state summaries such as `splendor pr-summary --since main`
 
 `splendor repo scan` is safe by default: it previews candidates without writing manifests or
 derived state. Registration requires `repo scan --apply` plus `--class ...` or `--all`.
@@ -175,12 +176,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M13-P2.4`
-- Current planned slice: `M13-P2`
-- Current PR sub-slice: `M13-P2.5`
+- Previous completed PR sub-slice: `M13-P2.5`
+- Current planned slice: `M13-P3`
+- Current PR sub-slice: `M13-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M13-P3`
-- Next planned PR sub-slice: `M13-P3.1`
+- Next planned PR sub-slice: `M13-P3.2`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -222,7 +223,7 @@ changing canonical source IDs. `M11-P2.1` is implemented: it adds CLI-first topi
 deterministic templates, and wiki index rebuild support. `M11-P3.1` is implemented: it adds query
 filters for tags/source refs and a compact agent-context handoff mode.
 
-`M12-P1.1`, `M12-P2.1`, and `M13-P1.1` are implemented. The current M13-P2 work responds to the
+`M12-P1.1`, `M12-P2.1`, and `M13-P1.1` are implemented. The M13-P2 sequence responded to the
 first real agent-experience report in issue #70 by redesigning repo discovery around safe
 candidate reports, curated source manifests, source freshness, and higher-signal agent handoffs.
 
@@ -251,3 +252,27 @@ stale/contested/review-needed pages, missing synthesis follow-up, active plannin
 maintenance reports, and query matches for the optional goal. `brief --agent-context` now leads
 with the same suggested work before the lower-level metadata lists. Use `--json` on either command
 for machine handoff.
+
+`M13-P2.5` is implemented: source-summary pages now keep readable in-repo source summaries compact
+and claim-bearing by default, while external, copied, parsed PDF, and OCR-derived sources keep
+fuller extracts when the generated artifact is the practical review surface. Human-facing output
+leads with source paths or refs before canonical source IDs where practical.
+
+`M13-P3.1` is the release-hardening pass. It reconciles the release-facing docs with the current
+CLI, clarifies generated-state review policy, and records the v1 readiness audit. Issues #41-#46
+are substantially implemented by M10-P0.2, M10-P0.3, and M13-P2.5; any remaining work there is
+polish or follow-up verification rather than core v1 scope. Issue #47 remains an ingest/run-state
+follow-up. Issues #30 and #37 remain post-v1 performance work. Issues #70 and #72 stay open as
+parent feedback loops, with #72's stable logical source identities, supersession lifecycle, full
+workspace refresh, pruning, and PR-summary ideas deferred to later M13-P3 or post-v1 planning.
+
+### v1 readiness checklist
+
+- [x] Safe repo discovery is non-mutating by default and requires explicit apply flags.
+- [x] Curated source manifests remain the durable registry instead of a broad file mirror.
+- [x] Source freshness reports changed curated workspace sources without mutating state.
+- [x] Agent handoff surfaces rank next actions before metadata.
+- [x] Generated source-summary pages have a clear review policy and path-first display.
+- [x] CLI, schema, quickstart, automation, and dogfooding docs describe the same current behavior.
+- [ ] Full refresh lifecycle, stable logical source IDs, supersession/pruning, and PR-summary
+  tooling are planned follow-ups, not v1 blockers.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ EOF
 uv run splendor --root /tmp/demo-repo add-source /tmp/demo-repo/product-note.md
 uv run splendor --root /tmp/demo-repo ingest --pending
 uv run splendor --root /tmp/demo-repo source lookup product-note
+# Use the source_id printed by source lookup in the next command.
 uv run splendor --root /tmp/demo-repo task create "Publish MVP docs" --priority high --source-ref <source-id>
 uv run splendor --root /tmp/demo-repo query "durable wiki"
 uv run splendor --root /tmp/demo-repo lint
@@ -259,12 +260,14 @@ fuller extracts when the generated artifact is the practical review surface. Hum
 leads with source paths or refs before canonical source IDs where practical.
 
 `M13-P3.1` is the release-hardening pass. It reconciles the release-facing docs with the current
-CLI, clarifies generated-state review policy, and records the v1 readiness audit. Issues #41-#46
-are substantially implemented by M10-P0.2, M10-P0.3, and M13-P2.5; any remaining work there is
-polish or follow-up verification rather than core v1 scope. Issue #47 remains an ingest/run-state
-follow-up. Issues #30 and #37 remain post-v1 performance work. Issues #70 and #72 stay open as
-parent feedback loops, with #72's stable logical source identities, supersession lifecycle, full
-workspace refresh, pruning, and PR-summary ideas deferred to later M13-P3 or post-v1 planning.
+CLI, clarifies generated-state review policy, and records the v1 readiness audit. The audit treats
+issue #41's briefing and non-mutating compile contract, #42's next-action hints, #43's pending
+ingest handoff, #44's query snippets, #45's web status/source detail pages, and #46's page-state
+visibility as represented in current behavior. It still calls out #41's mutating compile/update
+workflow as deferred. Issue #47 remains an ingest/run-state timing follow-up. Issues #30 and #37
+remain post-v1 performance work. Issues #70 and #72 stay open as parent feedback loops, with #72's
+stable logical source identities, supersession lifecycle, full workspace refresh, pruning, and
+PR-summary ideas deferred to later M13-P3 or post-v1 planning.
 
 ### v1 readiness checklist
 

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -93,6 +93,8 @@ Reviewed output paths:
 
 - `wiki/**`
 - `raw/sources/**`
+- source manifests, queue/run records, derived artifacts, and explicit reports when they are part
+  of the reviewed generated workspace update
 
 Permissions:
 
@@ -111,6 +113,7 @@ Review expectations:
 
 - confirm generated wiki/source-registry changes match the repository state
 - confirm the generating workflow's Splendor lint job passed
+- distinguish reviewer-significant generated artifacts from mechanical timestamp-only churn
 - manually dispatch or rerun normal CI if repository policy requires checks on the generated PR
 
 ## `planning-validator`
@@ -307,6 +310,14 @@ Required secrets:
 - `pr-agent-context` turns CI, review, and failing-check state into a maintained PR handoff comment.
 - `pre-commit.ci autofix trigger` bridges bot PRs and `pre-commit.ci` label-based autofix behavior.
 - `weekly-repo-review` is scheduled maintenance, not a merge gate.
+
+## v1 release-hardening boundaries
+
+The current automation layer supports CI, maintenance reports, generated-change PRs, PR context
+refresh, review automation, and optional weekly repo review. It does not yet provide stable logical
+source identities, supersession-aware pruning, a one-command full workspace refresh, or
+`splendor pr-summary --since main`. Those belong to later source-lifecycle or PR-summary slices,
+not the M13-P3.1 release-hardening pass.
 
 ## Planning update rule for PRs
 

--- a/docs/dogfood_knowledge_work_report.md
+++ b/docs/dogfood_knowledge_work_report.md
@@ -128,3 +128,13 @@ Follow-up issues opened:
 - https://github.com/splendor-dev/splendor/issues/46 — generated versus maintained page-state
   visibility.
 - https://github.com/splendor-dev/splendor/issues/47 — real ingest run durations in run records.
+
+## Current Status Note
+
+As of M13-P3.1, the core dogfood issues from #41-#46 are substantially represented in shipped
+behavior: project briefing and the non-mutating compile contract landed in M10-P0.2; next-action
+hints, query snippets, web status/source-detail views, and generated-versus-maintained page-state
+visibility landed across M10-P0.3 and M13-P2.5. #47 remains a runtime-record timing follow-up.
+The newer #70 and #72 field reports should be read as parent feedback loops: #70 drove M13-P2's
+safe discovery and agent handoff redesign, while #72's stable logical source identity and full
+workspace refresh lifecycle remain later work.

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -69,3 +69,14 @@ uv run splendor serve
 Then inspect `/browse`, `/status`, `/sources/<source-id>`, and
 `/search?q=LLM+Wiki+persistent+knowledge` in the local web UI. A sparse workspace should show an
 explicit empty state with next commands instead of appearing broken.
+
+## Current Release-Hardening Notes
+
+M13-P2 addressed the largest issue #70 dogfood failure: broad repo discovery is now a non-mutating
+candidate preview unless the operator explicitly applies a reviewed class or all-class selection.
+Use `source freshness`, `brief --agent-context`, and `suggest-next` before deciding whether a
+workspace needs ingest, synthesis review, queue repair, or planning follow-up.
+
+Do not expect the current workflow to provide stable logical source identities, source
+supersession/pruning, one-command full workspace refresh, or PR-summary generation yet. Those are
+tracked from issue #72 as later lifecycle improvements.

--- a/docs/github_automation_architecture.md
+++ b/docs/github_automation_architecture.md
@@ -145,3 +145,10 @@ Optional, external-activation, or secret-gated pieces:
 - `pre-commit.ci` SaaS activation
 - `OPENAI_API_KEY` for weekly repo review automation
 - any future token override for label application in autofix-trigger
+
+## Release-readiness status
+
+For v1, GitHub automation remains additive around the local CLI. Required release confidence comes
+from local validation plus CI, while generated-change and review automations are convenience
+layers. The current architecture intentionally stops short of PR-summary generation, automatic
+source supersession cleanup, or mutating web/hosted workflows.

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -10,8 +10,9 @@ not just a bug report. The accepted direction is the middle-ground redesign:
 - make broad repo discovery safe before it can create manifest or wiki churn
 - focus agent-facing value on freshness, contested knowledge, planning state, and next actions
 
-This note is a planning contract for the M13-P2 implementation sequence. It does not describe
-current runtime behavior where noted as planned.
+This note began as the planning contract for the M13-P2 implementation sequence. As of M13-P3.1,
+the safe-discovery, freshness, handoff, and path-first source-summary parts have landed; the issue
+remains open as the parent agent-usefulness feedback loop.
 
 ## What Went Wrong
 
@@ -53,9 +54,9 @@ Source-summary pages remain useful for opaque, transformed, external, PDF, OCR, 
 hard-to-read sources. For readable in-repo markdown and code, summaries should become policy-driven
 rather than assumed to be the primary value.
 
-## Planned Interface Direction
+## Implemented Interface Direction
 
-The next implementation slices should document and then implement these contracts:
+M13-P2 documented and implemented these contracts:
 
 - `splendor repo scan` defaults to a non-mutating candidate preview. Non-mutating means stdout
   output only by default: no source manifests, wiki pages, derived artifacts, queue records, run
@@ -70,12 +71,12 @@ The next implementation slices should document and then implement these contract
   without confirmation flags.
 - `repo scan` supports class filtering, such as `--class documentation`, `--class code`, and
   `--class configuration`.
-- `splendor.yaml` supports planned `sources.include_patterns` and `sources.exclude_patterns`.
+- `splendor.yaml` supports `sources.include_patterns` and `sources.exclude_patterns`.
 - Scan candidate output includes paths, classes, labels, ignore reasons, and whether a source is
   already curated.
-- M13-P2.2 must update CLI help, README/quickstart guidance, and tests around the new preview
-  default, the `--apply` compatibility path, JSON output, report persistence, class filters, and
-  large-candidate refusal.
+- M13-P2.2 updated CLI help, README/quickstart guidance, and tests around the preview default, the
+  `--apply` compatibility path, JSON output, report persistence, class filters, and large-candidate
+  refusal.
 - `splendor source freshness` reports curated sources whose current canonical file content differs
   from the manifest checksum, prints path-first status with exact next commands, supports JSON and
   explicit report output, separates historical source versions from actionable stale paths, and does
@@ -94,9 +95,21 @@ The next implementation slices should document and then implement these contract
 
 ## Roadmap Impact
 
-M13-P2 now owns the Issue #70 agent-usefulness redesign. Release finalization moves behind that
-work because Splendor is not v1-ready while a reasonable agent can accidentally register thousands
-of files from a broad scan.
+M13-P2 owns the Issue #70 agent-usefulness redesign. Release finalization moved behind that work
+because Splendor was not v1-ready while a reasonable agent could accidentally register thousands of
+files from a broad scan.
 
-Issue #70 remains open as the parent product-feedback issue until the implementation slices
-substantially address the scan safety, freshness, handoff, and path-first UX gaps.
+Issue #70 remains open as the parent product-feedback issue for residual agent-usefulness feedback
+after the scan safety, freshness, handoff, and path-first UX gaps were substantially addressed.
+
+## M13-P3.1 Issue Audit
+
+- #70 is substantially addressed for scan safety, curated curation, source freshness, ranked
+  handoff, and path-first source-summary UX, but it remains open as the parent feedback loop.
+- #72 is a separate parent feedback loop for source-refresh lifecycle and agent workflow. Its stable
+  logical source identities, `supersedes`/`superseded_by`, full workspace refresh, pruning, and
+  `pr-summary` requests remain later M13-P3 or post-v1 work.
+- #41-#46 are substantially implemented through M10-P0.2, M10-P0.3, and M13-P2.5. Remaining work,
+  if any, is polish, verification, or future mutating compile workflow rather than a v1 blocker.
+- #47 remains open as an ingest/run-state timing follow-up.
+- #30 and #37 remain post-v1 performance/scaling follow-ups.

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -64,9 +64,8 @@ M13-P2 documented and implemented these contracts:
 - `repo scan --json` emits the same preview as machine-readable JSON to stdout. Persisting a
   discovery report requires an explicit output flag such as `--report PATH`, and that flag writes
   only the report, not source manifests.
-- Mutating registration from scan requires `--apply`. This is an intentional safety-breaking
-  change from the current mutating default: the old behavior moves behind `--apply`, and the bare
-  command should clearly say that it is preview-only and print the exact apply command.
+- Mutating registration from scan requires `--apply`. This replaced the old mutating default: the
+  bare command now reports preview-only behavior and prints an explicit apply command.
 - Broad registration requires explicit class/all opt-in and should refuse huge candidate sets
   without confirmation flags.
 - `repo scan` supports class filtering, such as `--class documentation`, `--class code`, and
@@ -109,7 +108,18 @@ after the scan safety, freshness, handoff, and path-first UX gaps were substanti
 - #72 is a separate parent feedback loop for source-refresh lifecycle and agent workflow. Its stable
   logical source identities, `supersedes`/`superseded_by`, full workspace refresh, pruning, and
   `pr-summary` requests remain later M13-P3 or post-v1 work.
-- #41-#46 are substantially implemented through M10-P0.2, M10-P0.3, and M13-P2.5. Remaining work,
-  if any, is polish, verification, or future mutating compile workflow rather than a v1 blocker.
+- #41 has shipped `splendor brief [goal]`, `brief --agent-context`, and the non-mutating
+  `splendor wiki compile <source-id|title|path>` contract. Mutating compile/update support remains
+  deferred.
+- #42 has shipped restrained next-action hints around add-source, ingest, query/file-answer,
+  briefing, and suggest-next flows.
+- #43 has shipped pending ingest queue handoff for CLI-created sources, and docs now show the
+  `add-source -> ingest --pending -> source lookup` path so users do not need to copy long source
+  IDs for the first ingest.
+- #44 has shipped claim-bearing query snippets for generated source-summary pages.
+- #45 has shipped read-only web status and source-detail surfaces; mutating web actions remain out
+  of scope.
+- #46 has shipped clearer generated-versus-maintained page-state visibility across docs,
+  status/query output, source summaries, and web/status surfaces.
 - #47 remains open as an ingest/run-state timing follow-up.
 - #30 and #37 remain post-v1 performance/scaling follow-ups.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -171,6 +171,7 @@ most convenient review surface.
 After ingest, use the source ID from the command output to inspect likely synthesis follow-up:
 
 ```bash
+uv run splendor --root /tmp/demo-repo source lookup product-note
 uv run splendor --root /tmp/demo-repo wiki status
 uv run splendor --root /tmp/demo-repo wiki suggest <source-id>
 ```
@@ -221,6 +222,19 @@ uv run splendor --root /tmp/demo-repo serve
 ```
 
 Then open `/status` or `/sources/<source-id>` on the local server.
+
+## Release-ready review policy
+
+For v1-style PRs, treat source-summary pages, linked manifests, derived parsed/OCR artifacts, queue
+records, run records, and explicit scan/freshness/lint/health reports as reviewer-significant when
+they support the workspace update under review. They are deterministic state, not hand-written
+analysis. Failed or exploratory local reports do not need to be committed unless the report itself
+is the artifact being reviewed.
+
+`source refresh` currently creates a new canonical content-addressed source version when bytes
+change. Stable logical source identities, source supersession fields, automated pruning, topic-ref
+migration, and a one-command full workspace refresh remain planned follow-ups rather than required
+v1 behavior.
 
 ## 5. Add a planning record
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -168,11 +168,13 @@ Readable in-repo markdown/text/code summaries default to concise excerpts, while
 parsed PDF, and OCR-derived sources keep fuller extracts because the generated artifact may be the
 most convenient review surface.
 
-After ingest, use the source ID from the command output to inspect likely synthesis follow-up:
+After ingest, use the source ID from the ingest output or look it up by readable title/path before
+inspecting likely synthesis follow-up:
 
 ```bash
 uv run splendor --root /tmp/demo-repo source lookup product-note
 uv run splendor --root /tmp/demo-repo wiki status
+# Use the source_id printed by source lookup here.
 uv run splendor --root /tmp/demo-repo wiki suggest <source-id>
 ```
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -221,6 +221,9 @@ In this release:
 - copied sources still use `path` as the stored artifact path
 - workspace-backed sources temporarily mirror `source_ref` into `path`
 - no automatic manifest rewrite or schema-version bump is performed yet
+- source IDs remain content-addressed canonical IDs; stable logical source aliases,
+  `supersedes`/`superseded_by` source fields, automated pruning of superseded source summaries, and
+  topic-ref migration are not part of the current schema contract
 
 ## Knowledge page frontmatter
 
@@ -384,6 +387,16 @@ Current runtime behavior:
 - update the wiki index and log idempotently
 - mutating scan registration requires `repo refresh --apply-scan` plus `--class ...` or `--all`;
   large apply runs also require `--allow-large-apply`
+
+## v1 readiness notes
+
+- The current schema version remains `1`; M13-P3.1 does not introduce a migration or rewrite
+  existing manifests.
+- The release-ready core is file-based, deterministic, and compatible with legacy `path`-only
+  source manifests.
+- Source freshness, suggest-next, and agent briefing use existing records as read-only signals.
+- Richer lifecycle fields for stable logical source identities and supersession-aware history are
+  deferred so they can be designed without breaking the v1 manifest contract.
 
 ## Review config
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,17 +334,17 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M13-P2.4`
-- Current planned slice: `M13-P2`
-- Current PR sub-slice: `M13-P2.5`
+- Previous completed PR sub-slice: `M13-P2.5`
+- Current planned slice: `M13-P3`
+- Current PR sub-slice: `M13-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M13-P3`
-- Next planned PR sub-slice: `M13-P3.1`
+- Next planned PR sub-slice: `M13-P3.2`
 
-`M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The current M13-P2 sequence
+`M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
 shifting agent-facing value toward freshness, contested knowledge, planning state, and next
-actions. The lifecycle marker means `M13-P2.4` is in progress on feature branches and merged once
+actions. The lifecycle marker means `M13-P3.1` is in progress on feature branches and merged once
 the same committed state is observed on `main`.
 
 ---
@@ -789,6 +789,7 @@ freshness, contested knowledge, planning state, and next actions rather than mos
 - `M13-P2.3` Source freshness / manifest-drift workflow
 - `M13-P2.4` Agent handoff brief and suggest-next
 - `M13-P2.5` Source-summary policy and path-first UX
+- `M13-P3.1` Release hardening and v1 readiness
 
 ### Deliverables
 - v1 schema versions
@@ -811,10 +812,33 @@ are read-only and draw from source freshness, queue failures or pending work,
 stale/contested/review-needed pages, missing synthesis follow-up, active planning records, recent
 maintenance reports, and optional goal matches.
 
-`M13-P2.5` is in progress: generated source-summary pages stay deterministic while readable
+`M13-P2.5` is implemented: generated source-summary pages stay deterministic while readable
 in-repo markdown/text/code sources default to concise, claim-bearing excerpts. Human CLI surfaces
-should lead with source paths or source refs before canonical source IDs, while persisted
+lead with source paths or source refs before canonical source IDs where practical, while persisted
 frontmatter, manifests, and run records continue to use canonical IDs for compatibility.
+
+`M13-P3.1` is the release-hardening and v1 readiness audit. It keeps the implementation surface
+stable, reconciles README, quickstart, schema/product docs, roadmap, CI/GitHub automation docs, and
+dogfooding guidance with the current product, and records which open feedback issues are already
+substantially implemented. It does not add SQLite, vector search, background workers, mutating web
+UI, broad refresh lifecycle machinery, stable logical source identities, supersedes/superseded_by
+source semantics, pruning, or PR-summary tooling.
+
+### M13-P3 v1 release-readiness checklist
+
+- [x] M13-P2 safe discovery, source freshness, agent handoff, and path-first source-summary UX have
+  landed.
+- [x] Release-facing docs distinguish generated source-summary artifacts from maintained synthesis
+  pages and explain which generated state is reviewer-significant.
+- [x] The quickstart demonstrates the queue-backed `add-source -> ingest --pending -> lookup`
+  loop instead of requiring users to copy long IDs for the first ingest.
+- [x] Issue #70 remains the parent feedback loop for agent usefulness; the release notes identify
+  which parts are addressed by M13-P2 and which remain follow-up work.
+- [x] Issue #72 remains the parent feedback loop for source-refresh lifecycle and agent workflow;
+  stable logical source identities, source supersession, full workspace refresh, pruning, and
+  `pr-summary` remain later M13-P3 or post-v1 work.
+- [ ] Final release handoff should re-run the full validation suite, confirm open issue metadata,
+  and publish a release-note summary before tagging.
 
 ### Exit criteria
 - the product is stable enough for sustained real-world use

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -819,10 +819,10 @@ frontmatter, manifests, and run records continue to use canonical IDs for compat
 
 `M13-P3.1` is the release-hardening and v1 readiness audit. It keeps the implementation surface
 stable, reconciles README, quickstart, schema/product docs, roadmap, CI/GitHub automation docs, and
-dogfooding guidance with the current product, and records which open feedback issues are already
-substantially implemented. It does not add SQLite, vector search, background workers, mutating web
-UI, broad refresh lifecycle machinery, stable logical source identities, supersedes/superseded_by
-source semantics, pruning, or PR-summary tooling.
+dogfooding guidance with the current product, and records per-issue status for the open feedback
+threads. It does not add SQLite, vector search, background workers, mutating web UI, broad refresh
+lifecycle machinery, stable logical source identities, supersedes/superseded_by source semantics,
+pruning, or PR-summary tooling.
 
 ### M13-P3 v1 release-readiness checklist
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -736,7 +736,7 @@ This workflow should start with text-native sources and deterministic page-impac
 compile step may remain human-reviewed or LLM-assisted behind explicit confirmation until the
 contract is trustworthy.
 
-Initial `splendor wiki compile <source-id>` support is intentionally non-mutating. It validates the
+Current `splendor wiki compile <source-id>` support is intentionally non-mutating. It validates the
 source record and prints the review-gated contract: inspect the source summary, run source-impact
 suggestions, propose synthesis-page edits with provenance/run state, keep generated source-summary
 pages separate from maintained synthesis pages, and require human review before wiki synthesis is
@@ -760,6 +760,8 @@ Current implementation:
 - `splendor source refresh <source-id|title|path>` detects changed source content, registers the
   current bytes as a new canonical source version when the checksum changed, and queues ingest via
   the existing queue ledger while preserving active-lease and dead-letter protections.
+  Stable logical source identities, explicit source supersession fields, automated historical
+  pruning, and topic-ref migration remain later lifecycle work.
 - `splendor add-topic "Title"` scaffolds a maintained topic page under `wiki/topics/<slug>.md`
   with valid knowledge-page frontmatter, optional tags/source refs, and deterministic markdown
   templates for default synthesis, research synthesis, and issue tracking.
@@ -816,6 +818,17 @@ M13-P2 repo-discovery contracts:
 - `splendor suggest-next [goal]` ranks work from open tasks, stale sources, failed jobs, missing
   synthesis, contested/review-needed pages, maintenance reports, and goal matches. `--json` emits a
   machine-readable handoff payload.
+
+Release-readiness boundary:
+
+- v1 treats content-addressed source IDs as the persisted compatibility contract.
+- readable paths, titles, and source refs are lookup and display aids, not durable aliases yet.
+- generated source-summary pages, queue records, run records, derived artifacts, and explicit
+  reports are committed when they explain a reviewed workspace update; failed or exploratory local
+  reports can remain local.
+- issue #72's desired stable logical source identities, `supersedes`/`superseded_by` source
+  lifecycle, one-command workspace refresh, superseded-state pruning, and `pr-summary` surface are
+  post-v1 or later M13-P3 follow-ups unless a future roadmap slice explicitly pulls them forward.
 
 Later optional support:
 - additional OCR providers
@@ -1266,6 +1279,8 @@ These are not blockers to the spec, but should remain visible:
 7. whether a companion-repo linking model needs a first-class schema element
 8. post-v1 refinements to generated source-summary policy for readable in-repo markdown and code
    files, after the v1 default of concise claim-bearing excerpts has been exercised in real repos
+9. stable logical source identities, source supersession semantics, pruning policy, and PR-summary
+   tooling for lower-churn agent workflows
 
 ## 31. Summary Product Statement
 


### PR DESCRIPTION
## Summary

Implements M13-P3.1 release hardening and v1 readiness as a docs/planning pass after PR #76 completed M13-P2.5.

- advances synchronized planning state from M13-P2.5 to M13-P3.1 and queues M13-P3.2 as the conservative next release follow-up
- reconciles README, quickstart, roadmap, product/schema docs, automation docs, and dogfooding guidance with the current CLI surface
- adds a v1 readiness checklist and generated-state review policy for release-facing docs
- records the issue audit for #30, #37, #41-#47, #70, and #72 without closing #70 or #72
- keeps stable logical source identities, source supersession, full workspace refresh, pruning, and pr-summary support deferred to later M13-P3 or post-v1 work

## Issue linkage

Addresses the release-hardening audit for #70 and #72 parent feedback loops.
Documents current status for #30, #37, and #41-#47.
Does not close #70 or #72.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest` - 500 passed
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .` - passed
- `/Users/shaypalachy/.local/bin/uv run ruff check .` - passed
- `/Users/shaypalachy/.local/bin/uv run splendor lint` - passed

## Follow-ups

- M13-P3.2 final release checklist and post-v1 handoff
- issue #47 ingest/run timing fix
- issue #30 repo scan bulk registration performance
- issue #37 local web UI document-list scaling
- issue #72 source lifecycle work: stable logical source identities, supersession/pruning, full workspace refresh, topic-ref migration, and `splendor pr-summary --since main`
