### PR TITLE
M14-P0.1: Detail post-v1 retry gate

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M13-P3.1`
-- Last action taken: `M13-P3.1` is implemented; release hardening and v1 readiness audit are complete.
-- Current planned slice: `M13-P3`
-- Current PR sub-slice: `M13-P3.2`
+- Previous completed PR sub-slice: `M13-P3.2`
+- Last action taken: `M13-P3.2` is implemented; final release checklist and post-v1 handoff are complete.
+- Current planned slice: `M14-P0`
+- Current PR sub-slice: `M14-P0.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M14-P0`
-- Next planned PR sub-slice: `M14-P0.1`
+- Next planned slice: `M14-P1`
+- Next planned PR sub-slice: `M14-P1.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -217,6 +217,10 @@
   - [x] Keep #72, #47, #30, and #37 open as post-v1 feedback/performance/scaling work
   - [x] Create #79 for the deferred mutating compile/update path from #41
   - [x] Treat stable logical source identities, source supersession, full workspace refresh, generated-state pruning, topic-ref migration, and PR-summary as post-v1 lifecycle work
+- [x] Implement `M14-P0.1`: Split post-v1 source-lifecycle and workflow follow-ups
+  - [x] Record the detailed post-v1 PR breakdown before asking for a full SynthBanshee agent re-evaluation
+  - [x] Keep #72 as the parent feedback loop while naming child implementation slices
+  - [x] Treat source lifecycle, generated-state cleanup, and PR summary work as prerequisites for the major external-agent retry
 
 ## Context Pointers
 
@@ -247,6 +251,8 @@
 - `M13-P2` Issue #70 agent-usefulness redesign
 - `M13-P3` Extension/performance/release finalization
 - `M14-P0` Post-v1 planning intake
+- `M14-P1` Source lifecycle implementation
+- `M14-P2` PR summary and generated-state review handoff
 
 ## PR Sub-slice Queue
 
@@ -273,3 +279,8 @@
 - `M13-P3.1` Release hardening and v1 readiness
 - `M13-P3.2` Final release checklist and post-v1 handoff
 - `M14-P0.1` Split post-v1 source-lifecycle and workflow follow-ups
+- `M14-P1.1` Stable logical source identities
+- `M14-P1.2` Supersession-aware source refresh
+- `M14-P1.3` Safe workspace refresh path
+- `M14-P1.4` Superseded-state pruning and topic-ref migration
+- `M14-P2.1` PR summary and lower-noise generated-state review handoff

--- a/README.md
+++ b/README.md
@@ -178,12 +178,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M13-P3.1`
-- Current planned slice: `M13-P3`
-- Current PR sub-slice: `M13-P3.2`
+- Previous completed PR sub-slice: `M13-P3.2`
+- Current planned slice: `M14-P0`
+- Current PR sub-slice: `M14-P0.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M14-P0`
-- Next planned PR sub-slice: `M14-P0.1`
+- Next planned slice: `M14-P1`
+- Next planned PR sub-slice: `M14-P1.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -275,6 +275,11 @@ remain post-v1 performance work. Issue #70 is closed after the M13-P2/M13-P3.1 r
 stays open as the parent feedback loop for stable logical source identities, supersession
 lifecycle, full workspace refresh, pruning, and PR-summary ideas deferred to post-v1 planning.
 Issue #79 tracks the deferred mutating compile/update path from #41.
+
+`M14-P0.1` is the post-v1 planning intake before asking the SynthBanshee Claude agent for a full
+retry. It records the detailed sequence needed to make that retry meaningful: stable logical source
+identities, supersession-aware refresh, a safe workspace refresh path, superseded-state cleanup,
+topic-ref migration, and PR-oriented generated-state summary/review handoff.
 
 ### v1 readiness checklist
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M13-P3.1`
-- Current planned slice: `M13-P3`
-- Current PR sub-slice: `M13-P3.2`
+- Previous completed PR sub-slice: `M13-P3.2`
+- Current planned slice: `M14-P0`
+- Current PR sub-slice: `M14-P0.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M14-P0`
-- Next planned PR sub-slice: `M14-P0.1`
+- Next planned slice: `M14-P1`
+- Next planned PR sub-slice: `M14-P1.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -876,10 +876,35 @@ breaking the v1 file contracts.
 ### Candidate PR slices
 - `M14-P0` Post-v1 planning intake
 - `M14-P1` Source lifecycle design
