### PR TITLE
M14-P4.1 Authority Briefs

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M14-P2.1`
-- Last action taken: `M14-P2.1` is implemented; `splendor pr-summary --since main` gives a read-only PR handoff over source lifecycle, wiki, generated-state, and local maintenance report changes.
-- Current planned slice: `Source-lifecycle re-evaluation gate`
-- Current PR sub-slice: `M14-P3.1`
+- Previous completed PR sub-slice: `M14-P3.1`
+- Last action taken: `M14-P3.1` is implemented; the source-lifecycle re-evaluation gate recommends closing #72 and narrows the remaining handoff gap to #86.
+- Current planned slice: `Planning-doc authority and task-oriented agent briefs`
+- Current PR sub-slice: `M14-P4.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `Planning-doc authority and task-oriented agent briefs`
-- Next planned PR sub-slice: `M14-P4.1`
+- Next planned slice: `Post-v1 mutating compile/update workflow`
+- Next planned PR sub-slice: `TBD`
 - Current blockers: none
 
 ## Planning Notation
@@ -254,6 +254,11 @@
   - [x] Recommend closing #72 once maintainers accept the gate result because the remaining gap is now narrower
   - [x] Create #86 for planning-document authority metadata and task-oriented agent briefs
   - [x] Keep #79, #47, #37, and #30 as independent follow-ups
+- [x] Implement `M14-P4.1`: Planning-doc authority and task-oriented agent briefs
+  - [x] Add schema-version-1-compatible authority metadata for configured planning docs
+  - [x] Add optional maintained wiki authority metadata while excluding source summaries from maintained authority ranking
+  - [x] Teach `brief --agent-context` and `suggest-next` to rank task-relevant authority docs
+  - [x] Update tests, schema docs, README, roadmap, product spec, and handoff docs
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Implemented today:
 - `splendor wiki compile <source-id>` as a non-mutating review-gated contract description
 - `splendor wiki rebuild-index`
 - `splendor brief [goal]` and `splendor brief --agent-context [goal]`
+- config-backed authority briefs for maintained planning/docs context through
+  `brief --agent-context` and `suggest-next`
 - `splendor serve` for a read-only local browse/search/status/planning/runtime UI
 - read-only web `/status`, `/sources/<source-id>`, `/planning`, `/runs`, and `/queue` views
 - `splendor lint` and `splendor health`
@@ -170,6 +172,13 @@ status is labeled as latest local report state, not proof that this command ran 
 current `HEAD`. Use `--json` for agent handoff. The command does not run lint or health, write
 reports, call GitHub, or mutate workspace state.
 
+`splendor brief --agent-context [goal]` and `splendor suggest-next [goal]` also rank configured
+authority documents from `splendor.yaml` plus maintained wiki pages that opt into
+`authority_role` frontmatter. This lets agent handoff distinguish current authority, roadmap,
+historical review, proposal, reference, and generated-summary context, with freshness marked as
+current, watch, stale, or historical. Generated `source-summary` pages remain ingestion artifacts
+and are excluded from maintained authority ranking.
+
 Generated source-summary pages are deterministic ingestion artifacts. For readable in-repo
 markdown/text/code sources, Splendor defaults to concise claim-bearing excerpts and path-first
 display; copied, external, parsed PDF, and OCR-derived sources keep fuller extracts by default
@@ -198,12 +207,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M14-P2.1`
-- Current planned slice: `Source-lifecycle re-evaluation gate`
-- Current PR sub-slice: `M14-P3.1`
+- Previous completed PR sub-slice: `M14-P3.1`
+- Current planned slice: `Planning-doc authority and task-oriented agent briefs`
+- Current PR sub-slice: `M14-P4.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `Planning-doc authority and task-oriented agent briefs`
-- Next planned PR sub-slice: `M14-P4.1`
+- Next planned slice: `Post-v1 mutating compile/update workflow`
+- Next planned PR sub-slice: `TBD`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -330,6 +339,13 @@ on GitHub.
 controlled changed-source exercise through freshness, full workspace refresh, PR summary, lint, and
 health. It is not a new external SynthBanshee report; it recommends closing #72 after maintainer
 review and moves the remaining planning-doc authority / task-brief gap to #86.
+
+`M14-P4.1` adds planning-document authority metadata and task-oriented authority briefs. Workspaces
+can list maintained planning/docs files under `briefing.authority_documents` in `splendor.yaml`,
+and maintained wiki pages can opt into authority ranking with frontmatter fields
+`authority_role`, `authority_freshness`, and `authority_scope`. `brief --agent-context` and
+`suggest-next` include ranked authority docs for the goal while keeping generated source-summary
+artifacts separate from maintained authority.
 
 ### v1 readiness checklist
 

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -308,6 +308,9 @@ Required secrets:
 - `Claude Code Review` provides automated AI code review after CI `lint` and `test` pass, plus
   interactive follow-up.
 - `pr-agent-context` turns CI, review, and failing-check state into a maintained PR handoff comment.
+  Local `brief --agent-context` and `suggest-next` output may include ranked authority docs from
+  `splendor.yaml`, but workflow comments remain GitHub-state summaries rather than document
+  authority validators.
 - `pre-commit.ci autofix trigger` bridges bot PRs and `pre-commit.ci` label-based autofix behavior.
 - `weekly-repo-review` is scheduled maintenance, not a merge gate.
 

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -112,8 +112,8 @@ in issue #72.
   superseded source-summary pruning, topic-ref migration, and `splendor pr-summary --since main`
   have landed. The `M14-P3.1` source-lifecycle re-evaluation records that the broad #72 lifecycle
   loop can close once maintainers accept the gate result.
