### PR TITLE
M14-P1.1: Add stable logical source identities

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M13-P3.2`
-- Last action taken: `M13-P3.2` is implemented; final release checklist and post-v1 handoff are complete.
-- Current planned slice: `M14-P0`
-- Current PR sub-slice: `M14-P0.1`
+- Previous completed PR sub-slice: `M14-P0.1`
+- Last action taken: `M14-P0.1` is implemented; the post-v1 source-lifecycle and workflow retry sequence is documented.
+- Current planned slice: `M14-P1`
+- Current PR sub-slice: `M14-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M14-P1`
-- Next planned PR sub-slice: `M14-P1.1`
+- Next planned PR sub-slice: `M14-P1.2`
 - Current blockers: none
 
 ## Planning Notation
@@ -221,6 +221,11 @@
   - [x] Record the detailed post-v1 PR breakdown before asking for a full SynthBanshee agent re-evaluation
   - [x] Keep #72 as the parent feedback loop while naming child implementation slices
   - [x] Treat source lifecycle, generated-state cleanup, and PR summary work as prerequisites for the major external-agent retry
+- [x] Implement `M14-P1.1`: Stable logical source identities
+  - [x] Persist a stable `source:<workspace-path>` logical ID for workspace-backed source manifests
+  - [x] Preserve content-addressed `src-...` IDs as canonical manifest, queue, run, and source-summary identifiers
+  - [x] Expose logical IDs and aliases in source lookup, freshness, and refresh handoff output
+  - [x] Keep supersession-aware refresh, workspace refresh, pruning, topic-ref migration, PR summary, and mutating compile/update deferred
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -178,12 +178,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M13-P3.2`
-- Current planned slice: `M14-P0`
-- Current PR sub-slice: `M14-P0.1`
+- Previous completed PR sub-slice: `M14-P0.1`
+- Current planned slice: `M14-P1`
+- Current PR sub-slice: `M14-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M14-P1`
-- Next planned PR sub-slice: `M14-P1.1`
+- Next planned PR sub-slice: `M14-P1.2`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -276,10 +276,11 @@ stays open as the parent feedback loop for stable logical source identities, sup
 lifecycle, full workspace refresh, pruning, and PR-summary ideas deferred to post-v1 planning.
 Issue #79 tracks the deferred mutating compile/update path from #41.
 
-`M14-P0.1` is the post-v1 planning intake before asking the SynthBanshee Claude agent for a full
-retry. It records the detailed sequence needed to make that retry meaningful: stable logical source
-identities, supersession-aware refresh, a safe workspace refresh path, superseded-state cleanup,
-topic-ref migration, and PR-oriented generated-state summary/review handoff.
+`M14-P1.1` adds the first stable logical source identity layer above content-addressed source IDs:
+workspace-backed manifests now persist `source:<workspace-path>` logical IDs and path aliases while
+keeping `src-...` IDs as the compatibility contract. Supersession-aware refresh, safe workspace
+refresh, pruning/topic-ref migration, and PR-oriented generated-state summary/review handoff remain
+later slices before the SynthBanshee Claude retry.
 
 ### v1 readiness checklist
 
@@ -291,5 +292,5 @@ topic-ref migration, and PR-oriented generated-state summary/review handoff.
 - [x] CLI, schema, quickstart, automation, and dogfooding docs describe the same current behavior.
 - [x] Final release handoff names validation, issue state, GitHub metadata, known non-blockers,
   and the post-v1 queue.
-- [ ] Full refresh lifecycle, stable logical source IDs, supersession/pruning, and PR-summary
-  tooling are planned follow-ups, not v1 blockers.
+- [ ] Full refresh lifecycle, supersession/pruning, topic-ref migration, and PR-summary tooling are
+  planned follow-ups after the initial stable logical source identity layer.

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -107,9 +107,10 @@ in issue #72.
 
 - #70 is closed after the M13-P2/M13-P3.1 response for scan safety, curated curation, source
   freshness, ranked handoff, and path-first source-summary UX.
-- #72 is a separate parent feedback loop for source-refresh lifecycle and agent workflow. Its stable
-  logical source identities, `supersedes`/`superseded_by`, full workspace refresh, pruning, and
-  `pr-summary` requests remain post-v1 work.
+- #72 is a separate parent feedback loop for source-refresh lifecycle and agent workflow. Its
+  stable logical source identity layer has started with workspace-backed `source:<path>` aliases;
+  `supersedes`/`superseded_by`, full workspace refresh, pruning, and `pr-summary` requests remain
+  post-v1 work.
 - #41 has shipped `splendor brief [goal]`, `brief --agent-context`, and the non-mutating
   `splendor wiki compile <source-id|title|path>` contract. Mutating compile/update support remains
   deferred and is tracked by #79.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -80,6 +80,8 @@ Implemented fields:
 - `origin_url`
 - `original_path`
 - `materialized_at`
+- `logical_id`
+- `aliases`
 - `source_commit`
 - `source_class`
 - `source_labels`
@@ -118,6 +120,17 @@ Implemented fields:
   - Symlink-backed sources use `raw/sources/<source_id>/<filename>`.
 - `materialized_at`
   - Timestamp indicating when `storage_path` was created or last refreshed.
