### PR TITLE
M13-P3.2: Final release handoff

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M13-P2.5`
-- Last action taken: `M13-P2.5` is implemented; source-summary policy and path-first UX are complete.
+- Previous completed PR sub-slice: `M13-P3.1`
+- Last action taken: `M13-P3.1` is implemented; release hardening and v1 readiness audit are complete.
 - Current planned slice: `M13-P3`
-- Current PR sub-slice: `M13-P3.1`
+- Current PR sub-slice: `M13-P3.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M13-P3`
-- Next planned PR sub-slice: `M13-P3.2`
+- Next planned slice: `M14-P0`
+- Next planned PR sub-slice: `M14-P0.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -211,6 +211,12 @@
   - [x] Document v1 release-readiness checks and generated-state review expectations
   - [x] Audit issues #30, #37, #41-#47, #70, and #72 for completed work, remaining follow-ups, and post-v1 boundaries
   - [x] Keep stable logical source identities, supersession lifecycle, full workspace refresh, pruning, and PR-summary support deferred beyond this PR
+- [x] Implement `M13-P3.2`: Final release checklist and post-v1 handoff
+  - [x] Add a concise v1 release handoff checklist covering validation, docs state, GitHub metadata, issue state, known non-blockers, and post-v1 queue
+  - [x] Move planning state from `M13-P3.1` to `M13-P3.2`
+  - [x] Keep #72, #47, #30, and #37 open as post-v1 feedback/performance/scaling work
+  - [x] Create #79 for the deferred mutating compile/update path from #41
+  - [x] Treat stable logical source identities, source supersession, full workspace refresh, generated-state pruning, topic-ref migration, and PR-summary as post-v1 lifecycle work
 
 ## Context Pointers
 
@@ -240,6 +246,7 @@
 - `M13-P1` Schema/docs/migration stabilization
 - `M13-P2` Issue #70 agent-usefulness redesign
 - `M13-P3` Extension/performance/release finalization
+- `M14-P0` Post-v1 planning intake
 
 ## PR Sub-slice Queue
 
@@ -265,3 +272,4 @@
 - `M13-P2.5` Source-summary policy and path-first UX
 - `M13-P3.1` Release hardening and v1 readiness
 - `M13-P3.2` Final release checklist and post-v1 handoff
+- `M14-P0.1` Split post-v1 source-lifecycle and workflow follow-ups

--- a/README.md
+++ b/README.md
@@ -174,15 +174,16 @@ the source manifest, and kept separate from parsed PDF artifacts.
 - [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md)
 - [docs/schema_contracts.md](docs/schema_contracts.md)
 - [docs/ci_and_repo_automation.md](docs/ci_and_repo_automation.md)
+- [docs/v1_release_handoff.md](docs/v1_release_handoff.md)
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M13-P2.5`
+- Previous completed PR sub-slice: `M13-P3.1`
 - Current planned slice: `M13-P3`
-- Current PR sub-slice: `M13-P3.1`
+- Current PR sub-slice: `M13-P3.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M13-P3`
-- Next planned PR sub-slice: `M13-P3.2`
+- Next planned slice: `M14-P0`
+- Next planned PR sub-slice: `M14-P0.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -228,6 +229,11 @@ filters for tags/source refs and a compact agent-context handoff mode.
 first real agent-experience report in issue #70 by redesigning repo discovery around safe
 candidate reports, curated source manifests, source freshness, and higher-signal agent handoffs.
 
+`M13-P3.1` is implemented: release-facing docs, schema notes, automation guidance, and dogfooding
+guidance are reconciled with current behavior. `M13-P3.2` is the final release handoff slice: it
+records the v1 validation commands, issue state, GitHub metadata expectations, known non-blockers,
+and conservative post-v1 queue in [docs/v1_release_handoff.md](docs/v1_release_handoff.md).
+
 `M13-P2.1` is a docs/planning-only reset:
 
 - [x] record the accepted Issue #70 design response
