### PR TITLE
M14-P3.1: Record source-lifecycle re-evaluation gate

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M14-P1.4`
-- Last action taken: `M14-P1.4` is implemented; workspace refresh can prune superseded generated source-summary pages and migrate maintained wiki source refs.
-- Current planned slice: `M14-P2`
-- Current PR sub-slice: `M14-P2.1`
+- Previous completed PR sub-slice: `M14-P2.1`
+- Last action taken: `M14-P2.1` is implemented; `splendor pr-summary --since main` gives a read-only PR handoff over source lifecycle, wiki, generated-state, and local maintenance report changes.
+- Current planned slice: `Source-lifecycle re-evaluation gate`
+- Current PR sub-slice: `M14-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `SynthBanshee re-evaluation gate`
-- Next planned PR sub-slice: `TBD`
+- Next planned slice: `Planning-doc authority and task-oriented agent briefs`
+- Next planned PR sub-slice: `M14-P4.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -247,6 +247,13 @@
   - [x] Summarize curated source lifecycle, generated source-summary pages, maintained wiki pages, runtime/report churn, and latest local maintenance reports
   - [x] Add JSON output for agent handoff
   - [x] Keep mutating compile/update, broad discovery, repo-scan bulk optimization, web scaling, and ingest timing follow-ups deferred
+- [x] Implement `M14-P3.1`: Source-lifecycle re-evaluation gate
+  - [x] Run the current intended source freshness, workspace refresh, PR summary, lint, and health workflow against the post-`M14-P2.1` state
+  - [x] Run a disposable changed-source exercise against the full workspace refresh path
+  - [x] Compare the result against the original #72 SynthBanshee report
+  - [x] Recommend closing #72 once maintainers accept the gate result because the remaining gap is now narrower
+  - [x] Create #86 for planning-document authority metadata and task-oriented agent briefs
+  - [x] Keep #79, #47, #37, and #30 as independent follow-ups
 
 ## Context Pointers
 
@@ -279,6 +286,8 @@
 - `M14-P0` Post-v1 planning intake
 - `M14-P1` Source lifecycle implementation
 - `M14-P2` PR summary and generated-state review handoff
+- `M14-P3` Source-lifecycle re-evaluation gate
+- `M14-P4` Planning-doc authority and task-oriented agent briefs
 
 ## PR Sub-slice Queue
 
@@ -310,3 +319,5 @@
 - `M14-P1.3` Safe workspace refresh path
 - `M14-P1.4` Superseded-state pruning and topic-ref migration
 - `M14-P2.1` PR summary and lower-noise generated-state review handoff
+- `M14-P3.1` Source-lifecycle re-evaluation gate
+- `M14-P4.1` Planning-doc authority and task-oriented agent briefs

--- a/README.md
+++ b/README.md
@@ -194,15 +194,16 @@ the source manifest, and kept separate from parsed PDF artifacts.
 - [docs/schema_contracts.md](docs/schema_contracts.md)
 - [docs/ci_and_repo_automation.md](docs/ci_and_repo_automation.md)
 - [docs/v1_release_handoff.md](docs/v1_release_handoff.md)
+- [docs/m14_synthbanshee_reevaluation.md](docs/m14_synthbanshee_reevaluation.md)
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M14-P1.4`
-- Current planned slice: `M14-P2`
-- Current PR sub-slice: `M14-P2.1`
+- Previous completed PR sub-slice: `M14-P2.1`
+- Current planned slice: `Source-lifecycle re-evaluation gate`
+- Current PR sub-slice: `M14-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `SynthBanshee re-evaluation gate`
-- Next planned PR sub-slice: `TBD`
+- Next planned slice: `Planning-doc authority and task-oriented agent briefs`
+- Next planned PR sub-slice: `M14-P4.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -291,9 +292,10 @@ ingest handoff, #44's query snippets, #45's web status/source detail pages, and 
 visibility as represented in current behavior. It still calls out #41's mutating compile/update
 workflow as deferred. Issue #47 remains an ingest/run-state timing follow-up. Issues #30 and #37
 remain post-v1 performance work. Issue #70 is closed after the M13-P2/M13-P3.1 response. Issue #72