+- `logical_id`
+  - Stable logical source identity for workspace-backed sources.
+  - New workspace-backed registrations use `source:<workspace-path>`, for example
+    `source:docs/spec.md`.
+  - Content-addressed `source_id` values remain the canonical manifest filenames, queue payload
+    targets, run provenance, and generated source-summary page identifiers.
+- `aliases`
+  - Stable lookup aliases for the logical source identity.
+  - Workspace-backed registrations include the repo-relative path alias, and lookup/freshness JSON
+    also exposes the effective logical ID as an alias for agent handoff.
+  - External and legacy manifests may leave this empty.
 - `source_commit_capture`
   - Nullable persisted intent for git provenance capture:
     - `true` means commit capture was explicitly requested for registration and refresh
@@ -150,8 +163,8 @@ Implemented fields:
 - `splendor add-source --dir path` registers direct child files in deterministic path order.
 - Newly registered CLI sources are handed to the existing ingest queue as `ingest-<source-id>`
   records; already registered sources are reported without creating duplicate work.
-- `splendor source list` and `splendor source lookup [query]` provide a readable title/path to
-  `source_id` mapping. They are lookup surfaces only and do not rename canonical source IDs or
+- `splendor source list` and `splendor source lookup [query]` provide a readable title/path/logical
+  ID to `source_id` mapping. They are lookup surfaces only and do not rename canonical source IDs or
   generated `wiki/sources/src-...md` pages.
 - `splendor source refresh <source-id|title|path>` resolves the tracked workspace or external path,
   compares current bytes to the manifest checksum, registers changed content as a new canonical
@@ -395,8 +408,9 @@ Current runtime behavior:
 - The release-ready core is file-based, deterministic, and compatible with legacy `path`-only
   source manifests.
 - Source freshness, suggest-next, and agent briefing use existing records as read-only signals.
-- Richer lifecycle fields for stable logical source identities and supersession-aware history are
-  deferred so they can be designed without breaking the v1 manifest contract.
+- Stable logical source identities are schema-version-1-compatible optional fields above the
+  content-addressed `source_id` compatibility contract. Supersession-aware history remains deferred
+  so it can be designed without breaking the v1 manifest contract.
 - The final v1 handoff in `docs/v1_release_handoff.md` treats schema version `1`, legacy manifest
   compatibility, and deferred source-lifecycle fields as release checklist items rather than
   implicit assumptions.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -166,6 +166,9 @@ Implemented fields:
 - `splendor source list` and `splendor source lookup [query]` provide a readable title/path/logical
   ID to `source_id` mapping. They are lookup surfaces only and do not rename canonical source IDs or
   generated `wiki/sources/src-...md` pages.
+- Mutating source commands resolve source selectors strictly. Direct ingest accepts exact source
+  IDs, exact logical IDs, exact path aliases/source refs, or exact unambiguous titles; substring
+  matches remain limited to read-only lookup surfaces.
 - `splendor source refresh <source-id|title|path>` resolves the tracked workspace or external path,
   compares current bytes to the manifest checksum, registers changed content as a new canonical
   source version, preserves `source_commit_capture` intent, and queues ingest through the same queue
@@ -411,6 +414,9 @@ Current runtime behavior:
 - Stable logical source identities are schema-version-1-compatible optional fields above the
   content-addressed `source_id` compatibility contract. Supersession-aware history remains deferred
   so it can be designed without breaking the v1 manifest contract.
+- Lint validates present workspace-backed logical identity fields: `logical_id` must match
+  `source:<source_ref>`, persisted aliases must stay scoped to the canonical workspace path, and
+  exact identities must not point at conflicting canonical source refs.
 - The final v1 handoff in `docs/v1_release_handoff.md` treats schema version `1`, legacy manifest
   compatibility, and deferred source-lifecycle fields as release checklist items rather than
   implicit assumptions.

--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -187,6 +187,18 @@ Optional repo-relative path, usually under `raw/sources/`, used when a source is
 
 Timestamp capturing when the storage artifact was created or refreshed.
 
