### PR TITLE
M15-P1.1 Add reviewed wiki compile apply loop

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M14-P3.1`
-- Last action taken: `M14-P3.1` is implemented; the source-lifecycle re-evaluation gate recommends closing #72 and narrows the remaining handoff gap to #86.
-- Current planned slice: `Planning-doc authority and task-oriented agent briefs`
-- Current PR sub-slice: `M14-P4.1`
+- Previous completed PR sub-slice: `M14-P4.1`
+- Last action taken: `M14-P4.1` is implemented; planning-doc authority metadata and task-oriented agent briefs are in place, so #79 is now the highest-priority post-v1 workflow gap.
+- Current planned slice: `Post-v1 mutating compile/update workflow`
+- Current PR sub-slice: `M15-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `Post-v1 mutating compile/update workflow`
-- Next planned PR sub-slice: `TBD`
+- Next planned slice: `Compile/update expansion after first reviewed page apply`
+- Next planned PR sub-slice: `M15-P1.2`
 - Current blockers: none
 
 ## Planning Notation
@@ -259,6 +259,12 @@
   - [x] Add optional maintained wiki authority metadata while excluding source summaries from maintained authority ranking
   - [x] Teach `brief --agent-context` and `suggest-next` to rank task-relevant authority docs
   - [x] Update tests, schema docs, README, roadmap, product spec, and handoff docs
+- [x] Implement `M15-P1.1`: First reviewed compile/apply loop
+  - [x] Keep bare `splendor wiki compile <source-id|title|path>` as the non-mutating contract surface
+  - [x] Add deterministic `--page` proposals from generated source-summary evidence into one maintained synthesis page
+  - [x] Require explicit `--apply` before mutating a maintained topic/concept/entity/architecture/glossary page
+  - [x] Validate updated frontmatter and reject generated source-summary pages as compile targets
+  - [x] Keep #47, #37, and #30 as independent follow-ups
 
 ## Context Pointers
 
@@ -293,6 +299,7 @@
 - `M14-P2` PR summary and generated-state review handoff
 - `M14-P3` Source-lifecycle re-evaluation gate
 - `M14-P4` Planning-doc authority and task-oriented agent briefs
+- `M15-P1` Post-v1 mutating compile/update workflow
 
 ## PR Sub-slice Queue
 
@@ -326,3 +333,5 @@
 - `M14-P2.1` PR summary and lower-noise generated-state review handoff
 - `M14-P3.1` Source-lifecycle re-evaluation gate
 - `M14-P4.1` Planning-doc authority and task-oriented agent briefs
+- `M15-P1.1` First reviewed compile/apply loop
+- `M15-P1.2` Compile/update expansion after first reviewed page apply

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ Implemented today:
 - `splendor add-topic "Title"` with optional `--tags`, `--source-refs`, and `--template`
 - `splendor wiki status`
 - `splendor wiki suggest <source-id>`
-- `splendor wiki compile <source-id>` as a non-mutating review-gated contract description
+- `splendor wiki compile <source-id>` as a non-mutating review-gated contract description, plus
+  `splendor wiki compile <source-id> --page <page> --apply` for explicit reviewed synthesis-page
+  updates
 - `splendor wiki rebuild-index`
 - `splendor brief [goal]` and `splendor brief --agent-context [goal]`
 - config-backed authority briefs for maintained planning/docs context through
@@ -140,7 +142,7 @@ Implemented today:
 
 Not implemented yet:
 
-- mutating review-gated `splendor wiki compile`
+- multi-page or LLM-assisted mutating `splendor wiki compile`
 - heavyweight OCR/image extraction providers
 - mutating web UI actions such as add-source forms
 
@@ -207,12 +209,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M14-P3.1`
-- Current planned slice: `Planning-doc authority and task-oriented agent briefs`
-- Current PR sub-slice: `M14-P4.1`
+- Previous completed PR sub-slice: `M14-P4.1`
+- Current planned slice: `Post-v1 mutating compile/update workflow`
+- Current PR sub-slice: `M15-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `Post-v1 mutating compile/update workflow`
-- Next planned PR sub-slice: `TBD`
+- Next planned slice: `Compile/update expansion after first reviewed page apply`
+- Next planned PR sub-slice: `M15-P1.2`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -298,14 +300,15 @@ leads with source paths or refs before canonical source IDs where practical.
 CLI, clarifies generated-state review policy, and records the v1 readiness audit. The audit treats
 issue #41's briefing and non-mutating compile contract, #42's next-action hints, #43's pending
 ingest handoff, #44's query snippets, #45's web status/source detail pages, and #46's page-state
-visibility as represented in current behavior. It still calls out #41's mutating compile/update
-workflow as deferred. Issue #47 remains an ingest/run-state timing follow-up. Issues #30 and #37
+visibility as represented in current behavior. `M15-P1.1` now starts #41's deferred mutating
+compile/update workflow through #79 with explicit one-page proposal/apply semantics. Issue #47
+remains an ingest/run-state timing follow-up. Issues #30 and #37
 remain post-v1 performance work. Issue #70 is closed after the M13-P2/M13-P3.1 response. Issue #72
 is the parent feedback loop for the M14 source-lifecycle sequence; stable logical source
 identities, supersession lifecycle, safe workspace refresh, superseded summary pruning, topic-ref
 migration, and PR-summary support have landed. `M14-P3.1` recommends closing #72 once maintainers
 accept the gate result, with the narrower remaining handoff gap tracked by #86.
-Issue #79 tracks the deferred mutating compile/update path from #41.
+Issue #79 tracks the reviewed compile/update sequence that started in `M15-P1.1`.
 
 `M14-P1.1` adds the first stable logical source identity layer above content-addressed source IDs:
 workspace-backed manifests now persist `source:<workspace-path>` logical IDs and path aliases while
@@ -346,6 +349,14 @@ and maintained wiki pages can opt into authority ranking with frontmatter fields
 `authority_role`, `authority_freshness`, and `authority_scope`. `brief --agent-context` and
 `suggest-next` include ranked authority docs for the goal while keeping generated source-summary
 artifacts separate from maintained authority.
+
+`M15-P1.1` starts the post-v1 compile/update workflow from #79. Bare
+`splendor wiki compile <source-id|title|path>` remains non-mutating and prints the review contract.
+Adding `--page <maintained-page>` produces a deterministic proposed update from the generated
+source-summary page into a single maintained topic/concept/entity/architecture/glossary page.
+Adding `--apply` is the explicit operator acceptance step that writes only that maintained page,
+updates schema-bound frontmatter source refs/provenance links, and refuses generated
+source-summary pages as compile targets.
 
 ### v1 readiness checklist
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ Implemented today:
 - `splendor wiki status`
 - `splendor wiki suggest <source-id>`
 - `splendor wiki compile <source-id>` as a non-mutating review-gated contract description, plus
-  `splendor wiki compile <source-id> --page <page> --apply` for explicit reviewed synthesis-page
-  updates
+  `splendor wiki compile <source-id> --page <page>` for diff-backed proposals and
+  `--apply --proposal-hash <hash>` for explicit reviewed synthesis-page updates
 - `splendor wiki rebuild-index`
 - `splendor brief [goal]` and `splendor brief --agent-context [goal]`
 - config-backed authority briefs for maintained planning/docs context through
@@ -354,9 +354,12 @@ artifacts separate from maintained authority.
 `splendor wiki compile <source-id|title|path>` remains non-mutating and prints the review contract.
 Adding `--page <maintained-page>` produces a deterministic proposed update from the generated
 source-summary page into a single maintained topic/concept/entity/architecture/glossary page.
-Adding `--apply` is the explicit operator acceptance step that writes only that maintained page,
-updates schema-bound frontmatter source refs/provenance links, and refuses generated
-source-summary pages as compile targets.
+The proposal includes a unified diff, target/source-summary SHA-256 hashes, and a proposal hash.
+Adding `--apply --proposal-hash <hash>` is the explicit operator acceptance step that writes only
+that maintained page when the current target and source-summary inputs still match the reviewed
+proposal. Applied output updates schema-bound frontmatter source refs/provenance links, writes a
+managed `Compiled Source Evidence` section, and refuses generated source-summary pages as compile
+targets.
 
 ### v1 readiness checklist
 

--- a/docs/issue_70_design_response.md
+++ b/docs/issue_70_design_response.md
@@ -115,8 +115,8 @@ in issue #72.
 - #86 tracks the narrower planning-document authority metadata and task-oriented agent brief gap
   found by the `M14-P3.1` re-evaluation; `M14-P4.1` adds the initial metadata and ranking layer.
 - #41 has shipped `splendor brief [goal]`, `brief --agent-context`, and the non-mutating
