### PR TITLE
M14-P1.3 Safe workspace refresh path

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M14-P1.1`
-- Last action taken: `M14-P1.1` is implemented; stable logical source identities now sit above content-addressed source IDs for workspace-backed sources.
+- Previous completed PR sub-slice: `M14-P1.2`
+- Last action taken: `M14-P1.2` is implemented; source refresh now links workspace-backed source versions with `supersedes` / `superseded_by`.
 - Current planned slice: `M14-P1`
-- Current PR sub-slice: `M14-P1.2`
+- Current PR sub-slice: `M14-P1.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M14-P1`
-- Next planned PR sub-slice: `M14-P1.3`
+- Next planned PR sub-slice: `M14-P1.4`
 - Current blockers: none
 
 ## Planning Notation
@@ -231,6 +231,12 @@
   - [x] Keep content-addressed `src-...` IDs as immutable version IDs
   - [x] Let health treat superseded source versions as historical records without breaking old run/page provenance
   - [x] Keep full workspace refresh, pruning, topic-ref migration, PR summary, and mutating compile/update deferred
+- [x] Implement `M14-P1.3`: Safe workspace refresh path
+  - [x] Add `splendor workspace refresh --changed` over curated workspace-backed source manifests
+  - [x] Compose existing freshness detection with supersession-aware source refresh
+  - [x] Optionally ingest only refreshed sources' queue jobs with `--ingest`
+  - [x] Optionally rebuild `wiki/index.md` after successful ingest with `--rebuild-index`
+  - [x] Keep pruning, topic-ref migration, PR summary, broad discovery, and mutating compile/update deferred
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Implemented today:
   `splendor add-source --dir path`
 - `splendor source list`, `splendor source lookup [query]`, `splendor source freshness`, and
   `splendor source refresh <source-id|title|path>`
+- `splendor workspace refresh --changed` with optional `--ingest` and `--rebuild-index`
 - `splendor ingest <source-id>` and `splendor ingest --pending`
 - `splendor queue inspect [job-id]` and `splendor queue retry <job-id>`
 - `splendor repair ingest <source-id>`
@@ -139,8 +140,7 @@ Not implemented yet:
 - mutating review-gated `splendor wiki compile`
 - heavyweight OCR/image extraction providers
 - mutating web UI actions such as add-source forms
-- stable logical source identities and supersession-aware pruning
-- one-command full workspace refresh for changed sources
+- supersession-aware pruning and topic-ref migration
 - PR-oriented generated-state summaries such as `splendor pr-summary --since main`
 
 `splendor repo scan` is safe by default: it previews candidates without writing manifests or
@@ -150,6 +150,12 @@ source files to their manifest checksums, reports unchanged/changed/missing/unsu
 and prints exact `source refresh`/`ingest --pending` next commands for stale paths. `--json` emits
 the same preview for machine handoff, and `--report PATH` writes only an explicit freshness report.
 Relative report paths use the current working directory.
+`splendor workspace refresh --changed` composes that freshness view with the existing
+supersession-aware refresh path for changed curated workspace-backed sources. Add `--ingest` to
+ingest only queue jobs created or reused for the refreshed sources, and add `--rebuild-index` to
+regenerate `wiki/index.md` after that targeted ingest succeeds. JSON output reports both initial
+and final freshness counts. The command does not discover or register uncurated files, prune
+superseded generated state, migrate topic refs, or mutate maintained synthesis pages.
 
 Generated source-summary pages are deterministic ingestion artifacts. For readable in-repo
 markdown/text/code sources, Splendor defaults to concise claim-bearing excerpts and path-first
@@ -178,12 +184,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M14-P1.1`
+- Previous completed PR sub-slice: `M14-P1.2`
 - Current planned slice: `M14-P1`
-- Current PR sub-slice: `M14-P1.2`
+- Current PR sub-slice: `M14-P1.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M14-P1`
-- Next planned PR sub-slice: `M14-P1.3`
+- Next planned PR sub-slice: `M14-P1.4`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -272,8 +278,9 @@ ingest handoff, #44's query snippets, #45's web status/source detail pages, and 
 visibility as represented in current behavior. It still calls out #41's mutating compile/update
 workflow as deferred. Issue #47 remains an ingest/run-state timing follow-up. Issues #30 and #37
 remain post-v1 performance work. Issue #70 is closed after the M13-P2/M13-P3.1 response. Issue #72
