### PR TITLE
M14-P1.4 Prune superseded generated state

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M14-P1.2`
-- Last action taken: `M14-P1.2` is implemented; source refresh now links workspace-backed source versions with `supersedes` / `superseded_by`.
+- Previous completed PR sub-slice: `M14-P1.3`
+- Last action taken: `M14-P1.3` is implemented; workspace refresh can safely detect changed curated workspace-backed sources, refresh, ingest, and rebuild the index.
 - Current planned slice: `M14-P1`
-- Current PR sub-slice: `M14-P1.3`
+- Current PR sub-slice: `M14-P1.4`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M14-P1`
-- Next planned PR sub-slice: `M14-P1.4`
+- Next planned slice: `M14-P2`
+- Next planned PR sub-slice: `M14-P2.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -237,6 +237,11 @@
   - [x] Optionally ingest only refreshed sources' queue jobs with `--ingest`
   - [x] Optionally rebuild `wiki/index.md` after successful ingest with `--rebuild-index`
   - [x] Keep pruning, topic-ref migration, PR summary, broad discovery, and mutating compile/update deferred
+- [x] Implement `M14-P1.4`: Superseded generated-state pruning and topic-ref migration
+  - [x] Add explicit `workspace refresh --prune-superseded` cleanup for superseded generated source-summary pages
+  - [x] Keep historical source manifests and run records valid after generated summary pruning
+  - [x] Add explicit `workspace refresh --update-topic-refs` migration from superseded source IDs to active source versions
+  - [x] Keep PR summary, broad discovery, and mutating compile/update deferred
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ Implemented today:
   `splendor add-source --dir path`
 - `splendor source list`, `splendor source lookup [query]`, `splendor source freshness`, and
   `splendor source refresh <source-id|title|path>`
-- `splendor workspace refresh --changed` with optional `--ingest` and `--rebuild-index`
+- `splendor workspace refresh --changed` with optional `--ingest`, `--rebuild-index`,
+  `--prune-superseded`, and `--update-topic-refs`
 - `splendor ingest <source-id>` and `splendor ingest --pending`
 - `splendor queue inspect [job-id]` and `splendor queue retry <job-id>`
 - `splendor repair ingest <source-id>`
@@ -140,7 +141,6 @@ Not implemented yet:
 - mutating review-gated `splendor wiki compile`
 - heavyweight OCR/image extraction providers
 - mutating web UI actions such as add-source forms
-- supersession-aware pruning and topic-ref migration
 - PR-oriented generated-state summaries such as `splendor pr-summary --since main`
 
 `splendor repo scan` is safe by default: it previews candidates without writing manifests or
@@ -154,8 +154,13 @@ Relative report paths use the current working directory.
 supersession-aware refresh path for changed curated workspace-backed sources. Add `--ingest` to
 ingest only queue jobs created or reused for the refreshed sources, and add `--rebuild-index` to
 regenerate `wiki/index.md` after that targeted ingest succeeds. JSON output reports both initial
-and final freshness counts. The command does not discover or register uncurated files, prune
-superseded generated state, migrate topic refs, or mutate maintained synthesis pages.
+and final freshness counts. Add `--prune-superseded` to delete superseded generated
+`wiki/sources/<source-id>.md` summaries once a current successor summary exists, while keeping
+historical source manifests and run records. Add `--update-topic-refs` to rewrite maintained wiki
+page `source_refs` and generated source-reference list bullets from superseded source IDs to the
+active source version ID. Prune JSON reports skipped unsafe candidates with reasons rather than
+deleting ambiguous state. The command does not discover or register uncurated files or mutate
+maintained synthesis content beyond that explicit source-ref migration.
 
 Generated source-summary pages are deterministic ingestion artifacts. For readable in-repo
 markdown/text/code sources, Splendor defaults to concise claim-bearing excerpts and path-first
@@ -184,12 +189,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M14-P1.2`
+- Previous completed PR sub-slice: `M14-P1.3`
 - Current planned slice: `M14-P1`
-- Current PR sub-slice: `M14-P1.3`
+- Current PR sub-slice: `M14-P1.4`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M14-P1`
-- Next planned PR sub-slice: `M14-P1.4`
+- Next planned slice: `M14-P2`
+- Next planned PR sub-slice: `M14-P2.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -279,15 +284,13 @@ visibility as represented in current behavior. It still calls out #41's mutating
 workflow as deferred. Issue #47 remains an ingest/run-state timing follow-up. Issues #30 and #37
 remain post-v1 performance work. Issue #70 is closed after the M13-P2/M13-P3.1 response. Issue #72
 stays open as the parent feedback loop; stable logical source identities, supersession lifecycle,
-and safe workspace refresh have landed, while pruning, topic-ref migration, and PR-summary ideas
-remain post-v1 planning work.
+safe workspace refresh, superseded summary pruning, and topic-ref migration have landed, while
+PR-summary ideas remain post-v1 planning work.
 Issue #79 tracks the deferred mutating compile/update path from #41.
 
 `M14-P1.1` adds the first stable logical source identity layer above content-addressed source IDs:
 workspace-backed manifests now persist `source:<workspace-path>` logical IDs and path aliases while
-keeping `src-...` IDs as the compatibility contract. Safe workspace refresh, pruning/topic-ref
-migration, and PR-oriented generated-state summary/review handoff remain later slices before the
-SynthBanshee Claude retry.
+keeping `src-...` IDs as the compatibility contract.
 
 `M14-P1.2` makes source refresh supersession-aware: changed workspace-backed sources keep their
 stable logical ID, register a new content-addressed `src-...` version, and link the previous and