-  `splendor wiki compile <source-id|title|path>` contract. Mutating compile/update support remains
-  deferred and is tracked by #79.
+  `splendor wiki compile <source-id|title|path>` contract. Mutating compile/update support is
+  tracked by #79, with `M15-P1.1` starting the explicit one-page proposal/apply path.
 - #42 has shipped restrained next-action hints around add-source, ingest, query/file-answer,
   briefing, and suggest-next flows.
 - #43 has shipped pending ingest queue handoff for CLI-created sources, and docs now show the

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -212,11 +212,13 @@ Implemented fields:
   version, leaving prose and code-fence mentions untouched. The command does not perform broad repo
   discovery, register uncurated files, or run mutating synthesis compile/update workflows.
 - `splendor wiki compile <source-id|title|path>` remains non-mutating unless a maintained target
-  page is selected and `--apply` is supplied. `--page <maintained-page>` proposes a deterministic
-  update from the generated source-summary page into one maintained topic, concept, entity,
-  architecture, or glossary page. Proposed and applied updates add the source ID to frontmatter
-  `source_refs`, add provenance links with `supports` and `generated-from` roles, append a bounded
-  source-evidence block to the markdown body, and validate the resulting
+  page is selected and `--apply --proposal-hash <hash>` is supplied. `--page <maintained-page>`
+  proposes a deterministic update from the generated source-summary page into one maintained
+  topic, concept, entity, architecture, or glossary page. Proposed output includes a unified diff,
+  target/source-summary SHA-256 hashes, and a proposal hash derived from those inputs plus the
+  proposed page hash. Proposed and applied updates add the source ID to frontmatter `source_refs`,
+  add provenance links with `supports` and `generated-from` roles, append a managed
+  `Compiled Source Evidence` section to the markdown body, and validate the resulting
   `KnowledgePageFrontmatter` before reporting or writing. Generated source-summary pages are not
   valid compile targets.
 - `splendor pr-summary --since main` is a read-only PR handoff view over local git diff/status and

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -211,6 +211,14 @@ Implemented fields:
   source-reference list bullets from superseded source IDs to the active content-addressed source
   version, leaving prose and code-fence mentions untouched. The command does not perform broad repo
   discovery, register uncurated files, or run mutating synthesis compile/update workflows.
+- `splendor wiki compile <source-id|title|path>` remains non-mutating unless a maintained target
+  page is selected and `--apply` is supplied. `--page <maintained-page>` proposes a deterministic
+  update from the generated source-summary page into one maintained topic, concept, entity,
+  architecture, or glossary page. Proposed and applied updates add the source ID to frontmatter
+  `source_refs`, add provenance links with `supports` and `generated-from` roles, append a bounded
+  source-evidence block to the markdown body, and validate the resulting
+  `KnowledgePageFrontmatter` before reporting or writing. Generated source-summary pages are not
+  valid compile targets.
 - `splendor pr-summary --since main` is a read-only PR handoff view over local git diff/status and
   existing report files. It diffs from the merge base between `HEAD` and the base ref, respects
   configured workspace layout directories, and groups curated source manifests, generated

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -963,10 +963,12 @@ maintenance loop without weakening the generated-versus-maintained page boundary
 surface and adds a narrow reviewed implementation behind explicit page selection. Operators run
 `splendor wiki compile <source-id|title|path> --page <maintained-page>` to preview a deterministic
 update from the generated source-summary page into one maintained topic, concept, entity,
-architecture, or glossary page. The command appends a bounded source-evidence block, adds the
-source ID to `source_refs`, records provenance links to the source and source-summary page, and
-validates schema-version-1 frontmatter before reporting the proposal. It writes only when the
-operator repeats the command with `--apply`.
+architecture, or glossary page. The preview reports a unified diff, target/source-summary SHA-256
+hashes, and a proposal hash. The command appends a managed `Compiled Source Evidence` section,
+adds the source ID to `source_refs`, records provenance links to the source and source-summary
+page, and validates schema-version-1 frontmatter before reporting the proposal. It writes only
+when the operator repeats the command with `--apply --proposal-hash <hash>`, and that hash must
+match the current target/source-summary inputs.
 
 The first slice intentionally does not choose multiple pages automatically, call an LLM, create a
 web UI, register new sources, refresh broad workspace state, or address #47 ingest timing, #37 web

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M14-P3.1`
-- Current planned slice: `Planning-doc authority and task-oriented agent briefs`
-- Current PR sub-slice: `M14-P4.1`
+- Previous completed PR sub-slice: `M14-P4.1`
+- Current planned slice: `Post-v1 mutating compile/update workflow`
+- Current PR sub-slice: `M15-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `Post-v1 mutating compile/update workflow`
-- Next planned PR sub-slice: `TBD`
+- Next planned slice: `Compile/update expansion after first reviewed page apply`
+- Next planned PR sub-slice: `M15-P1.2`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -936,6 +936,41 @@ metadata for configured planning/docs files and optional maintained wiki frontma
 `brief --agent-context` and `suggest-next` to rank current authority, roadmap, historical review,
 proposal, reference, and generated-summary context for a stated goal. Generated source-summary
 artifacts remain separate from maintained authority ranking.
+
+## Candidate Milestone 15 — Post-v1 reviewed compile/update workflow
+
+### Goal
+Turn the deferred #79 compile/update path from #41 into a small, review-gated source-to-synthesis
+maintenance loop without weakening the generated-versus-maintained page boundary.
+
+### Scope
+- deterministic source-summary evidence extraction
+- explicit one-page maintained synthesis update proposals
+- operator-reviewed apply semantics
+- schema-bound maintained-page frontmatter validation
+- continued separation between generated source summaries and maintained synthesis pages
+
+### Candidate PR slices
+- `M15-P1` Reviewed compile/update loop
+
+### Candidate PR sub-slices
+- `M15-P1.1` First reviewed compile/apply loop
+- `M15-P1.2` Compile/update expansion after first reviewed page apply
+
+### M15-P1.1 first slice
+
+`M15-P1.1` keeps bare `splendor wiki compile <source-id|title|path>` as the non-mutating contract
+surface and adds a narrow reviewed implementation behind explicit page selection. Operators run
+`splendor wiki compile <source-id|title|path> --page <maintained-page>` to preview a deterministic
+update from the generated source-summary page into one maintained topic, concept, entity,
+architecture, or glossary page. The command appends a bounded source-evidence block, adds the
+source ID to `source_refs`, records provenance links to the source and source-summary page, and
+validates schema-version-1 frontmatter before reporting the proposal. It writes only when the
+operator repeats the command with `--apply`.
+
+The first slice intentionally does not choose multiple pages automatically, call an LLM, create a
+web UI, register new sources, refresh broad workspace state, or address #47 ingest timing, #37 web
+document-list scaling, or #30 repo-scan registration performance.
 
 ### Boundaries
 - Promote these candidates to committed roadmap slices only after the child issues and GitHub

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -745,11 +745,20 @@ This workflow should start with text-native sources and deterministic page-impac
 compile step may remain human-reviewed or LLM-assisted behind explicit confirmation until the
 contract is trustworthy.
 
-Current `splendor wiki compile <source-id>` support is intentionally non-mutating. It validates the
-source record and prints the review-gated contract: inspect the source summary, run source-impact
-suggestions, propose synthesis-page edits with provenance/run state, keep generated source-summary
-pages separate from maintained synthesis pages, and require human review before wiki synthesis is
-changed.
+Current `splendor wiki compile <source-id>` support remains intentionally non-mutating when no
+target page is provided. It validates the source record and prints the review-gated contract:
+inspect the source summary, run source-impact suggestions, propose synthesis-page edits with
+provenance/run state, keep generated source-summary pages separate from maintained synthesis pages,
+and require human review before wiki synthesis is changed.
+
+The first mutating slice is deliberately narrow. `splendor wiki compile <source-id|title|path>
+--page <maintained-page>` proposes a deterministic one-page update from the generated
+source-summary page into a maintained topic, concept, entity, architecture, or glossary page. The
+proposal adds bounded source evidence to the page body, adds the source ID to frontmatter
+`source_refs`, records provenance links to the source and generated source-summary page, and
+validates schema-version-1 frontmatter before reporting output. The command writes only when the
+operator supplies `--apply`, making apply the explicit reviewed accept step. Generated
+source-summary pages are rejected as compile targets.
 
 Command output should support the workflow without becoming noisy. After `add-source`, Splendor
 should print the exact next ingest command or enqueue the source for pending ingestion. After
@@ -814,8 +823,10 @@ Current implementation:
 - `splendor wiki suggest <source-id|title|path>` deterministically ranks existing synthesis pages using source
   metadata, source-summary text, frontmatter source refs, tags, source refs, and page content, with
   optional JSON output.
