### PR TITLE
M14-P1.2: Add supersession-aware source refresh

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M14-P0.1`
-- Last action taken: `M14-P0.1` is implemented; the post-v1 source-lifecycle and workflow retry sequence is documented.
+- Previous completed PR sub-slice: `M14-P1.1`
+- Last action taken: `M14-P1.1` is implemented; stable logical source identities now sit above content-addressed source IDs for workspace-backed sources.
 - Current planned slice: `M14-P1`
-- Current PR sub-slice: `M14-P1.1`
+- Current PR sub-slice: `M14-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M14-P1`
-- Next planned PR sub-slice: `M14-P1.2`
+- Next planned PR sub-slice: `M14-P1.3`
 - Current blockers: none
 
 ## Planning Notation
@@ -226,6 +226,11 @@
   - [x] Preserve content-addressed `src-...` IDs as canonical manifest, queue, run, and source-summary identifiers
   - [x] Expose logical IDs and aliases in source lookup, freshness, and refresh handoff output
   - [x] Keep supersession-aware refresh, workspace refresh, pruning, topic-ref migration, PR summary, and mutating compile/update deferred
+- [x] Implement `M14-P1.2`: Supersession-aware source refresh
+  - [x] Link changed workspace-backed source versions with `supersedes` and `superseded_by`
+  - [x] Keep content-addressed `src-...` IDs as immutable version IDs
+  - [x] Let health treat superseded source versions as historical records without breaking old run/page provenance
+  - [x] Keep full workspace refresh, pruning, topic-ref migration, PR summary, and mutating compile/update deferred
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -178,12 +178,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M14-P0.1`
+- Previous completed PR sub-slice: `M14-P1.1`
 - Current planned slice: `M14-P1`
-- Current PR sub-slice: `M14-P1.1`
+- Current PR sub-slice: `M14-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M14-P1`
-- Next planned PR sub-slice: `M14-P1.2`
+- Next planned PR sub-slice: `M14-P1.3`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -278,9 +278,15 @@ Issue #79 tracks the deferred mutating compile/update path from #41.
 
 `M14-P1.1` adds the first stable logical source identity layer above content-addressed source IDs:
 workspace-backed manifests now persist `source:<workspace-path>` logical IDs and path aliases while
-keeping `src-...` IDs as the compatibility contract. Supersession-aware refresh, safe workspace
-refresh, pruning/topic-ref migration, and PR-oriented generated-state summary/review handoff remain
-later slices before the SynthBanshee Claude retry.
+keeping `src-...` IDs as the compatibility contract. Safe workspace refresh, pruning/topic-ref
+migration, and PR-oriented generated-state summary/review handoff remain later slices before the
+SynthBanshee Claude retry.
+
+`M14-P1.2` makes source refresh supersession-aware: changed workspace-backed sources keep their
+stable logical ID, register a new content-addressed `src-...` version, and link the previous and
+current versions with `supersedes` / `superseded_by`. Health treats superseded workspace source
+versions as historical provenance instead of active current-byte targets. Full workspace refresh,
+pruning/topic-ref migration, and PR-summary support remain later slices before the retry.
 
 ### v1 readiness checklist
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -82,6 +82,8 @@ Implemented fields:
 - `materialized_at`
 - `logical_id`
 - `aliases`
+- `supersedes`
+- `superseded_by`
 - `source_commit`
 - `source_class`
 - `source_labels`
@@ -131,6 +133,14 @@ Implemented fields:
   - Workspace-backed registrations include the repo-relative path alias, and lookup/freshness JSON
     also exposes the effective logical ID as an alias for agent handoff.
   - External and legacy manifests may leave this empty.