@@ -265,9 +271,10 @@ issue #41's briefing and non-mutating compile contract, #42's next-action hints,
 ingest handoff, #44's query snippets, #45's web status/source detail pages, and #46's page-state
 visibility as represented in current behavior. It still calls out #41's mutating compile/update
 workflow as deferred. Issue #47 remains an ingest/run-state timing follow-up. Issues #30 and #37
-remain post-v1 performance work. Issues #70 and #72 stay open as parent feedback loops, with #72's
-stable logical source identities, supersession lifecycle, full workspace refresh, pruning, and
-PR-summary ideas deferred to later M13-P3 or post-v1 planning.
+remain post-v1 performance work. Issue #70 is closed after the M13-P2/M13-P3.1 response. Issue #72
+stays open as the parent feedback loop for stable logical source identities, supersession
+lifecycle, full workspace refresh, pruning, and PR-summary ideas deferred to post-v1 planning.
+Issue #79 tracks the deferred mutating compile/update path from #41.
 
 ### v1 readiness checklist
 
@@ -277,5 +284,7 @@ PR-summary ideas deferred to later M13-P3 or post-v1 planning.
 - [x] Agent handoff surfaces rank next actions before metadata.
 - [x] Generated source-summary pages have a clear review policy and path-first display.
 - [x] CLI, schema, quickstart, automation, and dogfooding docs describe the same current behavior.
+- [x] Final release handoff names validation, issue state, GitHub metadata, known non-blockers,
+  and the post-v1 queue.
 - [ ] Full refresh lifecycle, stable logical source IDs, supersession/pruning, and PR-summary
   tooling are planned follow-ups, not v1 blockers.

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -319,6 +319,11 @@ source identities, supersession-aware pruning, a one-command full workspace refr
 `splendor pr-summary --since main`. Those belong to later source-lifecycle or PR-summary slices,
 not the M13-P3.1 release-hardening pass.
 
+For the M13-P3.2 release handoff, `docs/v1_release_handoff.md` is the checklist that connects local
+validation, GitHub PR metadata, issue state, and known non-blockers. GitHub automation remains
+supporting infrastructure around the local CLI, not a substitute for the explicit validation
+commands named in that handoff.
+
 ## Planning update rule for PRs
 
 When a pull request is opened against work that came from a tracked plan, the PR should update the

--- a/docs/dogfood_knowledge_work_report.md
+++ b/docs/dogfood_knowledge_work_report.md
@@ -131,10 +131,11 @@ Follow-up issues opened:
 
 ## Current Status Note
 
-As of M13-P3.1, the core dogfood issues from #41-#46 are substantially represented in shipped
-behavior: project briefing and the non-mutating compile contract landed in M10-P0.2; next-action
-hints, query snippets, web status/source-detail views, and generated-versus-maintained page-state
-visibility landed across M10-P0.3 and M13-P2.5. #47 remains a runtime-record timing follow-up.
-The newer #70 and #72 field reports should be read as parent feedback loops: #70 drove M13-P2's
-safe discovery and agent handoff redesign, while #72's stable logical source identity and full
-workspace refresh lifecycle remain later work.
+As of M13-P3.2, the core dogfood issues from #41-#46 are represented in shipped behavior: project
+briefing and the non-mutating compile contract landed in M10-P0.2; next-action hints, query
+snippets, web status/source-detail views, and generated-versus-maintained page-state visibility
+landed across M10-P0.3 and M13-P2.5. The deferred mutating compile/update path from #41 is tracked
+by #79. #47 remains a runtime-record timing follow-up. #70 is closed after M13-P2's safe discovery
+and agent handoff redesign, while #72 remains the parent source lifecycle and agent-workflow
+feedback loop for stable logical source identity, full workspace refresh, generated-state pruning,
+and PR-summary work.

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -79,4 +79,5 @@ workspace needs ingest, synthesis review, queue repair, or planning follow-up.
 
 Do not expect the current workflow to provide stable logical source identities, source
 supersession/pruning, one-command full workspace refresh, or PR-summary generation yet. Those are
-tracked from issue #72 as later lifecycle improvements.
+tracked from issue #72 as later lifecycle improvements. For v1 release work, use
+`docs/v1_release_handoff.md` to separate release-blocking validation from the post-v1 dogfood queue.