-stays open as the parent feedback loop for stable logical source identities, supersession
-lifecycle, full workspace refresh, pruning, and PR-summary ideas deferred to post-v1 planning.
+stays open as the parent feedback loop; stable logical source identities, supersession lifecycle,
+and safe workspace refresh have landed, while pruning, topic-ref migration, and PR-summary ideas
+remain post-v1 planning work.
 Issue #79 tracks the deferred mutating compile/update path from #41.
 
 `M14-P1.1` adds the first stable logical source identity layer above content-addressed source IDs:
@@ -285,8 +292,13 @@ SynthBanshee Claude retry.
 `M14-P1.2` makes source refresh supersession-aware: changed workspace-backed sources keep their
 stable logical ID, register a new content-addressed `src-...` version, and link the previous and
 current versions with `supersedes` / `superseded_by`. Health treats superseded workspace source
-versions as historical provenance instead of active current-byte targets. Full workspace refresh,
-pruning/topic-ref migration, and PR-summary support remain later slices before the retry.
+versions as historical provenance instead of active current-byte targets.
+
+`M14-P1.3` adds the safe workspace refresh path:
+`splendor workspace refresh --changed --ingest --rebuild-index` detects changed curated
+workspace-backed sources, refreshes them through the supersession-aware source lifecycle, drains
+only the refreshed sources' ingest jobs, and rebuilds the wiki index. Pruning/topic-ref migration
+and PR-summary support remain later slices before the retry.
 
 ### v1 readiness checklist
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -195,6 +195,16 @@ Implemented fields:
   artifacts, queue records, run records, or reports.
 - Refresh uses the queue ledger directly, so active leases remain protected and dead-lettered jobs
   still require `splendor queue retry <job-id>` or `splendor repair ingest <source-id>`.
+- `splendor workspace refresh --changed` is the safe workspace-level mutating path over curated
+  workspace-backed source manifests. It uses `source freshness` to select changed active manifests,
+  refuses to continue when active curated workspace sources are missing, refreshes each changed
+  source through the supersession-aware source refresh path, and can ingest only the queue records
+  created or reused for those refreshed sources with `--ingest`.
+- `splendor workspace refresh --changed --ingest --rebuild-index` rebuilds `wiki/index.md` only
+  after the targeted refreshed-source ingest succeeds. JSON output reports both initial and final
+  freshness counts. The command does not perform broad repo discovery,
+  register uncurated files, prune superseded generated state, migrate topic refs, or run mutating
+  synthesis compile/update workflows.
 - `splendor suggest-next [goal]` is a read-only handoff view over existing deterministic state. It
   does not create planning records, queue jobs, manifests, wiki pages, run records, or reports.
   Human output is path-first where possible; `--json` emits ranked action objects with category,
@@ -253,6 +263,8 @@ In this release:
   without changing schema version `1`
 - automated pruning of superseded source summaries and topic-ref migration are not part of the
   current schema contract