+- `supersedes`
+  - Source version IDs this record supersedes.
+  - Refresh writes the previous active content-addressed `src-...` ID here when a changed
+    workspace-backed source creates a new source version.
+- `superseded_by`
+  - Source version ID that replaced this record for the same logical source.
+  - Health treats superseded workspace-backed records as historical version records instead of
+    active current-byte targets, so old run/page provenance remains valid after refresh.
 - `source_commit_capture`
   - Nullable persisted intent for git provenance capture:
     - `true` means commit capture was explicitly requested for registration and refresh
@@ -169,10 +179,11 @@ Implemented fields:
 - Mutating source commands resolve source selectors strictly. Direct ingest accepts exact source
   IDs, exact logical IDs, exact path aliases/source refs, or exact unambiguous titles; substring
   matches remain limited to read-only lookup surfaces.
-- `splendor source refresh <source-id|title|path>` resolves the tracked workspace or external path,
-  compares current bytes to the manifest checksum, registers changed content as a new canonical
-  source version, preserves `source_commit_capture` intent, and queues ingest through the same queue
-  handoff used by `add-source`.
+- `splendor source refresh <source-id|logical-id|title|path>` resolves the tracked workspace or
+  external path, compares current bytes to the manifest checksum, registers changed content as a
+  new canonical source version, preserves `source_commit_capture` intent, links the old and new
+  versions with `supersedes` / `superseded_by`, and queues ingest through the same queue handoff
+  used by `add-source`.
 - `splendor source freshness` is a non-mutating preview over curated source manifests. It reports
   path-first freshness state for workspace-backed canonical source refs, including unchanged,
   changed, missing, and unsupported statuses, manifest/current checksums where available, source
@@ -237,9 +248,11 @@ In this release:
 - copied sources still use `path` as the stored artifact path
 - workspace-backed sources temporarily mirror `source_ref` into `path`
 - no automatic manifest rewrite or schema-version bump is performed yet