--- a/docs/github_automation_architecture.md
+++ b/docs/github_automation_architecture.md
@@ -151,4 +151,6 @@ Optional, external-activation, or secret-gated pieces:
 For v1, GitHub automation remains additive around the local CLI. Required release confidence comes
 from local validation plus CI, while generated-change and review automations are convenience
 layers. The current architecture intentionally stops short of PR-summary generation, automatic
-source supersession cleanup, or mutating web/hosted workflows.
+source supersession cleanup, or mutating web/hosted workflows. The final release checklist lives in
+`docs/v1_release_handoff.md`; it names the validation commands, PR metadata, issue state, and
+post-v1 queue that should be checked before tagging.

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -10,9 +10,10 @@ not just a bug report. The accepted direction is the middle-ground redesign:
 - make broad repo discovery safe before it can create manifest or wiki churn
 - focus agent-facing value on freshness, contested knowledge, planning state, and next actions
 
-This note began as the planning contract for the M13-P2 implementation sequence. As of M13-P3.1,
-the safe-discovery, freshness, handoff, and path-first source-summary parts have landed; the issue
-remains open as the parent agent-usefulness feedback loop.
+This note began as the planning contract for the M13-P2 implementation sequence. As of M13-P3.2,
+the safe-discovery, freshness, handoff, path-first source-summary, and final release-handoff parts
+have landed; issue #70 is closed while #72 remains open as the source-refresh lifecycle and
+agent-workflow feedback loop.
 
 ## What Went Wrong
 
@@ -98,19 +99,20 @@ M13-P2 owns the Issue #70 agent-usefulness redesign. Release finalization moved 
 because Splendor was not v1-ready while a reasonable agent could accidentally register thousands of
 files from a broad scan.
 
-Issue #70 remains open as the parent product-feedback issue for residual agent-usefulness feedback
-after the scan safety, freshness, handoff, and path-first UX gaps were substantially addressed.
+Issue #70 is closed after the scan safety, freshness, handoff, and path-first UX gaps were
+substantially addressed. Residual source-refresh lifecycle and agent-workflow feedback is tracked
+in issue #72.
 
-## M13-P3.1 Issue Audit
+## M13-P3 Issue Audit
 
-- #70 is substantially addressed for scan safety, curated curation, source freshness, ranked
-  handoff, and path-first source-summary UX, but it remains open as the parent feedback loop.
+- #70 is closed after the M13-P2/M13-P3.1 response for scan safety, curated curation, source
+  freshness, ranked handoff, and path-first source-summary UX.
 - #72 is a separate parent feedback loop for source-refresh lifecycle and agent workflow. Its stable
   logical source identities, `supersedes`/`superseded_by`, full workspace refresh, pruning, and
-  `pr-summary` requests remain later M13-P3 or post-v1 work.
+  `pr-summary` requests remain post-v1 work.
 - #41 has shipped `splendor brief [goal]`, `brief --agent-context`, and the non-mutating
   `splendor wiki compile <source-id|title|path>` contract. Mutating compile/update support remains
-  deferred.
+  deferred and is tracked by #79.
 - #42 has shipped restrained next-action hints around add-source, ingest, query/file-answer,
   briefing, and suggest-next flows.
 - #43 has shipped pending ingest queue handoff for CLI-created sources, and docs now show the

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -217,6 +217,10 @@ directory.
 Refresh does not override active ingest leases or dead-letter protections; use `queue retry` or
 `repair ingest` for those recovery cases.
 
+For release verification, use `docs/v1_release_handoff.md` as the checklist. It keeps the
+quickstart focused on normal operator workflow while the handoff records validation commands,
+GitHub metadata expectations, issue state, and post-v1 follow-up boundaries.
+
 For a read-only browser view over the same status and source-detail contracts:
 
 ```bash

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -397,6 +397,9 @@ Current runtime behavior:
 - Source freshness, suggest-next, and agent briefing use existing records as read-only signals.
 - Richer lifecycle fields for stable logical source identities and supersession-aware history are
   deferred so they can be designed without breaking the v1 manifest contract.
+- The final v1 handoff in `docs/v1_release_handoff.md` treats schema version `1`, legacy manifest
+  compatibility, and deferred source-lifecycle fields as release checklist items rather than
+  implicit assumptions.
 
 ## Review config
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,17 +334,17 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M13-P2.5`
+- Previous completed PR sub-slice: `M13-P3.1`
 - Current planned slice: `M13-P3`