@@ -297,8 +300,13 @@ versions as historical provenance instead of active current-byte targets.
 `M14-P1.3` adds the safe workspace refresh path:
 `splendor workspace refresh --changed --ingest --rebuild-index` detects changed curated
 workspace-backed sources, refreshes them through the supersession-aware source lifecycle, drains
-only the refreshed sources' ingest jobs, and rebuilds the wiki index. Pruning/topic-ref migration
-and PR-summary support remain later slices before the retry.
+only the refreshed sources' ingest jobs, and rebuilds the wiki index.
+
+`M14-P1.4` adds explicit superseded generated-state cleanup to workspace refresh:
+`--prune-superseded` removes old generated source-summary pages only after a successor summary
+exists, and `--update-topic-refs` migrates maintained wiki source references to the active
+content-addressed source version while schema version `1` continues to validate `source_refs`
+against source manifests. Historical manifests and run records remain valid.
 
 ### v1 readiness checklist
 
@@ -310,5 +318,4 @@ and PR-summary support remain later slices before the retry.
 - [x] CLI, schema, quickstart, automation, and dogfooding docs describe the same current behavior.
 - [x] Final release handoff names validation, issue state, GitHub metadata, known non-blockers,
   and the post-v1 queue.
-- [ ] Full refresh lifecycle, supersession/pruning, topic-ref migration, and PR-summary tooling are
-  planned follow-ups after the initial stable logical source identity layer.
+- [ ] PR-summary tooling remains the next planned source-lifecycle handoff follow-up.

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -77,7 +77,7 @@ candidate preview unless the operator explicitly applies a reviewed class or all
 Use `source freshness`, `brief --agent-context`, and `suggest-next` before deciding whether a
 workspace needs ingest, synthesis review, queue repair, or planning follow-up.
 
-Do not expect the current workflow to provide stable logical source identities, source
-supersession/pruning, one-command full workspace refresh, or PR-summary generation yet. Those are
-tracked from issue #72 as later lifecycle improvements. For v1 release work, use
+The current workflow now provides stable logical source identities, source supersession, explicit
+workspace refresh, and explicit superseded-summary pruning/topic-ref migration. Do not expect
+PR-summary generation yet; it remains tracked from issue #72 as later lifecycle work. For v1 release work, use
 `docs/v1_release_handoff.md` to separate release-blocking validation from the post-v1 dogfood queue.

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -107,9 +107,9 @@ in issue #72.
 
 - #70 is closed after the M13-P2/M13-P3.1 response for scan safety, curated curation, source
   freshness, ranked handoff, and path-first source-summary UX.
-- #72 is a separate parent feedback loop for source-refresh lifecycle and agent workflow. Its
-  stable logical source identity layer has started with workspace-backed `source:<path>` aliases;
-  `supersedes`/`superseded_by`, full workspace refresh, pruning, and `pr-summary` requests remain
+- #72 is a separate parent feedback loop for source-refresh lifecycle and agent workflow. Stable
+  workspace-backed `source:<path>` aliases, `supersedes`/`superseded_by`, safe workspace refresh,
+  superseded source-summary pruning, and topic-ref migration have landed; `pr-summary` remains
   post-v1 work.
 - #41 has shipped `splendor brief [goal]`, `brief --agent-context`, and the non-mutating
   `splendor wiki compile <source-id|title|path>` contract. Mutating compile/update support remains

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -237,10 +237,10 @@ they support the workspace update under review. They are deterministic state, no
 analysis. Failed or exploratory local reports do not need to be committed unless the report itself
 is the artifact being reviewed.
 
-`source refresh` currently creates a new canonical content-addressed source version when bytes
-change. Stable logical source identities, source supersession fields, automated pruning, topic-ref
-migration, and a one-command full workspace refresh remain planned follow-ups rather than required
-v1 behavior.
+`source refresh` creates a new canonical content-addressed source version when bytes change.
+Workspace-backed sources keep stable logical IDs, and `workspace refresh --changed` can combine
+changed-source refresh, targeted ingest, index rebuild, superseded generated-summary pruning, and
+maintained-page topic-ref migration through explicit flags.
 
 ## 5. Add a planning record
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -202,9 +202,15 @@ Implemented fields:
   created or reused for those refreshed sources with `--ingest`.
 - `splendor workspace refresh --changed --ingest --rebuild-index` rebuilds `wiki/index.md` only
   after the targeted refreshed-source ingest succeeds. JSON output reports both initial and final
-  freshness counts. The command does not perform broad repo discovery,
-  register uncurated files, prune superseded generated state, migrate topic refs, or run mutating
-  synthesis compile/update workflows.
+  freshness counts. `--prune-superseded` deletes superseded generated source-summary pages after a
+  current successor summary exists, removes the pruned generated-page link from the superseded
+  source manifest, and preserves historical source manifests and run records. Health treats run
+  page refs for those exact pruned superseded workspace summaries as valid historical provenance
+  without exempting unrelated broken run refs. Prune JSON reports skipped unsafe candidates with
+  reasons. `--update-topic-refs` rewrites maintained wiki page `source_refs` and generated
+  source-reference list bullets from superseded source IDs to the active content-addressed source
+  version, leaving prose and code-fence mentions untouched. The command does not perform broad repo
+  discovery, register uncurated files, or run mutating synthesis compile/update workflows.
 - `splendor suggest-next [goal]` is a read-only handoff view over existing deterministic state. It
   does not create planning records, queue jobs, manifests, wiki pages, run records, or reports.
   Human output is path-first where possible; `--json` emits ranked action objects with category,