-stays open as the parent feedback loop; stable logical source identities, supersession lifecycle,
-safe workspace refresh, superseded summary pruning, and topic-ref migration have landed, while
-PR-summary support is now represented by `splendor pr-summary --since main`.
+is the parent feedback loop for the M14 source-lifecycle sequence; stable logical source
+identities, supersession lifecycle, safe workspace refresh, superseded summary pruning, topic-ref
+migration, and PR-summary support have landed. `M14-P3.1` recommends closing #72 once maintainers
+accept the gate result, with the narrower remaining handoff gap tracked by #86.
 Issue #79 tracks the deferred mutating compile/update path from #41.
 
 `M14-P1.1` adds the first stable logical source identity layer above content-addressed source IDs:
@@ -322,6 +324,12 @@ generated source-summary pages, maintained wiki/topic edits, generated queue/run
 latest local maintenance report status. The human output is path-first and layout-aware, and
 `--json` emits the same structure for agent handoff without mutating workspace state or depending
 on GitHub.
+
+`M14-P3.1` records the internal source-lifecycle re-evaluation gate in
+`docs/m14_synthbanshee_reevaluation.md`. The gate covers both the clean current state and a
+controlled changed-source exercise through freshness, full workspace refresh, PR summary, lint, and
+health. It is not a new external SynthBanshee report; it recommends closing #72 after maintainer
+review and moves the remaining planning-doc authority / task-brief gap to #86.
 
 ### v1 readiness checklist
 

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -110,7 +110,10 @@ in issue #72.
 - #72 is a separate parent feedback loop for source-refresh lifecycle and agent workflow. Stable
   workspace-backed `source:<path>` aliases, `supersedes`/`superseded_by`, safe workspace refresh,
   superseded source-summary pruning, topic-ref migration, and `splendor pr-summary --since main`
-  have landed; the parent issue remains open for the planned external-agent retry.
+  have landed. The `M14-P3.1` source-lifecycle re-evaluation records that the broad #72 lifecycle
+  loop can close once maintainers accept the gate result.
+- #86 tracks the narrower remaining planning-document authority metadata and task-oriented agent
+  brief gap found by the `M14-P3.1` re-evaluation.
 - #41 has shipped `splendor brief [goal]`, `brief --agent-context`, and the non-mutating
   `splendor wiki compile <source-id|title|path>` contract. Mutating compile/update support remains
   deferred and is tracked by #79.