+- safe workspace refresh composes existing source, queue, ingest, and wiki-index records without
+  changing schema version `1`
 
 ## Knowledge page frontmatter
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M14-P1.1`
+- Previous completed PR sub-slice: `M14-P1.2`
 - Current planned slice: `M14-P1`
-- Current PR sub-slice: `M14-P1.2`
+- Current PR sub-slice: `M14-P1.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M14-P1`
-- Next planned PR sub-slice: `M14-P1.3`
+- Next planned PR sub-slice: `M14-P1.4`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -842,8 +842,8 @@ performance/scaling follow-ups.
 - [x] Issue #70 is closed after the M13-P2/M13-P3.1 response for agent usefulness; release notes
   identify that #72 now owns remaining source lifecycle and agent-workflow follow-up.
 - [x] Issue #72 remains the parent feedback loop for source-refresh lifecycle and agent workflow;
-  stable logical source identities, source supersession, full workspace refresh, pruning, and
-  `pr-summary` remain post-v1 work.
+  stable logical source identities, source supersession, and safe workspace refresh have landed;
+  pruning and `pr-summary` remain post-v1 work.
 - [x] Issue #79 tracks the deferred mutating compile/update path from #41 so #41 can stay closed for
   the shipped v1 briefing and non-mutating compile-contract scope.
 - [x] Final release handoff records validation commands, docs state, issue state, GitHub metadata,
@@ -899,7 +899,9 @@ post-#72 lifecycle loop is substantially implemented. The intended sequence befo
 3. `M14-P1.2` makes source refresh supersession-aware, so changed sources do not leave stale runs
    or health failures for agents to clean manually before later topic-ref migration.
 4. `M14-P1.3` provides one safe workspace refresh path for changed-source detection, refresh,
-   ingest, index rebuild, and a health-clean end state.
+   ingest, index rebuild, and a health-clean end state. The first implementation is
+   `splendor workspace refresh --changed --ingest --rebuild-index`, limited to curated
+   workspace-backed source manifests.
 5. `M14-P1.4` handles superseded generated-state pruning and topic-ref migration.
 6. `M14-P2.1` adds `splendor pr-summary --since main` or an equivalent PR-oriented summary with
    lower-noise generated-state review guidance.

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -775,8 +775,15 @@ Current implementation:
   Stable logical source identities now remain constant for workspace-backed source paths across
   those content-addressed versions. Refresh also links changed versions with `supersedes` and
   `superseded_by` so health treats older workspace-backed manifests as historical records instead
-  of active current-byte targets. Automated historical pruning, safe full-workspace refresh, and
-  topic-ref migration remain later lifecycle work.
+  of active current-byte targets. Automated historical pruning and topic-ref migration remain later
+  lifecycle work.
+- `splendor workspace refresh --changed` safely refreshes only changed curated workspace-backed
+  sources by composing `source freshness` with the supersession-aware `source refresh` path. It
+  fails before mutating when active curated workspace sources are missing, can ingest only refreshed
+  sources' queue jobs with `--ingest`, and can rebuild `wiki/index.md` after successful targeted
+  ingest with `--rebuild-index`. JSON output reports both initial and final freshness counts. It
+  does not discover or register uncurated files, prune superseded generated state, migrate topic
+  refs, or mutate maintained synthesis pages.
 - `splendor add-topic "Title"` scaffolds a maintained topic page under `wiki/topics/<slug>.md`
   with valid knowledge-page frontmatter, optional tags/source refs, and deterministic markdown
   templates for default synthesis, research synthesis, and issue tracking.
@@ -847,9 +854,9 @@ Release-readiness boundary:
   reports can remain local.
 - issue #72's desired stable logical source identity and source-supersession layers have started
   with workspace-backed `source:<path>` aliases plus `supersedes`/`superseded_by` source-version
-  links. One-command workspace refresh, superseded-state pruning/topic-ref migration, and the
-  `pr-summary` surface remain follow-ups unless a future roadmap slice explicitly pulls them
-  forward.
+  links. The safe workspace refresh path over curated workspace-backed sources has also landed.
+  Superseded-state pruning/topic-ref migration and the `pr-summary` surface remain follow-ups
+  unless a future roadmap slice explicitly pulls them forward.
 - issue #79 tracks the deferred mutating compile/update workflow from #41; v1 ships briefing and
   the non-mutating compile contract only.
 - `docs/v1_release_handoff.md` is the v1 handoff checklist for final validation, GitHub metadata,

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -54,7 +54,6 @@ For this handoff:
 
 These items are intentionally not v1 release blockers:
 
-- one-command full workspace refresh
 - superseded generated-state pruning and topic-ref migration
 - `splendor pr-summary --since main`
 - authority and staleness metadata for living planning docs
@@ -67,10 +66,10 @@ These items are intentionally not v1 release blockers:
 
 The conservative next queue is:
 
-1. Continue #72 implementation after the workspace-backed `source:<path>` logical ID layer and
-   supersession-aware source refresh.
-2. Add the smallest full-workspace refresh slice that keeps changed-source detection, refresh,
-   ingest, index rebuild, and health coherent without breaking schema version `1` compatibility.
+1. Continue #72 implementation after the workspace-backed `source:<path>` logical ID layer,
+   supersession-aware source refresh, and safe workspace refresh path.
+2. Add superseded generated-state pruning and topic-ref migration on top of the explicit
+   supersession lifecycle.
 3. Add `splendor pr-summary --since main` only after source lifecycle churn is explicit enough to
    summarize reliably.
 4. Keep #79 as the tracked post-v1 compile/update workflow rather than reopening #41 for deferred

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -79,6 +79,10 @@ from splendor.commands.wiki import (
     render_wiki_suggest_json,
     suggest_source_pages,
 )
+from splendor.commands.workspace import (
+    refresh_workspace,
+    render_workspace_refresh_json,
+)
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import (
@@ -339,6 +343,36 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     wiki_rebuild_index_parser.set_defaults(handler=handle_wiki_rebuild_index)
+
+    workspace_parser = subparsers.add_parser(
+        "workspace", help="Run safe workspace-level maintenance workflows"
+    )
+    workspace_subparsers = workspace_parser.add_subparsers(dest="workspace_command", required=True)
+    workspace_refresh_parser = workspace_subparsers.add_parser(
+        "refresh", help="Refresh changed curated workspace-backed sources"
+    )
+    workspace_refresh_parser.add_argument(
+        "--changed",
+        action="store_true",
+        help="Refresh only curated workspace-backed sources whose bytes changed.",
+    )
+    workspace_refresh_parser.add_argument(
+        "--ingest",
+        action="store_true",
+        help="Ingest queue jobs created or reused for refreshed sources.",
+    )
+    workspace_refresh_parser.add_argument(
+        "--rebuild-index",
+        action="store_true",
+        help="Rebuild wiki/index.md after a successful pending ingest drain.",
+    )
+    workspace_refresh_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    workspace_refresh_parser.set_defaults(handler=handle_workspace_refresh)
 
     materialize_parser = subparsers.add_parser(
         "materialize-source", help="Create or refresh a source storage artifact"
@@ -1272,6 +1306,82 @@ def handle_wiki_rebuild_index(args: argparse.Namespace) -> int:
             "Sections: "
             + " ".join(f"{section}={count}" for section, count in result.sections.items())
         )
+    return 0
+
+
+def handle_workspace_refresh(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = refresh_workspace(
+            root,
+            changed=args.changed,
+            ingest=args.ingest,
+            rebuild_index=args.rebuild_index,
+        )
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_workspace_refresh_json(root, result))
+        return 1 if result.ingest is not None and result.ingest.failed else 0
+
+    print("Workspace refresh")
+    print(
+        "Initial freshness: "
+        f"total={result.initial_freshness.total} "
+        f"unchanged={result.initial_freshness.unchanged} "
+        f"changed={result.initial_freshness.changed} "
+        f"missing={result.initial_freshness.missing} "
+        f"unsupported={result.initial_freshness.unsupported} "
+        f"historical={result.initial_freshness.historical}"
+    )
+    if not result.refreshed:
+        print("No changed curated workspace-backed sources found.")
+    for refresh in result.refreshed:
+        source_ref = canonical_source_ref(refresh.refreshed.record)
+        print(f"- {source_ref}: refreshed source_id={refresh.refreshed.record.source_id}")
+        print(f"  Previous source ID: {refresh.requested.source_id}")
+        logical_id = effective_logical_id(refresh.refreshed.record)
+        if logical_id is not None:
+            print(f"  Logical ID: {logical_id}")
+        if refresh.queued and refresh.queue_path is not None:
+            print(f"  Queued ingest: {refresh.queue_path}")
+        else:
+            print(f"  Refresh skipped: {refresh.message}")
+
+    if result.ingest is not None:
+        for item in result.ingest.items:
+            print(f"  Ingest {item.source_id}: {item.outcome} ({item.message})")
+        print(
+            "Ingest summary: "
+            f"processed={result.ingest.processed} "
+            f"succeeded={result.ingest.succeeded} "
+            f"failed={result.ingest.failed} "
+            f"skipped={result.ingest.skipped}"
+        )
+
+    if result.index is not None:
+        print(f"Rebuilt index: {result.index.path}")
+        print(f"Pages indexed: {result.index.page_count}")
+    print(
+        "Final freshness: "
+        f"total={result.final_freshness.total} "
+        f"unchanged={result.final_freshness.unchanged} "
+        f"changed={result.final_freshness.changed} "
+        f"missing={result.final_freshness.missing} "
+        f"unsupported={result.final_freshness.unsupported} "
+        f"historical={result.final_freshness.historical}"
+    )
+
+    if result.ingest is not None and result.ingest.failed:
+        print("Next: splendor queue inspect")
+        return 1
+    if result.index is None and result.ingest is None and result.refreshed:
+        print("Next: splendor ingest --pending")
+    elif result.index is None and result.ingest is not None and result.ingest.succeeded:
+        print("Next: splendor wiki rebuild-index")
+    else:
+        print("Next: splendor source freshness")
     return 0
 
 

--- a/src/splendor/commands/workspace.py
+++ b/src/splendor/commands/workspace.py
@@ -1,0 +1,202 @@
+"""Workspace-level maintenance command helpers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from splendor.commands.ingest import DrainItemResult, DrainResult, run_ingest_job
+from splendor.commands.source import (
+    SourceFreshnessItem,
+    SourceFreshnessResult,
+    SourceRefreshResult,
+    refresh_source,
+    scan_source_freshness,
+)
+from splendor.commands.wiki import WikiIndexRebuildResult, rebuild_wiki_index
+from splendor.state.source_compat import canonical_source_ref, effective_logical_id
+
+
+@dataclass(frozen=True)
+class WorkspaceRefreshResult:
+    initial_freshness: SourceFreshnessResult
+    final_freshness: SourceFreshnessResult
+    refreshed: list[SourceRefreshResult]
+    ingest: DrainResult | None
+    index: WikiIndexRebuildResult | None
+
+
+def refresh_workspace(
+    root: Path,
+    *,
+    changed: bool,
+    ingest: bool = False,
+    rebuild_index: bool = False,
+) -> WorkspaceRefreshResult:
+    if not changed:
+        msg = "workspace refresh requires --changed in this release"
+        raise ValueError(msg)
+    if rebuild_index and not ingest:
+        msg = "workspace refresh --rebuild-index requires --ingest"
+        raise ValueError(msg)
+
+    initial_freshness = scan_source_freshness(root)
+    _raise_if_missing_active_workspace_sources(initial_freshness)
+    changed_items = [item for item in initial_freshness.sources if item.status == "changed"]
+    refreshed = [_refresh_changed_item(root, item) for item in changed_items]
+
+    ingest_result = _drain_refreshed_ingest_jobs(root, refreshed) if ingest else None
+    index_result = None
+    if rebuild_index and (ingest_result is None or ingest_result.failed == 0):
+        index_result = rebuild_wiki_index(root)
+    final_freshness = scan_source_freshness(root)
+
+    return WorkspaceRefreshResult(
+        initial_freshness=initial_freshness,
+        final_freshness=final_freshness,
+        refreshed=refreshed,
+        ingest=ingest_result,
+        index=index_result,
+    )
+
+
+def render_workspace_refresh_json(root: Path, result: WorkspaceRefreshResult) -> str:
+    return json.dumps(
+        {
+            "initial_freshness": _freshness_counts(result.initial_freshness),
+            "final_freshness": _freshness_counts(result.final_freshness),
+            "refreshed": [_refresh_payload(root, item) for item in result.refreshed],
+            "ingest": None if result.ingest is None else _ingest_payload(root, result.ingest),
+            "index": None if result.index is None else asdict(result.index),
+        },
+        indent=2,
+    )
+
+
+def _refresh_changed_item(root: Path, item: SourceFreshnessItem) -> SourceRefreshResult:
+    return refresh_source(root, item.canonical_path)
+
+
+def _raise_if_missing_active_workspace_sources(result: SourceFreshnessResult) -> None:
+    missing_paths = sorted(
+        {
+            item.canonical_path
+            for item in result.sources
+            if item.status == "missing" and item.source.superseded_by is None
+        }
+    )
+    if not missing_paths:
+        return
+    joined = ", ".join(missing_paths)
+    msg = f"workspace refresh cannot continue with missing curated sources: {joined}"
+    raise FileNotFoundError(msg)
+
+
+def _drain_refreshed_ingest_jobs(root: Path, refreshed: list[SourceRefreshResult]) -> DrainResult:
+    queue_paths = [
+        result.queue_path for result in refreshed if result.queued and result.queue_path is not None
+    ]
+    item_results: list[DrainItemResult] = []
+    processed = 0
+    succeeded = 0
+    failed = 0
+    skipped = 0
+
+    for queue_path in queue_paths:
+        source_id = queue_path.stem.removeprefix("ingest-")
+        try:
+            result = run_ingest_job(root, queue_path)
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            processed += 1
+            failed += 1
+            item_results.append(
+                DrainItemResult(
+                    source_id=source_id,
+                    queue_path=queue_path,
+                    outcome="failed",
+                    message=str(exc),
+                )
+            )
+            continue
+
+        if result.no_op:
+            skipped += 1
+            item_results.append(
+                DrainItemResult(
+                    source_id=result.source_id,
+                    queue_path=queue_path,
+                    outcome="skipped",
+                    message="already ingested for the current pipeline version",
+                )
+            )
+            continue
+
+        processed += 1
+        succeeded += 1
+        item_results.append(
+            DrainItemResult(
+                source_id=result.source_id,
+                queue_path=queue_path,
+                outcome="succeeded",
+                message=f"run {result.run_id}",
+            )
+        )
+
+    return DrainResult(
+        total=len(queue_paths),
+        processed=processed,
+        succeeded=succeeded,
+        failed=failed,
+        skipped=skipped,
+        items=item_results,
+    )
+
+
+def _freshness_counts(result: SourceFreshnessResult) -> dict[str, int]:
+    return {
+        "total": result.total,
+        "unchanged": result.unchanged,
+        "changed": result.changed,
+        "missing": result.missing,
+        "unsupported": result.unsupported,
+        "historical": result.historical,
+    }
+
+
+def _refresh_payload(root: Path, result: SourceRefreshResult) -> dict[str, object]:
+    queue_path = None
+    if result.queue_path is not None:
+        queue_path = result.queue_path.relative_to(root).as_posix()
+    return {
+        "path": canonical_source_ref(result.refreshed.record),
+        "requested_source_id": result.requested.source_id,
+        "requested_logical_id": effective_logical_id(result.requested),
+        "source_id": result.refreshed.record.source_id,
+        "logical_id": effective_logical_id(result.refreshed.record),
+        "supersedes": result.refreshed.record.supersedes,
+        "superseded_by": result.refreshed.record.superseded_by,
+        "changed": result.changed,
+        "queued": result.queued,
+        "queue_path": queue_path,
+        "message": result.message,
+    }
+
+
+def _ingest_payload(root: Path, result: DrainResult) -> dict[str, object]:
+    return {
+        "total": result.total,
+        "processed": result.processed,
+        "succeeded": result.succeeded,
+        "failed": result.failed,
+        "skipped": result.skipped,
+        "items": [
+            {
+                "source_id": item.source_id,
+                "queue_path": item.queue_path.relative_to(root).as_posix(),
+                "outcome": item.outcome,
+                "message": item.message,
+            }
+            for item in result.items
+        ],
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,6 +110,21 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     assert freshness.json_output is True
 
 
+def test_cli_workspace_refresh_parser_accepts_safe_refresh_flags() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(
+        ["workspace", "refresh", "--changed", "--ingest", "--rebuild-index", "--json"]
+    )
+
+    assert args.command == "workspace"
+    assert args.workspace_command == "refresh"
+    assert args.changed is True
+    assert args.ingest is True
+    assert args.rebuild_index is True
+    assert args.json_output is True
+
+
 def test_cli_query_parser_accepts_filters_and_no_question() -> None:
     parser = build_parser()
 
@@ -1040,6 +1055,146 @@ def test_cli_source_freshness_relative_report_uses_current_working_directory(
     assert payload["report_path"] == expected_report.as_posix()
     assert expected_report.exists()
     assert not (root / "reports" / "source-freshness.json").exists()
+
+
+def test_cli_workspace_refresh_requires_explicit_changed_flag(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "workspace", "refresh"])
+
+    assert exit_code == 1
+    assert "Error: workspace refresh requires --changed in this release" in capsys.readouterr().out
+
+
+def test_cli_workspace_refresh_rebuild_index_requires_ingest(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "workspace", "refresh", "--changed", "--rebuild-index"]
+    )
+
+    assert exit_code == 1
+    assert "Error: workspace refresh --rebuild-index requires --ingest" in capsys.readouterr().out
+
+
+def test_cli_workspace_refresh_changed_ingests_and_rebuilds_index(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "workspace",
+            "refresh",
+            "--changed",
+            "--ingest",
+            "--rebuild-index",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["initial_freshness"]["changed"] == 1
+    assert payload["final_freshness"]["changed"] == 0
+    assert payload["ingest"]["failed"] == 0
+    assert payload["ingest"]["succeeded"] == 1
+    assert payload["index"]["path"] == "wiki/index.md"
+    refreshed = payload["refreshed"][0]
+    assert refreshed["path"] == "brief.md"
+    assert refreshed["requested_source_id"] == original_id
+    assert refreshed["logical_id"] == "source:brief.md"
+    refreshed_id = refreshed["source_id"]
+    assert refreshed_id != original_id
+    assert refreshed["supersedes"] == [original_id]
+    assert (tmp_path / "wiki" / "sources" / f"{refreshed_id}.md").exists()
+    index_text = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+    assert f"sources/{refreshed_id}.md" in index_text
+
+    assert main(["--root", str(tmp_path), "lint"]) == 0
+    assert main(["--root", str(tmp_path), "health"]) == 0
+
+
+def test_cli_workspace_refresh_ingests_only_refreshed_sources(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    changed_source = tmp_path / "changed.md"
+    pending_source = tmp_path / "pending.md"
+    changed_source.write_text("# Changed\n\nOriginal.\n", encoding="utf-8")
+    pending_source.write_text("# Pending\n\nQueued separately.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(changed_source)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "add-source", str(pending_source)])
+    pending_id = next(
+        load_source_record(path).source_id
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if load_source_record(path).source_ref == "pending.md"
+    )
+    changed_source.write_text("# Changed\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "workspace", "refresh", "--changed", "--ingest", "--json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ingest"]["total"] == 1
+    assert payload["ingest"]["succeeded"] == 1
+    assert load_queue_item(tmp_path / "state" / "queue" / f"ingest-{pending_id}.json").status == (
+        "pending"
+    )
+    assert not (tmp_path / "wiki" / "sources" / f"{pending_id}.md").exists()
+
+
+def test_cli_workspace_refresh_fails_when_active_curated_source_is_missing(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "missing.md"
+    source.write_text("# Missing\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source.unlink()
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed"])
+
+    assert exit_code == 1
+    assert (
+        "Error: workspace refresh cannot continue with missing curated sources: missing.md"
+        in capsys.readouterr().out
+    )
+
+
+def test_cli_workspace_refresh_human_output_is_path_first(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Workspace refresh" in out
+    assert "Initial freshness:" in out
+    assert "Final freshness:" in out
+    assert "changed=1" in out
+    assert "changed=0" in out
+    assert re.search(r"- brief\.md: refreshed source_id=src-[a-f0-9]{16}", out)
+    assert f"Previous source ID: {original_id}" in out
+    assert "Next: splendor ingest --pending" in out
 
 
 def test_cli_source_refresh_preserves_active_lease_protection(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Implements `M14-P1.3` under parent slice `M14-P1` for issue #72.

- Adds `splendor workspace refresh --changed` as the conservative workspace-level refresh path over curated workspace-backed source manifests only.
- Composes existing source freshness detection with the supersession-aware `source refresh` lifecycle from `M14-P1.2`.
- Fails before mutating when active curated workspace-backed sources are missing.
- Adds optional `--ingest`, scoped to queue jobs created or reused for refreshed sources only, so unrelated pending ingest work is not drained by this command.
- Adds optional `--rebuild-index` to rebuild `wiki/index.md` after a successful targeted ingest.
- Emits path-first human output plus JSON output with both initial and final freshness counts for agent handoff.
- Updates planning state and docs for `M14-P1.3`, while keeping pruning/topic-ref migration, PR summary, broad discovery, and mutating compile/update out of scope.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`

## Issue Linkage

Advances #72.

Does not implement #79 mutating compile/update work, #47 ingest run-duration precision, #37 web document-list scaling, or #30 repo-scan registration optimization.

## Follow-up

Next planned PR sub-slice is `M14-P1.4`: superseded generated-state pruning and topic-ref migration. The SynthBanshee re-evaluation gate remains closed until `M14-P1.4` and `M14-P2.1` also land.