-- `splendor wiki compile <source-id|title|path>` exposes the review-gated compile-loop contract, validates the
-  source, and reports that it does not mutate synthesis pages yet.
+- `splendor wiki compile <source-id|title|path>` exposes the review-gated compile-loop contract
+  when no target page is supplied. With `--page <maintained-page>`, it proposes a deterministic
+  source-summary evidence update for one maintained synthesis page, and `--apply` explicitly
+  accepts and writes that page after frontmatter validation.
 - `splendor wiki rebuild-index` rewrites `wiki/index.md` from validated wiki page frontmatter,
   including maintained synthesis pages and generated source-summary pages, without mutating the
   pages themselves.
@@ -823,8 +834,8 @@ Current implementation:
   boilerplate when selecting snippets, supports tag/source filters, records those filters in JSON
   and saved snapshots, and text output points to `file-answer` when a saved query has matches.
 - `splendor file-answer` prints the created page and a restrained review hint after filing.
-- Mutating `splendor wiki compile <source-id>` remains deferred to a later reviewed compile-loop
-  slice.
+- Multi-page, LLM-assisted, and automatic-page-selection compile/update behavior remains deferred
+  to later reviewed compile-loop slices.
 
 M13-P2 repo-discovery contracts:
 
@@ -870,8 +881,9 @@ Release-readiness boundary:
   including explicit superseded source-summary pruning and maintained-page source-ref migration.
   The `pr-summary` surface now provides a read-only local PR handoff over that generated-state
   churn.
-- issue #79 tracks the deferred mutating compile/update workflow from #41; v1 ships briefing and
-  the non-mutating compile contract only.
+- issue #79 tracks the reviewed mutating compile/update workflow from #41; v1 shipped briefing and
+  the non-mutating compile contract, and `M15-P1.1` begins the explicit one-page proposal/apply
+  path.
 - `docs/v1_release_handoff.md` is the v1 handoff checklist for final validation, GitHub metadata,
   issue state, known non-blockers, and the conservative post-v1 queue.
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -754,11 +754,13 @@ and require human review before wiki synthesis is changed.
 The first mutating slice is deliberately narrow. `splendor wiki compile <source-id|title|path>
 --page <maintained-page>` proposes a deterministic one-page update from the generated
 source-summary page into a maintained topic, concept, entity, architecture, or glossary page. The
-proposal adds bounded source evidence to the page body, adds the source ID to frontmatter
-`source_refs`, records provenance links to the source and generated source-summary page, and
-validates schema-version-1 frontmatter before reporting output. The command writes only when the
-operator supplies `--apply`, making apply the explicit reviewed accept step. Generated
-source-summary pages are rejected as compile targets.
+proposal reports a unified diff, target/source-summary SHA-256 hashes, and a proposal hash. It
+adds a managed `Compiled Source Evidence` section to the page body, adds the source ID to
+frontmatter `source_refs`, records provenance links to the source and generated source-summary
+page, and validates schema-version-1 frontmatter before reporting output. The command writes only
+when the operator supplies `--apply --proposal-hash <hash>`, making apply an explicit reviewed
+accept step bound to the current target and source-summary inputs. Generated source-summary pages
+are rejected as compile targets.
 
 Command output should support the workflow without becoming noisy. After `add-source`, Splendor
 should print the exact next ingest command or enqueue the source for pending ingestion. After
@@ -825,8 +827,9 @@ Current implementation:
   optional JSON output.
 - `splendor wiki compile <source-id|title|path>` exposes the review-gated compile-loop contract
   when no target page is supplied. With `--page <maintained-page>`, it proposes a deterministic
-  source-summary evidence update for one maintained synthesis page, and `--apply` explicitly
-  accepts and writes that page after frontmatter validation.
+  source-summary evidence update and unified diff for one maintained synthesis page, and
+  `--apply --proposal-hash <hash>` explicitly accepts and writes that page after frontmatter and
+  proposal-hash validation.
 - `splendor wiki rebuild-index` rewrites `wiki/index.md` from validated wiki page frontmatter,
   including maintained synthesis pages and generated source-summary pages, without mutating the
   pages themselves.

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -55,7 +55,7 @@ For this handoff:
 - #86 tracks the planning-document authority and task-oriented agent brief gap addressed by
   `M14-P4.1`
 - #79 now owns the M15 reviewed compile/update sequence; `M15-P1.1` starts with explicit
-  one-page proposal/apply semantics rather than broad automatic synthesis updates
+  one-page diff/proposal-hash/apply semantics rather than broad automatic synthesis updates
 
 ## Known Non-Blockers
 
@@ -101,8 +101,8 @@ bundle is:
 The retry result is captured in `docs/m14_synthbanshee_reevaluation.md`. After `M14-P4.1`, future
 work starts from #79 unless #86 review identifies a narrower follow-up or a new real-agent run
 reopens a source-lifecycle regression. The first #79 slice is `M15-P1.1`: keep bare compile
-non-mutating, require `--page` for a deterministic proposal, and require `--apply` for the
-explicit reviewed write.
+non-mutating, require `--page` for a deterministic diff-backed proposal, and require
+`--apply --proposal-hash <hash>` for the explicit reviewed write.
 
 ## Tagging Readiness
 

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -54,6 +54,8 @@ For this handoff:
   maintainers accept the gate result
 - #86 tracks the planning-document authority and task-oriented agent brief gap addressed by
   `M14-P4.1`
+- #79 now owns the M15 reviewed compile/update sequence; `M15-P1.1` starts with explicit
+  one-page proposal/apply semantics rather than broad automatic synthesis updates
 
 ## Known Non-Blockers
 
@@ -75,8 +77,8 @@ The conservative next queue after the `M14-P3.1` gate is:
    task-oriented authority brief ranking.
 3. Keep using `splendor pr-summary --since main` during review handoff to explain source
    lifecycle, maintained wiki, source-summary, and mechanical generated-state changes.
-4. Keep #79 as the tracked post-v1 compile/update workflow rather than reopening #41 for deferred
-   scope.
+4. Continue #79 through `M15-P1.1`, the first reviewed compile/apply loop from source-summary
+   evidence into a single maintained synthesis page.
 5. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
    either one urgent.
 
@@ -97,8 +99,10 @@ bundle is:
    #72.
 
 The retry result is captured in `docs/m14_synthbanshee_reevaluation.md`. After `M14-P4.1`, future