--- a/docs/m14_synthbanshee_reevaluation.md
+++ b/docs/m14_synthbanshee_reevaluation.md
@@ -1,0 +1,147 @@
+# M14 Source-lifecycle Re-evaluation Gate
+
+## Context
+
+Issue #72 reported that Splendor was promising but not yet a high-leverage coding-agent assistant.
+The largest operational problem was the source-refresh lifecycle: changed workspace files produced
+new content-addressed source IDs, old records and run references became hard to reason about, topic
+pages could point at stale IDs, generated-state cleanup was manual, and PR reviewers had no concise
+summary of which generated changes mattered.
+
+The post-v1 M14 sequence addressed that lifecycle loop before this gate:
+
+- `M14-P0.1` split #72 into concrete child slices.
+- `M14-P1.1` added stable `source:<workspace-path>` logical IDs and aliases.
+- `M14-P1.2` added `supersedes` / `superseded_by` source refresh semantics.
+- `M14-P1.3` added `splendor workspace refresh --changed --ingest --rebuild-index`.
+- `M14-P1.4` added `--prune-superseded` and `--update-topic-refs`.
+- `M14-P2.1` added `splendor pr-summary --since main`.
+
+This note records the internal source-lifecycle re-evaluation gate after that sequence. It is not a
+new external SynthBanshee Claude report. Instead, it checks whether the concrete #72 lifecycle
+complaints can now pass through the current intended Splendor command path and records what should
+remain open for a later external-agent usefulness pass.
+
+## Baseline Workflow Run
+
+The current intended workflow was first run from `codex/m14-synthbanshee-reeval-gate`, based on
+`main` at `ef78fad0a77bf90b63cc3d45f2b1ba022bae39d6`.
+
+```bash
+/Users/shaypalachy/.local/bin/uv run splendor source freshness
+/Users/shaypalachy/.local/bin/uv run splendor workspace refresh --changed --ingest --rebuild-index --prune-superseded --update-topic-refs
+/Users/shaypalachy/.local/bin/uv run splendor pr-summary --since main
+/Users/shaypalachy/.local/bin/uv run splendor lint
+/Users/shaypalachy/.local/bin/uv run splendor health
+```
+
+Observed results:
+
+- `source freshness` reported `total=7 unchanged=7 changed=0 missing=0 unsupported=0 historical=0`.
+- `workspace refresh` found no changed curated workspace-backed sources, processed zero ingest jobs,
+  rebuilt `wiki/index.md`, pruned no superseded summaries, updated no topic refs, and ended with the
+  same clean freshness counts.
+- `pr-summary --since main` reported merge base `ef78fad0a77bf90b63cc3d45f2b1ba022bae39d6`, zero
+  changed paths, no curated source/wiki/generated-state changes, and clearly labeled latest local
+  lint and health reports as not tied to the current HEAD.
+- `splendor lint` passed with `Checked items: 258`.
+- `splendor health` passed with `Checked records: 42`.
+
+No manual cleanup of source manifests, generated source-summary pages, run records, queue records,
+or topic refs was needed.
+
+This baseline proves that the current clean no-op path remains coherent, but it is not enough by
+itself to close #72 because #72 was primarily about changed-source lifecycle behavior.
+
+## Controlled Changed-source Exercise
+
+To exercise the actual #72 failure mode without committing generated workspace churn into this docs
+PR, a disposable clone of this branch was created under `/tmp`. In that clone, one curated
+workspace-backed source was changed:
+
+```text
+raw/imports/llm-knowledge-work/karpathy-llm-wiki-pattern.md
+```
+
+The same intended command path was then run. Because that disposable clone did not have a local
+`main` branch, `splendor pr-summary --since main` failed with Git's `Needed a single revision`
+error. Re-running the PR summary against the available base ref, `origin/main`, succeeded. This
+does not invalidate the lifecycle result, but it is a real usability caveat for branch-only clones:
+agents should use a resolvable base ref such as `origin/main` when no local `main` exists.
+
+Observed changed-source results:
+
+- `source freshness` reported `total=7 unchanged=6 changed=1 missing=0 unsupported=0 historical=0`
+  and gave the exact `source refresh` and `ingest --pending` next commands for the changed source.
+- `workspace refresh --changed --ingest --rebuild-index --prune-superseded --update-topic-refs`
+  registered the changed source as
+  `src-29f995be0eb8d0db3c87fb4cb3612d20da2e4d0594ffd80ccc274ec1997f7b92`.
+- The previous active source
+  `src-51e62cdae9baf8dfd550ac791f21a7cc11cca2e372865907d35ab6eaeea31dac` was linked through
+  `supersedes` / `superseded_by` rather than treated as a broken active source.
+- The refreshed source was ingested successfully with one new queue record, one new run record, and
+  one new generated source-summary page.
+- The command skipped pruning the old source-summary page because it is still referenced by
+  `planning/tasks/task-harden-contradiction-review-boilerplate.md`; this is the correct conservative
+  behavior, not an unsafe deletion.
+- `--update-topic-refs` updated maintained topic/source refs in
+  `wiki/architecture/splendor-as-llm-wiki-compiler.md`, `wiki/concepts/llm-wiki-pattern.md`, and
+  `wiki/topics/llm-assisted-knowledge-work.md`.
+- Final freshness reported `total=8 unchanged=7 changed=0 missing=0 unsupported=0 historical=1`.
+- `splendor lint` passed with `Checked items: 273`.
+- `splendor health` passed with `Checked records: 46`.
+- `pr-summary --since origin/main` grouped the diff into refreshed/superseded curated sources,
+  generated source-summary pages, maintained wiki/topic pages, queue/run generated state, and
+  reviewer notes.
+
+The controlled exercise is the stronger evidence for the #72 lifecycle decision: it covered changed
+source detection, supersession, targeted ingest, index rebuild, conservative prune behavior,
+topic-ref migration, generated-state handoff, lint, and health.
+
+## Comparison With #72
+
+The #72 source-refresh lifecycle complaint is materially addressed by implementation and by the
+controlled changed-source exercise above. Agents now have a stable logical source layer for
+workspace-backed files, explicit source supersession for changed content, one obvious workspace
+refresh command, conservative pruning, topic-ref migration switches, and a PR summary that
+distinguishes maintained wiki changes from generated runtime/report churn.
+
+The generated-state review policy is also clearer. `pr-summary` does not mutate state and tells the
+reviewer when lint/health information comes from latest local reports rather than the current diff.
+That is a meaningful improvement over reconstructing review notes from `git status`, `wiki status`,
+and individual report files.
+
+The remaining weakness is narrower than #72 and should not be hidden by this gate. For this
+planning-heavy work, Splendor still did not replace direct reading of `AGENTS.md`, `.agent-plan.md`,
+the README planning block, roadmap, product spec, schema contracts, automation docs, issue response
+docs, and live GitHub issues. That is partly appropriate: the repository is the source of truth.
+The product gap is that Splendor has no explicit authority or staleness model for living planning
+documents, so agent-facing briefs cannot reliably rank current-state authority, roadmap intent,
+historical external reviews, proposals, and generated summaries for a task.
+
+## Issue Decision
+
+This PR recommends closing #72 once maintainers accept the gate result. Its broad source-lifecycle
+and PR-handoff asks have landed and were re-evaluated against both the clean no-op path and a
+controlled changed-source workflow.
+
+The remaining high-value gap is tracked as #86:
+`Add planning-doc authority metadata and task-oriented agent briefs`.
+
+If maintainers want a new independent external-agent report before closing #72, that should be
+requested explicitly as a fresh validation task. It should not block the narrower #86 follow-up from
+starting.
+
+Keep the following issues separate unless a future re-evaluation directly proves one has become
+urgent:
+
+- #79: mutating compile/update workflow.
+- #47: ingest run-duration precision.
+- #37: web document-list scaling.
+- #30: repo-scan registration optimization.
+
+## Next Slice
+
+The next planned M14 work should be `M14-P4.1`: planning-document authority metadata and
+task-oriented agent briefs. That work should improve the handoff layer without implementing #79 or
+changing schema version `1` without an explicit migration plan.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,18 +334,18 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M14-P1.4`
-- Current planned slice: `M14-P2`
-- Current PR sub-slice: `M14-P2.1`
+- Previous completed PR sub-slice: `M14-P2.1`
+- Current planned slice: `Source-lifecycle re-evaluation gate`
+- Current PR sub-slice: `M14-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `SynthBanshee re-evaluation gate`
-- Next planned PR sub-slice: `TBD`
+- Next planned slice: `Planning-doc authority and task-oriented agent briefs`
+- Next planned PR sub-slice: `M14-P4.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
 shifting agent-facing value toward freshness, contested knowledge, planning state, and next
-actions. The lifecycle marker means `M13-P3.2` is in progress on feature branches and merged once
-the same committed state is observed on `main`.
+actions. The lifecycle marker means the current sub-slice is in progress on feature branches and
+merged once the same committed state is observed on `main`.
 
 ---
 
@@ -877,6 +877,8 @@ breaking the v1 file contracts.
 - `M14-P0` Post-v1 planning intake
 - `M14-P1` Source lifecycle design
 - `M14-P2` PR summary and generated-state review handoff
+- `M14-P3` Source-lifecycle re-evaluation gate
+- `M14-P4` Planning-doc authority and task-oriented agent briefs
 
 ### Candidate PR sub-slices
 - `M14-P0.1` Split #72 into child issues and assign release metadata
@@ -885,11 +887,13 @@ breaking the v1 file contracts.
 - `M14-P1.3` Safe workspace refresh path
 - `M14-P1.4` Superseded-state pruning and topic-ref migration
 - `M14-P2.1` PR summary and lower-noise generated-state review handoff
+- `M14-P3.1` Source-lifecycle re-evaluation gate
+- `M14-P4.1` Planning-doc authority and task-oriented agent briefs
 
-### SynthBanshee re-evaluation gate
+### Source-lifecycle re-evaluation gate
 
-Do not ask the SynthBanshee Claude agent for the major "try Splendor again" evaluation until the
-post-#72 lifecycle loop is substantially implemented. The intended sequence before that ask is:
+The original #72 SynthBanshee report should not be treated as resolved until the post-#72 lifecycle
+loop is substantially implemented and re-evaluated. The intended sequence before that gate is:
 
 1. `M14-P0.1` splits #72 into child issues and assigns release metadata.
 2. `M14-P1.1` adds stable logical source identities while preserving content-addressed IDs for
@@ -906,9 +910,11 @@ post-#72 lifecycle loop is substantially implemented. The intended sequence befo
 6. `M14-P2.1` adds `splendor pr-summary --since main`, a read-only PR-oriented summary with
    lower-noise generated-state review guidance over local git state.
 
-After those slices land, the external-agent retry should use a comparable real planning or
-repo-maintenance workflow and explicitly compare against #72. Earlier feedback should be requested
-only for the narrower safe-discovery, freshness, and handoff surfaces already shipped in M13.
+After those slices land, the gate should use a comparable planning or repo-maintenance workflow and
+explicitly compare against #72. If the gate is performed internally rather than by a new external
+SynthBanshee run, the result must say so and must not claim to be a fresh external-agent report.
+Earlier feedback should be requested only for the narrower safe-discovery, freshness, and handoff
+surfaces already shipped in M13.
 
 `M14-P2.1` keeps the command non-mutating and schema-version-1-compatible. It summarizes
 merge-base curated source manifests, generated source-summary pages, maintained wiki/topic pages,
@@ -916,6 +922,18 @@ queue/run/report churn, latest local lint/health reports when available, and rev
 distinguish meaningful generated knowledge from mechanical runtime records. It respects configured
 layout paths and reports malformed changed source manifests without aborting the whole handoff.
 JSON output is available for agent handoff.
+
+`M14-P3.1` records the internal source-lifecycle re-evaluation gate after the post-#72 lifecycle
+sequence. The comparable workflow in `docs/m14_synthbanshee_reevaluation.md` used source freshness,
+the full workspace refresh command, `pr-summary`, `lint`, and `health` against both the clean
+current state and a disposable changed-source exercise. The result: the original source-refresh
+lifecycle pain from #72 is materially addressed, and this PR recommends closing #72 once
+maintainers accept the gate result. The remaining agent-usefulness gap is narrower and is tracked
+by #86: planning-document authority metadata and task-oriented agent briefs.
+
+`M14-P4.1` should address #86 without implementing #79. It should improve how Splendor ranks
+current-state planning docs, roadmap docs, historical reviews, proposals, generated summaries, and
+task-specific constraints in agent-facing handoff surfaces.
 
 ### Boundaries
 - Promote these candidates to committed roadmap slices only after the child issues and GitHub

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -49,8 +49,10 @@ For this handoff:
 - #47 remains open as the real ingest run-duration bug
 - #30 remains open as post-v1 repo-scan registration performance work
 - #37 remains open as post-v1 web document-list scaling work
-- #72 is unblocked for the planned SynthBanshee re-evaluation once `M14-P2.1` lands; do not close
-  the parent issue before the external retry is recorded
+- #72 is unblocked after `M14-P2.1`; the `M14-P3.1` source-lifecycle re-evaluation gate records
+  that the source-refresh lifecycle pain is materially addressed and recommends closing #72 once
+  maintainers accept the gate result
+- #86 tracks the narrower remaining planning-document authority and task-oriented agent brief gap
 
 ## Known Non-Blockers
 
@@ -63,20 +65,19 @@ These items are intentionally not v1 release blockers:
 
 ## Post-v1 Queue
 
-The conservative next queue is:
+The conservative next queue after the `M14-P3.1` gate is:
 
-1. Continue #72 implementation after the workspace-backed `source:<path>` logical ID layer,
-   supersession-aware source refresh, safe workspace refresh path, superseded generated-state
-   pruning, and topic-ref migration.
-2. Use `splendor pr-summary --since main` during review handoff to explain source lifecycle,
-   maintained wiki, source-summary, and mechanical generated-state changes.
-3. Keep #79 as the tracked post-v1 compile/update workflow rather than reopening #41 for deferred
+1. Close #72 once maintainers accept the gate PR, because its broad source-refresh lifecycle and PR
+   handoff asks have landed and been re-evaluated.
+2. Continue with #86 for planning-document authority metadata and task-oriented agent briefs.
+3. Keep using `splendor pr-summary --since main` during review handoff to explain source
+   lifecycle, maintained wiki, source-summary, and mechanical generated-state changes.
+4. Keep #79 as the tracked post-v1 compile/update workflow rather than reopening #41 for deferred
    scope.
-4. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
+5. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
    either one urgent.
 
-Do not ask the SynthBanshee Claude agent for the major "try Splendor again" re-evaluation until
-the source-lifecycle and generated-state review loop is materially improved. The planned retry
+The internal source-lifecycle re-evaluation gate is now complete in `M14-P3.1`. The completed retry
 bundle is:
 
 1. `M14-P0.1` Split #72 into child issues and assign release metadata.
@@ -88,10 +89,12 @@ bundle is:
 5. `M14-P1.4` Superseded generated-state pruning and topic-ref migration.
 6. `M14-P2.1` PR summary and lower-noise generated-state review handoff, including
    `splendor pr-summary --since main`.
+7. `M14-P3.1` Re-evaluate the comparable source-lifecycle workflow against the current command set,
+   including a controlled changed-source exercise, and record the close-or-split recommendation for
+   #72.
 
-After those slices land, ask the SynthBanshee Claude agent to retry a comparable real planning or
-repo-maintenance workflow and compare against the original #72 report. Before then, any retry
-should be framed narrowly around safe discovery, freshness, and handoff only.
+The retry result is captured in `docs/m14_synthbanshee_reevaluation.md`. Future work should start
+from #86 unless a new real-agent run reopens a source-lifecycle regression.
 
 ## Tagging Readiness
 


### PR DESCRIPTION
## Summary

- records the M14 internal source-lifecycle re-evaluation after the completed #72 lifecycle sequence
- adds a controlled changed-source exercise covering freshness, full workspace refresh, supersession, ingest, topic-ref migration, PR summary, lint, and health
- updates planning state across `.agent-plan.md`, README, roadmap, v1 handoff, and issue #70 response docs
- splits the remaining narrower agent gap into #86 for planning-document authority metadata and task-oriented agent briefs

## Gate result

The PR no longer claims to be a fresh external SynthBanshee/Claude report. It records an internal lifecycle gate and explicitly says so.

The source-refresh lifecycle pain from #72 is materially addressed: stable logical source IDs, supersession-aware refresh, workspace refresh, conservative superseded-summary pruning, topic-ref migration, and `splendor pr-summary` now cover the original sharp-edged workflow. The controlled changed-source exercise is the key evidence.

The remaining weakness is narrower than #72: planning-heavy tasks still need direct reading of current planning docs and issue threads because Splendor does not yet model planning-doc authority/staleness well enough for task-oriented briefs. That follow-up is tracked by #86.

This PR recommends closing #72 once maintainers accept the gate result.
Refs #72.
Refs #86.
Refs #79, #47, #37, #30.

## Validation

- `/Users/shaypalachy/.local/bin/uv run splendor source freshness`
- `/Users/shaypalachy/.local/bin/uv run splendor workspace refresh --changed --ingest --rebuild-index --prune-superseded --update-topic-refs`
- `/Users/shaypalachy/.local/bin/uv run splendor pr-summary --since main`
- Controlled disposable changed-source exercise, including `pr-summary --since origin/main` after discovering that the branch-only clone had no local `main` ref
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`