-- Current PR sub-slice: `M13-P3.1`
+- Current PR sub-slice: `M13-P3.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M13-P3`
-- Next planned PR sub-slice: `M13-P3.2`
+- Next planned slice: `M14-P0`
+- Next planned PR sub-slice: `M14-P0.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
 shifting agent-facing value toward freshness, contested knowledge, planning state, and next
-actions. The lifecycle marker means `M13-P3.1` is in progress on feature branches and merged once
+actions. The lifecycle marker means `M13-P3.2` is in progress on feature branches and merged once
 the same committed state is observed on `main`.
 
 ---
@@ -790,6 +790,7 @@ freshness, contested knowledge, planning state, and next actions rather than mos
 - `M13-P2.4` Agent handoff brief and suggest-next
 - `M13-P2.5` Source-summary policy and path-first UX
 - `M13-P3.1` Release hardening and v1 readiness
+- `M13-P3.2` Final release checklist and post-v1 handoff
 
 ### Deliverables
 - v1 schema versions
@@ -824,6 +825,12 @@ threads. It does not add SQLite, vector search, background workers, mutating web
 lifecycle machinery, stable logical source identities, supersedes/superseded_by source semantics,
 pruning, or PR-summary tooling.
 
+`M13-P3.2` is the final release checklist and post-v1 handoff. It keeps runtime behavior stable,
+adds the concise release handoff in `docs/v1_release_handoff.md`, and makes the post-v1 queue
+explicit: #72 owns source lifecycle and agent workflow follow-up; #47 owns ingest run durations;
+#79 owns the deferred mutating compile/update path from #41; #30 and #37 remain independent
+performance/scaling follow-ups.
+
 ### M13-P3 v1 release-readiness checklist
 
 - [x] M13-P2 safe discovery, source freshness, agent handoff, and path-first source-summary UX have
@@ -832,13 +839,17 @@ pruning, or PR-summary tooling.
   pages and explain which generated state is reviewer-significant.
 - [x] The quickstart demonstrates the queue-backed `add-source -> ingest --pending -> lookup`
   loop instead of requiring users to copy long IDs for the first ingest.
-- [x] Issue #70 remains the parent feedback loop for agent usefulness; the release notes identify
-  which parts are addressed by M13-P2 and which remain follow-up work.
+- [x] Issue #70 is closed after the M13-P2/M13-P3.1 response for agent usefulness; release notes
+  identify that #72 now owns remaining source lifecycle and agent-workflow follow-up.
 - [x] Issue #72 remains the parent feedback loop for source-refresh lifecycle and agent workflow;
   stable logical source identities, source supersession, full workspace refresh, pruning, and
-  `pr-summary` remain later M13-P3 or post-v1 work.
-- [ ] Final release handoff should re-run the full validation suite, confirm open issue metadata,
-  and publish a release-note summary before tagging.
+  `pr-summary` remain post-v1 work.
+- [x] Issue #79 tracks the deferred mutating compile/update path from #41 so #41 can stay closed for
+  the shipped v1 briefing and non-mutating compile-contract scope.
+- [x] Final release handoff records validation commands, docs state, issue state, GitHub metadata,
+  known non-blockers, and the post-v1 queue.
+- [ ] Tagging should happen only after the full validation suite, green CI on `main`, and release
+  notes that call out completed M13 work plus the explicit post-v1 queue.
 
 ### Exit criteria
 - the product is stable enough for sustained real-world use
@@ -847,6 +858,36 @@ pruning, or PR-summary tooling.
 - broad discovery cannot accidentally create large manifest/wiki churn
 - generated artifacts add value beyond readable source files
 - the difference between core and optional features is very clear
+
+## Candidate Milestone 14 — Post-v1 source lifecycle and agent workflow
+
+### Goal
+Turn the #72 feedback loop into small source-lifecycle and agent-workflow improvements without
+breaking the v1 file contracts.
+
+### Scope
+- stable logical source identity design
+- source supersession semantics
+- full workspace refresh workflow
+- superseded generated-state pruning and topic-ref migration
+- PR-oriented summary output
+- planning-doc authority and staleness metadata
+
+### Candidate PR slices
+- `M14-P0` Post-v1 planning intake
+- `M14-P1` Source lifecycle design
+
+### Candidate PR sub-slices
+- `M14-P0.1` Split #72 into child issues and assign release metadata
+- `M14-P1.1` Stable logical source identity and supersession design
+
+### Boundaries
+- Promote these candidates to committed roadmap slices only after the child issues and GitHub
+  milestone metadata exist.
+- Keep schema version `1` compatibility unless a future migration plan is explicit.
+- Preserve curated source manifests as the durable registry.
+- Keep #30 and #37 independent performance/scaling follow-ups unless real repository use makes
+  either one urgent.
 
 ---
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -828,7 +828,11 @@ Release-readiness boundary:
   reports can remain local.
 - issue #72's desired stable logical source identities, `supersedes`/`superseded_by` source
   lifecycle, one-command workspace refresh, superseded-state pruning, and `pr-summary` surface are
-  post-v1 or later M13-P3 follow-ups unless a future roadmap slice explicitly pulls them forward.
+  post-v1 follow-ups unless a future roadmap slice explicitly pulls them forward.
+- issue #79 tracks the deferred mutating compile/update workflow from #41; v1 ships briefing and
+  the non-mutating compile contract only.
+- `docs/v1_release_handoff.md` is the v1 handoff checklist for final validation, GitHub metadata,
+  issue state, known non-blockers, and the conservative post-v1 queue.
 
 Later optional support:
 - additional OCR providers
@@ -1270,7 +1274,7 @@ Splendor should be considered successful at the product-spec level if it can do 
 
 These are not blockers to the spec, but should remain visible:
 
-1. exact branch/review strategy for the initial release
+1. exact branch/review strategy for release tags after the initial v1 handoff
 2. whether source manifests live alongside raw files or centrally in `state/`
 3. exact page taxonomy naming
 4. whether code files are ingested directly or via projection/snapshot policies

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -1,0 +1,111 @@
+# v1 Release Handoff
+
+This checklist is the release handoff for `M13-P3.2`. It does not add runtime behavior. It records
+the final v1 verification path, issue state, GitHub metadata expectations, known non-blockers, and
+post-v1 queue after the `M13-P2` redesign and `M13-P3.1` release-hardening audit.
+
+## Release Validation
+
+Run these commands from the repository root before tagging or publishing a v1 release:
+
+```bash
+uv run pytest
+uv run ruff format --check .
+uv run ruff check .
+uv run splendor lint
+```
+
+For a CI-equivalent test job with coverage:
+
+```bash
+uv run pytest --cov=splendor --cov-report=term-missing --cov-report=xml
+```
+
+Before publishing release notes, verify that:
+
+- the `README.md` "What Comes Next" block, `.agent-plan.md`, and
+  `docs/splendor_mvp_to_v1_roadmap.md` planning-state lines match
+- `docs/splendor_product_spec.md` acceptance criteria still match shipped behavior
+- `docs/schema_contracts.md` still names schema version `1` and legacy manifest compatibility
+- `docs/quickstart.md` demonstrates the current safe source workflow
+- `docs/ci_and_repo_automation.md` and `docs/github_automation_architecture.md` still describe
+  GitHub automation as optional around the local CLI
+
+## GitHub Handoff
+
+Release PRs should be non-draft and should carry:
+
+- a detailed body covering changes, validation, limitations, and follow-up work
+- focused labels such as `type/docs`, `area/docs`, `area/planning`, and `release/post-mvp`
+- the `Milestone 13` milestone when it exists
+- explicit issue linkage for issues that are closed or intentionally kept open
+
+For this handoff:
+
+- #70 is closed and should remain the completed parent feedback loop for the `M13-P2` redesign
+- #72 remains open as the parent source-refresh lifecycle and agent-workflow feedback loop
+- #41-#46 are closed as completed v1 dogfood issues after closing comments named the shipped scope
+  and any deferred work; #79 tracks the deferred mutating compile/update path from #41
+- #47 remains open as the real ingest run-duration bug
+- #30 remains open as post-v1 repo-scan registration performance work
+- #37 remains open as post-v1 web document-list scaling work
+
+## Known Non-Blockers
+
+These items are intentionally not v1 release blockers:
+
+- stable logical source identities above content-addressed source IDs
+- `supersedes` / `superseded_by` source lifecycle semantics
+- one-command full workspace refresh
+- superseded generated-state pruning and topic-ref migration
+- `splendor pr-summary --since main`
+- authority and staleness metadata for living planning docs
+- lower-noise generated-state review policies beyond the current reviewer-significance guidance
+- ingest run-duration precision for #47
+- repo-scan bulk registration optimization for #30
+- web document-list scaling for #37
+
+## Post-v1 Queue
+
+The conservative next queue is:
+
+1. Split #72 into child slices when implementation starts, beginning with stable logical source
+   identity and source-supersession design.
+2. Add the smallest source lifecycle slice that keeps `source freshness`, `source refresh`, topic
+   refs, runs, and health checks coherent without breaking schema version `1` compatibility.
+3. Add `splendor pr-summary --since main` only after source lifecycle churn is explicit enough to
+   summarize reliably.
+4. Keep #79 as the tracked post-v1 compile/update workflow rather than reopening #41 for deferred
+   scope.
+5. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
+   either one urgent.
+
+## Tagging Readiness
+
+After the release PR merges, v1 tagging is ready when `main` has:
+
+- package version metadata updated for the intended v1 tag in both `pyproject.toml` and
+  `src/splendor/__init__.py`
+- a release-notes entry or GitHub release draft that names completed M13 work, validation, and the
+  explicit post-v1 queue
+- green CI for formatting, linting, tests, and coverage
+- a passing `splendor lint` planning-state check
+- no open issue mislabeled as a v1 blocker
+
+Use this final tagging sequence after those checks pass:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag -a v1.0.0 -m "Splendor v1.0.0"
+git push origin v1.0.0
+uv build
+```
+
+Before publishing artifacts outside GitHub, verify the built wheel/sdist from `dist/` in a clean
+environment with:
+
+```bash
+uv pip install dist/splendor-*.whl
+splendor --version
+```


