### PR TITLE
M14-P2.1 Add PR summary generated-state handoff

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M14-P1.3`
-- Last action taken: `M14-P1.3` is implemented; workspace refresh can safely detect changed curated workspace-backed sources, refresh, ingest, and rebuild the index.
-- Current planned slice: `M14-P1`
-- Current PR sub-slice: `M14-P1.4`
+- Previous completed PR sub-slice: `M14-P1.4`
+- Last action taken: `M14-P1.4` is implemented; workspace refresh can prune superseded generated source-summary pages and migrate maintained wiki source refs.
+- Current planned slice: `M14-P2`
+- Current PR sub-slice: `M14-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M14-P2`
-- Next planned PR sub-slice: `M14-P2.1`
+- Next planned slice: `SynthBanshee re-evaluation gate`
+- Next planned PR sub-slice: `TBD`
 - Current blockers: none
 
 ## Planning Notation
@@ -242,6 +242,11 @@
   - [x] Keep historical source manifests and run records valid after generated summary pruning
   - [x] Add explicit `workspace refresh --update-topic-refs` migration from superseded source IDs to active source versions
   - [x] Keep PR summary, broad discovery, and mutating compile/update deferred
+- [x] Implement `M14-P2.1`: PR summary and lower-noise generated-state review handoff
+  - [x] Add read-only `splendor pr-summary --since main`
+  - [x] Summarize curated source lifecycle, generated source-summary pages, maintained wiki pages, runtime/report churn, and latest local maintenance reports
+  - [x] Add JSON output for agent handoff
+  - [x] Keep mutating compile/update, broad discovery, repo-scan bulk optimization, web scaling, and ingest timing follow-ups deferred
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ Not implemented yet:
 - mutating review-gated `splendor wiki compile`
 - heavyweight OCR/image extraction providers
 - mutating web UI actions such as add-source forms
-- PR-oriented generated-state summaries such as `splendor pr-summary --since main`
 
 `splendor repo scan` is safe by default: it previews candidates without writing manifests or
 derived state. Registration requires `repo scan --apply` plus `--class ...` or `--all`.
@@ -161,6 +160,13 @@ page `source_refs` and generated source-reference list bullets from superseded s
 active source version ID. Prune JSON reports skipped unsafe candidates with reasons rather than
 deleting ambiguous state. The command does not discover or register uncurated files or mutate
 maintained synthesis content beyond that explicit source-ref migration.
+
+`splendor pr-summary --since main` is a read-only PR handoff command over local git state. It
+summarizes curated source manifests added, refreshed, or superseded; generated source-summary
+pages added, pruned, or changed; maintained wiki/topic pages changed; queue/run/report/derived
+generated-state churn; and the latest local lint/health report status when report files exist. Use
+`--json` for agent handoff. The command does not run lint or health, write reports, call GitHub, or
+mutate workspace state.
 
 Generated source-summary pages are deterministic ingestion artifacts. For readable in-repo
 markdown/text/code sources, Splendor defaults to concise claim-bearing excerpts and path-first
@@ -189,12 +195,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M14-P1.3`
-- Current planned slice: `M14-P1`
-- Current PR sub-slice: `M14-P1.4`
+- Previous completed PR sub-slice: `M14-P1.4`
+- Current planned slice: `M14-P2`
+- Current PR sub-slice: `M14-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M14-P2`
-- Next planned PR sub-slice: `M14-P2.1`
+- Next planned slice: `SynthBanshee re-evaluation gate`
+- Next planned PR sub-slice: `TBD`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -285,7 +291,7 @@ workflow as deferred. Issue #47 remains an ingest/run-state timing follow-up. Is
 remain post-v1 performance work. Issue #70 is closed after the M13-P2/M13-P3.1 response. Issue #72
 stays open as the parent feedback loop; stable logical source identities, supersession lifecycle,
 safe workspace refresh, superseded summary pruning, and topic-ref migration have landed, while
-PR-summary ideas remain post-v1 planning work.
+PR-summary support is now represented by `splendor pr-summary --since main`.
 Issue #79 tracks the deferred mutating compile/update path from #41.
 
 `M14-P1.1` adds the first stable logical source identity layer above content-addressed source IDs:
@@ -308,6 +314,12 @@ exists, and `--update-topic-refs` migrates maintained wiki source references to 
 content-addressed source version while schema version `1` continues to validate `source_refs`
 against source manifests. Historical manifests and run records remain valid.
 
+`M14-P2.1` adds the read-only PR handoff surface:
+`splendor pr-summary --since main` groups local changes into curated source lifecycle records,
+generated source-summary pages, maintained wiki/topic edits, generated queue/run/report churn, and
+latest local maintenance report status. The human output is path-first, and `--json` emits the
+same structure for agent handoff without mutating workspace state or depending on GitHub.
+
 ### v1 readiness checklist
 
 - [x] Safe repo discovery is non-mutating by default and requires explicit apply flags.
@@ -318,4 +330,4 @@ against source manifests. Historical manifests and run records remain valid.
 - [x] CLI, schema, quickstart, automation, and dogfooding docs describe the same current behavior.
 - [x] Final release handoff names validation, issue state, GitHub metadata, known non-blockers,
   and the post-v1 queue.
-- [ ] PR-summary tooling remains the next planned source-lifecycle handoff follow-up.
+- [x] PR-summary tooling gives reviewers a lower-noise generated-state handoff.

--- a/README.md
+++ b/README.md
@@ -161,12 +161,14 @@ active source version ID. Prune JSON reports skipped unsafe candidates with reas
 deleting ambiguous state. The command does not discover or register uncurated files or mutate
 maintained synthesis content beyond that explicit source-ref migration.
 
-`splendor pr-summary --since main` is a read-only PR handoff command over local git state. It
-summarizes curated source manifests added, refreshed, or superseded; generated source-summary
-pages added, pruned, or changed; maintained wiki/topic pages changed; queue/run/report/derived
-generated-state churn; and the latest local lint/health report status when report files exist. Use
-`--json` for agent handoff. The command does not run lint or health, write reports, call GitHub, or
-mutate workspace state.
+`splendor pr-summary --since main` is a read-only PR handoff command over local git state. It uses
+the merge base between `HEAD` and the base ref for PR-style diff semantics, then summarizes curated
+source manifests added, refreshed, superseded, or invalid; generated source-summary pages added,
+pruned, or changed; maintained wiki/topic pages changed; queue/run/report/derived generated-state
+churn; and the latest local lint/health report status when report files exist. Maintenance report
+status is labeled as latest local report state, not proof that this command ran validation for the
+current `HEAD`. Use `--json` for agent handoff. The command does not run lint or health, write
+reports, call GitHub, or mutate workspace state.
 
 Generated source-summary pages are deterministic ingestion artifacts. For readable in-repo
 markdown/text/code sources, Splendor defaults to concise claim-bearing excerpts and path-first
@@ -315,10 +317,11 @@ content-addressed source version while schema version `1` continues to validate 
 against source manifests. Historical manifests and run records remain valid.
 
 `M14-P2.1` adds the read-only PR handoff surface:
-`splendor pr-summary --since main` groups local changes into curated source lifecycle records,
+`splendor pr-summary --since main` groups merge-base changes into curated source lifecycle records,
 generated source-summary pages, maintained wiki/topic edits, generated queue/run/report churn, and
-latest local maintenance report status. The human output is path-first, and `--json` emits the
-same structure for agent handoff without mutating workspace state or depending on GitHub.
+latest local maintenance report status. The human output is path-first and layout-aware, and
+`--json` emits the same structure for agent handoff without mutating workspace state or depending
+on GitHub.
 
 ### v1 readiness checklist
 

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -376,3 +376,9 @@ the PR itself.
 
 If any of those publication steps are still missing, the work is still in progress even if the code
 changes are already committed locally.