+### `logical_id`
+
+Optional stable logical identity above the content-addressed `source_id`. Workspace-backed sources
+use `source:<workspace-path>`, for example `source:docs/spec.md`, while generated source-summary
+pages, queue records, and run provenance continue to use `src-...` IDs for compatibility.
+
+### `aliases`
+
+Optional stable lookup aliases for source resolution. Workspace-backed registrations persist the
+repo-relative path alias; lookup and freshness payloads also expose the effective logical ID as an
+alias for agent handoff.
+
 ### `source_commit_capture`
 
 Nullable intent flag controlling whether refresh should attempt source commit capture again:

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M13-P3.2`
-- Current planned slice: `M14-P0`
-- Current PR sub-slice: `M14-P0.1`
+- Previous completed PR sub-slice: `M14-P0.1`
+- Current planned slice: `M14-P1`
+- Current PR sub-slice: `M14-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M14-P1`
-- Next planned PR sub-slice: `M14-P1.1`
+- Next planned PR sub-slice: `M14-P1.2`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -880,7 +880,7 @@ breaking the v1 file contracts.
 
 ### Candidate PR sub-slices
 - `M14-P0.1` Split #72 into child issues and assign release metadata
-- `M14-P1.1` Stable logical source identity and supersession design
+- `M14-P1.1` Stable logical source identities
 - `M14-P1.2` Supersession-aware source refresh
 - `M14-P1.3` Safe workspace refresh path
 - `M14-P1.4` Superseded-state pruning and topic-ref migration
@@ -893,7 +893,9 @@ post-#72 lifecycle loop is substantially implemented. The intended sequence befo
 
 1. `M14-P0.1` splits #72 into child issues and assigns release metadata.
 2. `M14-P1.1` adds stable logical source identities while preserving content-addressed IDs for
-   compatibility.
+   compatibility. The first implementation persists `source:<workspace-path>` logical IDs and
+   aliases for workspace-backed source manifests without changing `src-...` manifest IDs,
+   generated source-summary page IDs, queue IDs, or run provenance.
 3. `M14-P1.2` makes source refresh supersession-aware, so changed sources do not leave stale runs,
    topic refs, or health failures for agents to clean manually.
 4. `M14-P1.3` provides one safe workspace refresh path for changed-source detection, refresh,

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -766,6 +766,9 @@ Current implementation:
   deterministic path order with filename-derived titles.
 - `splendor source list` and `splendor source lookup [query]` map human-readable titles, paths, and
   stable logical IDs back to canonical source IDs without renaming existing source-summary pages.
+- Mutating source commands use stricter selector resolution than lookup. Direct ingest accepts exact
+  source IDs, exact logical IDs, exact path aliases/source refs, or exact unambiguous titles, not
+  substring matches that can silently select the wrong source.
 - `splendor source refresh <source-id|title|path>` detects changed source content, registers the
   current bytes as a new canonical source version when the checksum changed, and queues ingest via
   the existing queue ledger while preserving active-lease and dead-letter protections.
@@ -835,6 +838,8 @@ Release-readiness boundary:
 - readable paths, titles, source refs, and logical IDs are lookup and display aids above that
   compatibility contract; generated source-summary pages and run provenance still use `src-...`
   identifiers.
+- lint checks present workspace-backed logical IDs and aliases so stale or hand-edited manifests do
+  not create conflicting exact source identities.
 - generated source-summary pages, queue records, run records, derived artifacts, and explicit
   reports are committed when they explain a reviewed workspace update; failed or exploratory local
   reports can remain local.

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -442,6 +442,15 @@ Field meanings:
   - Optional path to the materialized artifact under `raw/sources/` when one exists.
   - Pointer-backed sources use `raw/sources/<source_id>/pointer.json`.
   - Symlink-backed sources use `raw/sources/<source_id>/<filename>`.
+- `logical_id`
+  - Optional stable logical identity above the content-addressed `source_id`.
+  - Workspace-backed sources use `source:<workspace-path>`, for example
+    `source:docs/spec.md`, so agents can refer to a logical source across content refreshes.
+- `aliases`
+  - Optional stable lookup aliases for the source. Workspace-backed registrations persist the
+    repo-relative path alias and expose the effective logical ID through lookup/freshness payloads.
+  - These aliases do not replace content-addressed `src-...` IDs for manifests, queue records, run
+    records, or generated source-summary pages.
 - `source_commit_capture`
   - Optional nullable capture intent persisted separately from `source_commit`. `true` preserves an
     explicit capture request across refreshes, `false` preserves an explicit opt-out, and `null`
@@ -755,13 +764,14 @@ Current implementation:
   source ID.
 - `splendor add-source --glob "pattern"` and `splendor add-source --dir path` register batches in
   deterministic path order with filename-derived titles.
-- `splendor source list` and `splendor source lookup [query]` map human-readable titles and paths
-  back to canonical source IDs without renaming existing source-summary pages.
+- `splendor source list` and `splendor source lookup [query]` map human-readable titles, paths, and
+  stable logical IDs back to canonical source IDs without renaming existing source-summary pages.
 - `splendor source refresh <source-id|title|path>` detects changed source content, registers the
   current bytes as a new canonical source version when the checksum changed, and queues ingest via
   the existing queue ledger while preserving active-lease and dead-letter protections.
-  Stable logical source identities, explicit source supersession fields, automated historical
-  pruning, and topic-ref migration remain later lifecycle work.
+  Stable logical source identities now remain constant for workspace-backed source paths across
+  those content-addressed versions. Explicit source supersession fields, automated historical
+  pruning, safe full-workspace refresh, and topic-ref migration remain later lifecycle work.
 - `splendor add-topic "Title"` scaffolds a maintained topic page under `wiki/topics/<slug>.md`
   with valid knowledge-page frontmatter, optional tags/source refs, and deterministic markdown
   templates for default synthesis, research synthesis, and issue tracking.
@@ -822,13 +832,16 @@ M13-P2 repo-discovery contracts:
 Release-readiness boundary:
 
 - v1 treats content-addressed source IDs as the persisted compatibility contract.
-- readable paths, titles, and source refs are lookup and display aids, not durable aliases yet.
+- readable paths, titles, source refs, and logical IDs are lookup and display aids above that
+  compatibility contract; generated source-summary pages and run provenance still use `src-...`
+  identifiers.
 - generated source-summary pages, queue records, run records, derived artifacts, and explicit
   reports are committed when they explain a reviewed workspace update; failed or exploratory local
   reports can remain local.
-- issue #72's desired stable logical source identities, `supersedes`/`superseded_by` source
-  lifecycle, one-command workspace refresh, superseded-state pruning, and `pr-summary` surface are
-  post-v1 follow-ups unless a future roadmap slice explicitly pulls them forward.
+- issue #72's desired stable logical source identity layer has started with workspace-backed
+  `source:<path>` aliases. `supersedes`/`superseded_by` source lifecycle, one-command workspace
+  refresh, superseded-state pruning, and `pr-summary` surface remain post-v1 follow-ups unless a
+  future roadmap slice explicitly pulls them forward.
 - issue #79 tracks the deferred mutating compile/update workflow from #41; v1 ships briefing and
   the non-mutating compile contract only.
 - `docs/v1_release_handoff.md` is the v1 handoff checklist for final validation, GitHub metadata,

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -54,7 +54,8 @@ For this handoff:
 
 These items are intentionally not v1 release blockers:
 
-- stable logical source identities above content-addressed source IDs
+- supersession-aware lifecycle use of the stable logical source identities above content-addressed
+  source IDs
 - `supersedes` / `superseded_by` source lifecycle semantics
 - one-command full workspace refresh
 - superseded generated-state pruning and topic-ref migration
@@ -69,8 +70,8 @@ These items are intentionally not v1 release blockers:
 
 The conservative next queue is:
 
-1. Split #72 into child slices when implementation starts, beginning with stable logical source
-   identity and source-supersession design.
+1. Continue #72 implementation after the initial workspace-backed `source:<path>` logical ID layer,
+   beginning with supersession-aware source refresh.
 2. Add the smallest source lifecycle slice that keeps `source freshness`, `source refresh`, topic
    refs, runs, and health checks coherent without breaking schema version `1` compatibility.
 3. Add `splendor pr-summary --since main` only after source lifecycle churn is explicit enough to

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -63,6 +63,7 @@ from splendor.commands.source import (
     render_source_freshness_json,
     render_source_lookup_json,
     render_source_refresh_json,
+    resolve_source_query,
     scan_source_freshness,
     write_source_freshness_report,
 )
@@ -91,7 +92,7 @@ from splendor.schemas import (
 )
 from splendor.schemas.types import STORAGE_MODES
 from splendor.state.query_snapshot import last_query_path_for, write_query_snapshot
-from splendor.state.source_compat import canonical_source_ref
+from splendor.state.source_compat import canonical_source_ref, effective_logical_id
 from splendor.utils.provenance import summarize_provenance_links
 from splendor.utils.time import utc_now_iso
 
@@ -242,7 +243,7 @@ def build_parser() -> argparse.ArgumentParser:
     ingest_parser.add_argument(
         "source_id",
         nargs="?",
-        help="Registered source identifier to ingest",
+        help="Registered source ID, title, path, or logical ID to ingest",
     )
     ingest_parser.add_argument(
         "--pending",
@@ -777,6 +778,9 @@ def handle_add_source(args: argparse.Namespace) -> int:
         return _print_error(exc)
     action = "Already registered" if result.already_registered else "Registered"
     print(f"Source ref: {result.source_ref}")
+    logical_id = effective_logical_id(result.record)
+    if logical_id is not None:
+        print(f"Logical ID: {logical_id}")
     print(f"{action} source {result.source_id}")
     print(f"Manifest: {result.manifest_path}")
     print(f"Storage mode: {result.storage_mode}")
@@ -885,6 +889,9 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
         print(f"No source content change detected for {canonical_source_ref(result.requested)}")
         print(f"Source ID: {result.requested.source_id}")
     print(f"Source ref: {result.refreshed.source_ref}")
+    logical_id = effective_logical_id(result.refreshed.record)
+    if logical_id is not None:
+        print(f"Logical ID: {logical_id}")
     if result.queued and result.queue_path is not None:
         print(f"Queued ingest: {result.queue_path}")
         print("Next: splendor ingest --pending")
@@ -926,7 +933,9 @@ def handle_source_freshness(args: argparse.Namespace) -> int:
         source = item.source
         print(
             f"- {item.canonical_path}: {item.status} "
-            f"title={source.title} source_id={source.source_id}"
+            f"title={source.title} "
+            f"logical_id={effective_logical_id(source) or '-'} "
+            f"source_id={source.source_id}"
         )
         print(f"  Manifest: {item.manifest_path}")
         print(f"  Manifest checksum: {item.manifest_checksum}")
@@ -973,7 +982,8 @@ def handle_ingest(args: argparse.Namespace) -> int:
         return 1 if result.failed else 0
 
     try:
-        result = ingest_source(root, args.source_id)
+        source = resolve_source_query(root, args.source_id).source
+        result = ingest_source(root, source.source_id)
     except (FileNotFoundError, RuntimeError, ValueError) as exc:
         return _print_error(exc)
 
@@ -1120,9 +1130,11 @@ def _print_source_lookup_results(results: list[SourceLookupResult]) -> None:
         return
     for result in results:
         source = result.source
+        logical_id = effective_logical_id(source)
         print(
             f"- {canonical_source_ref(source)} [{source.status}] {source.title} "
-            f"source_id={source.source_id} ref={canonical_source_ref(source)}"
+            f"logical_id={logical_id or '-'} source_id={source.source_id} "
+            f"ref={canonical_source_ref(source)}"
         )
         print(f"  Manifest: {result.manifest_path}")
     print("Next: splendor source refresh <source-id|title|path>")

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -63,7 +63,7 @@ from splendor.commands.source import (
     render_source_freshness_json,
     render_source_lookup_json,
     render_source_refresh_json,
-    resolve_source_query,
+    resolve_source_query_exact,
     scan_source_freshness,
     write_source_freshness_report,
 )
@@ -982,7 +982,7 @@ def handle_ingest(args: argparse.Namespace) -> int:
         return 1 if result.failed else 0
 
     try:
-        source = resolve_source_query(root, args.source_id).source
+        source = resolve_source_query_exact(root, args.source_id).source
         result = ingest_source(root, source.source_id)
     except (FileNotFoundError, RuntimeError, ValueError) as exc:
         return _print_error(exc)

--- a/src/splendor/commands/add_source.py
+++ b/src/splendor/commands/add_source.py
@@ -6,12 +6,14 @@ from dataclasses import dataclass
 from glob import glob
 from pathlib import Path
 
+from splendor.schemas import SourceRecord
 from splendor.schemas.types import StorageMode
 from splendor.state.source_registry import register_source
 
 
 @dataclass(frozen=True)
 class AddSourceResult:
+    record: SourceRecord
     source_id: str
     manifest_path: Path
     stored_path: Path | None
@@ -84,6 +86,7 @@ def add_source(
         capture_source_commit=capture_source_commit,
     )
     return AddSourceResult(
+        record=registered.record,
         source_id=registered.record.source_id,
         manifest_path=registered.manifest_path,
         stored_path=registered.stored_path,

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -20,6 +20,7 @@ from splendor.schemas import (
     TaskRecord,
 )
 from splendor.state.paths import resolve_workspace_path
+from splendor.state.source_compat import canonical_source_ref, logical_source_id_for_ref
 from splendor.state.source_registry import load_source_record
 from splendor.utils.planning import iter_planning_paths, parse_planning_document, planning_directory
 from splendor.utils.wiki import parse_wiki_markdown
@@ -273,6 +274,13 @@ def _run_reference_integrity_checks(
         if manifest.record is None:
             continue
         source_by_id.setdefault(manifest.record.source_id, []).append(manifest)
+    source_refs_by_identity: dict[str, set[str]] = {}
+    for manifest in inventory.source_manifests:
+        if manifest.record is None:
+            continue
+        source = manifest.record
+        for identity in _source_identity_values(source):
+            source_refs_by_identity.setdefault(identity, set()).add(canonical_source_ref(source))
 
     for code, values in (
         ("duplicate-page-id", wiki_by_id),
@@ -393,6 +401,8 @@ def _run_reference_integrity_checks(
     for manifest in inventory.source_manifests:
         if manifest.record is None:
             continue
+        checked_count += 1 + len(manifest.record.aliases)
+        issues.extend(_source_identity_issues(root, manifest, source_refs_by_identity))
         checked_count += len(manifest.record.derived_artifacts)
         issues.extend(_derived_artifact_issues(root, layout, manifest))
         checked_count += len(manifest.record.linked_pages)
@@ -415,6 +425,75 @@ def _run_reference_integrity_checks(
     issues.extend(planning_state_issues)
 
     return _LintCheckResult(checked_count=checked_count, issues=issues)
+
+
+def _source_identity_values(source: SourceRecord) -> set[str]:
+    values = {source.source_id, canonical_source_ref(source)}
+    if source.original_path is not None:
+        values.add(source.original_path)
+    if source.logical_id is not None:
+        values.add(source.logical_id)
+    values.update(source.aliases)
+    return values
+
+
+def _source_identity_issues(
+    root: Path,
+    manifest: _SourceInventory,
+    source_refs_by_identity: dict[str, set[str]],
+) -> list[MaintenanceIssue]:
+    if manifest.record is None:
+        return []
+    source = manifest.record
+    manifest_relpath = workspace_relative_path(root, manifest.manifest_path)
+    issues: list[MaintenanceIssue] = []
+
+    if source.source_ref_kind == "workspace_path":
+        expected_logical_id = logical_source_id_for_ref(source.source_ref, source.source_ref_kind)
+        if source.logical_id is not None and source.logical_id != expected_logical_id:
+            issues.append(
+                MaintenanceIssue(
+                    code="invalid-source-logical-id",
+                    message=(
+                        "Workspace source logical_id must match source_ref: "
+                        f"expected {expected_logical_id}, got {source.logical_id}"
+                    ),
+                    path=manifest_relpath,
+                    record_id=source.source_id,
+                    check_name="source-identity",
+                )
+            )
+        allowed_aliases = {source.source_ref} if source.source_ref is not None else set()
+    else:
+        allowed_aliases = set()
+
+    for alias in source.aliases:
+        if alias in allowed_aliases:
+            continue
+        issues.append(
+            MaintenanceIssue(
+                code="invalid-source-alias",
+                message=f"Source alias is not valid for this source manifest: {alias}",
+                path=manifest_relpath,
+                record_id=source.source_id,
+                check_name="source-identity",
+            )
+        )
+
+    for identity in _source_identity_values(source):
+        source_refs = source_refs_by_identity.get(identity, set())
+        if len(source_refs) <= 1:
+            continue
+        issues.append(
+            MaintenanceIssue(
+                code="conflicting-source-identity",
+                message=(f"Source identity resolves to multiple canonical source refs: {identity}"),
+                path=manifest_relpath,
+                record_id=source.source_id,
+                check_name="source-identity",
+            )
+        )
+    return issues
 
 
 def _derived_artifact_issues(

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -118,6 +118,34 @@ def resolve_source_query(root: Path, query: str) -> SourceLookupResult:
     return _select_source_query_candidate(root, query)
 
 
+def resolve_source_query_exact(root: Path, query: str) -> SourceLookupResult:
+    matches = list_sources(root)
+    exact_id_matches = [match for match in matches if match.source.source_id == query]
+    if exact_id_matches:
+        return exact_id_matches[0]
+
+    exact_identity_matches = [
+        match
+        for match in matches
+        if canonical_source_ref(match.source) == query
+        or (match.source.original_path is not None and match.source.original_path == query)
+        or effective_logical_id(match.source) == query
+        or query in effective_aliases(match.source)
+    ]
+    if exact_identity_matches:
+        return _select_refresh_candidate(query, exact_identity_matches)
+
+    exact_title_matches = [
+        match for match in matches if match.source.title.casefold() == query.casefold()
+    ]
+    if exact_title_matches:
+        return _select_refresh_candidate(query, exact_title_matches)
+
+    label = "source ID" if query.startswith("src-") else "source"
+    msg = f"Unknown {label}: {query}"
+    raise FileNotFoundError(msg)
+
+
 def resolve_source_query_matches(root: Path, query: str) -> list[SourceLookupResult]:
     matches = lookup_sources(root, query)
     if not matches:

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -15,6 +15,8 @@ from splendor.state.paths import resolve_workspace_path
 from splendor.state.runtime import ingest_job_id
 from splendor.state.source_compat import (
     canonical_source_ref,
+    effective_aliases,
+    effective_logical_id,
     effective_materialized_path,
     effective_storage_mode,
 )
@@ -132,6 +134,8 @@ def resolve_source_query_matches(root: Path, query: str) -> list[SourceLookupRes
         for match in matches
         if canonical_source_ref(match.source) == query
         or (match.source.original_path is not None and match.source.original_path == query)
+        or effective_logical_id(match.source) == query
+        or query in effective_aliases(match.source)
     ]
     if exact_ref_matches:
         return sorted(exact_ref_matches, key=_latest_source_sort_key, reverse=True)
@@ -156,6 +160,8 @@ def _select_source_query_candidate(root: Path, query: str) -> SourceLookupResult
         or match.source.title.casefold() == query.casefold()
         or canonical_source_ref(match.source) == query
         or (match.source.original_path is not None and match.source.original_path == query)
+        or effective_logical_id(match.source) == query
+        or query in effective_aliases(match.source)
     ]
     candidates = exact_matches or matches
     if not candidates:
@@ -265,7 +271,9 @@ def render_source_refresh_json(root: Path, result: SourceRefreshResult) -> str:
     return json.dumps(
         {
             "requested_source_id": result.requested.source_id,
+            "requested_logical_id": effective_logical_id(result.requested),
             "source_id": result.refreshed.record.source_id,
+            "logical_id": effective_logical_id(result.refreshed.record),
             "changed": result.changed,
             "queued": result.queued,
             "queue_path": (
@@ -329,6 +337,8 @@ def _matches_source(source: SourceRecord, needle: str) -> bool:
         canonical_source_ref(source),
         legacy_path,
         source.original_path or "",
+        effective_logical_id(source) or "",
+        *effective_aliases(source),
     ]
     return any(needle in value.casefold() for value in haystacks)
 
@@ -496,6 +506,8 @@ def _freshness_payload(root: Path, item: SourceFreshnessItem) -> dict[str, objec
         "path": item.canonical_path,
         "status": item.status,
         "source_id": source.source_id,
+        "logical_id": effective_logical_id(source),
+        "aliases": effective_aliases(source),
         "title": source.title,
         "source_ref": canonical_source_ref(source),
         "source_ref_kind": source.source_ref_kind,
@@ -511,6 +523,8 @@ def _source_payload(root: Path, result: SourceLookupResult) -> dict[str, object]
     source = result.source
     return {
         "source_id": source.source_id,
+        "logical_id": effective_logical_id(source),
+        "aliases": effective_aliases(source),
         "title": source.title,
         "source_type": source.source_type,
         "status": source.status,

--- a/src/splendor/schemas/source.py
+++ b/src/splendor/schemas/source.py
@@ -48,6 +48,8 @@ class SourceRecord(StrictRecord):
     storage_mode: StorageMode | None = None
     storage_path: str | None = None
     materialized_at: str | None = None
+    logical_id: str | None = None
+    aliases: list[str] = Field(default_factory=list)
     source_commit_capture: bool | None = None
     source_commit: str | None = None
     source_class: SourceClass | None = None

--- a/src/splendor/state/source_compat.py
+++ b/src/splendor/state/source_compat.py
@@ -18,6 +18,36 @@ def canonical_source_ref(source: SourceRecord) -> str:
     return source.source_ref or source.original_path or source.path
 
 
+def logical_source_id_for_ref(
+    source_ref: str | None, source_ref_kind: SourceRefKind | str | None
+) -> str | None:
+    if source_ref_kind != "workspace_path" or source_ref is None:
+        return None
+    return f"source:{source_ref}"
+
+
+def effective_logical_id(source: SourceRecord) -> str | None:
+    return source.logical_id or logical_source_id_for_ref(source.source_ref, source.source_ref_kind)
+
+
+def effective_aliases(source: SourceRecord) -> list[str]:
+    aliases = list(source.aliases)
+    logical_id = effective_logical_id(source)
+    if logical_id is not None:
+        aliases.append(logical_id)
+    source_ref = canonical_source_ref(source)
+    if source.source_ref_kind == "workspace_path":
+        aliases.append(source_ref)
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for alias in aliases:
+        if alias and alias not in seen:
+            seen.add(alias)
+            deduped.append(alias)
+    return deduped
+
+
 def effective_stored_path(source: SourceRecord) -> str | None:
     if effective_storage_mode(source) != "copy":
         return None

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -17,6 +17,7 @@ from splendor.state.source_compat import (
     canonical_source_ref,
     effective_materialized_path,
     is_legacy_copied_manifest,
+    logical_source_id_for_ref,
 )
 from splendor.state.source_pointer import pointer_artifact_relpath, write_source_pointer
 from splendor.utils.fs import (
@@ -449,6 +450,7 @@ def register_source(
     source_id = stable_source_id(checksum)
     manifest_path = layout.source_records_dir / f"{source_id}.json"
     source_ref, source_ref_kind = _source_reference(root, candidate)
+    logical_id = logical_source_id_for_ref(source_ref, source_ref_kind)
     selected_storage_mode = _storage_mode_for_source(
         source_ref_kind=source_ref_kind,
         config=config,
@@ -502,6 +504,17 @@ def register_source(
             if updated != existing:
                 write_source_record(manifest_path, updated)
                 existing = updated
+        if logical_id is not None and (
+            existing.logical_id is None or source_ref not in existing.aliases
+        ):
+            aliases = sorted({*existing.aliases, source_ref})
+            updated = SourceRecord.model_validate(
+                existing.model_dump(mode="json")
+                | {"logical_id": existing.logical_id or logical_id, "aliases": aliases}
+            )
+            if updated != existing:
+                write_source_record(manifest_path, updated)
+                existing = updated
         return RegisteredSource(
             record=existing,
             manifest_path=manifest_path,
@@ -541,6 +554,8 @@ def register_source(
             stored_path.relative_to(root).as_posix() if stored_path is not None else None
         ),
         materialized_at=(added_at if stored_path is not None else None),
+        logical_id=logical_id,
+        aliases=([source_ref] if logical_id is not None else []),
         source_commit_capture=capture_source_commit,
         source_commit=source_commit,
         source_class=source_class,

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -62,6 +62,8 @@ def test_add_source_registers_workspace_file_without_copy_by_default(tmp_path: P
     assert manifest.storage_mode == "none"
     assert manifest.storage_path is None
     assert manifest.materialized_at is None
+    assert manifest.logical_id == "source:note.md"
+    assert manifest.aliases == ["note.md"]
     assert manifest.source_commit_capture is None
     assert manifest.source_class is None
     assert manifest.source_labels == []
@@ -145,6 +147,8 @@ def test_add_source_stores_workspace_relative_source_ref_for_nested_sources(tmp_
     manifest = load_source_record(result.manifest_path)
     assert result.source_ref == "docs/note.md"
     assert manifest.source_ref == "docs/note.md"
+    assert manifest.logical_id == "source:docs/note.md"
+    assert manifest.aliases == ["docs/note.md"]
     assert manifest.original_path == "docs/note.md"
 
 
@@ -165,6 +169,8 @@ def test_add_source_registers_external_sources_as_copies_by_default(tmp_path: Pa
         assert manifest.source_ref == str(source.resolve())
         assert manifest.source_ref_kind == "external_path"
         assert manifest.storage_mode == "copy"
+        assert manifest.logical_id is None
+        assert manifest.aliases == []
         assert manifest.original_path == str(source)
         assert manifest.materialized_at is not None
     finally:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -375,6 +375,7 @@ def test_cli_source_lookup_maps_readable_path_to_source_id(tmp_path: Path, capsy
     assert "Sources: 1" in out
     assert "Audio Quality Feedback" in out or "audio quality feedback" in out
     assert "docs/audio-quality-feedback.md" in out
+    assert "logical_id=source:docs/audio-quality-feedback.md" in out
     assert out.index("docs/audio-quality-feedback.md") < out.index("source_id=src-")
 
 
@@ -394,6 +395,25 @@ def test_cli_source_list_reports_registered_sources(tmp_path: Path, capsys) -> N
     assert "ref=brief.md" in out
 
 
+def test_cli_source_lookup_matches_stable_logical_id(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "docs" / "brief.md"
+    source.parent.mkdir()
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "source", "lookup", "source:docs/brief.md", "--json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [source["source_id"] for source in payload["sources"]] == [source_id]
+    assert payload["sources"][0]["logical_id"] == "source:docs/brief.md"
+
+
 def test_cli_source_list_json_reports_registered_sources(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     source = tmp_path / "brief.md"
@@ -407,6 +427,8 @@ def test_cli_source_list_json_reports_registered_sources(tmp_path: Path, capsys)
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
     assert [source["source_id"] for source in payload["sources"]] == [source_id]
+    assert payload["sources"][0]["logical_id"] == "source:brief.md"
+    assert payload["sources"][0]["aliases"] == ["brief.md", "source:brief.md"]
     assert payload["sources"][0]["source_ref"] == "brief.md"
 
 
@@ -425,6 +447,8 @@ def test_cli_source_lookup_json_reports_source_payload(tmp_path: Path, capsys) -
     assert payload["sources"] == [
         {
             "source_id": source_id,
+            "logical_id": "source:brief.md",
+            "aliases": ["brief.md", "source:brief.md"],
             "title": "brief",
             "source_type": "md",
             "status": "registered",
@@ -483,6 +507,9 @@ def test_cli_source_refresh_registers_changed_workspace_source_and_queues_it(
     refreshed_id = [path.stem for path in manifests if path.stem != original_id][0]
     assert f"Registered refreshed source ID: {refreshed_id}" in out
     assert (tmp_path / "state" / "queue" / f"ingest-{refreshed_id}.json").exists()
+    records = [load_source_record(path) for path in manifests]
+    assert {record.logical_id for record in records} == {"source:brief.md"}
+    assert {tuple(record.aliases) for record in records} == {("brief.md",)}
 
 
 def test_cli_source_refresh_reports_existing_version_match(tmp_path: Path, capsys) -> None:
@@ -540,7 +567,9 @@ def test_cli_source_refresh_json_reports_queue_handoff(tmp_path: Path, capsys) -
     ]
     assert payload == {
         "requested_source_id": original_id,
+        "requested_logical_id": "source:brief.md",
         "source_id": refreshed_ids[0],
+        "logical_id": "source:brief.md",
         "changed": True,
         "queued": True,
         "queue_path": f"state/queue/ingest-{refreshed_ids[0]}.json",
@@ -744,7 +773,9 @@ def test_cli_source_freshness_reports_changed_workspace_sources_without_mutating
     out = capsys.readouterr().out
     assert "Source freshness preview" in out
     assert "changed=1" in out
-    assert f"- brief.md: changed title=brief source_id={source_id}" in out
+    assert (
+        f"- brief.md: changed title=brief logical_id=source:brief.md source_id={source_id}" in out
+    )
     assert "Manifest checksum:" in out
     assert "Current checksum:" in out
     assert "Next: splendor source refresh brief.md" in out
@@ -1228,6 +1259,22 @@ def test_cli_ingest_command(tmp_path: Path, capsys) -> None:
     assert "Ingested source" in captured.out
     assert "Source ref: brief.md" in captured.out
     assert "Canonical content: workspace path" in captured.out
+
+
+def test_cli_ingest_command_accepts_stable_logical_id(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "docs" / "brief.md"
+    source.parent.mkdir()
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "source:docs/brief.md"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert f"Source ID: {source_id}" in captured.out
+    assert "Source ref: docs/brief.md" in captured.out
 
 
 def test_cli_ingest_command_reports_stored_artifact_for_copied_workspace_source(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1277,6 +1277,20 @@ def test_cli_ingest_command_accepts_stable_logical_id(tmp_path: Path, capsys) ->
     assert "Source ref: docs/brief.md" in captured.out
 
 
+def test_cli_ingest_command_rejects_fuzzy_source_match(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "docs" / "brief.md"
+    source.parent.mkdir()
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "doc"])
+
+    assert exit_code == 1
+    assert "Unknown source: doc" in capsys.readouterr().out
+
+
 def test_cli_ingest_command_reports_stored_artifact_for_copied_workspace_source(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -571,6 +571,57 @@ def test_run_lint_checks_requires_expected_provenance_roles_for_source_summary(
     ]
 
 
+def test_run_lint_checks_rejects_stale_workspace_source_identity(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source_path = tmp_path / "docs" / "brief.md"
+    source_path.parent.mkdir()
+    source_path.write_text("hello\n", encoding="utf-8")
+    added = add_source(tmp_path, source_path)
+    manifest = load_source_record(added.manifest_path)
+    write_source_record(
+        added.manifest_path,
+        manifest.model_copy(
+            update={
+                "logical_id": "source:docs/other.md",
+                "aliases": ["docs/brief.md", "docs/other.md"],
+            }
+        ),
+    )
+
+    result = _run_lint(tmp_path)
+
+    source_identity_issues = {
+        issue.code for issue in result.issues if issue.check_name == "source-identity"
+    }
+    assert source_identity_issues == {
+        "invalid-source-logical-id",
+        "invalid-source-alias",
+    }
+
+
+def test_run_lint_checks_rejects_source_identity_conflicts(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    first_path = tmp_path / "docs" / "first.md"
+    second_path = tmp_path / "docs" / "second.md"
+    first_path.parent.mkdir()
+    first_path.write_text("first\n", encoding="utf-8")
+    second_path.write_text("second\n", encoding="utf-8")
+    first = add_source(tmp_path, first_path)
+    second = add_source(tmp_path, second_path)
+    second_manifest = load_source_record(second.manifest_path)
+    write_source_record(
+        second.manifest_path,
+        second_manifest.model_copy(update={"logical_id": "source:docs/first.md"}),
+    )
+
+    result = _run_lint(tmp_path)
+
+    conflict_records = {
+        issue.record_id for issue in result.issues if issue.code == "conflicting-source-identity"
+    }
+    assert conflict_records == {first.source_id, second.source_id}
+
+
 def test_run_lint_checks_ignores_markdown_target_resolution_errors(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Planning notation

- PR sub-slice: `M14-P1.1`
- Parent planned slice: `M14-P1` Source lifecycle implementation
- Plan source: `.agent-plan.md`, README "What Comes Next", and `docs/splendor_mvp_to_v1_roadmap.md`

## Summary

- Adds schema-version-1-compatible `logical_id` and `aliases` fields to source manifests.
- Persists stable `source:<workspace-path>` logical IDs for workspace-backed sources while preserving content-addressed `src-...` IDs as the compatibility contract for manifests, queue jobs, run provenance, and generated source-summary pages.
- Extends source lookup, source freshness, source refresh JSON/human output, and direct CLI ingest resolution so agents can use stable logical IDs such as `source:docs/brief.md`.
- Hardens mutating ingest resolution so it accepts exact source IDs, exact logical IDs, exact path aliases/source refs, or exact unambiguous titles rather than fuzzy substring matches.
- Adds source-identity lint checks for stale logical IDs, invalid persisted aliases, and identities that conflict across canonical source refs.
- Updates focused tests plus schema/product/roadmap/handoff docs and planning state for `M14-P1.1`.

## Boundaries

This PR intentionally does not implement supersession-aware refresh, full workspace refresh, pruning, topic-ref migration, PR summary output, the deferred mutating compile/update workflow from #79, SQLite, vector search, background workers, or mutating web UI.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest` -> 505 passed
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .` -> passed
- `/Users/shaypalachy/.local/bin/uv run ruff check .` -> passed
- `/Users/shaypalachy/.local/bin/uv run splendor lint` -> passed

## Issue linkage

Refs #72. Keeps #79 out of scope.