-- source IDs remain content-addressed canonical IDs; stable logical source aliases,
-  `supersedes`/`superseded_by` source fields, automated pruning of superseded source summaries, and
-  topic-ref migration are not part of the current schema contract
+- source IDs remain content-addressed canonical IDs; stable logical source aliases and
+  `supersedes`/`superseded_by` lifecycle fields now describe workspace-backed refresh history
+  without changing schema version `1`
+- automated pruning of superseded source summaries and topic-ref migration are not part of the
+  current schema contract
 
 ## Knowledge page frontmatter
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M14-P0.1`
+- Previous completed PR sub-slice: `M14-P1.1`
 - Current planned slice: `M14-P1`
-- Current PR sub-slice: `M14-P1.1`
+- Current PR sub-slice: `M14-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M14-P1`
-- Next planned PR sub-slice: `M14-P1.2`
+- Next planned PR sub-slice: `M14-P1.3`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -896,8 +896,8 @@ post-#72 lifecycle loop is substantially implemented. The intended sequence befo
    compatibility. The first implementation persists `source:<workspace-path>` logical IDs and
    aliases for workspace-backed source manifests without changing `src-...` manifest IDs,
    generated source-summary page IDs, queue IDs, or run provenance.
-3. `M14-P1.2` makes source refresh supersession-aware, so changed sources do not leave stale runs,
-   topic refs, or health failures for agents to clean manually.
+3. `M14-P1.2` makes source refresh supersession-aware, so changed sources do not leave stale runs
+   or health failures for agents to clean manually before later topic-ref migration.
 4. `M14-P1.3` provides one safe workspace refresh path for changed-source detection, refresh,
    ingest, index rebuild, and a health-clean end state.
 5. `M14-P1.4` handles superseded generated-state pruning and topic-ref migration.

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -773,8 +773,10 @@ Current implementation:
   current bytes as a new canonical source version when the checksum changed, and queues ingest via
   the existing queue ledger while preserving active-lease and dead-letter protections.
   Stable logical source identities now remain constant for workspace-backed source paths across
-  those content-addressed versions. Explicit source supersession fields, automated historical
-  pruning, safe full-workspace refresh, and topic-ref migration remain later lifecycle work.
+  those content-addressed versions. Refresh also links changed versions with `supersedes` and
+  `superseded_by` so health treats older workspace-backed manifests as historical records instead
+  of active current-byte targets. Automated historical pruning, safe full-workspace refresh, and
+  topic-ref migration remain later lifecycle work.
 - `splendor add-topic "Title"` scaffolds a maintained topic page under `wiki/topics/<slug>.md`
   with valid knowledge-page frontmatter, optional tags/source refs, and deterministic markdown
   templates for default synthesis, research synthesis, and issue tracking.
@@ -843,10 +845,11 @@ Release-readiness boundary:
 - generated source-summary pages, queue records, run records, derived artifacts, and explicit
   reports are committed when they explain a reviewed workspace update; failed or exploratory local
   reports can remain local.
-- issue #72's desired stable logical source identity layer has started with workspace-backed
-  `source:<path>` aliases. `supersedes`/`superseded_by` source lifecycle, one-command workspace
-  refresh, superseded-state pruning, and `pr-summary` surface remain post-v1 follow-ups unless a
-  future roadmap slice explicitly pulls them forward.
+- issue #72's desired stable logical source identity and source-supersession layers have started
+  with workspace-backed `source:<path>` aliases plus `supersedes`/`superseded_by` source-version
+  links. One-command workspace refresh, superseded-state pruning/topic-ref migration, and the
+  `pr-summary` surface remain follow-ups unless a future roadmap slice explicitly pulls them
+  forward.
 - issue #79 tracks the deferred mutating compile/update workflow from #41; v1 ships briefing and
   the non-mutating compile contract only.
 - `docs/v1_release_handoff.md` is the v1 handoff checklist for final validation, GitHub metadata,

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -54,9 +54,6 @@ For this handoff:
 
 These items are intentionally not v1 release blockers:
 
-- supersession-aware lifecycle use of the stable logical source identities above content-addressed
-  source IDs
-- `supersedes` / `superseded_by` source lifecycle semantics
 - one-command full workspace refresh
 - superseded generated-state pruning and topic-ref migration
 - `splendor pr-summary --since main`
@@ -70,10 +67,10 @@ These items are intentionally not v1 release blockers:
 
 The conservative next queue is:
 
-1. Continue #72 implementation after the initial workspace-backed `source:<path>` logical ID layer,
-   beginning with supersession-aware source refresh.
-2. Add the smallest source lifecycle slice that keeps `source freshness`, `source refresh`, topic
-   refs, runs, and health checks coherent without breaking schema version `1` compatibility.
+1. Continue #72 implementation after the workspace-backed `source:<path>` logical ID layer and
+   supersession-aware source refresh.
+2. Add the smallest full-workspace refresh slice that keeps changed-source detection, refresh,
+   ingest, index rebuild, and health coherent without breaking schema version `1` compatibility.
 3. Add `splendor pr-summary --since main` only after source lifecycle churn is explicit enough to
    summarize reliably.
 4. Keep #79 as the tracked post-v1 compile/update workflow rather than reopening #41 for deferred
@@ -87,8 +84,8 @@ bundle is:
 
 1. `M14-P0.1` Split #72 into child issues and assign release metadata.
 2. `M14-P1.1` Stable logical source identities above content-addressed source IDs.
-3. `M14-P1.2` Supersession-aware source refresh, so changed files do not leave stale runs, topic
-   refs, or health failures for agents to clean manually.
+3. `M14-P1.2` Supersession-aware source refresh, so changed files do not leave stale runs or
+   health failures for agents to clean manually.
 4. `M14-P1.3` Safe workspace refresh path covering changed-source detection, refresh, ingest,
    index rebuild, and a health-clean end state.
 5. `M14-P1.4` Superseded generated-state pruning and topic-ref migration.

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -885,6 +885,10 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
                 print(f"Matched existing source version: {result.refreshed.record.source_id}")
             else:
                 print(f"Registered refreshed source ID: {result.refreshed.record.source_id}")
+            print(
+                "Superseded previous source version: "
+                f"{result.requested.source_id} -> {result.refreshed.record.source_id}"
+            )
     else:
         print(f"No source content change detected for {canonical_source_ref(result.requested)}")
         print(f"Source ID: {result.requested.source_id}")
@@ -892,6 +896,10 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
     logical_id = effective_logical_id(result.refreshed.record)
     if logical_id is not None:
         print(f"Logical ID: {logical_id}")
+    if result.refreshed.record.supersedes:
+        print(f"Supersedes: {', '.join(result.refreshed.record.supersedes)}")
+    if result.refreshed.record.superseded_by is not None:
+        print(f"Superseded by: {result.refreshed.record.superseded_by}")
     if result.queued and result.queue_path is not None:
         print(f"Queued ingest: {result.queue_path}")
         print("Next: splendor ingest --pending")

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -48,6 +48,14 @@ def _validate_storage_policy(source: SourceRecord) -> None:
         raise ValueError("Copied source is missing path")
 
 
+def _should_resolve_source_content(source: SourceRecord) -> bool:
+    if source.superseded_by is None:
+        return True
+    return not (
+        source.source_ref_kind == "workspace_path" and effective_storage_mode(source) == "none"
+    )
+
+
 def _append_issue(
     issues: list[MaintenanceIssue],
     *,
@@ -118,7 +126,8 @@ def _load_source_records(
         try:
             source = load_source_record(manifest_path)
             _validate_storage_policy(source)
-            resolve_source_content(root, source, layout.raw_sources_dir)
+            if _should_resolve_source_content(source):
+                resolve_source_content(root, source, layout.raw_sources_dir)
         except Exception as exc:
             invalid_ids.add(source_id)
             _append_issue(

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -270,10 +270,12 @@ def _run_reference_integrity_checks(
         planning_by_kind[record.kind].setdefault(record.record_id, []).append(record)
 
     source_by_id: dict[str, list[_SourceInventory]] = {}
+    source_by_ref: dict[str, list[_SourceInventory]] = {}
     for manifest in inventory.source_manifests:
         if manifest.record is None:
             continue
         source_by_id.setdefault(manifest.record.source_id, []).append(manifest)
+        source_by_ref.setdefault(canonical_source_ref(manifest.record), []).append(manifest)
     source_refs_by_identity: dict[str, set[str]] = {}
     for manifest in inventory.source_manifests:
         if manifest.record is None:
@@ -403,6 +405,10 @@ def _run_reference_integrity_checks(
             continue
         checked_count += 1 + len(manifest.record.aliases)
         issues.extend(_source_identity_issues(root, manifest, source_refs_by_identity))
+        checked_count += len(manifest.record.supersedes) + (
+            1 if manifest.record.superseded_by is not None else 0
+        )
+        issues.extend(_source_lifecycle_issues(root, manifest, source_by_id, source_by_ref))
         checked_count += len(manifest.record.derived_artifacts)
         issues.extend(_derived_artifact_issues(root, layout, manifest))
         checked_count += len(manifest.record.linked_pages)
@@ -494,6 +500,128 @@ def _source_identity_issues(
             )
         )
     return issues
+
+
+def _source_lifecycle_issues(
+    root: Path,
+    manifest: _SourceInventory,
+    source_by_id: dict[str, list[_SourceInventory]],
+    source_by_ref: dict[str, list[_SourceInventory]],
+) -> list[MaintenanceIssue]:
+    if manifest.record is None:
+        return []
+    source = manifest.record
+    manifest_relpath = workspace_relative_path(root, manifest.manifest_path)
+    issues: list[MaintenanceIssue] = []
+    active_versions = [
+        ref_manifest.record
+        for ref_manifest in source_by_ref.get(canonical_source_ref(source), [])
+        if ref_manifest.record is not None and ref_manifest.record.superseded_by is None
+    ]
+    if source.superseded_by is None and len(active_versions) > 1:
+        issues.append(
+            MaintenanceIssue(
+                code="multiple-active-source-versions",
+                message=(
+                    "Multiple active source versions share the same canonical source ref: "
+                    f"{canonical_source_ref(source)}"
+                ),
+                path=manifest_relpath,
+                record_id=source.source_id,
+                check_name="source-lifecycle",
+            )
+        )
+
+    for superseded_id in source.supersedes:
+        target = _single_source_record(source_by_id, superseded_id)
+        if target is None:
+            issues.append(
+                MaintenanceIssue(
+                    code="missing-source-supersedes-ref",
+                    message=f"Source supersedes unknown source: {superseded_id}",
+                    path=manifest_relpath,
+                    record_id=source.source_id,
+                    check_name="source-lifecycle",
+                )
+            )
+            continue
+        if canonical_source_ref(target) != canonical_source_ref(source):
+            issues.append(
+                MaintenanceIssue(
+                    code="invalid-source-supersession-ref",
+                    message=(
+                        f"Source supersedes a different canonical source ref: {superseded_id}"
+                    ),
+                    path=manifest_relpath,
+                    record_id=source.source_id,
+                    check_name="source-lifecycle",
+                )
+            )
+        if target.superseded_by != source.source_id:
+            issues.append(
+                MaintenanceIssue(
+                    code="invalid-source-supersession-link",
+                    message=(
+                        "Source supersedes a record that does not point back with "
+                        f"superseded_by: {superseded_id}"
+                    ),
+                    path=manifest_relpath,
+                    record_id=source.source_id,
+                    check_name="source-lifecycle",
+                )
+            )
+
+    if source.superseded_by is None:
+        return issues
+
+    successor = _single_source_record(source_by_id, source.superseded_by)
+    if successor is None:
+        issues.append(
+            MaintenanceIssue(
+                code="missing-source-superseded-by-ref",
+                message=f"Source superseded_by references unknown source: {source.superseded_by}",
+                path=manifest_relpath,
+                record_id=source.source_id,
+                check_name="source-lifecycle",
+            )
+        )
+        return issues
+    if canonical_source_ref(successor) != canonical_source_ref(source):
+        issues.append(
+            MaintenanceIssue(
+                code="invalid-source-supersession-ref",
+                message=(
+                    "Source superseded_by points at a different canonical source ref: "
+                    f"{source.superseded_by}"
+                ),
+                path=manifest_relpath,
+                record_id=source.source_id,
+                check_name="source-lifecycle",
+            )
+        )
+    if source.source_id not in successor.supersedes:
+        issues.append(
+            MaintenanceIssue(
+                code="invalid-source-supersession-link",
+                message=(
+                    "Source superseded_by points at a record that does not include this source in "
+                    f"supersedes: {source.superseded_by}"
+                ),
+                path=manifest_relpath,
+                record_id=source.source_id,
+                check_name="source-lifecycle",
+            )
+        )
+    return issues
+
+
+def _single_source_record(
+    source_by_id: dict[str, list[_SourceInventory]], source_id: str
+) -> SourceRecord | None:
+    matches = source_by_id.get(source_id, [])
+    if len(matches) != 1:
+        return None
+    return matches[0].record
 
 
 def _derived_artifact_issues(

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -25,6 +25,7 @@ from splendor.state.source_registry import (
     load_source_record,
     register_source,
     resolve_manifest_storage_path,
+    write_source_record,
 )
 from splendor.utils.hashing import sha256_file
 
@@ -225,6 +226,10 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
             source_labels=requested.source_labels,
             discovered_by=requested.discovered_by,
         )
+        refreshed = _record_source_supersession(
+            requested_match=requested_match,
+            refreshed=refreshed,
+        )
     else:
         refreshed = RegisteredSource(
             record=requested,
@@ -288,6 +293,41 @@ def _existing_materialized_path(root: Path, source: SourceRecord) -> Path | None
     return resolve_manifest_storage_path(root, stored_path_value)
 
 
+def _record_source_supersession(
+    *,
+    requested_match: SourceLookupResult,
+    refreshed: RegisteredSource,
+) -> RegisteredSource:
+    requested = requested_match.source
+    current = refreshed.record
+    if current.source_id == requested.source_id:
+        return refreshed
+
+    if requested.superseded_by != current.source_id:
+        updated_requested = SourceRecord.model_validate(
+            requested.model_dump(mode="json") | {"superseded_by": current.source_id}
+        )
+        write_source_record(requested_match.manifest_path, updated_requested)
+
+    current_supersedes = list(current.supersedes)
+    if requested.source_id not in current_supersedes:
+        current_supersedes.append(requested.source_id)
+
+    updated_current_fields: dict[str, object] = {}
+    if current.superseded_by is not None:
+        updated_current_fields["superseded_by"] = None
+    if current_supersedes != current.supersedes:
+        updated_current_fields["supersedes"] = current_supersedes
+    if not updated_current_fields:
+        return refreshed
+
+    updated_current = SourceRecord.model_validate(
+        current.model_dump(mode="json") | updated_current_fields
+    )
+    write_source_record(refreshed.manifest_path, updated_current)
+    return replace(refreshed, record=updated_current)
+
+
 def render_source_lookup_json(root: Path, results: list[SourceLookupResult]) -> str:
     return json.dumps(
         {"sources": [_source_payload(root, result) for result in results]},
@@ -302,6 +342,14 @@ def render_source_refresh_json(root: Path, result: SourceRefreshResult) -> str:
             "requested_logical_id": effective_logical_id(result.requested),
             "source_id": result.refreshed.record.source_id,
             "logical_id": effective_logical_id(result.refreshed.record),
+            "supersedes": result.refreshed.record.supersedes,
+            "superseded_by": result.refreshed.record.superseded_by,
+            "requested_superseded_by": (
+                result.refreshed.record.source_id
+                if result.changed
+                and result.refreshed.record.source_id != result.requested.source_id
+                else result.requested.superseded_by
+            ),
             "changed": result.changed,
             "queued": result.queued,
             "queue_path": (
@@ -450,12 +498,13 @@ def _workspace_freshness_items(
 
     layout = resolve_layout(root, load_config(root))
     current_checksum = sha256_file(source_path)
-    latest_result = max(results, key=_latest_source_sort_key)
+    active_results = [result for result in results if result.source.superseded_by is None]
+    latest_result = max(active_results or results, key=_latest_source_sort_key)
 
     items = []
     for result in results:
         source = result.source
-        if source.source_id != latest_result.source.source_id:
+        if source.superseded_by is not None or source.source_id != latest_result.source.source_id:
             items.append(
                 SourceFreshnessItem(
                     source=source,
@@ -465,8 +514,8 @@ def _workspace_freshness_items(
                     manifest_checksum=source.checksum,
                     current_checksum=current_checksum,
                     message=(
-                        "older source version for this workspace path; "
-                        "latest manifest is freshness target"
+                        "superseded source version for this workspace path; "
+                        "active manifest is freshness target"
                     ),
                     next_commands=[],
                 )
@@ -536,6 +585,8 @@ def _freshness_payload(root: Path, item: SourceFreshnessItem) -> dict[str, objec
         "source_id": source.source_id,
         "logical_id": effective_logical_id(source),
         "aliases": effective_aliases(source),
+        "supersedes": source.supersedes,
+        "superseded_by": source.superseded_by,
         "title": source.title,
         "source_ref": canonical_source_ref(source),
         "source_ref_kind": source.source_ref_kind,
@@ -556,6 +607,8 @@ def _source_payload(root: Path, result: SourceLookupResult) -> dict[str, object]
         "title": source.title,
         "source_type": source.source_type,
         "status": source.status,
+        "supersedes": source.supersedes,
+        "superseded_by": source.superseded_by,
         "source_ref": canonical_source_ref(source),
         "source_ref_kind": source.source_ref_kind,
         "original_path": source.original_path,

--- a/src/splendor/schemas/source.py
+++ b/src/splendor/schemas/source.py
@@ -50,6 +50,8 @@ class SourceRecord(StrictRecord):
     materialized_at: str | None = None
     logical_id: str | None = None
     aliases: list[str] = Field(default_factory=list)
+    supersedes: list[str] = Field(default_factory=list)
+    superseded_by: str | None = None
     source_commit_capture: bool | None = None
     source_commit: str | None = None
     source_class: SourceClass | None = None

--- a/src/splendor/state/source_compat.py
+++ b/src/splendor/state/source_compat.py
@@ -48,6 +48,10 @@ def effective_aliases(source: SourceRecord) -> list[str]:
     return deduped
 
 
+def is_superseded_source(source: SourceRecord) -> bool:
+    return source.superseded_by is not None
+
+
 def effective_stored_path(source: SourceRecord) -> str | None:
     if effective_storage_mode(source) != "copy":
         return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -452,6 +452,8 @@ def test_cli_source_lookup_json_reports_source_payload(tmp_path: Path, capsys) -
             "title": "brief",
             "source_type": "md",
             "status": "registered",
+            "supersedes": [],
+            "superseded_by": None,
             "source_ref": "brief.md",
             "source_ref_kind": "workspace_path",
             "original_path": "brief.md",
@@ -510,6 +512,10 @@ def test_cli_source_refresh_registers_changed_workspace_source_and_queues_it(
     records = [load_source_record(path) for path in manifests]
     assert {record.logical_id for record in records} == {"source:brief.md"}
     assert {tuple(record.aliases) for record in records} == {("brief.md",)}
+    records_by_id = {record.source_id: record for record in records}
+    assert records_by_id[original_id].superseded_by == refreshed_id
+    assert records_by_id[refreshed_id].supersedes == [original_id]
+    assert records_by_id[refreshed_id].superseded_by is None
 
 
 def test_cli_source_refresh_reports_existing_version_match(tmp_path: Path, capsys) -> None:
@@ -529,6 +535,14 @@ def test_cli_source_refresh_reports_existing_version_match(tmp_path: Path, capsy
     out = capsys.readouterr().out
     assert f"Matched existing source version: {original_id}" in out
     assert f"Registered refreshed source {original_id}" not in out
+    records = {
+        load_source_record(path).source_id: load_source_record(path)
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+    }
+    refreshed_id = next(source_id for source_id in records if source_id != original_id)
+    assert records[refreshed_id].superseded_by == original_id
+    assert records[original_id].supersedes == [refreshed_id]
+    assert records[original_id].superseded_by is None
 
 
 def test_source_refresh_noop_returns_existing_materialized_path(tmp_path: Path, capsys) -> None:
@@ -570,6 +584,9 @@ def test_cli_source_refresh_json_reports_queue_handoff(tmp_path: Path, capsys) -
         "requested_logical_id": "source:brief.md",
         "source_id": refreshed_ids[0],
         "logical_id": "source:brief.md",
+        "supersedes": [original_id],
+        "superseded_by": None,
+        "requested_superseded_by": refreshed_ids[0],
         "changed": True,
         "queued": True,
         "queue_path": f"state/queue/ingest-{refreshed_ids[0]}.json",

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -63,6 +63,48 @@ def test_run_health_checks_accepts_ocr_derived_artifact_links(tmp_path: Path) ->
     assert result.issues == []
 
 
+def test_run_health_checks_accepts_superseded_workspace_source_versions(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    refreshed = add_source(tmp_path, source)
+    original = load_source_record(added.manifest_path).model_copy(
+        update={"superseded_by": refreshed.source_id}
+    )
+    updated = load_source_record(refreshed.manifest_path).model_copy(
+        update={"supersedes": [added.source_id]}
+    )
+    write_source_record(added.manifest_path, original)
+    write_source_record(refreshed.manifest_path, updated)
+
+    result = _run_health(tmp_path)
+
+    assert result.issues == []
+
+
+def test_run_health_checks_still_validates_superseded_copied_source_artifacts(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="copy")
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={"superseded_by": "src-next"}
+    )
+    write_source_record(added.manifest_path, source_record)
+    assert added.stored_path is not None
+    added.stored_path.unlink()
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["source-health-check-failed"]
+
+
 def test_run_health_checks_reports_invalid_queue_and_run_records(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     (tmp_path / "state" / "queue" / "ingest-bad.json").write_text("{bad json}\n", encoding="utf-8")

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -265,6 +265,75 @@ def test_run_lint_checks_accepts_ocr_derived_artifact_links(tmp_path: Path) -> N
     assert result.issues == []
 
 
+def test_run_lint_checks_validates_source_supersession_refs(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    refreshed = add_source(tmp_path, source)
+    original = load_source_record(added.manifest_path).model_copy(
+        update={"superseded_by": refreshed.source_id}
+    )
+    updated = load_source_record(refreshed.manifest_path).model_copy(
+        update={"supersedes": [added.source_id]}
+    )
+    write_source_record(added.manifest_path, original)
+    write_source_record(refreshed.manifest_path, updated)
+
+    result = _run_lint(tmp_path)
+
+    assert result.issues == []
+
+
+def test_run_lint_checks_reports_broken_source_supersession_refs(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={"supersedes": ["src-missing"], "superseded_by": "src-also-missing"}
+    )
+    write_source_record(added.manifest_path, source_record)
+
+    result = _run_lint(tmp_path)
+
+    assert {issue.code for issue in result.issues} == {
+        "missing-source-superseded-by-ref",
+        "missing-source-supersedes-ref",
+    }
+
+
+def test_run_lint_checks_reports_one_way_source_supersession_refs(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    refreshed = add_source(tmp_path, source)
+    original = load_source_record(added.manifest_path).model_copy(
+        update={"superseded_by": refreshed.source_id}
+    )
+    write_source_record(added.manifest_path, original)
+
+    result = _run_lint(tmp_path)
+
+    assert any(issue.code == "invalid-source-supersession-link" for issue in result.issues)
+
+
+def test_run_lint_checks_reports_multiple_active_source_versions(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    add_source(tmp_path, source)
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    add_source(tmp_path, source)
+
+    result = _run_lint(tmp_path)
+
+    assert any(issue.code == "multiple-active-source-versions" for issue in result.issues)
+
+
 def test_run_lint_checks_reports_missing_wiki_refs_and_related_pages(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     _write_wiki_page(


### PR DESCRIPTION
## Summary

Implements `M14-P1.2` under the `M14-P1` source lifecycle sequence for #72.

- Add schema-v1-compatible source lifecycle fields, `supersedes` and `superseded_by`, while preserving content-addressed `src-...` source IDs as immutable version IDs.
- Make `splendor source refresh <source-id|logical-id|title|path>` link changed workspace-backed source versions through those lifecycle fields and surface the links in human and JSON output.
- Keep `source freshness` focused on the active source version for a workspace path while reporting superseded versions as historical.
- Teach `health` to treat superseded workspace source manifests as historical provenance rather than active current-byte targets, so older runs/pages remain valid after refresh.
- Add lint validation for broken source supersession links.
- Update schema/product/roadmap/release-handoff docs and synchronized planning state for `M14-P1.2`.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`

## Scope Notes

This intentionally does not implement full workspace refresh, pruning, topic-ref migration, PR-summary output, mutating compile/update workflow (#79), ingest run-duration fixes (#47), repo-scan registration optimization (#30), or web document-list scaling (#37). Those remain separate follow-ups in the M14/post-v1 queue.

Advances #72.