-- #86 tracks the narrower remaining planning-document authority metadata and task-oriented agent
-  brief gap found by the `M14-P3.1` re-evaluation.
+- #86 tracks the narrower planning-document authority metadata and task-oriented agent brief gap
+  found by the `M14-P3.1` re-evaluation; `M14-P4.1` adds the initial metadata and ranking layer.
 - #41 has shipped `splendor brief [goal]`, `brief --agent-context`, and the non-mutating
   `splendor wiki compile <source-id|title|path>` contract. Mutating compile/update support remains
   deferred and is tracked by #79.

--- a/docs/m14_synthbanshee_reevaluation.md
+++ b/docs/m14_synthbanshee_reevaluation.md
@@ -142,6 +142,6 @@ urgent:
 
 ## Next Slice
 
-The next planned M14 work should be `M14-P4.1`: planning-document authority metadata and
-task-oriented agent briefs. That work should improve the handoff layer without implementing #79 or
-changing schema version `1` without an explicit migration plan.
+`M14-P4.1` follows this gate with planning-document authority metadata and task-oriented agent
+briefs. That work improves the handoff layer without implementing #79 or changing schema version
+`1` without an explicit migration plan.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -293,6 +293,9 @@ Minimal frontmatter contract for wiki pages:
 - `page_id`
 - `status`
 - `review_state`
+- `authority_role`
+- `authority_freshness`
+- `authority_scope`
 - `source_refs`
 - `generated_by_run_ids`
 - `last_generated_at`
@@ -312,6 +315,9 @@ Current runtime behavior:
   markdown scaffolds; templates do not generate source-summary content or LLM-authored synthesis
 - `splendor wiki rebuild-index` rewrites `wiki/index.md` from validated wiki page frontmatter and
   does not mutate generated source-summary pages
+- maintained wiki pages may opt into agent authority ranking with `authority_role`,
+  `authority_freshness`, and `authority_scope`; generated `source-summary` pages are ignored by
+  maintained authority ranking even if those fields are present
 - source-summary pages written by `splendor ingest` now use `review_state: machine-generated`
 - those pages persist `last_generated_at`
 - those pages persist structured provenance links back to the source manifest, ingest run, and
@@ -338,6 +344,26 @@ Strict record contracts currently exist for:
 
 The implemented fields follow the product spec closely and reserve room for future markdown-backed
 renderers and CLI creation commands.
+
+## Briefing authority metadata
+
+`splendor.yaml` may include a `briefing.authority_documents` list for maintained planning,
+roadmap, schema, automation, release, and design documents that are not wiki pages. Each entry is
+schema-version-1-compatible config, not generated state:
+
+- `path`: normalized repo-relative document path; absolute paths, parent traversal, empty paths,
+  and backslash separators are rejected
+- `role`: one of `current-authority`, `roadmap`, `historical-review`, `proposal`, `reference`, or
+  `generated-summary`
+- `freshness`: one of `current`, `watch`, `stale`, or `historical`
+- `title`: optional display title
+- `purpose`: optional handoff reason
+- `applies_to`: optional task/topic terms used during goal ranking
+
+`splendor brief --agent-context [goal]` and `splendor suggest-next [goal]` use this metadata as a
+read-only ranking signal. Missing configured files are excluded from the ranked authority list,
+reported as authority warnings in the brief, and surfaced by `splendor lint` as
+`missing-authority-document`.
 
 Task records now also reserve:
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M14-P2.1`
-- Current planned slice: `Source-lifecycle re-evaluation gate`
-- Current PR sub-slice: `M14-P3.1`
+- Previous completed PR sub-slice: `M14-P3.1`
+- Current planned slice: `Planning-doc authority and task-oriented agent briefs`
+- Current PR sub-slice: `M14-P4.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `Planning-doc authority and task-oriented agent briefs`
-- Next planned PR sub-slice: `M14-P4.1`
+- Next planned slice: `Post-v1 mutating compile/update workflow`
+- Next planned PR sub-slice: `TBD`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -931,9 +931,11 @@ lifecycle pain from #72 is materially addressed, and this PR recommends closing 
 maintainers accept the gate result. The remaining agent-usefulness gap is narrower and is tracked
 by #86: planning-document authority metadata and task-oriented agent briefs.
 
-`M14-P4.1` should address #86 without implementing #79. It should improve how Splendor ranks
-current-state planning docs, roadmap docs, historical reviews, proposals, generated summaries, and
-task-specific constraints in agent-facing handoff surfaces.
+`M14-P4.1` addresses #86 without implementing #79. It adds schema-version-1-compatible authority
+metadata for configured planning/docs files and optional maintained wiki frontmatter, then teaches
+`brief --agent-context` and `suggest-next` to rank current authority, roadmap, historical review,
+proposal, reference, and generated-summary context for a stated goal. Generated source-summary
+artifacts remain separate from maintained authority ranking.
 
 ### Boundaries
 - Promote these candidates to committed roadmap slices only after the child issues and GitHub

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1029,14 +1029,19 @@ Current implementation:
 
 - `splendor brief [goal]` assembles a terminal-friendly and JSON project brief from deterministic
   query matches, wiki status, active planning records, recent sources/runs, latest lint/health
-  reports, the last query snapshot, and likely next actions.
+  reports, the last query snapshot, ranked authority docs, and likely next actions.
 - `splendor brief --agent-context [goal]` renders the same deterministic state as a compact
   coding-agent handoff with relevant matches, source refs, wiki status, active planning records,
-  recent sources/runs, maintenance reports, warnings, and ranked suggested actions.
+  ranked authority docs, recent sources/runs, maintenance reports, warnings, and ranked suggested
+  actions.
 - `splendor suggest-next [goal]` renders the ranked action subset directly. It is read-only and
   deterministic, and ranks source freshness, queue failures or pending work, stale/contested or