+
+For Splendor-generated state changes, run `splendor pr-summary --since main` before publication
+when practical. The command is read-only and uses local git state plus existing lint/health reports
+to explain curated source changes, maintained wiki edits, source-summary changes, and mechanical
+queue/run/report churn for reviewers. It does not replace the required validation commands or
+GitHub metadata checks.

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -378,7 +378,8 @@ If any of those publication steps are still missing, the work is still in progre
 changes are already committed locally.
 
 For Splendor-generated state changes, run `splendor pr-summary --since main` before publication
-when practical. The command is read-only and uses local git state plus existing lint/health reports
-to explain curated source changes, maintained wiki edits, source-summary changes, and mechanical
-queue/run/report churn for reviewers. It does not replace the required validation commands or
-GitHub metadata checks.
+when practical. The command is read-only and uses local merge-base git state plus existing
+lint/health reports to explain curated source changes, maintained wiki edits, source-summary
+changes, and mechanical queue/run/report churn for reviewers. It labels lint/health status as
+latest local report state; it does not replace the required validation commands or GitHub metadata
+checks.

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -109,8 +109,8 @@ in issue #72.
   freshness, ranked handoff, and path-first source-summary UX.
 - #72 is a separate parent feedback loop for source-refresh lifecycle and agent workflow. Stable
   workspace-backed `source:<path>` aliases, `supersedes`/`superseded_by`, safe workspace refresh,
-  superseded source-summary pruning, and topic-ref migration have landed; `pr-summary` remains
-  post-v1 work.
+  superseded source-summary pruning, topic-ref migration, and `splendor pr-summary --since main`
+  have landed; the parent issue remains open for the planned external-agent retry.
 - #41 has shipped `splendor brief [goal]`, `brief --agent-context`, and the non-mutating
   `splendor wiki compile <source-id|title|path>` contract. Mutating compile/update support remains
   deferred and is tracked by #79.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -211,6 +211,12 @@ Implemented fields:
   source-reference list bullets from superseded source IDs to the active content-addressed source
   version, leaving prose and code-fence mentions untouched. The command does not perform broad repo
   discovery, register uncurated files, or run mutating synthesis compile/update workflows.
+- `splendor pr-summary --since main` is a read-only PR handoff view over local git diff/status and
+  existing report files. It groups curated source manifests, generated source-summary pages,
+  maintained wiki/topic pages, queue/run/report/derived generated-state churn, latest local
+  lint/health report status when available, and reviewer notes. `--json` emits the same structure
+  for agents. The command does not create manifests, queue jobs, wiki pages, run records, reports,
+  or GitHub state.
 - `splendor suggest-next [goal]` is a read-only handoff view over existing deterministic state. It
   does not create planning records, queue jobs, manifests, wiki pages, run records, or reports.
   Human output is path-first where possible; `--json` emits ranked action objects with category,
@@ -272,6 +278,8 @@ In this release:
   rewrite
 - safe workspace refresh composes existing source, queue, ingest, wiki-index, and wiki-frontmatter
   records without changing schema version `1`
+- PR-summary output is derived from existing schema-version-1 files and local git state; it is not a
+  persisted schema and does not require a schema-version bump
 
 ## Knowledge page frontmatter
 
@@ -443,9 +451,10 @@ Current runtime behavior:
 - The release-ready core is file-based, deterministic, and compatible with legacy `path`-only
   source manifests.
 - Source freshness, suggest-next, and agent briefing use existing records as read-only signals.
-- Stable logical source identities are schema-version-1-compatible optional fields above the
-  content-addressed `source_id` compatibility contract. Supersession-aware history remains deferred
-  so it can be designed without breaking the v1 manifest contract.
+- Stable logical source identities, supersession-aware history, superseded summary pruning,
+  maintained-page source-ref migration, and PR-summary handoff output are all
+  schema-version-1-compatible layers above the content-addressed `source_id` compatibility
+  contract.
 - Lint validates present workspace-backed logical identity fields: `logical_id` must match
   `source:<source_ref>`, persisted aliases must stay scoped to the canonical workspace path, and
   exact identities must not point at conflicting canonical source refs.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -212,11 +212,13 @@ Implemented fields:
   version, leaving prose and code-fence mentions untouched. The command does not perform broad repo
   discovery, register uncurated files, or run mutating synthesis compile/update workflows.
 - `splendor pr-summary --since main` is a read-only PR handoff view over local git diff/status and