-work should start from #79 unless #86 review identifies a narrower follow-up or a new real-agent
-run reopens a source-lifecycle regression.
+work starts from #79 unless #86 review identifies a narrower follow-up or a new real-agent run
+reopens a source-lifecycle regression. The first #79 slice is `M15-P1.1`: keep bare compile
+non-mutating, require `--page` for a deterministic proposal, and require `--apply` for the
+explicit reviewed write.
 
 ## Tagging Readiness
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -75,10 +75,12 @@ from splendor.commands.source import (
 from splendor.commands.wiki import (
     add_topic_page,
     build_wiki_status,
+    compile_source_into_page,
     describe_wiki_compile_contract,
     rebuild_wiki_index,
     render_topic_scaffold_json,
     render_wiki_compile_contract_json,
+    render_wiki_compile_proposal_json,
     render_wiki_index_rebuild_json,
     render_wiki_status_json,
     render_wiki_suggest_json,
@@ -330,6 +332,18 @@ def build_parser() -> argparse.ArgumentParser:
     )
     wiki_compile_parser.add_argument(
         "source_id", help="Registered source ID, title, or path to inspect"
+    )
+    wiki_compile_parser.add_argument(
+        "--page",
+        help=(
+            "Maintained synthesis page path, page ID, or exact title to propose updates for. "
+            "Without --page the command prints the compile contract only."
+        ),
+    )
+    wiki_compile_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the proposed page update after explicit operator review.",
     )
     wiki_compile_parser.add_argument(
         "--json",
@@ -1296,13 +1310,46 @@ def handle_wiki_suggest(args: argparse.Namespace) -> int:
 
 def handle_wiki_compile(args: argparse.Namespace) -> int:
     root = args.root.resolve()
+    if args.apply and not args.page:
+        return _print_error(ValueError("wiki compile --apply requires --page"))
     try:
-        result = describe_wiki_compile_contract(root, args.source_id)
+        if args.page:
+            result = compile_source_into_page(
+                root,
+                args.source_id,
+                page_query=args.page,
+                apply=args.apply,
+            )
+        else:
+            result = describe_wiki_compile_contract(root, args.source_id)
     except (FileNotFoundError, ValueError) as exc:
         return _print_error(exc)
 
     if args.json_output:
-        print(render_wiki_compile_contract_json(result))
+        if args.page:
+            print(render_wiki_compile_proposal_json(result))
+        else:
+            print(render_wiki_compile_contract_json(result))
+        return 0
+
+    if args.page:
+        print(f"Source ref: {result.source_ref}")
+        print(f"Source ID: {result.source_id}")
+        print(f"Title: {result.source_title}")
+        print(f"Status: {result.source_status}")
+        print(f"Target page: {result.target_path}")
+        print(f"Source summary: {result.source_summary_path}")
+        print(f"Compile status: {result.status}")
+        print(f"Mutates wiki: {'yes' if result.mutates else 'no'}")
+        print("Evidence:")
+        for line in result.evidence_lines:
+            print(f"- {line}")
+        if not args.apply and result.changed:
+            print("Next steps:")
+            print(
+                f"- Review the proposed markdown, then run "
+                f"`splendor wiki compile {result.source_id} --page {result.target_path} --apply`."
+            )
         return 0
 
     print(f"Source ref: {result.source_ref}")

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -346,6 +346,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Apply the proposed page update after explicit operator review.",
     )
     wiki_compile_parser.add_argument(
+        "--proposal-hash",
+        help="Proposal hash from a reviewed `wiki compile --page` preview. Required with --apply.",
+    )
+    wiki_compile_parser.add_argument(
         "--json",
         action="store_true",
         dest="json_output",
@@ -1312,6 +1316,12 @@ def handle_wiki_compile(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     if args.apply and not args.page:
         return _print_error(ValueError("wiki compile --apply requires --page"))
+    if args.apply and not args.proposal_hash:
+        return _print_error(ValueError("wiki compile --apply requires --proposal-hash"))
+    if args.proposal_hash and not args.apply:
+        return _print_error(
+            ValueError("wiki compile --proposal-hash can only be used with --apply")
+        )
     try:
         if args.page:
             result = compile_source_into_page(
@@ -1319,6 +1329,7 @@ def handle_wiki_compile(args: argparse.Namespace) -> int:
                 args.source_id,
                 page_query=args.page,
                 apply=args.apply,
+                proposal_hash=args.proposal_hash,
             )
         else:
             result = describe_wiki_compile_contract(root, args.source_id)
@@ -1341,14 +1352,20 @@ def handle_wiki_compile(args: argparse.Namespace) -> int:
         print(f"Source summary: {result.source_summary_path}")
         print(f"Compile status: {result.status}")
         print(f"Mutates wiki: {'yes' if result.mutates else 'no'}")
+        print(f"Target SHA-256: {result.target_sha256}")
+        print(f"Source summary SHA-256: {result.source_summary_sha256}")
+        print(f"Proposal hash: {result.proposal_hash}")
         print("Evidence:")
         for line in result.evidence_lines:
             print(f"- {line}")
+        if result.proposed_diff:
+            print("Proposed diff:")
+            print(result.proposed_diff, end="" if result.proposed_diff.endswith("\n") else "\n")
         if not args.apply and result.changed:
             print("Next steps:")
             print(
-                f"- Review the proposed markdown, then run "
-                f"`splendor wiki compile {result.source_id} --page {result.target_path} --apply`."
+                f"- Review the diff, then run `splendor wiki compile {result.source_id} "
+                f"--page {result.target_path} --apply --proposal-hash {result.proposal_hash}`."
             )
         return 0
 

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -7,6 +7,8 @@ import posixpath
 import re
 from collections import Counter
 from dataclasses import asdict, dataclass, field
+from difflib import unified_diff
+from hashlib import sha256
 from pathlib import Path
 
 import yaml
@@ -155,7 +157,12 @@ class WikiCompileProposal:
     applied: bool
     changed: bool
     evidence_lines: list[str]
+    evidence_sections: list[str]
     proposed_source_refs: list[str]
+    target_sha256: str
+    source_summary_sha256: str
+    proposal_hash: str
+    proposed_diff: str
     proposed_markdown: str
 
 
@@ -718,6 +725,7 @@ def compile_source_into_page(
     *,
     page_query: str,
     apply: bool = False,
+    proposal_hash: str | None = None,
 ) -> WikiCompileProposal:
     config = load_config(root)
     layout = resolve_layout(root, config)
@@ -737,7 +745,7 @@ def compile_source_into_page(
         raise ValueError(msg)
 
     summary_page = _single_source_summary_page(pages, source.source_id)
-    evidence_lines = _compile_evidence_lines(summary_page.body)
+    evidence_lines, evidence_sections = _compile_evidence_lines(summary_page.body)
     if not evidence_lines:
         msg = f"Source summary has no deterministic evidence lines: {summary_page.path}"
         raise ValueError(msg)
@@ -760,7 +768,29 @@ def compile_source_into_page(
 
     target_path = root / target_page.path
     current_markdown = target_path.read_text(encoding="utf-8")
+    summary_markdown = (root / summary_page.path).read_text(encoding="utf-8")
+    target_sha = _sha256_text(current_markdown)
+    summary_sha = _sha256_text(summary_markdown)
+    computed_proposal_hash = _compile_proposal_hash(
+        source_id=source.source_id,
+        target_path=target_page.path,
+        target_sha256=target_sha,
+        source_summary_path=summary_page.path,
+        source_summary_sha256=summary_sha,
+        proposed_markdown=proposed_markdown,
+    )
+    proposed_diff = _render_compile_diff(
+        target_path=target_page.path,
+        current_markdown=current_markdown,
+        proposed_markdown=proposed_markdown,
+    )
     changed = current_markdown != proposed_markdown
+    if apply and proposal_hash != computed_proposal_hash:
+        msg = (
+            "wiki compile --apply requires the proposal hash from the reviewed preview. "
+            f"Expected {computed_proposal_hash} for the current inputs."
+        )
+        raise ValueError(msg)
     if apply and changed:
         write_text_atomic(target_path, proposed_markdown)
 
@@ -780,7 +810,12 @@ def compile_source_into_page(
         applied=apply and changed,
         changed=changed,
         evidence_lines=evidence_lines,
+        evidence_sections=evidence_sections,
         proposed_source_refs=proposed_frontmatter.source_refs,
+        target_sha256=target_sha,
+        source_summary_sha256=summary_sha,
+        proposal_hash=computed_proposal_hash,
+        proposed_diff=proposed_diff,
         proposed_markdown=proposed_markdown,
     )
 
@@ -878,19 +913,59 @@ def _compile_body(
     summary_link = posixpath.relpath(summary_path, start=posixpath.dirname(target_path))
     evidence = "\n".join(f"- {line}" for line in evidence_lines)
     block = (
-        f"## Source Evidence: {source.title}\n\n"
+        f"### {source.title}\n\n"
         f"{start_marker}\n"
         f"- Source ref: `{canonical_source_ref(source)}`\n"
         f"- Source summary: [{summary_path}]({summary_link})\n\n"
-        "### Evidence\n\n"
+        "#### Evidence\n\n"
         f"{evidence}\n"
         f"<!-- splendor-compile:end source={source.source_id} -->\n"
     )
-    return body.rstrip() + "\n\n" + block
+    section_heading = "## Compiled Source Evidence"
+    section_intro = (
+        "This managed section records reviewed source-summary evidence accepted into this "
+        "maintained page.\n"
+    )
+    if section_heading in body:
+        return _append_to_compiled_evidence_section(body, section_heading, block)
+    return body.rstrip() + f"\n\n{section_heading}\n\n{section_intro}\n{block}"
 
 
-def _compile_evidence_lines(summary_body: str) -> list[str]:
-    section_text = _section_text(summary_body, {"summary", "key facts", "extract"})
+def _append_to_compiled_evidence_section(body: str, section_heading: str, block: str) -> str:
+    lines = body.rstrip().splitlines()
+    section_index = next(
+        (index for index, line in enumerate(lines) if line.strip() == section_heading),
+        None,
+    )
+    if section_index is None:
+        return body.rstrip() + "\n\n" + block
+    next_section_index = next(
+        (
+            index
+            for index, line in enumerate(lines[section_index + 1 :], start=section_index + 1)
+            if line.startswith("## ") and line.strip() != section_heading
+        ),
+        len(lines),
+    )
+    before = "\n".join(lines[:next_section_index]).rstrip()
+    after = "\n".join(lines[next_section_index:]).strip()
+    updated = before + "\n\n" + block.rstrip()
+    if after:
+        updated += "\n\n" + after
+    return updated + "\n"
+
+
+def _compile_evidence_lines(summary_body: str) -> tuple[list[str], list[str]]:
+    lines, sections = _compile_evidence_lines_from_sections(summary_body, ["summary", "key facts"])
+    if lines:
+        return lines, sections
+    return _compile_evidence_lines_from_sections(summary_body, ["extract"])
+
+
+def _compile_evidence_lines_from_sections(
+    summary_body: str, headings: list[str]
+) -> tuple[list[str], list[str]]:
+    section_text = _section_text(summary_body, set(headings))
     lines: list[str] = []
     for raw_line in section_text.splitlines():
         line = raw_line.strip()
@@ -913,7 +988,7 @@ def _compile_evidence_lines(summary_body: str) -> list[str]:
             lines.append(line)
         if len(lines) == 5:
             break
-    return lines
+    return lines, headings if lines else []
 
 
 def _render_wiki_page(frontmatter: KnowledgePageFrontmatter, body: str) -> str:
@@ -927,6 +1002,49 @@ def _validate_compiled_markdown(page_ref: str, content: str) -> None:
     if not body.startswith("\n"):
         msg = f"Compiled page lost markdown body separation: {page_ref}"
         raise ValueError(msg)
+
+
+def _sha256_text(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+def _compile_proposal_hash(
+    *,
+    source_id: str,
+    target_path: str,
+    target_sha256: str,
+    source_summary_path: str,
+    source_summary_sha256: str,
+    proposed_markdown: str,
+) -> str:
+    payload = {
+        "source_id": source_id,
+        "target_path": target_path,
+        "target_sha256": target_sha256,
+        "source_summary_path": source_summary_path,
+        "source_summary_sha256": source_summary_sha256,
+        "proposed_markdown_sha256": _sha256_text(proposed_markdown),
+    }
+    return _sha256_text(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+
+def _render_compile_diff(
+    *,
+    target_path: str,
+    current_markdown: str,
+    proposed_markdown: str,
+) -> str:
+    diff_lines = unified_diff(
+        current_markdown.splitlines(),
+        proposed_markdown.splitlines(),
+        fromfile=target_path,
+        tofile=f"{target_path} (proposed)",
+        lineterm="",
+    )
+    diff_text = "\n".join(diff_lines)
+    if diff_text:
+        return diff_text + "\n"
+    return ""
 
 
 def render_wiki_status_json(status: WikiStatus) -> str:

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import posixpath
 import re
 from collections import Counter
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+
+import yaml
 
 from splendor.commands.source import resolve_source_query, resolve_source_query_matches
 from splendor.config import load_config
@@ -16,6 +19,7 @@ from splendor.state.runtime import load_queue_item, load_run_record
 from splendor.state.source_compat import canonical_source_ref
 from splendor.state.source_registry import load_source_record
 from splendor.utils.fs import write_text_atomic
+from splendor.utils.provenance import dedupe_provenance_links, make_provenance_link
 from splendor.utils.wiki import parse_wiki_markdown, render_frontmatter
 
 SYNTHESIS_KINDS = {"architecture", "concept", "entity", "glossary", "topic"}
@@ -133,6 +137,26 @@ class WikiCompileContract:
     status: str
     contract: list[str]
     next_steps: list[str]
+
+
+@dataclass(frozen=True)
+class WikiCompileProposal:
+    source_id: str
+    source_title: str
+    source_ref: str
+    source_status: str
+    target_path: str
+    target_page_id: str
+    target_title: str
+    target_kind: str
+    source_summary_path: str
+    status: str
+    mutates: bool
+    applied: bool
+    changed: bool
+    evidence_lines: list[str]
+    proposed_source_refs: list[str]
+    proposed_markdown: str
 
 
 @dataclass(frozen=True)
@@ -688,6 +712,223 @@ def describe_wiki_compile_contract(root: Path, source_id: str) -> WikiCompileCon
     )
 
 
+def compile_source_into_page(
+    root: Path,
+    source_id: str,
+    *,
+    page_query: str,
+    apply: bool = False,
+) -> WikiCompileProposal:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    source = resolve_source_query(root, source_id).source
+    pages, invalid_pages = load_wiki_pages(root, layout)
+    if invalid_pages:
+        msg = f"Cannot compile with invalid wiki pages present: {invalid_pages[0].path}"
+        raise ValueError(msg)
+
+    target_page = _resolve_compile_target_page(root, layout, pages, page_query)
+    if target_page.frontmatter.kind not in SYNTHESIS_KINDS:
+        msg = (
+            "Compile target must be a maintained synthesis page "
+            f"({', '.join(sorted(SYNTHESIS_KINDS))}), got {target_page.frontmatter.kind}: "
+            f"{target_page.path}"
+        )
+        raise ValueError(msg)
+
+    summary_page = _single_source_summary_page(pages, source.source_id)
+    evidence_lines = _compile_evidence_lines(summary_page.body)
+    if not evidence_lines:
+        msg = f"Source summary has no deterministic evidence lines: {summary_page.path}"
+        raise ValueError(msg)
+
+    proposed_frontmatter = _compile_frontmatter(
+        target_page.frontmatter,
+        source_id=source.source_id,
+        summary_page_id=summary_page.frontmatter.page_id,
+        summary_path=summary_page.path,
+    )
+    proposed_body = _compile_body(
+        target_page.body,
+        source=source,
+        target_path=target_page.path,
+        summary_path=summary_page.path,
+        evidence_lines=evidence_lines,
+    )
+    proposed_markdown = _render_wiki_page(proposed_frontmatter, proposed_body)
+    _validate_compiled_markdown(target_page.path, proposed_markdown)
+
+    target_path = root / target_page.path
+    current_markdown = target_path.read_text(encoding="utf-8")
+    changed = current_markdown != proposed_markdown
+    if apply and changed:
+        write_text_atomic(target_path, proposed_markdown)
+
+    status = "applied" if apply and changed else "no-op" if not changed else "proposed"
+    return WikiCompileProposal(
+        source_id=source.source_id,
+        source_title=source.title,
+        source_ref=canonical_source_ref(source),
+        source_status=source.status,
+        target_path=target_page.path,
+        target_page_id=target_page.frontmatter.page_id,
+        target_title=target_page.frontmatter.title,
+        target_kind=target_page.frontmatter.kind,
+        source_summary_path=summary_page.path,
+        status=status,
+        mutates=apply and changed,
+        applied=apply and changed,
+        changed=changed,
+        evidence_lines=evidence_lines,
+        proposed_source_refs=proposed_frontmatter.source_refs,
+        proposed_markdown=proposed_markdown,
+    )
+
+
+def _resolve_compile_target_page(
+    root: Path,
+    layout,
+    pages: list[WikiPageSnapshot],
+    page_query: str,
+) -> WikiPageSnapshot:
+    raw_path = Path(page_query)
+    candidate_paths: list[Path] = []
+    if raw_path.is_absolute():
+        candidate_paths.append(raw_path)
+    else:
+        candidate_paths.extend([root / raw_path, layout.wiki_dir / raw_path])
+
+    for candidate_path in candidate_paths:
+        if not candidate_path.exists():
+            continue
+        resolved = candidate_path.resolve()
+        if not resolved.is_relative_to(root):
+            msg = f"Compile target must be inside the workspace: {page_query}"
+            raise ValueError(msg)
+        page_ref = _relative(root, resolved)
+        matches = [page for page in pages if page.path == page_ref]
+        if matches:
+            return matches[0]
+
+    exact_matches = [
+        page
+        for page in pages
+        if page.frontmatter.page_id == page_query or page.frontmatter.title == page_query
+    ]
+    if len(exact_matches) == 1:
+        return exact_matches[0]
+    if len(exact_matches) > 1:
+        msg = f"Ambiguous compile target: {page_query}"
+        raise ValueError(msg)
+    msg = f"Unknown compile target page: {page_query}"
+    raise ValueError(msg)
+
+
+def _single_source_summary_page(pages: list[WikiPageSnapshot], source_id: str) -> WikiPageSnapshot:
+    summary_pages = _source_summary_pages(pages, source_id)
+    if len(summary_pages) == 1:
+        return summary_pages[0]
+    if not summary_pages:
+        msg = f"Source has no generated source-summary page yet: {source_id}"
+        raise ValueError(msg)
+    msg = f"Source has multiple source-summary pages: {source_id}"
+    raise ValueError(msg)
+
+
+def _compile_frontmatter(
+    frontmatter: KnowledgePageFrontmatter,
+    *,
+    source_id: str,
+    summary_page_id: str,
+    summary_path: str,
+) -> KnowledgePageFrontmatter:
+    source_refs = _dedupe_preserve_order([*frontmatter.source_refs, source_id])
+    provenance_links = dedupe_provenance_links(
+        [
+            *frontmatter.provenance_links,
+            make_provenance_link(
+                source_id=source_id,
+                role="supports",
+                note="Compiled source evidence accepted into maintained synthesis.",
+            ),
+            make_provenance_link(
+                page_id=summary_page_id,
+                path_ref=summary_path,
+                role="generated-from",
+                note="Generated source-summary page used as compile evidence.",
+            ),
+        ]
+    )
+    return frontmatter.model_copy(
+        update={"source_refs": source_refs, "provenance_links": provenance_links}
+    )
+
+
+def _compile_body(
+    body: str,
+    *,
+    source: SourceRecord,
+    target_path: str,
+    summary_path: str,
+    evidence_lines: list[str],
+) -> str:
+    start_marker = f"<!-- splendor-compile:start source={source.source_id} -->"
+    if start_marker in body:
+        return body
+    summary_link = posixpath.relpath(summary_path, start=posixpath.dirname(target_path))
+    evidence = "\n".join(f"- {line}" for line in evidence_lines)
+    block = (
+        f"## Source Evidence: {source.title}\n\n"
+        f"{start_marker}\n"
+        f"- Source ref: `{canonical_source_ref(source)}`\n"
+        f"- Source summary: [{summary_path}]({summary_link})\n\n"
+        "### Evidence\n\n"
+        f"{evidence}\n"
+        f"<!-- splendor-compile:end source={source.source_id} -->\n"
+    )
+    return body.rstrip() + "\n\n" + block
+
+
+def _compile_evidence_lines(summary_body: str) -> list[str]:
+    section_text = _section_text(summary_body, {"summary", "key facts", "extract"})
+    lines: list[str] = []
+    for raw_line in section_text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("```") or line.startswith("~~~"):
+            continue
+        if line.startswith("#"):
+            continue
+        if line.startswith(_GENERATED_KEY_FACT_PREFIXES):
+            continue
+        if line.startswith(("- ", "* ")):
+            line = line[2:].strip()
+        line = re.sub(r"\s+", " ", line).strip()
+        if not line:
+            continue
+        if len(line) > 180:
+            line = line[:177].rstrip() + "..."
+        if line not in lines:
+            lines.append(line)
+        if len(lines) == 5:
+            break
+    return lines
+
+
+def _render_wiki_page(frontmatter: KnowledgePageFrontmatter, body: str) -> str:
+    return f"---\n{render_frontmatter(frontmatter)}\n---\n{body}"
+
+
+def _validate_compiled_markdown(page_ref: str, content: str) -> None:
+    frontmatter_text, body = content.removeprefix("---\n").split("\n---\n", maxsplit=1)
+    payload = yaml.safe_load(frontmatter_text) or {}
+    KnowledgePageFrontmatter.model_validate(payload)
+    if not body.startswith("\n"):
+        msg = f"Compiled page lost markdown body separation: {page_ref}"
+        raise ValueError(msg)
+
+
 def render_wiki_status_json(status: WikiStatus) -> str:
     return json.dumps(
         {
@@ -729,6 +970,10 @@ def render_wiki_suggest_json(result: WikiSuggestResult) -> str:
 
 
 def render_wiki_compile_contract_json(result: WikiCompileContract) -> str:
+    return json.dumps(asdict(result), indent=2)
+
+
+def render_wiki_compile_proposal_json(result: WikiCompileProposal) -> str:
     return json.dumps(asdict(result), indent=2)
 
 

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -12,6 +12,7 @@ from hashlib import sha256
 from pathlib import Path
 
 import yaml
+from pydantic import ValidationError
 
 from splendor.commands.source import resolve_source_query, resolve_source_query_matches
 from splendor.config import load_config
@@ -956,10 +957,7 @@ def _append_to_compiled_evidence_section(body: str, section_heading: str, block:
 
 
 def _compile_evidence_lines(summary_body: str) -> tuple[list[str], list[str]]:
-    lines, sections = _compile_evidence_lines_from_sections(summary_body, ["summary", "key facts"])
-    if lines:
-        return lines, sections
-    return _compile_evidence_lines_from_sections(summary_body, ["extract"])
+    return _compile_evidence_lines_from_sections(summary_body, ["summary", "key facts"])
 
 
 def _compile_evidence_lines_from_sections(
@@ -967,11 +965,15 @@ def _compile_evidence_lines_from_sections(
 ) -> tuple[list[str], list[str]]:
     section_text = _section_text(summary_body, set(headings))
     lines: list[str] = []
+    in_fence = False
     for raw_line in section_text.splitlines():
         line = raw_line.strip()
         if not line:
             continue
         if line.startswith("```") or line.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
             continue
         if line.startswith("#"):
             continue
@@ -992,13 +994,26 @@ def _compile_evidence_lines_from_sections(
 
 
 def _render_wiki_page(frontmatter: KnowledgePageFrontmatter, body: str) -> str:
-    return f"---\n{render_frontmatter(frontmatter)}\n---\n{body}"
+    normalized_body = body.strip()
+    return f"---\n{render_frontmatter(frontmatter)}\n---\n\n{normalized_body}\n"
 
 
 def _validate_compiled_markdown(page_ref: str, content: str) -> None:
-    frontmatter_text, body = content.removeprefix("---\n").split("\n---\n", maxsplit=1)
-    payload = yaml.safe_load(frontmatter_text) or {}
-    KnowledgePageFrontmatter.model_validate(payload)
+    try:
+        frontmatter_text, body = content.removeprefix("---\n").split("\n---\n", maxsplit=1)
+    except ValueError as exc:
+        msg = f"Compiled page {page_ref} has malformed YAML frontmatter"
+        raise ValueError(msg) from exc
+    try:
+        payload = yaml.safe_load(frontmatter_text) or {}
+    except yaml.YAMLError as exc:
+        msg = f"Compiled page {page_ref} has invalid YAML frontmatter"
+        raise ValueError(msg) from exc
+    try:
+        KnowledgePageFrontmatter.model_validate(payload)
+    except ValidationError as exc:
+        msg = f"Compiled page {page_ref} failed schema validation: {exc}"
+        raise ValueError(msg) from exc
     if not body.startswith("\n"):
         msg = f"Compiled page lost markdown body separation: {page_ref}"
         raise ValueError(msg)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -236,6 +236,21 @@ def test_cli_wiki_rebuild_index_parser_accepts_json_flag() -> None:
     assert args.json_output is True
 
 
+def test_cli_wiki_compile_parser_accepts_reviewed_apply_page() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(
+        ["wiki", "compile", "src-example", "--page", "wiki/topics/example.md", "--apply", "--json"]
+    )
+
+    assert args.command == "wiki"
+    assert args.wiki_command == "compile"
+    assert args.source_id == "src-example"
+    assert args.page == "wiki/topics/example.md"
+    assert args.apply is True
+    assert args.json_output is True
+
+
 def test_cli_serve_parser_uses_default_host_and_port() -> None:
     parser = build_parser()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -240,7 +240,17 @@ def test_cli_wiki_compile_parser_accepts_reviewed_apply_page() -> None:
     parser = build_parser()
 
     args = parser.parse_args(
-        ["wiki", "compile", "src-example", "--page", "wiki/topics/example.md", "--apply", "--json"]
+        [
+            "wiki",
+            "compile",
+            "src-example",
+            "--page",
+            "wiki/topics/example.md",
+            "--apply",
+            "--proposal-hash",
+            "abc123",
+            "--json",
+        ]
     )
 
     assert args.command == "wiki"
@@ -248,6 +258,7 @@ def test_cli_wiki_compile_parser_accepts_reviewed_apply_page() -> None:
     assert args.source_id == "src-example"
     assert args.page == "wiki/topics/example.md"
     assert args.apply is True
+    assert args.proposal_hash == "abc123"
     assert args.json_output is True
 
 

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -672,6 +672,159 @@ def test_wiki_compile_reports_unknown_source(tmp_path: Path, capsys) -> None:
     assert "Unknown source ID: src-missing" in capsys.readouterr().out
 
 
+def test_wiki_compile_proposes_maintained_page_update_without_mutating(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-loop.md"
+    source.write_text(
+        "# Compile loop\n\n"
+        "## Summary\n\n"
+        "Reviewed compile turns source evidence into maintained synthesis.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "compile-loop.md",
+        kind="topic",
+        title="Compile loop",
+        page_id="topic-compile-loop",
+        body="# Compile loop\n\n## Summary\n\nExisting synthesis.\n",
+    )
+    target_path = tmp_path / "wiki" / "topics" / "compile-loop.md"
+    before = target_path.read_text(encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "wiki",
+            "compile",
+            added.source_id,
+            "--page",
+            "wiki/topics/compile-loop.md",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "proposed"
+    assert payload["mutates"] is False
+    assert payload["changed"] is True
+    assert payload["target_path"] == "wiki/topics/compile-loop.md"
+    assert payload["source_summary_path"] == f"wiki/sources/{added.source_id}.md"
+    assert added.source_id in payload["proposed_source_refs"]
+    assert "<!-- splendor-compile:start" in payload["proposed_markdown"]
+    assert "Reviewed compile turns source evidence" in payload["proposed_markdown"]
+    assert target_path.read_text(encoding="utf-8") == before
+
+
+def test_wiki_compile_apply_updates_only_maintained_target_page(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-loop.md"
+    source.write_text(
+        "# Compile loop\n\n## Summary\n\nCompile apply records evidence with source provenance.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    source_summary_path = tmp_path / "wiki" / "sources" / f"{added.source_id}.md"
+    source_summary_before = source_summary_path.read_text(encoding="utf-8")
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "compile-loop.md",
+        kind="topic",
+        title="Compile loop",
+        page_id="topic-compile-loop",
+        body="# Compile loop\n\n## Summary\n\nExisting synthesis.\n",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "wiki",
+            "compile",
+            added.source_id,
+            "--page",
+            "topic-compile-loop",
+            "--apply",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "applied"
+    assert payload["mutates"] is True
+    target = parse_wiki_markdown(tmp_path / "wiki" / "topics" / "compile-loop.md")
+    assert target.frontmatter.kind == "topic"
+    assert target.frontmatter.source_refs == [added.source_id]
+    assert [link.source_id for link in target.frontmatter.provenance_links if link.source_id] == [
+        added.source_id
+    ]
+    assert "## Source Evidence: compile loop" in target.body
+    assert "Compile apply records evidence" in target.body
+    assert source_summary_path.read_text(encoding="utf-8") == source_summary_before
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "wiki",
+            "compile",
+            added.source_id,
+            "--page",
+            "topic-compile-loop",
+            "--apply",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "no-op"
+    assert payload["mutates"] is False
+
+
+def test_wiki_compile_rejects_generated_source_summary_target(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-loop.md"
+    source.write_text("# Compile loop\n\nSynthesis belongs elsewhere.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "wiki",
+            "compile",
+            added.source_id,
+            "--page",
+            f"wiki/sources/{added.source_id}.md",
+        ]
+    )
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "Compile target must be a maintained synthesis page" in out
+    assert "source-summary" in out
+
+
+def test_wiki_compile_apply_requires_page(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "compile", "src-missing", "--apply"])
+
+    assert exit_code == 1
+    assert "wiki compile --apply requires --page" in capsys.readouterr().out
+
+
 def test_brief_json_includes_goal_state_matches_planning_and_next_actions(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -728,6 +728,47 @@ def test_wiki_compile_proposes_maintained_page_update_without_mutating(
     assert target_path.read_text(encoding="utf-8") == before
 
 
+def test_wiki_compile_text_proposal_prints_reviewable_diff_and_hash(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-loop.md"
+    source.write_text(
+        "# Compile loop\n\n## Summary\n\nText output must be reviewable before apply.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "compile-loop.md",
+        kind="topic",
+        title="Compile loop",
+        page_id="topic-compile-loop",
+        body="# Compile loop\n\n## Summary\n\nExisting synthesis.\n",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "wiki",
+            "compile",
+            added.source_id,
+            "--page",
+            "wiki/topics/compile-loop.md",
+        ]
+    )
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Target SHA-256:" in out
+    assert "Source summary SHA-256:" in out
+    assert "Proposal hash:" in out
+    assert "Proposed diff:" in out
+    assert "--- wiki/topics/compile-loop.md" in out
+    assert "+++ wiki/topics/compile-loop.md (proposed)" in out
+    assert "--apply --proposal-hash" in out
+
+
 def test_wiki_compile_apply_updates_only_maintained_target_page(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "compile-loop.md"
@@ -814,6 +855,80 @@ def test_wiki_compile_apply_updates_only_maintained_target_page(tmp_path: Path, 
     assert payload["mutates"] is False
 
 
+def test_wiki_compile_inserts_additional_sources_inside_managed_section(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    source_a = tmp_path / "compile-loop-a.md"
+    source_b = tmp_path / "compile-loop-b.md"
+    source_a.write_text(
+        "# Compile loop A\n\n## Summary\n\nFirst accepted evidence.\n", encoding="utf-8"
+    )
+    source_b.write_text(
+        "# Compile loop B\n\n## Summary\n\nSecond accepted evidence.\n", encoding="utf-8"
+    )
+    added_a = add_source(tmp_path, source_a)
+    added_b = add_source(tmp_path, source_b)
+    main(["--root", str(tmp_path), "ingest", added_a.source_id])
+    main(["--root", str(tmp_path), "ingest", added_b.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "compile-loop.md",
+        kind="topic",
+        title="Compile loop",
+        page_id="topic-compile-loop",
+        body=(
+            "# Compile loop\n\n"
+            "## Summary\n\n"
+            "Existing synthesis.\n\n"
+            "## Compiled Source Evidence\n\n"
+            "This managed section records reviewed source-summary evidence accepted into this "
+            "maintained page.\n\n"
+            "## Later Section\n\n"
+            "Keep me last.\n"
+        ),
+    )
+    capsys.readouterr()
+
+    for added in (added_a, added_b):
+        main(
+            [
+                "--root",
+                str(tmp_path),
+                "wiki",
+                "compile",
+                added.source_id,
+                "--page",
+                "topic-compile-loop",
+                "--json",
+            ]
+        )
+        proposal = json.loads(capsys.readouterr().out)
+        exit_code = main(
+            [
+                "--root",
+                str(tmp_path),
+                "wiki",
+                "compile",
+                added.source_id,
+                "--page",
+                "topic-compile-loop",
+                "--apply",
+                "--proposal-hash",
+                proposal["proposal_hash"],
+            ]
+        )
+        assert exit_code == 0
+        capsys.readouterr()
+
+    body = parse_wiki_markdown(tmp_path / "wiki" / "topics" / "compile-loop.md").body
+    managed_section = body.split("## Compiled Source Evidence", maxsplit=1)[1].split(
+        "## Later Section", maxsplit=1
+    )[0]
+    assert "First accepted evidence." in managed_section
+    assert "Second accepted evidence." in managed_section
+    assert body.rstrip().endswith("Keep me last.")
+
+
 def test_wiki_compile_apply_rejects_stale_proposal_hash(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "compile-loop.md"
@@ -867,6 +982,204 @@ def test_wiki_compile_apply_rejects_stale_proposal_hash(tmp_path: Path, capsys) 
 
     assert exit_code == 1
     assert "requires the proposal hash from the reviewed preview" in capsys.readouterr().out
+
+
+def test_wiki_compile_rejects_invalid_wiki_pages(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-loop.md"
+    source.write_text(
+        "# Compile loop\n\n## Summary\n\nCannot compile with invalid pages.\n", encoding="utf-8"
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "compile-loop.md",
+        kind="topic",
+        title="Compile loop",
+        page_id="topic-compile-loop",
+        body="# Compile loop\n\n## Summary\n\nExisting synthesis.\n",
+    )
+    (tmp_path / "wiki" / "topics" / "broken.md").write_text("not frontmatter", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "wiki",
+            "compile",
+            added.source_id,
+            "--page",
+            "topic-compile-loop",
+        ]
+    )
+
+    assert exit_code == 1
+    assert "Cannot compile with invalid wiki pages present" in capsys.readouterr().out
+
+
+def test_wiki_compile_rejects_source_without_summary_page(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-loop.md"
+    source.write_text("# Compile loop\n\nRegistered but not ingested.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "compile-loop.md",
+        kind="topic",
+        title="Compile loop",
+        page_id="topic-compile-loop",
+        body="# Compile loop\n\n## Summary\n\nExisting synthesis.\n",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "wiki",
+            "compile",
+            added.source_id,
+            "--page",
+            "topic-compile-loop",
+        ]
+    )
+
+    assert exit_code == 1
+    assert "Source has no generated source-summary page yet" in capsys.readouterr().out
+
+
+def test_wiki_compile_rejects_unknown_absolute_and_ambiguous_targets(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-loop.md"
+    source.write_text(
+        "# Compile loop\n\n## Summary\n\nTarget resolution must be exact.\n", encoding="utf-8"
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "compile-loop-a.md",
+        kind="topic",
+        title="Compile loop",
+        page_id="topic-compile-loop-a",
+        body="# Compile loop\n",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "compile-loop-b.md",
+        kind="topic",
+        title="Compile loop",
+        page_id="topic-compile-loop-b",
+        body="# Compile loop\n",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "wiki", "compile", added.source_id, "--page", "missing"]
+    )
+    assert exit_code == 1
+    assert "Unknown compile target page: missing" in capsys.readouterr().out
+
+    outside = tmp_path.parent / "outside-compile-target.md"
+    outside.write_text("---\nkind: topic\n---\n", encoding="utf-8")
+    exit_code = main(
+        ["--root", str(tmp_path), "wiki", "compile", added.source_id, "--page", str(outside)]
+    )
+    assert exit_code == 1
+    assert "Compile target must be inside the workspace" in capsys.readouterr().out
+
+    exit_code = main(
+        ["--root", str(tmp_path), "wiki", "compile", added.source_id, "--page", "Compile loop"]
+    )
+    assert exit_code == 1
+    assert "Ambiguous compile target: Compile loop" in capsys.readouterr().out
+
+
+def test_wiki_compile_rejects_duplicate_source_summary_pages(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-loop.md"
+    source.write_text(
+        "# Compile loop\n\n## Summary\n\nDuplicate summaries should fail.\n", encoding="utf-8"
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "compile-loop.md",
+        kind="topic",
+        title="Compile loop",
+        page_id="topic-compile-loop",
+        body="# Compile loop\n\n## Summary\n\nExisting synthesis.\n",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "sources" / "duplicate-summary.md",
+        kind="source-summary",
+        title="Duplicate summary",
+        page_id="duplicate-summary",
+        source_refs=[added.source_id],
+        body="# Duplicate summary\n\n## Summary\n\nDuplicate evidence.\n",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "wiki",
+            "compile",
+            added.source_id,
+            "--page",
+            "topic-compile-loop",
+        ]
+    )
+
+    assert exit_code == 1
+    assert "Source has multiple source-summary pages" in capsys.readouterr().out
+
+
+def test_wiki_compile_skips_fenced_extract_contents(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-loop.md"
+    source.write_text("# Compile loop\n\n```python\nprint('raw code')\n```\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    summary_path = tmp_path / "wiki" / "sources" / f"{added.source_id}.md"
+    summary = parse_wiki_markdown(summary_path)
+    summary_frontmatter = yaml.safe_dump(
+        summary.frontmatter.model_dump(mode="json"), sort_keys=False
+    ).strip()
+    summary_path.write_text(
+        f"---\n{summary_frontmatter}\n"
+        "---\n\n"
+        f"# {summary.frontmatter.title}\n\n"
+        "## Extract\n\n"
+        "```text\n"
+        "raw code should not become evidence\n"
+        "```\n",
+        encoding="utf-8",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "compile-loop.md",
+        kind="topic",
+        title="Compile loop",
+        page_id="topic-compile-loop",
+        body="# Compile loop\n\n## Summary\n\nExisting synthesis.\n",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "wiki",
+            "compile",
+            added.source_id,
+            "--page",
+            "topic-compile-loop",
+        ]
+    )
+
+    assert exit_code == 1
+    assert "Source summary has no deterministic evidence lines" in capsys.readouterr().out
 
 
 def test_wiki_compile_rejects_generated_source_summary_target(tmp_path: Path, capsys) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -717,7 +717,13 @@ def test_wiki_compile_proposes_maintained_page_update_without_mutating(
     assert payload["target_path"] == "wiki/topics/compile-loop.md"
     assert payload["source_summary_path"] == f"wiki/sources/{added.source_id}.md"
     assert added.source_id in payload["proposed_source_refs"]
+    assert payload["target_sha256"]
+    assert payload["source_summary_sha256"]
+    assert payload["proposal_hash"]
+    assert "--- wiki/topics/compile-loop.md" in payload["proposed_diff"]
+    assert "+++ wiki/topics/compile-loop.md (proposed)" in payload["proposed_diff"]
     assert "<!-- splendor-compile:start" in payload["proposed_markdown"]
+    assert "## Compiled Source Evidence" in payload["proposed_markdown"]
     assert "Reviewed compile turns source evidence" in payload["proposed_markdown"]
     assert target_path.read_text(encoding="utf-8") == before
 
@@ -742,6 +748,22 @@ def test_wiki_compile_apply_updates_only_maintained_target_page(tmp_path: Path, 
     )
     capsys.readouterr()
 
+    preview_exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "wiki",
+            "compile",
+            added.source_id,
+            "--page",
+            "topic-compile-loop",
+            "--json",
+        ]
+    )
+
+    assert preview_exit_code == 0
+    preview_payload = json.loads(capsys.readouterr().out)
+
     exit_code = main(
         [
             "--root",
@@ -752,6 +774,8 @@ def test_wiki_compile_apply_updates_only_maintained_target_page(tmp_path: Path, 
             "--page",
             "topic-compile-loop",
             "--apply",
+            "--proposal-hash",
+            preview_payload["proposal_hash"],
             "--json",
         ]
     )
@@ -766,7 +790,8 @@ def test_wiki_compile_apply_updates_only_maintained_target_page(tmp_path: Path, 
     assert [link.source_id for link in target.frontmatter.provenance_links if link.source_id] == [
         added.source_id
     ]
-    assert "## Source Evidence: compile loop" in target.body
+    assert "## Compiled Source Evidence" in target.body
+    assert "### compile loop" in target.body
     assert "Compile apply records evidence" in target.body
     assert source_summary_path.read_text(encoding="utf-8") == source_summary_before
 
@@ -779,7 +804,6 @@ def test_wiki_compile_apply_updates_only_maintained_target_page(tmp_path: Path, 
             added.source_id,
             "--page",
             "topic-compile-loop",
-            "--apply",
             "--json",
         ]
     )
@@ -788,6 +812,61 @@ def test_wiki_compile_apply_updates_only_maintained_target_page(tmp_path: Path, 
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "no-op"
     assert payload["mutates"] is False
+
+
+def test_wiki_compile_apply_rejects_stale_proposal_hash(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-loop.md"
+    source.write_text(
+        "# Compile loop\n\n## Summary\n\nCompile apply needs a fresh proposal.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    target_path = tmp_path / "wiki" / "topics" / "compile-loop.md"
+    write_wiki_page(
+        target_path,
+        kind="topic",
+        title="Compile loop",
+        page_id="topic-compile-loop",
+        body="# Compile loop\n\n## Summary\n\nExisting synthesis.\n",
+    )
+    capsys.readouterr()
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "wiki",
+            "compile",
+            added.source_id,
+            "--page",
+            "topic-compile-loop",
+            "--json",
+        ]
+    )
+    preview_payload = json.loads(capsys.readouterr().out)
+    target_path.write_text(
+        target_path.read_text(encoding="utf-8") + "\nManual reviewer edit.\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "wiki",
+            "compile",
+            added.source_id,
+            "--page",
+            "topic-compile-loop",
+            "--apply",
+            "--proposal-hash",
+            preview_payload["proposal_hash"],
+        ]
+    )
+
+    assert exit_code == 1
+    assert "requires the proposal hash from the reviewed preview" in capsys.readouterr().out
 
 
 def test_wiki_compile_rejects_generated_source_summary_target(tmp_path: Path, capsys) -> None:
@@ -823,6 +902,29 @@ def test_wiki_compile_apply_requires_page(tmp_path: Path, capsys) -> None:
 
     assert exit_code == 1
     assert "wiki compile --apply requires --page" in capsys.readouterr().out
+
+
+def test_wiki_compile_apply_requires_proposal_hash(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-loop.md"
+    source.write_text("# Compile loop\n\nSynthesis belongs elsewhere.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "wiki",
+            "compile",
+            added.source_id,
+            "--page",
+            "topic-compile-loop",
+            "--apply",
+        ]
+    )
+
+    assert exit_code == 1
+    assert "wiki compile --apply requires --proposal-hash" in capsys.readouterr().out
 
 
 def test_brief_json_includes_goal_state_matches_planning_and_next_actions(


### PR DESCRIPTION
## Summary

Implements the first narrow slice of the post-v1 mutating compile/update workflow tracked by #79.

- Keeps bare `splendor wiki compile <source-id|title|path>` as the existing non-mutating review contract.
- Adds `splendor wiki compile <source-id|title|path> --page <maintained-page>` to produce a deterministic one-page proposal from a generated source-summary page into a maintained topic/concept/entity/architecture/glossary page.
- Makes proposals reviewable in human output and JSON by including a unified diff, target/source-summary SHA-256 hashes, and a proposal hash.
- Requires explicit `--apply --proposal-hash <hash>` acceptance semantics, so apply is bound to the reviewed target/source-summary inputs and refuses stale proposals.
- Records source refs and provenance links on the maintained page, writes a managed `Compiled Source Evidence` section, rejects generated source-summary pages as compile targets, and keeps #47, #37, and #30 out of scope.
- Updates README, roadmap, product spec, schema contracts, release handoff, issue #70 response, and planning state for `M15-P1.1`.

Refs #79.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`

## Follow-up

`M15-P1.2` should expand compile/update behavior only after this one-page reviewed apply path has been exercised. Multi-page selection, LLM-assisted synthesis, mutating web UI, broad refresh, ingest timing (#47), web scaling (#37), and repo-scan performance (#30) remain separate follow-ups.