-  review-needed pages, missing synthesis follow-up, active planning records, recent maintenance
-  reports, and query matches for the optional goal.
+  review-needed pages, missing synthesis follow-up, task-relevant authority docs, active planning
+  records, recent maintenance reports, and query matches for the optional goal.
+- Authority docs come from `briefing.authority_documents` in `splendor.yaml` and optional
+  maintained wiki page frontmatter (`authority_role`, `authority_freshness`, and
+  `authority_scope`). Generated source-summary pages are excluded from maintained authority
+  ranking.
 - Briefing is read-only and does not replace `splendor query`; query finds records, while briefing
   packages the surrounding project state needed to resume work.
 
@@ -1328,8 +1333,8 @@ These are not blockers to the spec, but should remain visible:
 7. whether a companion-repo linking model needs a first-class schema element
 8. post-v1 refinements to generated source-summary policy for readable in-repo markdown and code
    files, after the v1 default of concise claim-bearing excerpts has been exercised in real repos
-9. authority and staleness metadata for living planning docs after the source-lifecycle and
-   PR-summary handoff loop has been exercised in real repos
+9. richer authority lifecycle policy for living planning docs after the initial M14-P4.1 metadata
+   and task-oriented brief ranking has been exercised in real repos
 
 ## 31. Summary Product Statement
 

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -52,13 +52,15 @@ For this handoff:
 - #72 is unblocked after `M14-P2.1`; the `M14-P3.1` source-lifecycle re-evaluation gate records
   that the source-refresh lifecycle pain is materially addressed and recommends closing #72 once
   maintainers accept the gate result
-- #86 tracks the narrower remaining planning-document authority and task-oriented agent brief gap
+- #86 tracks the planning-document authority and task-oriented agent brief gap addressed by
+  `M14-P4.1`
 
 ## Known Non-Blockers
 
 These items are intentionally not v1 release blockers:
 
-- authority and staleness metadata for living planning docs
+- richer post-M14 authority lifecycle policy after the initial planning-doc authority briefs have
+  been exercised in real repositories
 - ingest run-duration precision for #47
 - repo-scan bulk registration optimization for #30
 - web document-list scaling for #37
@@ -69,7 +71,8 @@ The conservative next queue after the `M14-P3.1` gate is:
 
 1. Close #72 once maintainers accept the gate PR, because its broad source-refresh lifecycle and PR
    handoff asks have landed and been re-evaluated.
-2. Continue with #86 for planning-document authority metadata and task-oriented agent briefs.
+2. Review #86 through `M14-P4.1`, which adds initial planning-document authority metadata and
+   task-oriented authority brief ranking.
 3. Keep using `splendor pr-summary --since main` during review handoff to explain source
    lifecycle, maintained wiki, source-summary, and mechanical generated-state changes.
 4. Keep #79 as the tracked post-v1 compile/update workflow rather than reopening #41 for deferred
@@ -93,8 +96,9 @@ bundle is:
    including a controlled changed-source exercise, and record the close-or-split recommendation for
    #72.
 
-The retry result is captured in `docs/m14_synthbanshee_reevaluation.md`. Future work should start
-from #86 unless a new real-agent run reopens a source-lifecycle regression.
+The retry result is captured in `docs/m14_synthbanshee_reevaluation.md`. After `M14-P4.1`, future
+work should start from #79 unless #86 review identifies a narrower follow-up or a new real-agent
+run reopens a source-lifecycle regression.
 
 ## Tagging Readiness
 

--- a/splendor.yaml
+++ b/splendor.yaml
@@ -22,3 +22,76 @@ queue:
   - 60
   - 300
   - 900
+briefing:
+  authority_documents:
+  - path: AGENTS.md
+    role: current-authority
+    freshness: current
+    purpose: Static repo-specific agent rules and completion gate.
+    applies_to:
+    - agent handoff
+    - PR workflow
+  - path: README.md
+    role: current-authority
+    freshness: current
+    purpose: Current user-facing project entrypoint and What Comes Next planning state.
+    applies_to:
+    - agent handoff
+    - planning state
+  - path: .agent-plan.md
+    role: current-authority
+    freshness: current
+    purpose: Dynamic agent planning state for the active roadmap slice.
+    applies_to:
+    - agent handoff
+    - planning state
+  - path: docs/splendor_mvp_to_v1_roadmap.md
+    role: roadmap
+    freshness: current
+    purpose: Current roadmap authority for milestone scope and next planned slices.
+    applies_to:
+    - roadmap
+    - milestone planning
+  - path: docs/splendor_product_spec.md
+    role: current-authority
+    freshness: current
+    purpose: Product behavior authority for briefing, handoff, and source lifecycle semantics.
+    applies_to:
+    - product contract
+    - agent handoff
+  - path: docs/schema_contracts.md
+    role: current-authority
+    freshness: current
+    purpose: Schema and deterministic state contract reference.
+    applies_to:
+    - schemas
+    - CLI contracts
+  - path: docs/ci_and_repo_automation.md
+    role: current-authority
+    freshness: current
+    purpose: Automation and GitHub workflow behavior reference.
+    applies_to:
+    - CI
+    - repository automation
+  - path: docs/v1_release_handoff.md
+    role: reference
+    freshness: watch
+    purpose: v1 release handoff and known post-v1 follow-up queue.
+    applies_to:
+    - release handoff
+    - post-v1 planning
+  - path: docs/m14_synthbanshee_reevaluation.md
+    role: historical-review
+    freshness: current
+    purpose: M14-P3.1 internal re-evaluation of the #72 source-lifecycle feedback loop.
+    applies_to:
+    - issue 72
+    - issue 86
+    - agent handoff
+  - path: docs/issue_70_design_response.md
+    role: historical-review
+    freshness: watch
+    purpose: Design response to the first real agent-experience report and remaining follow-ups.
+    applies_to:
+    - issue 70
+    - agent experience

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -1726,6 +1726,10 @@ def handle_brief(args: argparse.Namespace) -> int:
         print("Relevant records:")
         for match in result.matches:
             print(f"- {match.path} [{match.kind}] score={match.score}: {match.title}")