### PR DESCRIPTION
## Summary

- Add `docs/v1_release_handoff.md` as the concise v1 release checklist covering validation commands, docs state, GitHub metadata, issue state, known non-blockers, release mechanics, and post-v1 queue.
- Move synchronized planning state from `M13-P3.1` to `M13-P3.2` and define `M14-P0.1` as a post-v1 planning intake rather than prematurely committing a full M14 implementation slice.
- Reconcile release-facing docs around #70 closed status, #72 as the remaining parent lifecycle feedback loop, #79 as the deferred compile/update tracker, and #30/#37/#47 as open post-v1 follow-ups.

## Issue triage

- Closed #41, #42, #43, #44, #45, and #46 with comments naming the shipped v1 scope and deferred boundaries.
- Created #79 for the deferred mutating compile/update path from #41, and commented on #41 with that follow-up link.
- Kept #47 open for real ingest run durations.
- Kept #30 and #37 open as post-v1 performance/scaling follow-ups.
- Kept #72 open and commented with the documented split: stable logical source identities, supersession lifecycle, full workspace refresh, generated-state pruning/topic-ref migration, `splendor pr-summary --since main`, planning authority/staleness metadata, and lower-noise generated-state review policy.
- #70 remains closed after the M13-P2/M13-P3.1 response.

## Validation

These commands passed locally using `/Users/shaypalachy/.local/bin/uv` because `uv` is not on this shell's PATH:

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

## Boundaries

This is a docs/planning release handoff. It intentionally does not implement stable logical source identities, source supersession, full workspace refresh, pruning, PR-summary tooling, SQLite, vector search, background workers, mutating web UI, or broad source-refresh internals.