+- `M14-P2` PR summary and generated-state review handoff
 
 ### Candidate PR sub-slices
 - `M14-P0.1` Split #72 into child issues and assign release metadata
 - `M14-P1.1` Stable logical source identity and supersession design
+- `M14-P1.2` Supersession-aware source refresh
+- `M14-P1.3` Safe workspace refresh path
+- `M14-P1.4` Superseded-state pruning and topic-ref migration
+- `M14-P2.1` PR summary and lower-noise generated-state review handoff
+
+### SynthBanshee re-evaluation gate
+
+Do not ask the SynthBanshee Claude agent for the major "try Splendor again" evaluation until the
+post-#72 lifecycle loop is substantially implemented. The intended sequence before that ask is:
+
+1. `M14-P0.1` splits #72 into child issues and assigns release metadata.
+2. `M14-P1.1` adds stable logical source identities while preserving content-addressed IDs for
+   compatibility.
+3. `M14-P1.2` makes source refresh supersession-aware, so changed sources do not leave stale runs,
+   topic refs, or health failures for agents to clean manually.
+4. `M14-P1.3` provides one safe workspace refresh path for changed-source detection, refresh,
+   ingest, index rebuild, and a health-clean end state.
+5. `M14-P1.4` handles superseded generated-state pruning and topic-ref migration.
+6. `M14-P2.1` adds `splendor pr-summary --since main` or an equivalent PR-oriented summary with
+   lower-noise generated-state review guidance.
+
+After those slices land, the external-agent retry should use a comparable real planning or
+repo-maintenance workflow and explicitly compare against #72. Earlier feedback should be requested
+only for the narrower safe-discovery, freshness, and handoff surfaces already shipped in M13.
 
 ### Boundaries
 - Promote these candidates to committed roadmap slices only after the child issues and GitHub

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -80,6 +80,24 @@ The conservative next queue is:
 5. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
    either one urgent.
 
+Do not ask the SynthBanshee Claude agent for the major "try Splendor again" re-evaluation until
+the source-lifecycle and generated-state review loop is materially improved. The planned retry
+bundle is:
+
+1. `M14-P0.1` Split #72 into child issues and assign release metadata.
+2. `M14-P1.1` Stable logical source identities above content-addressed source IDs.
+3. `M14-P1.2` Supersession-aware source refresh, so changed files do not leave stale runs, topic
+   refs, or health failures for agents to clean manually.
+4. `M14-P1.3` Safe workspace refresh path covering changed-source detection, refresh, ingest,
+   index rebuild, and a health-clean end state.
+5. `M14-P1.4` Superseded generated-state pruning and topic-ref migration.
+6. `M14-P2.1` PR summary and lower-noise generated-state review handoff, including
+   `splendor pr-summary --since main` or an equivalent reviewed output.
+
+After those slices land, ask the SynthBanshee Claude agent to retry a comparable real planning or
+repo-maintenance workflow and compare against the original #72 report. Before then, any retry
+should be framed narrowly around safe discovery, freshness, and handoff only.
+
 ## Tagging Readiness
 
 After the release PR merges, v1 tagging is ready when `main` has:


### PR DESCRIPTION
## Summary

- move synchronized planning state to `M14-P0.1`
- add the explicit post-v1 PR sequence needed before asking the SynthBanshee Claude agent for a full retry
- mirror the retry gate in the release handoff, roadmap, README, and agent plan

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

## Boundaries

Docs/planning only. This does not implement source lifecycle machinery, PR-summary tooling, or generated-state cleanup.