@@ -261,10 +267,11 @@ In this release:
 - source IDs remain content-addressed canonical IDs; stable logical source aliases and
   `supersedes`/`superseded_by` lifecycle fields now describe workspace-backed refresh history
   without changing schema version `1`
-- automated pruning of superseded source summaries and topic-ref migration are not part of the
-  current schema contract
-- safe workspace refresh composes existing source, queue, ingest, and wiki-index records without
-  changing schema version `1`
+- explicit pruning of superseded source-summary pages and maintained-page source-ref migration are
+  workspace maintenance operations over existing schema version `1` fields, not a manifest schema
+  rewrite
+- safe workspace refresh composes existing source, queue, ingest, wiki-index, and wiki-frontmatter
+  records without changing schema version `1`
 
 ## Knowledge page frontmatter
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M14-P1.2`
+- Previous completed PR sub-slice: `M14-P1.3`
 - Current planned slice: `M14-P1`
-- Current PR sub-slice: `M14-P1.3`
+- Current PR sub-slice: `M14-P1.4`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M14-P1`
-- Next planned PR sub-slice: `M14-P1.4`
+- Next planned slice: `M14-P2`
+- Next planned PR sub-slice: `M14-P2.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -842,8 +842,8 @@ performance/scaling follow-ups.
 - [x] Issue #70 is closed after the M13-P2/M13-P3.1 response for agent usefulness; release notes
   identify that #72 now owns remaining source lifecycle and agent-workflow follow-up.
 - [x] Issue #72 remains the parent feedback loop for source-refresh lifecycle and agent workflow;
-  stable logical source identities, source supersession, and safe workspace refresh have landed;
-  pruning and `pr-summary` remain post-v1 work.
+  stable logical source identities, source supersession, safe workspace refresh, superseded
+  summary pruning, and topic-ref migration have landed; `pr-summary` remains post-v1 work.
 - [x] Issue #79 tracks the deferred mutating compile/update path from #41 so #41 can stay closed for
   the shipped v1 briefing and non-mutating compile-contract scope.
 - [x] Final release handoff records validation commands, docs state, issue state, GitHub metadata,

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -775,15 +775,20 @@ Current implementation:
   Stable logical source identities now remain constant for workspace-backed source paths across
   those content-addressed versions. Refresh also links changed versions with `supersedes` and
   `superseded_by` so health treats older workspace-backed manifests as historical records instead
-  of active current-byte targets. Automated historical pruning and topic-ref migration remain later
-  lifecycle work.
+  of active current-byte targets.
 - `splendor workspace refresh --changed` safely refreshes only changed curated workspace-backed
   sources by composing `source freshness` with the supersession-aware `source refresh` path. It
   fails before mutating when active curated workspace sources are missing, can ingest only refreshed
   sources' queue jobs with `--ingest`, and can rebuild `wiki/index.md` after successful targeted
-  ingest with `--rebuild-index`. JSON output reports both initial and final freshness counts. It
-  does not discover or register uncurated files, prune superseded generated state, migrate topic
-  refs, or mutate maintained synthesis pages.
+  ingest with `--rebuild-index`. JSON output reports both initial and final freshness counts.
+  `--prune-superseded` deletes old generated source-summary pages only after a current successor
+  summary exists, removes stale generated-page links from the superseded source manifest, and keeps
+  historical source manifests and run records valid. Unsafe prune candidates are reported with
+  skip reasons instead of silently ignored. `--update-topic-refs` rewrites maintained wiki page
+  `source_refs` and generated source-reference list bullets from superseded source IDs to the
+  active content-addressed source version, while leaving prose and code-fence mentions untouched.
+  It does not discover or register uncurated files or run mutating synthesis compile/update
+  workflows.
 - `splendor add-topic "Title"` scaffolds a maintained topic page under `wiki/topics/<slug>.md`
   with valid knowledge-page frontmatter, optional tags/source refs, and deterministic markdown
   templates for default synthesis, research synthesis, and issue tracking.
@@ -854,9 +859,10 @@ Release-readiness boundary:
   reports can remain local.
 - issue #72's desired stable logical source identity and source-supersession layers have started
   with workspace-backed `source:<path>` aliases plus `supersedes`/`superseded_by` source-version
-  links. The safe workspace refresh path over curated workspace-backed sources has also landed.
-  Superseded-state pruning/topic-ref migration and the `pr-summary` surface remain follow-ups
-  unless a future roadmap slice explicitly pulls them forward.
+  links. The safe workspace refresh path over curated workspace-backed sources has also landed,
+  including explicit superseded source-summary pruning and maintained-page source-ref migration.
+  The `pr-summary` surface remains a follow-up unless a future roadmap slice explicitly pulls it
+  forward.
 - issue #79 tracks the deferred mutating compile/update workflow from #41; v1 ships briefing and
   the non-mutating compile contract only.
 - `docs/v1_release_handoff.md` is the v1 handoff checklist for final validation, GitHub metadata,

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -54,7 +54,6 @@ For this handoff:
 
 These items are intentionally not v1 release blockers:
 
-- superseded generated-state pruning and topic-ref migration
 - `splendor pr-summary --since main`
 - authority and staleness metadata for living planning docs
 - lower-noise generated-state review policies beyond the current reviewer-significance guidance
@@ -67,14 +66,13 @@ These items are intentionally not v1 release blockers:
 The conservative next queue is:
 
 1. Continue #72 implementation after the workspace-backed `source:<path>` logical ID layer,
-   supersession-aware source refresh, and safe workspace refresh path.
-2. Add superseded generated-state pruning and topic-ref migration on top of the explicit
-   supersession lifecycle.
-3. Add `splendor pr-summary --since main` only after source lifecycle churn is explicit enough to
+   supersession-aware source refresh, safe workspace refresh path, superseded generated-state
+   pruning, and topic-ref migration.
+2. Add `splendor pr-summary --since main` only after source lifecycle churn is explicit enough to
    summarize reliably.
-4. Keep #79 as the tracked post-v1 compile/update workflow rather than reopening #41 for deferred
+3. Keep #79 as the tracked post-v1 compile/update workflow rather than reopening #41 for deferred
    scope.
-5. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
+4. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
    either one urgent.
 
 Do not ask the SynthBanshee Claude agent for the major "try Splendor again" re-evaluation until

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -367,6 +367,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Rebuild wiki/index.md after a successful pending ingest drain.",
     )
     workspace_refresh_parser.add_argument(
+        "--prune-superseded",
+        action="store_true",
+        help="Delete superseded generated source-summary pages after a successor exists.",
+    )
+    workspace_refresh_parser.add_argument(
+        "--update-topic-refs",
+        action="store_true",
+        help="Rewrite maintained wiki source_refs from superseded source IDs to active versions.",
+    )
+    workspace_refresh_parser.add_argument(
         "--json",
         action="store_true",
         dest="json_output",
@@ -1317,6 +1327,8 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
             changed=args.changed,
             ingest=args.ingest,
             rebuild_index=args.rebuild_index,
+            prune_superseded=args.prune_superseded,
+            update_topic_refs=args.update_topic_refs,
         )
     except (FileNotFoundError, RuntimeError, ValueError) as exc:
         return _print_error(exc)
@@ -1363,6 +1375,24 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
     if result.index is not None:
         print(f"Rebuilt index: {result.index.path}")
         print(f"Pages indexed: {result.index.page_count}")
+    if result.pruning is not None:
+        if not result.pruning.pruned and not result.pruning.skipped:
+            print("Pruned superseded source summaries: none")
+        for item in result.pruning.pruned:
+            print(f"Pruned superseded source summary: {item.path}")
+            print(f"  Source ID: {item.source_id}")
+            print(f"  Superseded by: {item.superseded_by}")
+        for item in result.pruning.skipped:
+            print(f"Skipped superseded source summary: {item.path}")
+            print(f"  Source ID: {item.source_id}")
+            print(f"  Reason: {item.reason}")
+    if result.topic_ref_migration is not None:
+        if not result.topic_ref_migration.updated:
+            print("Updated topic source refs: none")
+        for item in result.topic_ref_migration.updated:
+            replacement_text = ", ".join(f"{old}->{new}" for old, new in item.replacements.items())
+            print(f"Updated topic source refs: {item.path}")
+            print(f"  Replacements: {replacement_text}")
     print(
         "Final freshness: "
         f"total={result.final_freshness.total} "

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -56,6 +56,44 @@ def _should_resolve_source_content(source: SourceRecord) -> bool:
     )
 
 
+def _is_superseded_workspace_source(
+    source_id: str,
+    source_records: dict[str, tuple[Path, SourceRecord]],
+) -> bool:
+    source_entry = source_records.get(source_id)
+    if source_entry is None:
+        return False
+    _, source = source_entry
+    return (
+        source.superseded_by is not None
+        and source.source_ref_kind == "workspace_path"
+        and effective_storage_mode(source) == "none"
+    )
+
+
+def _is_expected_pruned_source_summary_page_id(
+    page_id: str,
+    run_record: RunRecord,
+    source_records: dict[str, tuple[Path, SourceRecord]],
+) -> bool:
+    return page_id in run_record.source_ids and _is_superseded_workspace_source(
+        page_id, source_records
+    )
+
+
+def _is_expected_pruned_source_summary_ref(
+    page_ref: str,
+    run_record: RunRecord,
+    source_records: dict[str, tuple[Path, SourceRecord]],
+) -> bool:
+    for source_id in run_record.source_ids:
+        if not _is_superseded_workspace_source(source_id, source_records):
+            continue
+        if page_ref == f"wiki/sources/{source_id}.md":
+            return True
+    return False
+
+
 def _append_issue(
     issues: list[MaintenanceIssue],
     *,
@@ -661,6 +699,8 @@ def _validate_run_record(
     for page_id in run_record.page_ids:
         if page_id in wiki_pages:
             continue
+        if _is_expected_pruned_source_summary_page_id(page_id, run_record, source_records):
+            continue
         _append_issue(
             issues,
             code="missing-run-page-id",
@@ -684,6 +724,8 @@ def _validate_run_record(
             )
             continue
         if not resolved.is_file():
+            if _is_expected_pruned_source_summary_ref(page_ref, run_record, source_records):
+                continue
             _append_issue(
                 issues,
                 code="missing-run-page-ref",
@@ -704,14 +746,17 @@ def _validate_run_record(
                 check_name="run-provenance",
             )
         if link.page_id is not None and link.page_id not in wiki_pages:
-            _append_issue(
-                issues,
-                code="missing-run-provenance-page-ref",
-                message=f"Run provenance references unknown page: {link.page_id}",
-                path=run_relpath,
-                record_id=canonical_run_id,
-                check_name="run-provenance",
-            )
+            if not _is_expected_pruned_source_summary_page_id(
+                link.page_id, run_record, source_records
+            ):
+                _append_issue(
+                    issues,
+                    code="missing-run-provenance-page-ref",
+                    message=f"Run provenance references unknown page: {link.page_id}",
+                    path=run_relpath,
+                    record_id=canonical_run_id,
+                    check_name="run-provenance",
+                )
         if (
             link.run_id is not None
             and link.run_id != canonical_run_id
@@ -740,6 +785,8 @@ def _validate_run_record(
             )
             continue
         if not resolved.exists():
+            if _is_expected_pruned_source_summary_ref(link.path_ref, run_record, source_records):
+                continue
             _append_issue(
                 issues,
                 code="missing-run-provenance-path",

--- a/src/splendor/commands/workspace.py
+++ b/src/splendor/commands/workspace.py
@@ -15,7 +15,49 @@ from splendor.commands.source import (
     scan_source_freshness,
 )
 from splendor.commands.wiki import WikiIndexRebuildResult, rebuild_wiki_index
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import SourceRecord
 from splendor.state.source_compat import canonical_source_ref, effective_logical_id
+from splendor.state.source_registry import load_source_record, write_source_record
+from splendor.utils.fs import write_text_atomic
+from splendor.utils.wiki import parse_wiki_markdown, render_frontmatter
+
+
+@dataclass(frozen=True)
+class PrunedSourceSummary:
+    path: str
+    source_id: str
+    superseded_by: str
+    manifest_path: str
+
+
+@dataclass(frozen=True)
+class SkippedPruneSourceSummary:
+    path: str
+    source_id: str
+    superseded_by: str | None
+    manifest_path: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class PruneSupersededResult:
+    candidates: int
+    pruned: list[PrunedSourceSummary]
+    skipped: list[SkippedPruneSourceSummary]
+
+
+@dataclass(frozen=True)
+class TopicRefMigration:
+    path: str
+    replacements: dict[str, str]
+
+
+@dataclass(frozen=True)
+class TopicRefMigrationResult:
+    candidates: int
+    updated: list[TopicRefMigration]
 
 
 @dataclass(frozen=True)
@@ -25,6 +67,8 @@ class WorkspaceRefreshResult:
     refreshed: list[SourceRefreshResult]
     ingest: DrainResult | None
     index: WikiIndexRebuildResult | None
+    pruning: PruneSupersededResult | None
+    topic_ref_migration: TopicRefMigrationResult | None
 
 
 def refresh_workspace(
@@ -33,6 +77,8 @@ def refresh_workspace(
     changed: bool,
     ingest: bool = False,
     rebuild_index: bool = False,
+    prune_superseded: bool = False,
+    update_topic_refs: bool = False,
 ) -> WorkspaceRefreshResult:
     if not changed:
         msg = "workspace refresh requires --changed in this release"
@@ -50,6 +96,17 @@ def refresh_workspace(
     index_result = None
     if rebuild_index and (ingest_result is None or ingest_result.failed == 0):
         index_result = rebuild_wiki_index(root)
+    topic_ref_migration_result = migrate_superseded_topic_refs(root) if update_topic_refs else None
+    pruning_result = prune_superseded_source_summaries(root) if prune_superseded else None
+    if rebuild_index and (
+        (pruning_result is not None and pruning_result.pruned)
+        or (
+            topic_ref_migration_result is not None
+            and topic_ref_migration_result.updated
+            and index_result is None
+        )
+    ):
+        index_result = rebuild_wiki_index(root)
     final_freshness = scan_source_freshness(root)
 
     return WorkspaceRefreshResult(
@@ -58,7 +115,163 @@ def refresh_workspace(
         refreshed=refreshed,
         ingest=ingest_result,
         index=index_result,
+        pruning=pruning_result,
+        topic_ref_migration=topic_ref_migration_result,
     )
+
+
+def prune_superseded_source_summaries(root: Path) -> PruneSupersededResult:
+    layout = resolve_layout(root, load_config(root))
+    sources = _load_sources_by_id(layout)
+    pruned: list[PrunedSourceSummary] = []
+    skipped: list[SkippedPruneSourceSummary] = []
+    candidates = 0
+
+    for source_id, source in sorted(sources.items()):
+        if source.superseded_by is None or source.source_ref_kind != "workspace_path":
+            continue
+        page_path = layout.wiki_dir / "sources" / f"{source_id}.md"
+        if not page_path.is_file():
+            continue
+        candidates += 1
+        manifest_path = layout.source_records_dir / f"{source_id}.json"
+        page_relpath = page_path.relative_to(root).as_posix()
+
+        successor = sources.get(source.superseded_by)
+        if successor is None:
+            skipped.append(
+                _skipped_prune_summary(
+                    root,
+                    manifest_path=manifest_path,
+                    path=page_relpath,
+                    source=source,
+                    reason=f"superseded_by source is missing: {source.superseded_by}",
+                )
+            )
+            continue
+        successor_page = layout.wiki_dir / "sources" / f"{successor.source_id}.md"
+        if not successor_page.is_file():
+            successor_page_ref = successor_page.relative_to(root).as_posix()
+            skipped.append(
+                _skipped_prune_summary(
+                    root,
+                    manifest_path=manifest_path,
+                    path=page_relpath,
+                    source=source,
+                    reason=f"successor source-summary page is missing: {successor_page_ref}",
+                )
+            )
+            continue
+
+        try:
+            parsed = parse_wiki_markdown(page_path)
+        except ValueError as exc:
+            skipped.append(
+                _skipped_prune_summary(
+                    root,
+                    manifest_path=manifest_path,
+                    path=page_relpath,
+                    source=source,
+                    reason=str(exc),
+                )
+            )
+            continue
+        if parsed.frontmatter.kind != "source-summary" or parsed.frontmatter.page_id != source_id:
+            skipped.append(
+                _skipped_prune_summary(
+                    root,
+                    manifest_path=manifest_path,
+                    path=page_relpath,
+                    source=source,
+                    reason=(f"wiki page is not the expected source-summary for {source_id}"),
+                )
+            )
+            continue
+
+        blocking_reason = _prune_blocking_reference_reason(
+            root,
+            layout,
+            page_id=source_id,
+            page_ref=page_relpath,
+            candidate_path=page_path,
+        )
+        if blocking_reason is not None:
+            skipped.append(
+                _skipped_prune_summary(
+                    root,
+                    manifest_path=manifest_path,
+                    path=page_relpath,
+                    source=source,
+                    reason=blocking_reason,
+                )
+            )
+            continue
+
+        _remove_pruned_page_links(manifest_path, source, page_relpath)
+        page_path.unlink()
+        pruned.append(
+            PrunedSourceSummary(
+                path=page_relpath,
+                source_id=source_id,
+                superseded_by=successor.source_id,
+                manifest_path=manifest_path.relative_to(root).as_posix(),
+            )
+        )
+
+    return PruneSupersededResult(candidates=candidates, pruned=pruned, skipped=skipped)
+
+
+def migrate_superseded_topic_refs(root: Path) -> TopicRefMigrationResult:
+    layout = resolve_layout(root, load_config(root))
+    sources = _load_sources_by_id(layout)
+    replacements = _superseded_source_replacements(sources)
+    updated: list[TopicRefMigration] = []
+    candidates = 0
+    if not replacements:
+        return TopicRefMigrationResult(candidates=0, updated=[])
+
+    for page_path in sorted(layout.wiki_dir.rglob("*.md")):
+        if page_path.name == ".gitkeep" or page_path in {layout.index_file, layout.log_file}:
+            continue
+        try:
+            parsed = parse_wiki_markdown(page_path)
+        except ValueError:
+            continue
+        if parsed.frontmatter.kind == "source-summary":
+            continue
+        page_replacements = {
+            source_id: replacements[source_id]
+            for source_id in parsed.frontmatter.source_refs
+            if source_id in replacements
+        }
+        body = parsed.body
+        for old_id, new_id in replacements.items():
+            migrated_body = _migrate_source_ref_body_lines(body, old_id=old_id, new_id=new_id)
+            if migrated_body == body:
+                continue
+            page_replacements.setdefault(old_id, new_id)
+            body = migrated_body
+        if not page_replacements:
+            continue
+
+        candidates += 1
+        migrated_refs = [
+            page_replacements.get(source_ref, source_ref)
+            for source_ref in parsed.frontmatter.source_refs
+        ]
+        frontmatter = parsed.frontmatter.model_copy(
+            update={"source_refs": _dedupe_preserve_order(migrated_refs)}
+        )
+        content = f"---\n{render_frontmatter(frontmatter)}\n---\n{body}"
+        write_text_atomic(page_path, content)
+        updated.append(
+            TopicRefMigration(
+                path=page_path.relative_to(root).as_posix(),
+                replacements=dict(sorted(page_replacements.items())),
+            )
+        )
+
+    return TopicRefMigrationResult(candidates=candidates, updated=updated)
 
 
 def render_workspace_refresh_json(root: Path, result: WorkspaceRefreshResult) -> str:
@@ -69,9 +282,158 @@ def render_workspace_refresh_json(root: Path, result: WorkspaceRefreshResult) ->
             "refreshed": [_refresh_payload(root, item) for item in result.refreshed],
             "ingest": None if result.ingest is None else _ingest_payload(root, result.ingest),
             "index": None if result.index is None else asdict(result.index),
+            "pruning": None if result.pruning is None else asdict(result.pruning),
+            "topic_ref_migration": (
+                None if result.topic_ref_migration is None else asdict(result.topic_ref_migration)
+            ),
         },
         indent=2,
     )
+
+
+def _load_sources_by_id(layout) -> dict[str, SourceRecord]:
+    return {
+        path.stem: load_source_record(path)
+        for path in sorted(layout.source_records_dir.glob("*.json"))
+        if path.is_file()
+    }
+
+
+def _skipped_prune_summary(
+    root: Path,
+    *,
+    manifest_path: Path,
+    path: str,
+    source: SourceRecord,
+    reason: str,
+) -> SkippedPruneSourceSummary:
+    return SkippedPruneSourceSummary(
+        path=path,
+        source_id=source.source_id,
+        superseded_by=source.superseded_by,
+        manifest_path=manifest_path.relative_to(root).as_posix(),
+        reason=reason,
+    )
+
+
+def _remove_pruned_page_links(manifest_path: Path, source: SourceRecord, page_ref: str) -> None:
+    linked_pages = [value for value in source.linked_pages if value != page_ref]
+    provenance_links = [
+        link
+        for link in source.provenance_links
+        if not (
+            link.page_id == source.source_id
+            and link.role == "generated-page"
+            and link.path_ref == page_ref
+        )
+    ]
+    if linked_pages == source.linked_pages and provenance_links == source.provenance_links:
+        return
+    updated = source.model_copy(
+        update={"linked_pages": linked_pages, "provenance_links": provenance_links}
+    )
+    write_source_record(manifest_path, updated)
+
+
+def _prune_blocking_reference_reason(
+    root: Path,
+    layout,
+    *,
+    page_id: str,
+    page_ref: str,
+    candidate_path: Path,
+) -> str | None:
+    for wiki_path in sorted(layout.wiki_dir.rglob("*.md")):
+        if wiki_path in {candidate_path, layout.index_file, layout.log_file}:
+            continue
+        if wiki_path.name == ".gitkeep":
+            continue
+        wiki_ref = wiki_path.relative_to(root).as_posix()
+        text = wiki_path.read_text(encoding="utf-8")
+        if page_ref in text:
+            return f"referenced by wiki page body: {wiki_ref}"
+        try:
+            parsed = parse_wiki_markdown(wiki_path)
+        except ValueError:
+            continue
+        frontmatter = parsed.frontmatter
+        if page_id in frontmatter.related_pages:
+            return f"referenced by wiki page related_pages: {wiki_ref}"
+        for link in frontmatter.provenance_links:
+            if link.page_id == page_id or link.path_ref == page_ref:
+                return f"referenced by wiki page provenance: {wiki_ref}"
+        for contradiction in frontmatter.contradictions:
+            if page_id in contradiction.related_page_ids:
+                return f"referenced by wiki page contradiction: {wiki_ref}"
+            for evidence in contradiction.evidence:
+                if evidence.page_id == page_id:
+                    return f"referenced by wiki page contradiction evidence: {wiki_ref}"
+
+    for planning_path in sorted(layout.planning_dir.rglob("*.md")):
+        if planning_path.name == ".gitkeep" or not planning_path.is_file():
+            continue
+        text = planning_path.read_text(encoding="utf-8")
+        if page_ref in text:
+            planning_ref = planning_path.relative_to(root).as_posix()
+            return f"referenced by planning record: {planning_ref}"
+
+    return None
+
+
+def _migrate_source_ref_body_lines(body: str, *, old_id: str, new_id: str) -> str:
+    lines = body.splitlines(keepends=True)
+    migrated: list[str] = []
+    in_source_references = False
+    for line in lines:
+        newline = ""
+        content = line
+        if line.endswith("\r\n"):
+            content = line[:-2]
+            newline = "\r\n"
+        elif line.endswith("\n"):
+            content = line[:-1]
+            newline = "\n"
+        stripped = content.strip()
+        if stripped.startswith("## "):
+            in_source_references = stripped == "## Source References"
+        if in_source_references and stripped == f"- `{old_id}`":
+            leading = content[: len(content) - len(content.lstrip())]
+            migrated.append(f"{leading}- `{new_id}`{newline}")
+            continue
+        migrated.append(line)
+    return "".join(migrated)
+
+
+def _superseded_source_replacements(sources: dict[str, SourceRecord]) -> dict[str, str]:
+    replacements: dict[str, str] = {}
+    for source_id, source in sources.items():
+        current_id = _current_source_id(source, sources)
+        if current_id != source_id:
+            replacements[source_id] = current_id
+    return replacements
+
+
+def _current_source_id(source: SourceRecord, sources: dict[str, SourceRecord]) -> str:
+    seen = {source.source_id}
+    current = source
+    while current.superseded_by is not None and current.superseded_by not in seen:
+        successor = sources.get(current.superseded_by)
+        if successor is None:
+            break
+        seen.add(successor.source_id)
+        current = successor
+    return current.source_id
+
+
+def _dedupe_preserve_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
 
 
 def _refresh_changed_item(root: Path, item: SourceFreshnessItem) -> SourceRefreshResult:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1124,6 +1124,145 @@ def test_cli_workspace_refresh_changed_ingests_and_rebuilds_index(tmp_path: Path
     assert main(["--root", str(tmp_path), "health"]) == 0
 
 
+def test_cli_workspace_refresh_prunes_superseded_summaries_and_updates_topic_refs(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    write_config(tmp_path, config)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "add-topic",
+            "Brief Synthesis",
+            "--source-refs",
+            original_id,
+        ]
+    )
+    topic_path = tmp_path / "wiki" / "topics" / "brief-synthesis.md"
+    topic_path.write_text(
+        topic_path.read_text(encoding="utf-8")
+        + "\nHistorical note: keep old source id in prose "
+        + f"`{original_id}`.\n\n"
+        + "```text\n"
+        + f"`{original_id}`\n"
+        + "```\n\n"
+        + "## Historical\n\n"
+        + f"- `{original_id}`\n",
+        encoding="utf-8",
+    )
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "workspace",
+            "refresh",
+            "--changed",
+            "--ingest",
+            "--rebuild-index",
+            "--prune-superseded",
+            "--update-topic-refs",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    refreshed_id = payload["refreshed"][0]["source_id"]
+    assert payload["pruning"]["pruned"] == [
+        {
+            "path": f"wiki/sources/{original_id}.md",
+            "source_id": original_id,
+            "superseded_by": refreshed_id,
+            "manifest_path": f"state/manifests/sources/{original_id}.json",
+        }
+    ]
+    assert payload["topic_ref_migration"]["updated"] == [
+        {
+            "path": "wiki/topics/brief-synthesis.md",
+            "replacements": {original_id: refreshed_id},
+        }
+    ]
+    assert not (tmp_path / "wiki" / "sources" / f"{original_id}.md").exists()
+    assert (tmp_path / "wiki" / "sources" / f"{refreshed_id}.md").exists()
+    original_manifest = load_source_record(
+        tmp_path / "state" / "manifests" / "sources" / f"{original_id}.json"
+    )
+    assert f"wiki/sources/{original_id}.md" not in original_manifest.linked_pages
+
+    topic_text = (tmp_path / "wiki" / "topics" / "brief-synthesis.md").read_text(encoding="utf-8")
+    frontmatter_text = topic_text.removeprefix("---\n").split("\n---\n", maxsplit=1)[0]
+    topic_frontmatter = yaml.safe_load(frontmatter_text)
+    assert topic_frontmatter["source_refs"] == [refreshed_id]
+    assert f"- `{refreshed_id}`" in topic_text
+    assert f"Historical note: keep old source id in prose `{original_id}`." in topic_text
+    assert f"```text\n`{original_id}`\n```" in topic_text
+    assert f"## Historical\n\n- `{original_id}`" in topic_text
+    index_text = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+    assert f"sources/{original_id}.md" not in index_text
+    assert f"sources/{refreshed_id}.md" in index_text
+
+    assert main(["--root", str(tmp_path), "lint"]) == 0
+    assert main(["--root", str(tmp_path), "health"]) == 0
+
+
+def test_cli_workspace_refresh_reports_skipped_superseded_prune_candidates(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "workspace",
+            "refresh",
+            "--changed",
+            "--ingest",
+            "--rebuild-index",
+        ]
+    )
+    old_summary = tmp_path / "wiki" / "sources" / f"{original_id}.md"
+    old_summary.write_text("not frontmatter\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "workspace",
+            "refresh",
+            "--changed",
+            "--prune-superseded",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["pruning"]["candidates"] == 1
+    assert payload["pruning"]["pruned"] == []
+    assert payload["pruning"]["skipped"][0]["path"] == f"wiki/sources/{original_id}.md"
+    assert payload["pruning"]["skipped"][0]["source_id"] == original_id
+    assert "missing YAML frontmatter" in payload["pruning"]["skipped"][0]["reason"]
+    assert old_summary.exists()
+
+
 def test_cli_workspace_refresh_ingests_only_refreshed_sources(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     changed_source = tmp_path / "changed.md"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -11,7 +11,7 @@ from splendor.commands.ingest import enqueue_ingest_job
 from splendor.commands.init import initialize_workspace
 from splendor.config import default_config, load_config, write_config
 from splendor.layout import resolve_layout
-from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord
+from splendor.schemas import KnowledgePageFrontmatter, ProvenanceLink, QueueItemRecord, RunRecord
 from splendor.state.runtime import write_queue_item, write_run_record
 from splendor.state.source_registry import load_source_record, write_source_record
 
@@ -84,6 +84,56 @@ def test_run_health_checks_accepts_superseded_workspace_source_versions(
     result = _run_health(tmp_path)
 
     assert result.issues == []
+
+
+def test_run_health_checks_only_exempts_exact_pruned_superseded_summary_refs(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    refreshed = add_source(tmp_path, source)
+    original = load_source_record(added.manifest_path).model_copy(
+        update={"superseded_by": refreshed.source_id}
+    )
+    updated = load_source_record(refreshed.manifest_path).model_copy(
+        update={"supersedes": [added.source_id]}
+    )
+    write_source_record(added.manifest_path, original)
+    write_source_record(refreshed.manifest_path, updated)
+    run = RunRecord(
+        run_id="run-pruned",
+        job_id=f"ingest-{added.source_id}",
+        job_type="ingest_source",
+        started_at="2026-01-01T00:00:00+00:00",
+        finished_at="2026-01-01T00:00:01+00:00",
+        status="succeeded",
+        pipeline_version=__version__,
+        source_ids=[added.source_id],
+        page_ids=[added.source_id, "topic-missing"],
+        page_refs=[f"wiki/sources/{added.source_id}.md", "wiki/topics/missing.md"],
+        provenance_links=[
+            ProvenanceLink(
+                page_id=added.source_id,
+                path_ref=f"wiki/sources/{added.source_id}.md",
+                role="generated-page",
+            ),
+            ProvenanceLink(page_id="topic-missing", role="generated-page"),
+            ProvenanceLink(path_ref="wiki/topics/missing.md", role="generated-page"),
+        ],
+    )
+    write_run_record(tmp_path / "state" / "runs" / "run-pruned.json", run)
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == [
+        "missing-run-page-id",
+        "missing-run-page-ref",
+        "missing-run-provenance-page-ref",
+        "missing-run-provenance-path",
+    ]
 
 
 def test_run_health_checks_still_validates_superseded_copied_source_artifacts(


### PR DESCRIPTION
## Summary

Implements `M14-P1.4` under parent slice `M14-P1` for the #72 source-refresh lifecycle feedback loop.

- Adds explicit `splendor workspace refresh --changed --prune-superseded` cleanup for superseded generated source-summary pages once a current successor summary exists.
- Keeps historical source manifests and run records on disk, removes stale generated-page links from superseded manifests, and teaches `splendor health` that pruned generated pages for superseded workspace source versions are valid historical provenance.
- Adds explicit `splendor workspace refresh --changed --update-topic-refs` migration for maintained wiki source refs from superseded content-addressed IDs to the active source version ID.
- Extends workspace refresh JSON/human output and docs around the explicit pruning/migration contract while preserving schema version `1` compatibility.
- Rolls planning state to `M14-P1.4`, with `M14-P2.1` as the next PR sub-slice.

## Scope notes

This intentionally does not implement `splendor pr-summary --since main` (`M14-P2.1`), mutating compile/update work (#79), broad repo discovery, repo-scan bulk optimization (#30), web document-list scaling (#37), or ingest run-duration precision (#47).

Refs #72.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`