-  existing report files. It groups curated source manifests, generated source-summary pages,
-  maintained wiki/topic pages, queue/run/report/derived generated-state churn, latest local
-  lint/health report status when available, and reviewer notes. `--json` emits the same structure
-  for agents. The command does not create manifests, queue jobs, wiki pages, run records, reports,
-  or GitHub state.
+  existing report files. It diffs from the merge base between `HEAD` and the base ref, respects
+  configured workspace layout directories, and groups curated source manifests, generated
+  source-summary pages, maintained wiki/topic pages, queue/run/report/derived generated-state
+  churn, latest local lint/health report status when available, and reviewer notes. Malformed
+  changed source manifests are reported as invalid curated-source changes instead of aborting the
+  whole summary. `--json` emits the same structure for agents. The command does not create
+  manifests, queue jobs, wiki pages, run records, reports, or GitHub state.
 - `splendor suggest-next [goal]` is a read-only handoff view over existing deterministic state. It
   does not create planning records, queue jobs, manifests, wiki pages, run records, or reports.
   Human output is path-first where possible; `--json` emits ranked action objects with category,

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M14-P1.3`
-- Current planned slice: `M14-P1`
-- Current PR sub-slice: `M14-P1.4`
+- Previous completed PR sub-slice: `M14-P1.4`
+- Current planned slice: `M14-P2`
+- Current PR sub-slice: `M14-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M14-P2`
-- Next planned PR sub-slice: `M14-P2.1`
+- Next planned slice: `SynthBanshee re-evaluation gate`
+- Next planned PR sub-slice: `TBD`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -821,9 +821,9 @@ frontmatter, manifests, and run records continue to use canonical IDs for compat
 `M13-P3.1` is the release-hardening and v1 readiness audit. It keeps the implementation surface
 stable, reconciles README, quickstart, schema/product docs, roadmap, CI/GitHub automation docs, and
 dogfooding guidance with the current product, and records per-issue status for the open feedback
-threads. It does not add SQLite, vector search, background workers, mutating web UI, broad refresh
-lifecycle machinery, stable logical source identities, supersedes/superseded_by source semantics,
-pruning, or PR-summary tooling.
+threads. Later M14 slices added stable logical source identities, supersedes/superseded_by source
+semantics, safe workspace refresh, pruning, topic-ref migration, and PR-summary tooling without
+adding SQLite, vector search, background workers, mutating web UI, or broad refresh discovery.
 
 `M13-P3.2` is the final release checklist and post-v1 handoff. It keeps runtime behavior stable,
 adds the concise release handoff in `docs/v1_release_handoff.md`, and makes the post-v1 queue
@@ -843,7 +843,7 @@ performance/scaling follow-ups.
   identify that #72 now owns remaining source lifecycle and agent-workflow follow-up.
 - [x] Issue #72 remains the parent feedback loop for source-refresh lifecycle and agent workflow;
   stable logical source identities, source supersession, safe workspace refresh, superseded
-  summary pruning, and topic-ref migration have landed; `pr-summary` remains post-v1 work.
+  summary pruning, topic-ref migration, and `splendor pr-summary --since main` have landed.
 - [x] Issue #79 tracks the deferred mutating compile/update path from #41 so #41 can stay closed for
   the shipped v1 briefing and non-mutating compile-contract scope.
 - [x] Final release handoff records validation commands, docs state, issue state, GitHub metadata,
@@ -903,12 +903,18 @@ post-#72 lifecycle loop is substantially implemented. The intended sequence befo
    `splendor workspace refresh --changed --ingest --rebuild-index`, limited to curated
    workspace-backed source manifests.
 5. `M14-P1.4` handles superseded generated-state pruning and topic-ref migration.
-6. `M14-P2.1` adds `splendor pr-summary --since main` or an equivalent PR-oriented summary with
-   lower-noise generated-state review guidance.
+6. `M14-P2.1` adds `splendor pr-summary --since main`, a read-only PR-oriented summary with
+   lower-noise generated-state review guidance over local git state.
 
 After those slices land, the external-agent retry should use a comparable real planning or
 repo-maintenance workflow and explicitly compare against #72. Earlier feedback should be requested
 only for the narrower safe-discovery, freshness, and handoff surfaces already shipped in M13.
+
+`M14-P2.1` keeps the command non-mutating and schema-version-1-compatible. It summarizes curated
+source manifests, generated source-summary pages, maintained wiki/topic pages, queue/run/report
+churn, latest local lint/health reports when available, and reviewer notes that distinguish
+meaningful generated knowledge from mechanical runtime records. JSON output is available for agent
+handoff.
 
 ### Boundaries
 - Promote these candidates to committed roadmap slices only after the child issues and GitHub

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -910,11 +910,12 @@ After those slices land, the external-agent retry should use a comparable real p
 repo-maintenance workflow and explicitly compare against #72. Earlier feedback should be requested
 only for the narrower safe-discovery, freshness, and handoff surfaces already shipped in M13.
 
-`M14-P2.1` keeps the command non-mutating and schema-version-1-compatible. It summarizes curated
-source manifests, generated source-summary pages, maintained wiki/topic pages, queue/run/report
-churn, latest local lint/health reports when available, and reviewer notes that distinguish
-meaningful generated knowledge from mechanical runtime records. JSON output is available for agent
-handoff.
+`M14-P2.1` keeps the command non-mutating and schema-version-1-compatible. It summarizes
+merge-base curated source manifests, generated source-summary pages, maintained wiki/topic pages,
+queue/run/report churn, latest local lint/health reports when available, and reviewer notes that
+distinguish meaningful generated knowledge from mechanical runtime records. It respects configured
+layout paths and reports malformed changed source manifests without aborting the whole handoff.
+JSON output is available for agent handoff.
 
 ### Boundaries
 - Promote these candidates to committed roadmap slices only after the child issues and GitHub

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -790,10 +790,12 @@ Current implementation:
   It does not discover or register uncurated files or run mutating synthesis compile/update
   workflows.
 - `splendor pr-summary --since main` is a read-only PR handoff command. It uses local git
-  diff/status and existing report files to group curated source lifecycle changes, generated
-  source-summary pages, maintained wiki/topic edits, queue/run/report/derived churn, latest local
-  lint/health report status, and reviewer notes that separate meaningful generated knowledge from
-  mechanical runtime records. `--json` emits the same summary for agent handoff.
+  diff/status from the merge base with the base ref, respects configured layout paths, and uses
+  existing report files to group curated source lifecycle changes, generated source-summary pages,
+  maintained wiki/topic edits, queue/run/report/derived churn, latest local lint/health report
+  status, and reviewer notes that separate meaningful generated knowledge from mechanical runtime
+  records. Latest maintenance status is explicitly reported as local report state rather than
+  fresh validation for the current `HEAD`. `--json` emits the same summary for agent handoff.
 - `splendor add-topic "Title"` scaffolds a maintained topic page under `wiki/topics/<slug>.md`
   with valid knowledge-page frontmatter, optional tags/source refs, and deterministic markdown
   templates for default synthesis, research synthesis, and issue tracking.

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -789,6 +789,11 @@ Current implementation:
   active content-addressed source version, while leaving prose and code-fence mentions untouched.
   It does not discover or register uncurated files or run mutating synthesis compile/update
   workflows.
+- `splendor pr-summary --since main` is a read-only PR handoff command. It uses local git
+  diff/status and existing report files to group curated source lifecycle changes, generated
+  source-summary pages, maintained wiki/topic edits, queue/run/report/derived churn, latest local
+  lint/health report status, and reviewer notes that separate meaningful generated knowledge from
+  mechanical runtime records. `--json` emits the same summary for agent handoff.
 - `splendor add-topic "Title"` scaffolds a maintained topic page under `wiki/topics/<slug>.md`
   with valid knowledge-page frontmatter, optional tags/source refs, and deterministic markdown
   templates for default synthesis, research synthesis, and issue tracking.
@@ -861,8 +866,8 @@ Release-readiness boundary:
   with workspace-backed `source:<path>` aliases plus `supersedes`/`superseded_by` source-version
   links. The safe workspace refresh path over curated workspace-backed sources has also landed,
   including explicit superseded source-summary pruning and maintained-page source-ref migration.
-  The `pr-summary` surface remains a follow-up unless a future roadmap slice explicitly pulls it
-  forward.
+  The `pr-summary` surface now provides a read-only local PR handoff over that generated-state
+  churn.
 - issue #79 tracks the deferred mutating compile/update workflow from #41; v1 ships briefing and
   the non-mutating compile contract only.
 - `docs/v1_release_handoff.md` is the v1 handoff checklist for final validation, GitHub metadata,
@@ -918,6 +923,10 @@ A source should not be re-ingested merely because it exists in the repo. Re-inge
 - the user explicitly requests re-ingestion
 - a repair job targets the source
 - a source refresh detects changed content and registers the current source version
+
+PR handoff summarization should not trigger re-ingestion. `splendor pr-summary --since main`
+observes local git state and existing report artifacts only; it does not refresh sources, enqueue
+jobs, run maintenance checks, or write reports.
 
 ## 16. Queue Model
 
@@ -1317,8 +1326,8 @@ These are not blockers to the spec, but should remain visible:
 7. whether a companion-repo linking model needs a first-class schema element
 8. post-v1 refinements to generated source-summary policy for readable in-repo markdown and code
    files, after the v1 default of concise claim-bearing excerpts has been exercised in real repos
-9. stable logical source identities, source supersession semantics, pruning policy, and PR-summary
-   tooling for lower-churn agent workflows
+9. authority and staleness metadata for living planning docs after the source-lifecycle and
+   PR-summary handoff loop has been exercised in real repos
 
 ## 31. Summary Product Statement
 

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -49,14 +49,14 @@ For this handoff:
 - #47 remains open as the real ingest run-duration bug
 - #30 remains open as post-v1 repo-scan registration performance work
 - #37 remains open as post-v1 web document-list scaling work
+- #72 is unblocked for the planned SynthBanshee re-evaluation once `M14-P2.1` lands; do not close
+  the parent issue before the external retry is recorded
 
 ## Known Non-Blockers
 
 These items are intentionally not v1 release blockers:
 
-- `splendor pr-summary --since main`
 - authority and staleness metadata for living planning docs
-- lower-noise generated-state review policies beyond the current reviewer-significance guidance
 - ingest run-duration precision for #47
 - repo-scan bulk registration optimization for #30
 - web document-list scaling for #37
@@ -68,8 +68,8 @@ The conservative next queue is:
 1. Continue #72 implementation after the workspace-backed `source:<path>` logical ID layer,
    supersession-aware source refresh, safe workspace refresh path, superseded generated-state
    pruning, and topic-ref migration.
-2. Add `splendor pr-summary --since main` only after source lifecycle churn is explicit enough to
-   summarize reliably.
+2. Use `splendor pr-summary --since main` during review handoff to explain source lifecycle,
+   maintained wiki, source-summary, and mechanical generated-state changes.
 3. Keep #79 as the tracked post-v1 compile/update workflow rather than reopening #41 for deferred
    scope.
 4. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
@@ -87,7 +87,7 @@ bundle is:
    index rebuild, and a health-clean end state.
 5. `M14-P1.4` Superseded generated-state pruning and topic-ref migration.
 6. `M14-P2.1` PR summary and lower-noise generated-state review handoff, including
-   `splendor pr-summary --since main` or an equivalent reviewed output.
+   `splendor pr-summary --since main`.
 
 After those slices land, ask the SynthBanshee Claude agent to retry a comparable real planning or
 repo-maintenance workflow and compare against the original #72 report. Before then, any retry

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -1448,6 +1448,7 @@ def handle_pr_summary(args: argparse.Namespace) -> int:
         return 0
 
     print(f"PR summary since {summary.since}")
+    print(f"Merge base: {summary.merge_base}")
     if summary.head is not None:
         print(f"Head: {summary.head}")
     print(f"Changed paths: {summary.changed_path_count}")
@@ -1464,6 +1465,8 @@ def handle_pr_summary(args: argparse.Namespace) -> int:
             print(f"  Supersedes: {', '.join(source.supersedes)}")
         if source.superseded_by is not None:
             print(f"  Superseded by: {source.superseded_by}")
+        if source.error is not None:
+            print(f"  Error: {source.error}")
 
     _print_path_group("Generated source-summary pages", summary.source_summary_pages)
     _print_path_group("Maintained wiki/topic pages", summary.maintained_wiki_pages)
@@ -1472,7 +1475,7 @@ def handle_pr_summary(args: argparse.Namespace) -> int:
         _print_path_group(f"- {label}", group, indent="  ")
     _print_path_group("Other changed paths", summary.other_paths)
 
-    print("Latest local maintenance reports:")
+    print("Latest local maintenance reports (not tied to current HEAD):")
     for command in ("lint", "health"):
         status = summary.maintenance.get(command)
         if status is None:
@@ -1482,6 +1485,7 @@ def handle_pr_summary(args: argparse.Namespace) -> int:
             f"- {command}: {status.status} path={status.path} "
             f"issues={status.issue_count if status.issue_count is not None else '-'}"
         )
+        print(f"  Warning: {status.warning}")
 
     print("Reviewer notes:")
     for note in summary.reviewer_notes:

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -36,6 +36,11 @@ from splendor.commands.planning import (
     list_tasks,
     update_question_answer,
 )
+from splendor.commands.pr_summary import (
+    PathGroup,
+    build_pr_summary,
+    render_pr_summary_json,
+)
 from splendor.commands.query import run_query
 from splendor.commands.queue import (
     QueueItemSnapshot,
@@ -383,6 +388,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     workspace_refresh_parser.set_defaults(handler=handle_workspace_refresh)
+
+    pr_summary_parser = subparsers.add_parser(
+        "pr-summary", help="Summarize PR-relevant Splendor state changes"
+    )
+    pr_summary_parser.add_argument(
+        "--since",
+        default="main",
+        help="Base git ref to compare against. Defaults to main.",
+    )
+    pr_summary_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    pr_summary_parser.set_defaults(handler=handle_pr_summary)
 
     materialize_parser = subparsers.add_parser(
         "materialize-source", help="Create or refresh a source storage artifact"
@@ -1413,6 +1434,71 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
     else:
         print("Next: splendor source freshness")
     return 0
+
+
+def handle_pr_summary(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        summary = build_pr_summary(root, since=args.since)
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_pr_summary_json(summary))
+        return 0
+
+    print(f"PR summary since {summary.since}")
+    if summary.head is not None:
+        print(f"Head: {summary.head}")
+    print(f"Changed paths: {summary.changed_path_count}")
+    print("Curated sources:")
+    if not summary.curated_sources:
+        print("- none")
+    for source in summary.curated_sources:
+        print(f"- {source.path}: {source.action} source_id={source.source_id}")
+        if source.source_ref is not None:
+            print(f"  Source ref: {source.source_ref}")
+        if source.logical_id is not None:
+            print(f"  Logical ID: {source.logical_id}")
+        if source.supersedes:
+            print(f"  Supersedes: {', '.join(source.supersedes)}")
+        if source.superseded_by is not None:
+            print(f"  Superseded by: {source.superseded_by}")
+
+    _print_path_group("Generated source-summary pages", summary.source_summary_pages)
+    _print_path_group("Maintained wiki/topic pages", summary.maintained_wiki_pages)
+    print("Generated state:")
+    for label, group in summary.generated_state.items():
+        _print_path_group(f"- {label}", group, indent="  ")
+    _print_path_group("Other changed paths", summary.other_paths)
+
+    print("Latest local maintenance reports:")
+    for command in ("lint", "health"):
+        status = summary.maintenance.get(command)
+        if status is None:
+            print(f"- {command}: no local report found")
+            continue
+        print(
+            f"- {command}: {status.status} path={status.path} "
+            f"issues={status.issue_count if status.issue_count is not None else '-'}"
+        )
+
+    print("Reviewer notes:")
+    for note in summary.reviewer_notes:
+        print(f"- {note}")
+    return 0
+
+
+def _print_path_group(label: str, group: PathGroup, *, indent: str = "") -> None:
+    print(f"{indent}{label}: total={group.total}")
+    for path in group.added:
+        print(f"{indent}- added: {path}")
+    for path in group.changed:
+        print(f"{indent}- changed: {path}")
+    for item in group.renamed:
+        print(f"{indent}- renamed: {item['from']} -> {item['to']}")
+    for path in group.deleted:
+        print(f"{indent}- deleted: {path}")
 
 
 def handle_materialize_source(args: argparse.Namespace) -> int:

--- a/src/splendor/commands/pr_summary.py
+++ b/src/splendor/commands/pr_summary.py
@@ -1,0 +1,367 @@
+"""Read-only PR-oriented generated-state summaries."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from splendor.config import load_config
+from splendor.layout import ResolvedLayout, resolve_layout
+from splendor.schemas import SourceRecord
+from splendor.schemas.maintenance import MaintenanceReport
+from splendor.state.source_compat import canonical_source_ref, effective_logical_id
+from splendor.state.source_registry import load_source_record
+
+
+@dataclass(frozen=True)
+class ChangedPath:
+    status: str
+    path: str
+    old_path: str | None = None
+
+
+@dataclass(frozen=True)
+class SourceChange:
+    action: str
+    path: str
+    source_id: str
+    title: str | None
+    source_ref: str | None
+    logical_id: str | None
+    supersedes: list[str]
+    superseded_by: str | None
+    old_path: str | None = None
+
+
+@dataclass(frozen=True)
+class PathGroup:
+    added: list[str]
+    changed: list[str]
+    deleted: list[str]
+    renamed: list[dict[str, str]]
+
+    @property
+    def total(self) -> int:
+        return len(self.added) + len(self.changed) + len(self.deleted) + len(self.renamed)
+
+
+@dataclass(frozen=True)
+class MaintenanceStatus:
+    command: str
+    status: str
+    path: str
+    created_at: str | None
+    checked_count: int | None
+    issue_count: int | None
+    fatal_error: str | None
+
+
+@dataclass(frozen=True)
+class PrSummary:
+    since: str
+    head: str | None
+    changed_path_count: int
+    curated_sources: list[SourceChange]
+    source_summary_pages: PathGroup
+    maintained_wiki_pages: PathGroup
+    generated_state: dict[str, PathGroup]
+    other_paths: PathGroup
+    maintenance: dict[str, MaintenanceStatus | None]
+    reviewer_notes: list[str]
+
+
+def build_pr_summary(root: Path, *, since: str) -> PrSummary:
+    root = root.resolve()
+    _assert_git_ref(root, since)
+    layout = resolve_layout(root, load_config(root))
+    changes = _changed_paths(root, since=since)
+    source_changes = _source_changes(root, since=since, changes=changes)
+    source_summary_pages = _group_paths(
+        change for change in changes if _is_source_summary_path(change.path)
+    )
+    maintained_wiki_pages = _group_paths(
+        change for change in changes if _is_maintained_wiki_path(change.path)
+    )
+    generated_state = {
+        "queue": _group_paths(
+            change for change in changes if change.path.startswith("state/queue/")
+        ),
+        "runs": _group_paths(change for change in changes if change.path.startswith("state/runs/")),
+        "queries": _group_paths(
+            change for change in changes if change.path.startswith("state/queries/")
+        ),
+        "reports": _group_paths(change for change in changes if change.path.startswith("reports/")),
+        "derived": _group_paths(change for change in changes if change.path.startswith("derived/")),
+    }
+    categorized = set()
+    for change in changes:
+        if _is_categorized_path(change, layout):
+            categorized.add(change.path)
+    other_paths = _group_paths(change for change in changes if change.path not in categorized)
+    maintenance = {
+        "lint": _latest_maintenance_status(root, command="lint"),
+        "health": _latest_maintenance_status(root, command="health"),
+    }
+    summary = PrSummary(
+        since=since,
+        head=_git_text(root, ["rev-parse", "--short", "HEAD"], required=False),
+        changed_path_count=len(changes),
+        curated_sources=source_changes,
+        source_summary_pages=source_summary_pages,
+        maintained_wiki_pages=maintained_wiki_pages,
+        generated_state=generated_state,
+        other_paths=other_paths,
+        maintenance=maintenance,
+        reviewer_notes=[],
+    )
+    return PrSummary(
+        since=summary.since,
+        head=summary.head,
+        changed_path_count=summary.changed_path_count,
+        curated_sources=summary.curated_sources,
+        source_summary_pages=summary.source_summary_pages,
+        maintained_wiki_pages=summary.maintained_wiki_pages,
+        generated_state=summary.generated_state,
+        other_paths=summary.other_paths,
+        maintenance=summary.maintenance,
+        reviewer_notes=_reviewer_notes(summary),
+    )
+
+
+def render_pr_summary_json(summary: PrSummary) -> str:
+    return json.dumps(asdict(summary), indent=2, sort_keys=True) + "\n"
+
+
+def _assert_git_ref(root: Path, ref: str) -> None:
+    _git_text(root, ["rev-parse", "--verify", f"{ref}^{{commit}}"])
+
+
+def _git_text(root: Path, args: list[str], *, required: bool = True) -> str | None:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        if required:
+            message = result.stderr.strip() or result.stdout.strip() or "git command failed"
+            raise ValueError(message)
+        return None
+    return result.stdout.strip()
+
+
+def _changed_paths(root: Path, *, since: str) -> list[ChangedPath]:
+    output = _git_text(root, ["diff", "--name-status", "-M", since, "--"]) or ""
+    changes: dict[str, ChangedPath] = {}
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+        if status.startswith("R") and len(parts) == 3:
+            changes[parts[2]] = ChangedPath(status="R", old_path=parts[1], path=parts[2])
+        elif len(parts) >= 2:
+            changes[parts[1]] = ChangedPath(status=status[0], path=parts[1])
+
+    status_output = _git_text(root, ["status", "--short", "--untracked-files=all"], required=False)
+    for line in (status_output or "").splitlines():
+        if not line.startswith("?? "):
+            continue
+        path = line[3:].strip()
+        if path and path not in changes:
+            changes[path] = ChangedPath(status="A", path=path)
+    return sorted(changes.values(), key=lambda change: change.path)
+
+
+def _source_changes(root: Path, *, since: str, changes: list[ChangedPath]) -> list[SourceChange]:
+    layout = resolve_layout(root, load_config(root))
+    result: list[SourceChange] = []
+    for change in changes:
+        if not _is_source_manifest_path(change.path, layout):
+            continue
+        current = _load_current_source(root, change.path)
+        previous = _load_source_at_ref(root, since, change.old_path or change.path)
+        source = current or previous
+        if source is None:
+            continue
+        action = _source_action(change, current=current, previous=previous)
+        result.append(
+            SourceChange(
+                action=action,
+                path=change.path,
+                old_path=change.old_path,
+                source_id=source.source_id,
+                title=source.title,
+                source_ref=canonical_source_ref(source),
+                logical_id=effective_logical_id(source),
+                supersedes=list(source.supersedes),
+                superseded_by=source.superseded_by,
+            )
+        )
+    return result
+
+
+def _is_source_manifest_path(path: str, layout: ResolvedLayout) -> bool:
+    source_dir = layout.source_records_dir.relative_to(layout.root).as_posix()
+    return path.startswith(f"{source_dir}/") and path.endswith(".json")
+
+
+def _load_current_source(root: Path, path: str) -> SourceRecord | None:
+    source_path = root / path
+    if not source_path.is_file():
+        return None
+    return load_source_record(source_path)
+
+
+def _load_source_at_ref(root: Path, ref: str, path: str) -> SourceRecord | None:
+    content = _git_text(root, ["show", f"{ref}:{path}"], required=False)
+    if content is None:
+        return None
+    payload = json.loads(content)
+    return SourceRecord.model_validate(payload)
+
+
+def _source_action(
+    change: ChangedPath,
+    *,
+    current: SourceRecord | None,
+    previous: SourceRecord | None,
+) -> str:
+    if change.status == "D":
+        return "removed"
+    if current is not None and current.supersedes:
+        return "refreshed"
+    if (
+        previous is not None
+        and current is not None
+        and current.superseded_by != previous.superseded_by
+    ):
+        return "superseded"
+    if change.status == "A":
+        return "added"
+    if change.status == "R":
+        return "renamed"
+    return "changed"
+
+
+def _is_source_summary_path(path: str) -> bool:
+    return path.startswith("wiki/sources/") and path.endswith(".md")
+
+
+def _is_maintained_wiki_path(path: str) -> bool:
+    return path.startswith("wiki/") and path.endswith(".md") and not _is_source_summary_path(path)
+
+
+def _in_group(change: ChangedPath, group_key: str) -> bool:
+    return change.path.startswith(
+        {
+            "queue": "state/queue/",
+            "runs": "state/runs/",
+            "queries": "state/queries/",
+            "reports": "reports/",
+            "derived": "derived/",
+        }[group_key]
+    )
+
+
+def _is_categorized_path(change: ChangedPath, layout: ResolvedLayout) -> bool:
+    return (
+        _is_source_manifest_path(change.path, layout)
+        or _is_source_summary_path(change.path)
+        or _is_maintained_wiki_path(change.path)
+        or any(_in_group(change, key) for key in ("queue", "runs", "queries", "reports", "derived"))
+    )
+
+
+def _group_paths(changes: Iterable[ChangedPath]) -> PathGroup:
+    added: list[str] = []
+    changed: list[str] = []
+    deleted: list[str] = []
+    renamed: list[dict[str, str]] = []
+    for change in changes:
+        if change.status == "A":
+            added.append(change.path)
+        elif change.status == "D":
+            deleted.append(change.path)
+        elif change.status == "R" and change.old_path is not None:
+            renamed.append({"from": change.old_path, "to": change.path})
+        else:
+            changed.append(change.path)
+    return PathGroup(
+        added=sorted(added),
+        changed=sorted(changed),
+        deleted=sorted(deleted),
+        renamed=sorted(renamed, key=lambda item: item["to"]),
+    )
+
+
+def _latest_maintenance_status(root: Path, *, command: str) -> MaintenanceStatus | None:
+    report_dir = root / "reports" / command
+    candidates = sorted(report_dir.glob("*.json"))
+    if not candidates:
+        return None
+    latest = candidates[-1]
+    try:
+        report = MaintenanceReport.model_validate_json(latest.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return MaintenanceStatus(
+            command=command,
+            status="unreadable",
+            path=latest.relative_to(root).as_posix(),
+            created_at=None,
+            checked_count=None,
+            issue_count=None,
+            fatal_error=str(exc),
+        )
+    return MaintenanceStatus(
+        command=command,
+        status=report.status,
+        path=latest.relative_to(root).as_posix(),
+        created_at=report.created_at,
+        checked_count=report.checked_count,
+        issue_count=report.issue_count,
+        fatal_error=report.fatal_error,
+    )
+
+
+def _reviewer_notes(summary: PrSummary) -> list[str]:
+    notes: list[str] = []
+    if summary.curated_sources:
+        notes.append(
+            "Review curated source manifests first: added/refreshed/superseded entries explain "
+            "the source lifecycle behind generated wiki and runtime churn."
+        )
+    if summary.source_summary_pages.total:
+        notes.append(
+            "Review added or changed source-summary pages for extracted claims; deleted "
+            "wiki/sources pages are usually mechanical when their source manifest is superseded."
+        )
+    if summary.maintained_wiki_pages.total:
+        notes.append(
+            "Review maintained wiki/topic pages as authored synthesis, especially source_refs "
+            "updates that redirect from superseded source IDs to active versions."
+        )
+    runtime_total = sum(summary.generated_state[key].total for key in ("queue", "runs", "reports"))
+    if runtime_total:
+        notes.append(
+            "Treat queue, run, and report files as generated-state evidence unless a failure, "
+            "dead-letter, or report issue changes the reviewer decision."
+        )
+    for command, status in summary.maintenance.items():
+        if status is None:
+            notes.append(
+                f"No local {command} report was found; run `splendor {command}` before handoff."
+            )
+        elif status.status != "passed":
+            notes.append(
+                f"Latest {command} report is {status.status} at {status.path}; "
+                "inspect it before PR review."
+            )
+    if not notes:
+        notes.append("No Splendor generated-state changes were detected since the base ref.")
+    return notes

--- a/src/splendor/commands/pr_summary.py
+++ b/src/splendor/commands/pr_summary.py
@@ -27,13 +27,14 @@ class ChangedPath:
 class SourceChange:
     action: str
     path: str
-    source_id: str
+    source_id: str | None
     title: str | None
     source_ref: str | None
     logical_id: str | None
     supersedes: list[str]
     superseded_by: str | None
     old_path: str | None = None
+    error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -53,6 +54,8 @@ class MaintenanceStatus:
     command: str
     status: str
     path: str
+    scope: str
+    warning: str
     created_at: str | None
     checked_count: int | None
     issue_count: int | None
@@ -62,6 +65,7 @@ class MaintenanceStatus:
 @dataclass(frozen=True)
 class PrSummary:
     since: str
+    merge_base: str
     head: str | None
     changed_path_count: int
     curated_sources: list[SourceChange]
@@ -77,24 +81,37 @@ def build_pr_summary(root: Path, *, since: str) -> PrSummary:
     root = root.resolve()
     _assert_git_ref(root, since)
     layout = resolve_layout(root, load_config(root))
-    changes = _changed_paths(root, since=since)
-    source_changes = _source_changes(root, since=since, changes=changes)
+    merge_base = _merge_base(root, since=since)
+    changes = _changed_paths(root, base_ref=merge_base)
+    source_changes = _source_changes(root, base_ref=merge_base, layout=layout, changes=changes)
     source_summary_pages = _group_paths(
-        change for change in changes if _is_source_summary_path(change.path)
+        change for change in changes if _is_source_summary_path(change.path, layout)
     )
     maintained_wiki_pages = _group_paths(
-        change for change in changes if _is_maintained_wiki_path(change.path)
+        change for change in changes if _is_maintained_wiki_path(change.path, layout)
     )
     generated_state = {
         "queue": _group_paths(
-            change for change in changes if change.path.startswith("state/queue/")
+            change for change in changes if _is_layout_child(change.path, layout, layout.queue_dir)
         ),
-        "runs": _group_paths(change for change in changes if change.path.startswith("state/runs/")),
+        "runs": _group_paths(
+            change for change in changes if _is_layout_child(change.path, layout, layout.runs_dir)
+        ),
         "queries": _group_paths(
-            change for change in changes if change.path.startswith("state/queries/")
+            change
+            for change in changes
+            if _is_layout_child(change.path, layout, layout.queries_dir)
         ),
-        "reports": _group_paths(change for change in changes if change.path.startswith("reports/")),
-        "derived": _group_paths(change for change in changes if change.path.startswith("derived/")),
+        "reports": _group_paths(
+            change
+            for change in changes
+            if _is_layout_child(change.path, layout, layout.reports_dir)
+        ),
+        "derived": _group_paths(
+            change
+            for change in changes
+            if _is_layout_child(change.path, layout, layout.derived_dir)
+        ),
     }
     categorized = set()
     for change in changes:
@@ -102,11 +119,12 @@ def build_pr_summary(root: Path, *, since: str) -> PrSummary:
             categorized.add(change.path)
     other_paths = _group_paths(change for change in changes if change.path not in categorized)
     maintenance = {
-        "lint": _latest_maintenance_status(root, command="lint"),
-        "health": _latest_maintenance_status(root, command="health"),
+        "lint": _latest_maintenance_status(root, layout=layout, command="lint"),
+        "health": _latest_maintenance_status(root, layout=layout, command="health"),
     }
     summary = PrSummary(
         since=since,
+        merge_base=merge_base,
         head=_git_text(root, ["rev-parse", "--short", "HEAD"], required=False),
         changed_path_count=len(changes),
         curated_sources=source_changes,
@@ -119,6 +137,7 @@ def build_pr_summary(root: Path, *, since: str) -> PrSummary:
     )
     return PrSummary(
         since=summary.since,
+        merge_base=summary.merge_base,
         head=summary.head,
         changed_path_count=summary.changed_path_count,
         curated_sources=summary.curated_sources,
@@ -139,6 +158,10 @@ def _assert_git_ref(root: Path, ref: str) -> None:
     _git_text(root, ["rev-parse", "--verify", f"{ref}^{{commit}}"])
 
 
+def _merge_base(root: Path, *, since: str) -> str:
+    return _git_text(root, ["merge-base", since, "HEAD"]) or since
+
+
 def _git_text(root: Path, args: list[str], *, required: bool = True) -> str | None:
     result = subprocess.run(
         ["git", *args],
@@ -155,8 +178,8 @@ def _git_text(root: Path, args: list[str], *, required: bool = True) -> str | No
     return result.stdout.strip()
 
 
-def _changed_paths(root: Path, *, since: str) -> list[ChangedPath]:
-    output = _git_text(root, ["diff", "--name-status", "-M", since, "--"]) or ""
+def _changed_paths(root: Path, *, base_ref: str) -> list[ChangedPath]:
+    output = _git_text(root, ["diff", "--name-status", "-M", base_ref, "--"]) or ""
     changes: dict[str, ChangedPath] = {}
     for line in output.splitlines():
         if not line.strip():
@@ -178,18 +201,42 @@ def _changed_paths(root: Path, *, since: str) -> list[ChangedPath]:
     return sorted(changes.values(), key=lambda change: change.path)
 
 
-def _source_changes(root: Path, *, since: str, changes: list[ChangedPath]) -> list[SourceChange]:
-    layout = resolve_layout(root, load_config(root))
+def _source_changes(
+    root: Path,
+    *,
+    base_ref: str,
+    layout: ResolvedLayout,
+    changes: list[ChangedPath],
+) -> list[SourceChange]:
     result: list[SourceChange] = []
     for change in changes:
         if not _is_source_manifest_path(change.path, layout):
             continue
-        current = _load_current_source(root, change.path)
-        previous = _load_source_at_ref(root, since, change.old_path or change.path)
+        current, current_error = _load_current_source(root, change.path)
+        previous, previous_error = _load_source_at_ref(
+            root, base_ref, change.old_path or change.path
+        )
         source = current or previous
+        error = current_error or previous_error
         if source is None:
+            result.append(
+                SourceChange(
+                    action="invalid",
+                    path=change.path,
+                    old_path=change.old_path,
+                    source_id=Path(change.path).stem,
+                    title=None,
+                    source_ref=None,
+                    logical_id=None,
+                    supersedes=[],
+                    superseded_by=None,
+                    error=error or "source manifest could not be loaded",
+                )
+            )
             continue
         action = _source_action(change, current=current, previous=previous)
+        if error is not None:
+            action = "invalid"
         result.append(
             SourceChange(
                 action=action,
@@ -201,6 +248,7 @@ def _source_changes(root: Path, *, since: str, changes: list[ChangedPath]) -> li
                 logical_id=effective_logical_id(source),
                 supersedes=list(source.supersedes),
                 superseded_by=source.superseded_by,
+                error=error,
             )
         )
     return result
@@ -211,19 +259,25 @@ def _is_source_manifest_path(path: str, layout: ResolvedLayout) -> bool:
     return path.startswith(f"{source_dir}/") and path.endswith(".json")
 
 
-def _load_current_source(root: Path, path: str) -> SourceRecord | None:
+def _load_current_source(root: Path, path: str) -> tuple[SourceRecord | None, str | None]:
     source_path = root / path
     if not source_path.is_file():
-        return None
-    return load_source_record(source_path)
+        return None, None
+    try:
+        return load_source_record(source_path), None
+    except Exception as exc:
+        return None, str(exc)
 
 
-def _load_source_at_ref(root: Path, ref: str, path: str) -> SourceRecord | None:
+def _load_source_at_ref(root: Path, ref: str, path: str) -> tuple[SourceRecord | None, str | None]:
     content = _git_text(root, ["show", f"{ref}:{path}"], required=False)
     if content is None:
-        return None
-    payload = json.loads(content)
-    return SourceRecord.model_validate(payload)
+        return None, None
+    try:
+        payload = json.loads(content)
+        return SourceRecord.model_validate(payload), None
+    except Exception as exc:
+        return None, str(exc)
 
 
 def _source_action(
@@ -249,32 +303,33 @@ def _source_action(
     return "changed"
 
 
-def _is_source_summary_path(path: str) -> bool:
-    return path.startswith("wiki/sources/") and path.endswith(".md")
+def _is_layout_child(path: str, layout: ResolvedLayout, directory: Path) -> bool:
+    prefix = directory.relative_to(layout.root).as_posix()
+    return path.startswith(f"{prefix}/")
 
 
-def _is_maintained_wiki_path(path: str) -> bool:
-    return path.startswith("wiki/") and path.endswith(".md") and not _is_source_summary_path(path)
+def _is_source_summary_path(path: str, layout: ResolvedLayout) -> bool:
+    return _is_layout_child(path, layout, layout.wiki_sources_dir) and path.endswith(".md")
 
 
-def _in_group(change: ChangedPath, group_key: str) -> bool:
-    return change.path.startswith(
-        {
-            "queue": "state/queue/",
-            "runs": "state/runs/",
-            "queries": "state/queries/",
-            "reports": "reports/",
-            "derived": "derived/",
-        }[group_key]
+def _is_maintained_wiki_path(path: str, layout: ResolvedLayout) -> bool:
+    return (
+        _is_layout_child(path, layout, layout.wiki_dir)
+        and path.endswith(".md")
+        and not _is_source_summary_path(path, layout)
     )
 
 
 def _is_categorized_path(change: ChangedPath, layout: ResolvedLayout) -> bool:
     return (
         _is_source_manifest_path(change.path, layout)
-        or _is_source_summary_path(change.path)
-        or _is_maintained_wiki_path(change.path)
-        or any(_in_group(change, key) for key in ("queue", "runs", "queries", "reports", "derived"))
+        or _is_source_summary_path(change.path, layout)
+        or _is_maintained_wiki_path(change.path, layout)
+        or _is_layout_child(change.path, layout, layout.queue_dir)
+        or _is_layout_child(change.path, layout, layout.runs_dir)
+        or _is_layout_child(change.path, layout, layout.queries_dir)
+        or _is_layout_child(change.path, layout, layout.reports_dir)
+        or _is_layout_child(change.path, layout, layout.derived_dir)
     )
 
 
@@ -300,12 +355,15 @@ def _group_paths(changes: Iterable[ChangedPath]) -> PathGroup:
     )
 
 
-def _latest_maintenance_status(root: Path, *, command: str) -> MaintenanceStatus | None:
-    report_dir = root / "reports" / command
+def _latest_maintenance_status(
+    root: Path, *, layout: ResolvedLayout, command: str
+) -> MaintenanceStatus | None:
+    report_dir = layout.reports_dir / command
     candidates = sorted(report_dir.glob("*.json"))
     if not candidates:
         return None
     latest = candidates[-1]
+    warning = "Latest local report only; not tied to the current HEAD or diff."
     try:
         report = MaintenanceReport.model_validate_json(latest.read_text(encoding="utf-8"))
     except Exception as exc:
@@ -313,6 +371,8 @@ def _latest_maintenance_status(root: Path, *, command: str) -> MaintenanceStatus
             command=command,
             status="unreadable",
             path=latest.relative_to(root).as_posix(),
+            scope="latest_local_report",
+            warning=warning,
             created_at=None,
             checked_count=None,
             issue_count=None,
@@ -322,6 +382,8 @@ def _latest_maintenance_status(root: Path, *, command: str) -> MaintenanceStatus
         command=command,
         status=report.status,
         path=latest.relative_to(root).as_posix(),
+        scope="latest_local_report",
+        warning=warning,
         created_at=report.created_at,
         checked_count=report.checked_count,
         issue_count=report.issue_count,
@@ -357,7 +419,11 @@ def _reviewer_notes(summary: PrSummary) -> list[str]:
             notes.append(
                 f"No local {command} report was found; run `splendor {command}` before handoff."
             )
-        elif status.status != "passed":
+        else:
+            notes.append(
+                f"{command} status is from the latest local report, not from this command."
+            )
+        if status is not None and status.status != "passed":
             notes.append(
                 f"Latest {command} report is {status.status} at {status.path}; "
                 "inspect it before PR review."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import json
 import re
 import shutil
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -122,6 +123,16 @@ def test_cli_workspace_refresh_parser_accepts_safe_refresh_flags() -> None:
     assert args.changed is True
     assert args.ingest is True
     assert args.rebuild_index is True
+    assert args.json_output is True
+
+
+def test_cli_pr_summary_parser_accepts_since_and_json() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["pr-summary", "--since", "origin/main", "--json"])
+
+    assert args.command == "pr-summary"
+    assert args.since == "origin/main"
     assert args.json_output is True
 
 
@@ -1334,6 +1345,84 @@ def test_cli_workspace_refresh_human_output_is_path_first(tmp_path: Path, capsys
     assert re.search(r"- brief\.md: refreshed source_id=src-[a-f0-9]{16}", out)
     assert f"Previous source ID: {original_id}" in out
     assert "Next: splendor ingest --pending" in out
+
+
+def test_cli_pr_summary_reports_generated_state_without_mutating(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    _git_init_main(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "lint"])
+    main(["--root", str(tmp_path), "health"])
+    capsys.readouterr()
+    report_paths_before = sorted(
+        path.relative_to(tmp_path).as_posix() for path in tmp_path.glob("reports/**/*.json")
+    )
+
+    exit_code = main(["--root", str(tmp_path), "pr-summary", "--since", "main", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    source_manifest = payload["curated_sources"][0]
+    assert source_manifest["action"] == "added"
+    assert source_manifest["path"].startswith("state/manifests/sources/")
+    assert source_manifest["source_ref"] == "brief.md"
+    assert source_manifest["logical_id"] == "source:brief.md"
+    assert payload["source_summary_pages"]["added"] == [
+        f"wiki/sources/{source_manifest['source_id']}.md"
+    ]
+    assert payload["generated_state"]["queue"]["added"] == [
+        f"state/queue/ingest-{source_manifest['source_id']}.json"
+    ]
+    assert payload["generated_state"]["runs"]["added"]
+    assert payload["maintenance"]["lint"]["status"] == "passed"
+    assert payload["maintenance"]["health"]["status"] == "passed"
+    assert any("queue, run, and report files" in note for note in payload["reviewer_notes"])
+    assert (
+        sorted(path.relative_to(tmp_path).as_posix() for path in tmp_path.glob("reports/**/*.json"))
+        == report_paths_before
+    )
+
+
+def test_cli_pr_summary_human_output_is_path_first(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    _git_init_main(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "pr-summary", "--since", "main"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "PR summary since main" in out
+    assert re.search(r"- state/manifests/sources/src-[a-f0-9]+\.json: added", out)
+    assert "Source ref: brief.md" in out
+    assert "Generated state:" in out
+    assert "- queue: total=1" in out
+    assert "No local lint report was found" in out
+
+
+def _git_init_main(root: Path) -> None:
+    subprocesses = [
+        ["git", "init", "-b", "main"],
+        ["git", "config", "user.email", "splendor@example.test"],
+        ["git", "config", "user.name", "Splendor Tests"],
+        ["git", "add", "."],
+        ["git", "commit", "-m", "baseline"],
+    ]
+    for command in subprocesses:
+        result = subprocess.run(
+            command,
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
 
 
 def test_cli_source_refresh_preserves_active_lease_protection(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1378,6 +1378,8 @@ def test_cli_pr_summary_reports_generated_state_without_mutating(tmp_path: Path,
     ]
     assert payload["generated_state"]["runs"]["added"]
     assert payload["maintenance"]["lint"]["status"] == "passed"
+    assert payload["maintenance"]["lint"]["scope"] == "latest_local_report"
+    assert "not tied to the current HEAD" in payload["maintenance"]["lint"]["warning"]
     assert payload["maintenance"]["health"]["status"] == "passed"
     assert any("queue, run, and report files" in note for note in payload["reviewer_notes"])
     assert (
@@ -1399,11 +1401,90 @@ def test_cli_pr_summary_human_output_is_path_first(tmp_path: Path, capsys) -> No
     assert exit_code == 0
     out = capsys.readouterr().out
     assert "PR summary since main" in out
+    assert "Merge base:" in out
     assert re.search(r"- state/manifests/sources/src-[a-f0-9]+\.json: added", out)
     assert "Source ref: brief.md" in out
     assert "Generated state:" in out
     assert "- queue: total=1" in out
     assert "No local lint report was found" in out
+
+
+def test_cli_pr_summary_uses_merge_base_when_main_advances(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    _git_init_main(tmp_path)
+    _git_run(tmp_path, ["git", "switch", "-c", "feature"])
+    feature_path = tmp_path / "feature.md"
+    feature_path.write_text("# Feature\n", encoding="utf-8")
+    _git_run(tmp_path, ["git", "add", "feature.md"])
+    _git_run(tmp_path, ["git", "commit", "-m", "feature change"])
+    _git_run(tmp_path, ["git", "switch", "main"])
+    main_path = tmp_path / "main-only.md"
+    main_path.write_text("# Main only\n", encoding="utf-8")
+    _git_run(tmp_path, ["git", "add", "main-only.md"])
+    _git_run(tmp_path, ["git", "commit", "-m", "main change"])
+    _git_run(tmp_path, ["git", "switch", "feature"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "pr-summary", "--since", "main", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["merge_base"] != _git_stdout(tmp_path, ["git", "rev-parse", "main"])
+    assert payload["other_paths"]["added"] == ["feature.md"]
+    assert "main-only.md" not in json.dumps(payload)
+
+
+def test_cli_pr_summary_respects_custom_layout_paths(tmp_path: Path, capsys) -> None:
+    config = load_config(tmp_path)
+    config.layout.wiki_dir = "knowledge"
+    config.layout.state_dir = "custom-state"
+    config.layout.reports_dir = "custom-reports"
+    config.layout.source_records_dir = "custom-state/manifests/sources"
+    write_config(tmp_path, config)
+    main(["--root", str(tmp_path), "init"])
+    _git_init_main(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "lint"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "pr-summary", "--since", "main", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    source_id = payload["curated_sources"][0]["source_id"]
+    assert payload["curated_sources"][0]["path"] == (
+        f"custom-state/manifests/sources/{source_id}.json"
+    )
+    assert payload["source_summary_pages"]["added"] == [f"knowledge/sources/{source_id}.md"]
+    assert payload["generated_state"]["queue"]["added"] == [
+        f"custom-state/queue/ingest-{source_id}.json"
+    ]
+    assert payload["generated_state"]["reports"]["added"]
+    assert payload["maintenance"]["lint"]["path"].startswith("custom-reports/lint/")
+
+
+def test_cli_pr_summary_reports_invalid_source_manifest_without_aborting(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    _git_init_main(tmp_path)
+    manifest = tmp_path / "state" / "manifests" / "sources" / "src-bad.json"
+    manifest.write_text("{bad json}\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "pr-summary", "--since", "main", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["curated_sources"]) == 1
+    invalid_source = payload["curated_sources"][0]
+    assert invalid_source["action"] == "invalid"
+    assert "Invalid JSON" in invalid_source["error"]
+    assert invalid_source["path"] == "state/manifests/sources/src-bad.json"
+    assert invalid_source["source_id"] == "src-bad"
 
 
 def _git_init_main(root: Path) -> None:
@@ -1415,14 +1496,30 @@ def _git_init_main(root: Path) -> None:
         ["git", "commit", "-m", "baseline"],
     ]
     for command in subprocesses:
-        result = subprocess.run(
-            command,
-            cwd=root,
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        assert result.returncode == 0, result.stderr
+        _git_run(root, command)
+
+
+def _git_run(root: Path, command: list[str]) -> None:
+    result = subprocess.run(
+        command,
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def _git_stdout(root: Path, command: list[str]) -> str:
+    result = subprocess.run(
+        command,
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
 
 
 def test_cli_source_refresh_preserves_active_lease_protection(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Implements `M14-P2.1` by adding a read-only `splendor pr-summary --since main` command for PR-oriented generated-state review handoff.

- Adds `splendor pr-summary` with human and JSON output over local merge-base git diff/status plus existing lint/health reports.
- Groups curated source manifest lifecycle changes, generated source-summary pages, maintained wiki/topic pages, queue/run/report/derived churn, and other paths.
- Adds reviewer notes that distinguish meaningful generated state from mechanical queue/run/report evidence.
- Hardens the summary path for advanced base refs, configured layout directories, invalid changed source manifests, and stale/local maintenance report semantics.
- Updates README, schema/product docs, release handoff, issue #70 design response, CI automation docs, roadmap, and `.agent-plan.md` for `M14-P2.1`.

## Scope Boundaries

- Non-mutating: the command does not refresh sources, enqueue work, run lint/health, write reports, or call GitHub.
- Preserves schema version `1`; PR summary output is derived from existing files and local git state, not a persisted schema.
- Keeps #79 mutating compile/update, #30 repo-scan bulk optimization, #37 web document-list scaling, and #47 ingest run-duration precision out of scope.
- Does not request the SynthBanshee re-evaluation; it unblocks that gate after merge.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest` -> 527 passed
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .` -> passed
- `/Users/shaypalachy/.local/bin/uv run ruff check .` -> passed
- `/Users/shaypalachy/.local/bin/uv run splendor lint` -> passed
- `/Users/shaypalachy/.local/bin/uv run splendor health` -> passed
- `/Users/shaypalachy/.local/bin/uv run splendor pr-summary --since main --json` -> reports no Splendor generated-state changes for this code/docs PR and latest local lint/health reports passed, explicitly labeled as latest local reports

## Issue Linkage

Advances #72. Keeps #79, #47, #37, and #30 open as separate follow-ups.