+    if result.authority_briefs:
+        print("Authority docs:")
+        for item in result.authority_briefs:
+            print(f"- {item.path} [{item.role}/{item.freshness}] score={item.score}: {item.title}")
     if result.planning_items:
         print("Active planning:")
         for item in result.planning_items:
@@ -1784,6 +1788,10 @@ def _print_agent_context(result: ProjectBrief) -> None:
             print(f"- {match.path} [{match.kind}] score={match.score} sources={source_refs}")
             if match.snippet:
                 print(f"  {match.snippet}")
+    if result.authority_briefs:
+        print("Authority docs:")
+        for item in result.authority_briefs[:5]:
+            print(f"- {item.path} [{item.role}/{item.freshness}] score={item.score} {item.title}")
     if result.planning_items:
         print("Active planning:")
         for item in result.planning_items:

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -3,13 +3,19 @@
 from __future__ import annotations
 
 import json
+import re
 import shlex
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 
 from splendor.config import load_config
 from splendor.layout import resolve_layout
-from splendor.schemas import MaintenanceReport, QuerySnapshot, SourceRecord
+from splendor.schemas import (
+    KnowledgePageFrontmatter,
+    MaintenanceReport,
+    QuerySnapshot,
+    SourceRecord,
+)
 from splendor.state.query_snapshot import last_query_path_for
 from splendor.state.source_compat import canonical_source_ref
 from splendor.utils.planning import (
@@ -44,6 +50,7 @@ _SUGGESTION_CATEGORY_LIMITS = {
     "queue": 3,
     "wiki-validation": 2,
     "goal-match": 3,
+    "authority": 3,
     "planning": 2,
     "synthesis": 2,
     "wiki-review": 2,
@@ -56,14 +63,34 @@ _SUGGESTION_CATEGORY_ORDER = {
     "queue": 1,
     "wiki-validation": 2,
     "goal-match": 3,
-    "planning": 4,
-    "synthesis": 5,
-    "wiki-review": 6,
-    "maintenance": 7,
-    "query": 8,
-    "orientation": 9,
+    "authority": 4,
+    "planning": 5,
+    "synthesis": 6,
+    "wiki-review": 7,
+    "maintenance": 8,
+    "query": 9,
+    "orientation": 10,
 }
 _SUGGESTION_PRIORITY_ORDER = {"high": 0, "medium": 1, "low": 2}
+_AUTHORITY_LIMIT = 6
+_TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]{1,}")
+_AUTHORITY_ROLE_ORDER = {
+    "current-authority": 0,
+    "roadmap": 1,
+    "reference": 2,
+    "proposal": 3,
+    "historical-review": 4,
+    "generated-summary": 5,
+}
+_AUTHORITY_ROLE_SCORE = {
+    "current-authority": 60,
+    "roadmap": 45,
+    "reference": 35,
+    "proposal": 25,
+    "historical-review": 20,
+    "generated-summary": 5,
+}
+_AUTHORITY_FRESHNESS_SCORE = {"current": 25, "watch": 10, "stale": -10, "historical": -20}
 _PLANNING_STATUSES = {
     "task": {"todo", "in_progress", "blocked"},
     "milestone": {"planned", "active"},
@@ -93,6 +120,17 @@ class BriefPlanningItem:
     title: str
     status: str
     path: str
+
+
+@dataclass(frozen=True)
+class AuthorityBrief:
+    rank: int
+    path: str
+    title: str
+    role: str
+    freshness: str
+    score: int
+    reason: str
 
 
 @dataclass(frozen=True)
@@ -151,6 +189,7 @@ class SuggestNextResult:
     queue: QueueInspectResult
     freshness: SourceFreshnessResult
     matches: list[BriefMatch]
+    authority_briefs: list[AuthorityBrief]
     planning_items: list[BriefPlanningItem]
     latest_reports: list[BriefReportSnapshot]
     warnings: list[BriefWarning]
@@ -166,6 +205,7 @@ class BriefStateSnapshot:
     queue: QueueInspectResult
     freshness: SourceFreshnessResult
     matches: list[BriefMatch]
+    authority_briefs: list[AuthorityBrief]
     planning_items: list[BriefPlanningItem]
     recent_sources: list[BriefSourceItem]
     recent_runs: list[RecentRunSnapshot]
@@ -183,6 +223,7 @@ class ProjectBrief:
     query_summary: str | None
     status: WikiStatus
     matches: list[BriefMatch]
+    authority_briefs: list[AuthorityBrief]
     planning_items: list[BriefPlanningItem]
     recent_sources: list[BriefSourceItem]
     recent_runs: list[RecentRunSnapshot]
@@ -199,6 +240,7 @@ def build_project_brief(root: Path, goal: str | None) -> ProjectBrief:
     next_actions = _next_actions(
         status=snapshot.status,
         matches=snapshot.matches,
+        authority_briefs=snapshot.authority_briefs,
         planning_items=snapshot.planning_items,
         warnings=snapshot.warnings,
         suggested_actions=suggested_actions,
@@ -208,6 +250,7 @@ def build_project_brief(root: Path, goal: str | None) -> ProjectBrief:
         query_summary=snapshot.query_summary,
         status=snapshot.status,
         matches=snapshot.matches,
+        authority_briefs=snapshot.authority_briefs,
         planning_items=snapshot.planning_items,
         recent_sources=snapshot.recent_sources,
         recent_runs=snapshot.recent_runs,
@@ -229,6 +272,7 @@ def build_suggest_next(root: Path, goal: str | None = None) -> SuggestNextResult
         queue=snapshot.queue,
         freshness=snapshot.freshness,
         matches=snapshot.matches,
+        authority_briefs=snapshot.authority_briefs,
         planning_items=snapshot.planning_items,
         latest_reports=snapshot.latest_reports,
         warnings=snapshot.warnings,
@@ -262,6 +306,8 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
     sources = load_sources(layout)
     sources_by_id = {source.source_id: source for source in sources}
     wiki_pages, invalid_wiki_pages = load_wiki_pages(root, layout)
+    authority_briefs, authority_warnings = _authority_briefs(root, config, wiki_pages, goal)
+    warnings.extend(authority_warnings)
     recent_sources = _recent_sources(sources)
     recent_runs = status.recent_runs
     latest_reports = _latest_reports(root, layout)
@@ -275,6 +321,7 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
         queue=queue,
         freshness=freshness,
         matches=matches,
+        authority_briefs=authority_briefs,
         planning_items=planning_items,
         recent_sources=recent_sources,
         recent_runs=recent_runs,
@@ -343,6 +390,127 @@ def _active_planning_items(
     return items[:_BRIEF_PLANNING_LIMIT], warnings
 
 
+def _authority_briefs(root: Path, config, pages: list[WikiPageSnapshot], goal: str | None):
+    items: list[AuthorityBrief] = []
+    warnings: list[BriefWarning] = []
+    goal_tokens = _tokens(goal or "")
+
+    for doc in config.briefing.authority_documents:
+        path = Path(doc.path)
+        absolute = root / path
+        if absolute.exists() and absolute.is_file():
+            body = absolute.read_text(encoding="utf-8", errors="replace")
+        else:
+            warnings.append(
+                BriefWarning(
+                    area="authority",
+                    path=path.as_posix(),
+                    message="Configured authority document is missing.",
+                )
+            )
+            continue
+        title = doc.title or _title_from_markdown(body) or path.name
+        reason = doc.purpose or f"{doc.role} document for {path.as_posix()}"
+        score = _authority_score(
+            role=doc.role,
+            freshness=doc.freshness,
+            goal_tokens=goal_tokens,
+            text=" ".join([title, reason, " ".join(doc.applies_to), path.as_posix(), body]),
+        )
+        items.append(
+            AuthorityBrief(
+                rank=0,
+                path=path.as_posix(),
+                title=title,
+                role=doc.role,
+                freshness=doc.freshness,
+                score=score,
+                reason=reason,
+            )
+        )
+
+    for page in pages:
+        if page.frontmatter.kind == "source-summary":
+            continue
+        if page.frontmatter.authority_role is None:
+            continue
+        freshness = page.frontmatter.authority_freshness or _derived_authority_freshness(
+            page.frontmatter
+        )
+        reason = (
+            "Maintained wiki page marked for agent briefing"
+            if not page.frontmatter.authority_scope
+            else "Applies to " + ", ".join(page.frontmatter.authority_scope)
+        )
+        score = _authority_score(
+            role=page.frontmatter.authority_role,
+            freshness=freshness,
+            goal_tokens=goal_tokens,
+            text=" ".join(
+                [
+                    page.frontmatter.title,
+                    page.frontmatter.page_id,
+                    page.path,
+                    " ".join(page.frontmatter.authority_scope),
+                    page.body,
+                ]
+            ),
+        )
+        items.append(
+            AuthorityBrief(
+                rank=0,
+                path=page.path,
+                title=page.frontmatter.title,
+                role=page.frontmatter.authority_role,
+                freshness=freshness,
+                score=score,
+                reason=reason,
+            )
+        )
+
+    ranked = sorted(
+        enumerate(items),
+        key=lambda item: (
+            -item[1].score,
+            _AUTHORITY_ROLE_ORDER.get(item[1].role, 99),
+            item[0],
+            item[1].path,
+        ),
+    )
+    return [
+        replace(item, rank=rank)
+        for rank, (_sequence, item) in enumerate(ranked[:_AUTHORITY_LIMIT], start=1)
+    ], warnings
+
+
+def _authority_score(*, role: str, freshness: str, goal_tokens: set[str], text: str) -> int:
+    score = _AUTHORITY_ROLE_SCORE.get(role, 0) + _AUTHORITY_FRESHNESS_SCORE.get(freshness, 0)
+    if goal_tokens:
+        overlap = goal_tokens & _tokens(text)
+        score += min(len(overlap), 6) * 12
+    return score
+
+
+def _derived_authority_freshness(frontmatter: KnowledgePageFrontmatter) -> str:
+    if frontmatter.status == "stale" or frontmatter.review_state in {"contested", "stale"}:
+        return "stale"
+    if frontmatter.status == "draft" or frontmatter.review_state in {"draft", "machine-generated"}:
+        return "watch"
+    return "current"
+
+
+def _title_from_markdown(body: str) -> str | None:
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped.removeprefix("# ").strip() or None
+    return None
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_TOKEN_PATTERN.findall(text.lower()))
+
+
 def _recent_sources(sources: list[SourceRecord]) -> list[BriefSourceItem]:
     sources = sorted(sources, key=lambda source: (source.added_at, source.source_id))
     return [
@@ -395,6 +563,7 @@ def _next_actions(
     *,
     status: WikiStatus,
     matches: list[BriefMatch],
+    authority_briefs: list[AuthorityBrief],
     planning_items: list[BriefPlanningItem],
     warnings: list[BriefWarning],
     suggested_actions: list[SuggestedAction],
@@ -418,6 +587,8 @@ def _next_actions(
         actions.append("Review draft, stale, contested, or machine-generated synthesis pages.")
     if matches:
         actions.append("Open the top matching wiki or planning records for the stated goal.")
+    if authority_briefs:
+        actions.append("Read the top authority docs before changing planning-heavy behavior.")
     if planning_items:
         actions.append("Continue or close the active planning records listed in this brief.")
     if warnings:
@@ -551,6 +722,17 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
             None,
             path=match.path,
             record_id=match.record_id,
+        )
+
+    for authority in snapshot.authority_briefs[:3]:
+        priority = "medium" if authority.role in {"current-authority", "roadmap"} else "low"
+        add(
+            priority,
+            "authority",
+            f"Read authority doc {authority.path}",
+            f"{authority.role}/{authority.freshness}: {authority.reason}",
+            None,
+            path=authority.path,
         )
 
     for item in snapshot.planning_items:
@@ -704,6 +886,7 @@ def render_suggest_next_json(result: SuggestNextResult) -> str:
                 "status_counts": result.queue.status_counts,
             },
             "matches": [asdict(match) for match in result.matches],
+            "authority_briefs": [asdict(brief) for brief in result.authority_briefs],
             "planning_items": [asdict(item) for item in result.planning_items],
             "latest_reports": [asdict(report) for report in result.latest_reports],
             "warnings": [asdict(warning) for warning in result.warnings],
@@ -719,6 +902,7 @@ def render_project_brief_json(brief: ProjectBrief) -> str:
             "query_summary": brief.query_summary,
             "status": asdict(brief.status),
             "matches": [asdict(match) for match in brief.matches],
+            "authority_briefs": [asdict(item) for item in brief.authority_briefs],
             "planning_items": [asdict(item) for item in brief.planning_items],
             "recent_sources": [asdict(source) for source in brief.recent_sources],
             "recent_runs": [asdict(run) for run in brief.recent_runs],
@@ -749,6 +933,7 @@ def render_agent_context_json(brief: ProjectBrief) -> str:
                 "sources_missing_synthesis": brief.status.sources_missing_synthesis,
             },
             "matches": [asdict(match) for match in brief.matches],
+            "authority_briefs": [asdict(item) for item in brief.authority_briefs],
             "source_refs": _agent_context_source_refs(brief),
             "suggested_actions": [asdict(action) for action in brief.suggested_actions],
             "active_planning": [asdict(item) for item in brief.planning_items],

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from urllib.parse import urlsplit
 
 from splendor.commands.maintenance import MaintenanceCheckResult, workspace_relative_path
+from splendor.config import load_config
 from splendor.layout import ResolvedLayout, required_directories
 from splendor.schemas import (
     DecisionRecord,
@@ -252,6 +253,7 @@ def _run_reference_integrity_checks(
     checked_count = 0
     issues: list[MaintenanceIssue] = []
     inventory = inventory_result.context.inventory
+    config = load_config(root)
 
     wiki_by_id: dict[str, list[_WikiPageInventory]] = {}
     wiki_by_path: dict[str, _WikiPageInventory] = {}
@@ -309,6 +311,21 @@ def _run_reference_integrity_checks(
         if page.frontmatter is not None
         for contradiction in page.frontmatter.contradictions
     }
+
+    checked_count += len(config.briefing.authority_documents)
+    for doc in config.briefing.authority_documents:
+        path = root / doc.path
+        if path.is_file():
+            continue
+        issues.append(
+            MaintenanceIssue(
+                code="missing-authority-document",
+                message="Configured authority document is missing",
+                path=doc.path,
+                record_id=doc.role,
+                check_name="briefing-authority",
+            )
+        )
 
     for page in inventory.wiki_pages:
         if page.frontmatter is None:

--- a/src/splendor/config.py
+++ b/src/splendor/config.py
@@ -5,11 +5,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Annotated
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Annotated, Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from splendor.schemas.types import SourceClass, StorageMode, SummaryMode
 
@@ -76,6 +76,47 @@ class QueueConfig(BaseModel):
     )
 
 
+class AuthorityDocumentConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    role: Literal[
+        "current-authority",
+        "roadmap",
+        "historical-review",
+        "proposal",
+        "reference",
+        "generated-summary",
+    ] = "reference"
+    freshness: Literal["current", "watch", "stale", "historical"] = "current"
+    title: str | None = None
+    purpose: str | None = None
+    applies_to: list[str] = Field(default_factory=list)
+
+    @field_validator("path")
+    @classmethod
+    def validate_repo_relative_path(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("authority document path must not be empty")
+        posix_path = PurePosixPath(normalized)
+        if posix_path.is_absolute() or PureWindowsPath(normalized).is_absolute():
+            raise ValueError("authority document path must be repo-relative")
+        if "\\" in normalized:
+            raise ValueError("authority document path must use POSIX separators")
+        if any(part in {"", ".", ".."} for part in posix_path.parts):
+            raise ValueError("authority document path must be normalized and stay inside the repo")
+        if posix_path.as_posix() != normalized:
+            raise ValueError("authority document path must be normalized")
+        return normalized
+
+
+class BriefingConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority_documents: list[AuthorityDocumentConfig] = Field(default_factory=list)
+
+
 class SplendorConfig(BaseModel):
     schema_version: str = "1"
     project_name: str = "Splendor workspace"
@@ -83,6 +124,7 @@ class SplendorConfig(BaseModel):
     sources: SourcesConfig = Field(default_factory=SourcesConfig)
     queue: QueueConfig = Field(default_factory=QueueConfig)
     reviews: ReviewsConfig = Field(default_factory=ReviewsConfig)
+    briefing: BriefingConfig = Field(default_factory=BriefingConfig)
 
 
 def config_path_for(root: Path) -> Path:

--- a/src/splendor/schemas/wiki.py
+++ b/src/splendor/schemas/wiki.py
@@ -18,6 +18,19 @@ class KnowledgePageFrontmatter(StrictRecord):
     page_id: str
     status: Literal["draft", "active", "stale"] = "draft"
     review_state: PageReviewState = "draft"
+    authority_role: (
+        Literal[
+            "current-authority",
+            "roadmap",
+            "historical-review",
+            "proposal",
+            "reference",
+            "generated-summary",
+        ]
+        | None
+    ) = None
+    authority_freshness: Literal["current", "watch", "stale", "historical"] | None = None
+    authority_scope: list[str] = Field(default_factory=list)
     source_refs: list[str] = Field(default_factory=list)
     generated_by_run_ids: list[str] = Field(default_factory=list)
     last_generated_at: str | None = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ def test_default_config_includes_source_policy_defaults() -> None:
     assert config.queue.max_attempts == 3
     assert config.queue.lease_ttl_seconds == 300
     assert config.queue.retry_backoff_seconds == [60, 300, 900]
+    assert config.briefing.authority_documents == []
 
 
 def test_load_config_accepts_yaml_without_sources_block(tmp_path: Path) -> None:
@@ -83,6 +84,61 @@ def test_load_config_accepts_queue_policy(tmp_path: Path) -> None:
     assert config.queue.max_attempts == 5
     assert config.queue.lease_ttl_seconds == 120
     assert config.queue.retry_backoff_seconds == [1, 2, 3]
+
+
+def test_load_config_accepts_briefing_authority_documents(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        (
+            "schema_version: '1'\n"
+            "project_name: Example\n"
+            "briefing:\n"
+            "  authority_documents:\n"
+            "    - path: README.md\n"
+            "      role: current-authority\n"
+            "      freshness: current\n"
+            "      purpose: Current project entrypoint.\n"
+            "      applies_to: [agent handoff]\n"
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(tmp_path)
+
+    authority = config.briefing.authority_documents[0]
+    assert authority.path == "README.md"
+    assert authority.role == "current-authority"
+    assert authority.applies_to == ["agent handoff"]
+
+
+def test_load_config_rejects_unknown_briefing_keys(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        ("schema_version: '1'\nproject_name: Example\nbriefing:\n  authority_documentz: []\n"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError):
+        load_config(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "path", ["/etc/hosts", "../README.md", "docs/../README.md", "docs\\brief.md", ""]
+)
+def test_load_config_rejects_non_repo_relative_authority_document_paths(
+    tmp_path: Path, path: str
+) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        (
+            "schema_version: '1'\n"
+            "project_name: Example\n"
+            "briefing:\n"
+            "  authority_documents:\n"
+            f"    - path: {path!r}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError):
+        load_config(tmp_path)
 
 
 def test_load_config_rejects_unknown_queue_keys(tmp_path: Path) -> None:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -9,7 +9,7 @@ from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.lint import run_lint_checks
 from splendor.commands.planning import create_task
-from splendor.config import load_config
+from splendor.config import AuthorityDocumentConfig, load_config, write_config
 from splendor.layout import resolve_layout
 from splendor.schemas import (
     ContradictionAnnotation,
@@ -229,6 +229,23 @@ def test_run_lint_checks_reports_invalid_source_manifest(tmp_path: Path) -> None
     assert [issue.code for issue in result.issues] == ["invalid-source-manifest"]
     assert "\n" not in result.issues[0].message
     assert str(tmp_path) not in result.issues[0].message
+
+
+def test_run_lint_checks_reports_missing_authority_document(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(path="missing.md", role="current-authority")
+    ]
+    write_config(tmp_path, config)
+
+    result = _run_lint(tmp_path)
+
+    issues = [issue for issue in result.issues if issue.check_name == "briefing-authority"]
+    assert len(issues) == 1
+    assert issues[0].code == "missing-authority-document"
+    assert issues[0].path == "missing.md"
+    assert issues[0].record_id == "current-authority"
 
 
 def test_run_lint_checks_reports_missing_source_derived_artifact(tmp_path: Path) -> None:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -78,6 +78,9 @@ def test_knowledge_page_frontmatter_defaults_review_and_provenance_fields() -> N
     )
 
     assert record.review_state == "draft"
+    assert record.authority_role is None
+    assert record.authority_freshness is None
+    assert record.authority_scope == []
     assert record.last_generated_at is None
     assert record.provenance_links == []
     assert record.contradictions == []

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -7,7 +7,7 @@ from splendor.cli import main
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.wiki import add_topic_page, rebuild_wiki_index
-from splendor.config import load_config, write_config
+from splendor.config import AuthorityDocumentConfig, load_config, write_config
 from splendor.schemas import KnowledgePageFrontmatter, MaintenanceReport
 from splendor.state.source_registry import load_source_record
 from splendor.utils.wiki import parse_wiki_markdown
@@ -22,6 +22,9 @@ def write_wiki_page(
     review_state: str = "draft",
     source_refs: list[str] | None = None,
     tags: list[str] | None = None,
+    authority_role: str | None = None,
+    authority_freshness: str | None = None,
+    authority_scope: list[str] | None = None,
     body: str = "",
 ) -> None:
     frontmatter = KnowledgePageFrontmatter(
@@ -32,6 +35,9 @@ def write_wiki_page(
         review_state=review_state,
         source_refs=source_refs or [],
         tags=tags or [],
+        authority_role=authority_role,
+        authority_freshness=authority_freshness,
+        authority_scope=authority_scope or [],
         confidence=0.8,
     )
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -844,6 +850,162 @@ def test_brief_agent_context_text_output_is_compact(tmp_path: Path, capsys) -> N
     assert "Suggested next:" in out
     assert "Wiki status:" in out
     assert "Next actions:" in out
+
+
+def test_brief_agent_context_ranks_configured_authority_docs(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / "README.md").write_text(
+        "# Project README\n\nAuthority for current agent handoff workflow.\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "roadmap.md").write_text(
+        "# Roadmap\n\nRoadmap for future agent handoff work.\n", encoding="utf-8"
+    )
+    (docs / "old-review.md").write_text(
+        "# Old Review\n\nHistorical agent handoff review.\n", encoding="utf-8"
+    )
+    config = load_config(tmp_path)
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path="docs/old-review.md",
+            role="historical-review",
+            freshness="historical",
+            purpose="Older review context.",
+            applies_to=["agent handoff"],
+        ),
+        AuthorityDocumentConfig(
+            path="README.md",
+            role="current-authority",
+            freshness="current",
+            purpose="Current project entrypoint.",
+            applies_to=["agent handoff"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/roadmap.md",
+            role="roadmap",
+            freshness="current",
+            purpose="Planned future work.",
+            applies_to=["agent handoff"],
+        ),
+    ]
+    write_config(tmp_path, config)
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "brief", "--agent-context", "agent", "handoff", "--json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    authority = payload["authority_briefs"]
+    assert [item["path"] for item in authority[:3]] == [
+        "README.md",
+        "docs/roadmap.md",
+        "docs/old-review.md",
+    ]
+    assert authority[0]["role"] == "current-authority"
+    authority_actions = [
+        action for action in payload["suggested_actions"] if action["category"] == "authority"
+    ]
+    assert authority_actions
+    assert authority_actions[0]["path"] == "README.md"
+
+
+def test_brief_agent_context_warns_but_does_not_rank_missing_authority_docs(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path="missing.md",
+            role="current-authority",
+            freshness="current",
+        )
+    ]
+    write_config(tmp_path, config)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "brief", "--agent-context", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["authority_briefs"] == []
+    assert all(
+        not action["title"].startswith("Read authority doc")
+        for action in payload["suggested_actions"]
+    )
+    assert payload["warnings"] == [
+        {
+            "area": "authority",
+            "path": "missing.md",
+            "message": "Configured authority document is missing.",
+        }
+    ]
+
+
+def test_suggest_next_uses_wiki_authority_metadata_but_skips_source_summaries(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "agent-handoff.md",
+        kind="topic",
+        title="Agent handoff authority",
+        page_id="topic-agent-handoff",
+        authority_role="current-authority",
+        authority_freshness="current",
+        authority_scope=["agent handoff"],
+        body="Maintained agent handoff decisions live here.",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "sources" / "src-generated.md",
+        kind="source-summary",
+        title="Generated summary",
+        page_id="src-generated",
+        authority_role="current-authority",
+        authority_freshness="current",
+        body="Generated source summaries are not maintained authority.",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "suggest-next", "agent", "handoff", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    authority = [action for action in payload["actions"] if action["category"] == "authority"]
+    assert authority
+    assert authority[0]["path"] == "wiki/topics/agent-handoff.md"
+    assert all(action["path"] != "wiki/sources/src-generated.md" for action in authority)
+
+
+def test_suggest_next_derives_draft_wiki_authority_freshness_as_watch(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "draft-authority.md",
+        kind="topic",
+        title="Draft authority",
+        page_id="topic-draft-authority",
+        authority_role="current-authority",
+        body="Draft authority notes for agent handoff.",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "suggest-next", "agent", "handoff", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    authority_brief = payload["authority_briefs"][0]
+    assert authority_brief["path"] == "wiki/topics/draft-authority.md"
+    assert authority_brief["freshness"] == "watch"
+    authority_actions = [
+        action for action in payload["actions"] if action["category"] == "authority"
+    ]
+    assert authority_actions[0]["reason"].startswith("current-authority/watch:")
 
 
 def test_suggest_next_json_ranks_changed_sources_before_review_work(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Implements `M14-P4.1` for #86 by adding a narrow, schema-version-1-compatible authority/staleness model for planning-heavy handoff context.

## What changed

- Added `briefing.authority_documents` config metadata for maintained planning, roadmap, schema, automation, release, and design docs.
- Added optional maintained wiki frontmatter fields: `authority_role`, `authority_freshness`, and `authority_scope`.
- Taught `splendor brief --agent-context` and `splendor suggest-next` to rank task-relevant authority docs and include them in JSON/text handoff output.
- Kept generated `source-summary` pages separate from maintained authority ranking.
- Hardened the authority contract after self-review: authority paths must be normalized repo-relative paths, missing configured docs are warnings/lint issues instead of ranked reads, and draft wiki authority defaults to watch rather than current.
- Updated Splendor's own `splendor.yaml` authority document registry and synchronized M14-P4.1 planning state.
- Updated README, roadmap, schema contracts, product spec, automation docs, and handoff/design notes.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`

## Boundaries

- Does not implement the mutating compile/update workflow from #79.
- Does not take on #47 ingest timing precision, #37 web scaling, or #30 repo-scan registration optimization.

Closes #86.
