### PR TITLE
M14-P1.5 Add stale source ingest path

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M14-P4.1`
-- Last action taken: `M14-P4.1` is implemented; planning-doc authority metadata and task-oriented agent briefs are in place, so #79 is now the highest-priority post-v1 workflow gap.
-- Current planned slice: `Post-v1 mutating compile/update workflow`
-- Current PR sub-slice: `M15-P1.1`
+- Previous completed PR sub-slice: `M15-P1.1`
+- Last action taken: `M15-P1.1` is implemented; the next PR returns to open Milestone 14 source-lifecycle repair by adding an explicit stale-source ingest path for #93.
+- Current planned slice: `Post-v1 source lifecycle repair: stale-source ingestion`
+- Current PR sub-slice: `M14-P1.5`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `Compile/update expansion after first reviewed page apply`
-- Next planned PR sub-slice: `M15-P1.2`
+- Next planned slice: `Repo refresh missing/broken source tolerance`
+- Next planned PR sub-slice: `M14-P1.6`
 - Current blockers: none
 
 ## Planning Notation
@@ -265,6 +265,11 @@
   - [x] Require explicit `--apply` before mutating a maintained topic/concept/entity/architecture/glossary page
   - [x] Validate updated frontmatter and reject generated source-summary pages as compile targets
   - [x] Keep #47, #37, and #30 as independent follow-ups
+- [x] Implement `M14-P1.5`: Stale-source ingestion for checksum-drifted curated sources
+  - [x] Add an explicit `splendor ingest --changed` path for changed curated workspace-backed sources
+  - [x] Compose source freshness, supersession-aware source refresh, and targeted queue ingestion
+  - [x] Report missing curated sources without rewriting manifests or draining unrelated queue work
+  - [x] Add human and JSON output plus focused stale/no-op/error tests
 
 ## Context Pointers
 
@@ -330,6 +335,8 @@
 - `M14-P1.2` Supersession-aware source refresh
 - `M14-P1.3` Safe workspace refresh path
 - `M14-P1.4` Superseded-state pruning and topic-ref migration
+- `M14-P1.5` Stale-source ingestion for checksum-drifted curated sources
+- `M14-P1.6` Repo refresh missing/broken source tolerance
 - `M14-P2.1` PR summary and lower-noise generated-state review handoff
 - `M14-P3.1` Source-lifecycle re-evaluation gate
 - `M14-P4.1` Planning-doc authority and task-oriented agent briefs

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Implemented today:
   `splendor source refresh <source-id|title|path>`
 - `splendor workspace refresh --changed` with optional `--ingest`, `--rebuild-index`,
   `--prune-superseded`, and `--update-topic-refs`
-- `splendor ingest <source-id>` and `splendor ingest --pending`
+- `splendor ingest <source-id>`, `splendor ingest --pending`, and `splendor ingest --changed`
 - `splendor queue inspect [job-id]` and `splendor queue retry <job-id>`
 - `splendor repair ingest <source-id>`
 - `splendor materialize-source <source-id>`
@@ -165,6 +165,13 @@ active source version ID. Prune JSON reports skipped unsafe candidates with reas
 deleting ambiguous state. The command does not discover or register uncurated files or mutate
 maintained synthesis content beyond that explicit source-ref migration.
 
+`splendor ingest --changed` is the narrower stale-ingest repair path for checksum-drifted curated
+workspace-backed sources when old ingest queue records are already `done`. It refreshes changed
+source versions through the same supersession-aware source lifecycle, ingests only those refreshed
+queue jobs, reports a clean no-op when no curated source bytes changed, and blocks with diagnostics
+when active curated sources are missing. `--json` emits initial/final freshness counts, refreshed
+source IDs, targeted ingest outcomes, and the summary.
+
 `splendor pr-summary --since main` is a read-only PR handoff command over local git state. It uses
 the merge base between `HEAD` and the base ref for PR-style diff semantics, then summarizes curated
 source manifests added, refreshed, superseded, or invalid; generated source-summary pages added,
@@ -209,12 +216,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M14-P4.1`
-- Current planned slice: `Post-v1 mutating compile/update workflow`
-- Current PR sub-slice: `M15-P1.1`
+- Previous completed PR sub-slice: `M15-P1.1`
+- Current planned slice: `Post-v1 source lifecycle repair: stale-source ingestion`
+- Current PR sub-slice: `M14-P1.5`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `Compile/update expansion after first reviewed page apply`
-- Next planned PR sub-slice: `M15-P1.2`
+- Next planned slice: `Repo refresh missing/broken source tolerance`
+- Next planned PR sub-slice: `M14-P1.6`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -329,6 +336,12 @@ only the refreshed sources' ingest jobs, and rebuilds the wiki index.
 exists, and `--update-topic-refs` migrates maintained wiki source references to the active
 content-addressed source version while schema version `1` continues to validate `source_refs`
 against source manifests. Historical manifests and run records remain valid.
+
+`M14-P1.5` adds the explicit stale-ingest repair path for issue #93:
+`splendor ingest --changed` detects checksum-drifted curated workspace-backed sources, refreshes
+them into current canonical source versions, and ingests only those refreshed queue jobs even when
+the previous queue item was already `done`. Missing curated sources are reported before mutation so
+operators can repair paths separately.
 
 `M14-P2.1` adds the read-only PR handoff surface:
 `splendor pr-summary --since main` groups merge-base changes into curated source lifecycle records,

--- a/README.md
+++ b/README.md
@@ -168,9 +168,10 @@ maintained synthesis content beyond that explicit source-ref migration.
 `splendor ingest --changed` is the narrower stale-ingest repair path for checksum-drifted curated
 workspace-backed sources when old ingest queue records are already `done`. It refreshes changed
 source versions through the same supersession-aware source lifecycle, ingests only those refreshed
-queue jobs, reports a clean no-op when no curated source bytes changed, and blocks with diagnostics
-when active curated sources are missing. `--json` emits initial/final freshness counts, refreshed
-source IDs, targeted ingest outcomes, and the summary.
+queue jobs, reports a clean no-op when no curated source bytes changed, and reports missing active
+curated sources without preventing valid changed sources from being processed. `--json` emits
+initial/final freshness counts, missing-source diagnostics, refreshed source IDs, targeted ingest
+outcomes, and the summary.
 
 `splendor pr-summary --since main` is a read-only PR handoff command over local git state. It uses
 the merge base between `HEAD` and the base ref for PR-style diff semantics, then summarizes curated
@@ -340,8 +341,8 @@ against source manifests. Historical manifests and run records remain valid.
 `M14-P1.5` adds the explicit stale-ingest repair path for issue #93:
 `splendor ingest --changed` detects checksum-drifted curated workspace-backed sources, refreshes
 them into current canonical source versions, and ingests only those refreshed queue jobs even when
-the previous queue item was already `done`. Missing curated sources are reported before mutation so
-operators can repair paths separately.
+the previous queue item was already `done`. Missing curated sources are reported as unresolved
+diagnostics while valid changed sources continue through refresh and ingest.
 
 `M14-P2.1` adds the read-only PR handoff surface:
 `splendor pr-summary --since main` groups merge-base changes into curated source lifecycle records,

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -212,12 +212,12 @@ Implemented fields:
   version, leaving prose and code-fence mentions untouched. The command does not perform broad repo
   discovery, register uncurated files, or run mutating synthesis compile/update workflows.
 - `splendor ingest --changed` is the narrow stale-source ingestion path for checksum-drifted
-  curated workspace-backed sources. It scans source freshness, refuses to mutate while active
-  curated workspace sources are missing, refreshes each changed source through the existing
+  curated workspace-backed sources. It scans source freshness, reports missing active curated
+  workspace sources as unresolved diagnostics, refreshes each changed source through the existing
   supersession-aware source refresh path, and runs only the refreshed sources' queue records. It
   reports a clean no-op when no curated workspace-backed source bytes changed. `--json` emits
-  initial and final freshness counts, refreshed source IDs, targeted queue outcomes, and summary
-  counts.
+  initial and final freshness counts, missing-source diagnostics, refreshed source IDs, targeted
+  queue outcomes, and summary counts.
 - `splendor wiki compile <source-id|title|path>` remains non-mutating unless a maintained target
   page is selected and `--apply --proposal-hash <hash>` is supplied. `--page <maintained-page>`
   proposes a deterministic update from the generated source-summary page into one maintained

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -211,6 +211,13 @@ Implemented fields:
   source-reference list bullets from superseded source IDs to the active content-addressed source
   version, leaving prose and code-fence mentions untouched. The command does not perform broad repo
   discovery, register uncurated files, or run mutating synthesis compile/update workflows.
+- `splendor ingest --changed` is the narrow stale-source ingestion path for checksum-drifted
+  curated workspace-backed sources. It scans source freshness, refuses to mutate while active
+  curated workspace sources are missing, refreshes each changed source through the existing
+  supersession-aware source refresh path, and runs only the refreshed sources' queue records. It
+  reports a clean no-op when no curated workspace-backed source bytes changed. `--json` emits
+  initial and final freshness counts, refreshed source IDs, targeted queue outcomes, and summary
+  counts.
 - `splendor wiki compile <source-id|title|path>` remains non-mutating unless a maintained target
   page is selected and `--apply --proposal-hash <hash>` is supplied. `--page <maintained-page>`
   proposes a deterministic update from the generated source-summary page into one maintained

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M14-P4.1`
-- Current planned slice: `Post-v1 mutating compile/update workflow`
-- Current PR sub-slice: `M15-P1.1`
+- Previous completed PR sub-slice: `M15-P1.1`
+- Current planned slice: `Post-v1 source lifecycle repair: stale-source ingestion`
+- Current PR sub-slice: `M14-P1.5`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `Compile/update expansion after first reviewed page apply`
-- Next planned PR sub-slice: `M15-P1.2`
+- Next planned slice: `Repo refresh missing/broken source tolerance`
+- Next planned PR sub-slice: `M14-P1.6`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -886,6 +886,8 @@ breaking the v1 file contracts.
 - `M14-P1.2` Supersession-aware source refresh
 - `M14-P1.3` Safe workspace refresh path
 - `M14-P1.4` Superseded-state pruning and topic-ref migration
+- `M14-P1.5` Stale-source ingestion for checksum-drifted curated sources
+- `M14-P1.6` Repo refresh missing/broken source tolerance
 - `M14-P2.1` PR summary and lower-noise generated-state review handoff
 - `M14-P3.1` Source-lifecycle re-evaluation gate
 - `M14-P4.1` Planning-doc authority and task-oriented agent briefs
@@ -907,7 +909,12 @@ loop is substantially implemented and re-evaluated. The intended sequence before
    `splendor workspace refresh --changed --ingest --rebuild-index`, limited to curated
    workspace-backed source manifests.
 5. `M14-P1.4` handles superseded generated-state pruning and topic-ref migration.
-6. `M14-P2.1` adds `splendor pr-summary --since main`, a read-only PR-oriented summary with
+6. `M14-P1.5` adds explicit stale-source ingestion with `splendor ingest --changed`, so
+   checksum-drifted curated sources can be refreshed and ingested even when previous queue jobs are
+   already `done`.
+7. `M14-P1.6` should make repo/workspace refresh tolerate missing or broken curated sources by
+   skipping them with diagnostics while continuing valid refresh work.
+8. `M14-P2.1` adds `splendor pr-summary --since main`, a read-only PR-oriented summary with
    lower-noise generated-state review guidance over local git state.
 
 After those slices land, the gate should use a comparable planning or repo-maintenance workflow and
@@ -936,6 +943,12 @@ metadata for configured planning/docs files and optional maintained wiki frontma
 `brief --agent-context` and `suggest-next` to rank current authority, roadmap, historical review,
 proposal, reference, and generated-summary context for a stated goal. Generated source-summary
 artifacts remain separate from maintained authority ranking.
+
+`M14-P1.5` temporarily supersedes the documented M15 follow-up because issue #93 is an open
+Milestone 14 MVP source-lifecycle repair. It adds `splendor ingest --changed` as a narrow bridge
+from source freshness to supersession-aware source refresh and targeted ingest. The command does
+not discover uncurated files, does not drain unrelated pending jobs, and reports missing curated
+sources before mutation so path-repair work can remain separate.
 
 ## Candidate Milestone 15 — Post-v1 reviewed compile/update workflow
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -948,7 +948,7 @@ artifacts remain separate from maintained authority ranking.
 Milestone 14 MVP source-lifecycle repair. It adds `splendor ingest --changed` as a narrow bridge
 from source freshness to supersession-aware source refresh and targeted ingest. The command does
 not discover uncurated files, does not drain unrelated pending jobs, and reports missing curated
-sources before mutation so path-repair work can remain separate.
+sources as unresolved diagnostics while continuing valid changed-source repair work.
 
 ## Candidate Milestone 15 — Post-v1 reviewed compile/update workflow
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -804,7 +804,8 @@ Current implementation:
   curated workspace-backed sources. It composes the freshness scan, supersession-aware source
   refresh, and targeted queue worker path so a changed source can be re-ingested even when its
   previous queue record is already `done`. It does not drain unrelated pending jobs, reports no-op
-  unchanged workspaces cleanly, and blocks with missing-source diagnostics before rewriting records.
+  unchanged workspaces cleanly, and reports missing-source diagnostics while continuing to process
+  valid changed sources.
 - `splendor pr-summary --since main` is a read-only PR handoff command. It uses local git
   diff/status from the merge base with the base ref, respects configured layout paths, and uses
   existing report files to group curated source lifecycle changes, generated source-summary pages,

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -800,6 +800,11 @@ Current implementation:
   active content-addressed source version, while leaving prose and code-fence mentions untouched.
   It does not discover or register uncurated files or run mutating synthesis compile/update
   workflows.
+- `splendor ingest --changed` is the focused stale-ingest repair command for checksum-drifted
+  curated workspace-backed sources. It composes the freshness scan, supersession-aware source
+  refresh, and targeted queue worker path so a changed source can be re-ingested even when its
+  previous queue record is already `done`. It does not drain unrelated pending jobs, reports no-op
+  unchanged workspaces cleanly, and blocks with missing-source diagnostics before rewriting records.
 - `splendor pr-summary --since main` is a read-only PR handoff command. It uses local git
   diff/status from the merge base with the base ref, respects configured layout paths, and uses
   existing report files to group curated source lifecycle changes, generated source-summary pages,
@@ -882,8 +887,9 @@ Release-readiness boundary:
   with workspace-backed `source:<path>` aliases plus `supersedes`/`superseded_by` source-version
   links. The safe workspace refresh path over curated workspace-backed sources has also landed,
   including explicit superseded source-summary pruning and maintained-page source-ref migration.
-  The `pr-summary` surface now provides a read-only local PR handoff over that generated-state
-  churn.
+  The `ingest --changed` repair path handles checksum-drifted curated workspace sources whose
+  previous queue records are already done, and the `pr-summary` surface provides a read-only local
+  PR handoff over that generated-state churn.
 - issue #79 tracks the reviewed mutating compile/update workflow from #41; v1 shipped briefing and
   the non-mutating compile contract, and `M15-P1.1` begins the explicit one-page proposal/apply
   path.

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -64,6 +64,8 @@ These items are intentionally not v1 release blockers:
 - richer post-M14 authority lifecycle policy after the initial planning-doc authority briefs have
   been exercised in real repositories
 - ingest run-duration precision for #47
+- repo refresh tolerance for missing or broken curated sources after the narrower #93 stale-ingest
+  repair
 - repo-scan bulk registration optimization for #30
 - web document-list scaling for #37
 
@@ -77,9 +79,13 @@ The conservative next queue after the `M14-P3.1` gate is:
    task-oriented authority brief ranking.
 3. Keep using `splendor pr-summary --since main` during review handoff to explain source
    lifecycle, maintained wiki, source-summary, and mechanical generated-state changes.
-4. Continue #79 through `M15-P1.1`, the first reviewed compile/apply loop from source-summary
-   evidence into a single maintained synthesis page.
-5. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
+4. Use `M14-P1.5` for issue #93 before continuing post-MVP expansion: add an explicit
+   `splendor ingest --changed` path for checksum-drifted curated sources whose old queue items are
+   already done.
+5. Use `M14-P1.6` for issue #90 after #93: repo/workspace refresh should skip missing or broken
+   curated sources with diagnostics while continuing valid refresh work.
+6. Continue #79 through `M15-P1.2` after the open Milestone 14 P1 repair issues are handled.
+7. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
    either one urgent.
 
 The internal source-lifecycle re-evaluation gate is now complete in `M14-P3.1`. The completed retry

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -22,7 +22,12 @@ from splendor.commands.file_answer import (
     file_answer_from_last_query,
 )
 from splendor.commands.health import run_health_checks
-from splendor.commands.ingest import drain_pending_ingest_jobs, enqueue_ingest_job, ingest_source
+from splendor.commands.ingest import (
+    drain_pending_ingest_jobs,
+    enqueue_ingest_job,
+    ingest_source,
+    run_ingest_job,
+)
 from splendor.commands.init import initialize_workspace
 from splendor.commands.lint import run_lint_checks
 from splendor.commands.maintenance import execute_maintenance_command, render_report_json
@@ -260,6 +265,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--pending",
         action="store_true",
         help="Drain pending ingestion jobs from the queue.",
+    )
+    ingest_parser.add_argument(
+        "--changed",
+        action="store_true",
+        help="Refresh and ingest checksum-drifted curated workspace-backed sources.",
+    )
+    ingest_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output for --changed.",
     )
     ingest_parser.set_defaults(handler=handle_ingest)
 
@@ -1044,6 +1060,9 @@ def handle_source_freshness(args: argparse.Namespace) -> int:
 
 def handle_ingest(args: argparse.Namespace) -> int:
     root = args.root.resolve()
+    if args.changed:
+        return _handle_ingest_changed(args)
+
     if args.pending:
         try:
             result = drain_pending_ingest_jobs(root)
@@ -1096,6 +1115,229 @@ def handle_ingest(args: argparse.Namespace) -> int:
         "commit explicit reports only when they support the reviewed workspace update."
     )
     return 0
+
+
+def _handle_ingest_changed(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        freshness = scan_source_freshness(root)
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        return _print_error(exc)
+
+    missing_items = [item for item in freshness.sources if item.status == "missing"]
+    if missing_items:
+        payload = {
+            "status": "blocked",
+            "initial_freshness": _source_freshness_counts(freshness),
+            "missing": [_freshness_item_payload(root, item) for item in missing_items],
+            "refreshed": [],
+            "ingest": [],
+            "summary": {"processed": 0, "succeeded": 0, "failed": 0, "skipped": 0},
+        }
+        if args.json_output:
+            print(json.dumps(payload, indent=2))
+        else:
+            print("Stale ingest blocked")
+            print(_format_source_freshness_counts("Freshness", freshness))
+            print("Missing curated sources:")
+            for item in missing_items:
+                print(f"- {item.canonical_path}: {item.message}")
+            print("Next: splendor source freshness")
+        return 1
+
+    changed_items = [item for item in freshness.sources if item.status == "changed"]
+    if not changed_items:
+        payload = {
+            "status": "no-op",
+            "initial_freshness": _source_freshness_counts(freshness),
+            "missing": [],
+            "refreshed": [],
+            "ingest": [],
+            "summary": {"processed": 0, "succeeded": 0, "failed": 0, "skipped": 0},
+        }
+        if args.json_output:
+            print(json.dumps(payload, indent=2))
+        else:
+            print("No changed curated workspace-backed sources found.")
+            print(_format_source_freshness_counts("Freshness", freshness))
+        return 0
+
+    refreshed_payloads: list[dict[str, object]] = []
+    ingest_payloads: list[dict[str, object]] = []
+    processed = 0
+    succeeded = 0
+    failed = 0
+    skipped = 0
+
+    for item in changed_items:
+        try:
+            refresh = refresh_source(root, item.source.source_id)
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            failed += 1
+            refreshed_payloads.append(
+                {
+                    "requested_source_id": item.source.source_id,
+                    "source_ref": item.canonical_path,
+                    "status": "failed",
+                    "message": str(exc),
+                }
+            )
+            continue
+
+        refreshed_payloads.append(
+            {
+                "requested_source_id": refresh.requested.source_id,
+                "refreshed_source_id": refresh.refreshed.record.source_id,
+                "source_ref": canonical_source_ref(refresh.refreshed.record),
+                "changed": refresh.changed,
+                "queued": refresh.queued,
+                "queue_path": (
+                    None
+                    if refresh.queue_path is None
+                    else refresh.queue_path.relative_to(root).as_posix()
+                ),
+                "message": refresh.message,
+            }
+        )
+
+        if refresh.queue_path is None:
+            skipped += 1
+            ingest_payloads.append(
+                {
+                    "source_id": refresh.refreshed.record.source_id,
+                    "outcome": "skipped",
+                    "message": refresh.message,
+                }
+            )
+            continue
+
+        try:
+            ingest_result = run_ingest_job(root, refresh.queue_path)
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            processed += 1
+            failed += 1
+            ingest_payloads.append(
+                {
+                    "source_id": refresh.refreshed.record.source_id,
+                    "queue_path": refresh.queue_path.relative_to(root).as_posix(),
+                    "outcome": "failed",
+                    "message": str(exc),
+                }
+            )
+            continue
+
+        if ingest_result.no_op:
+            skipped += 1
+            ingest_payloads.append(
+                {
+                    "source_id": ingest_result.source_id,
+                    "queue_path": refresh.queue_path.relative_to(root).as_posix(),
+                    "outcome": "skipped",
+                    "message": "already ingested for the current pipeline version",
+                }
+            )
+            continue
+
+        processed += 1
+        succeeded += 1
+        ingest_payloads.append(
+            {
+                "source_id": ingest_result.source_id,
+                "queue_path": refresh.queue_path.relative_to(root).as_posix(),
+                "outcome": "succeeded",
+                "message": f"run {ingest_result.run_id}",
+                "run_id": ingest_result.run_id,
+                "page_path": (
+                    None
+                    if ingest_result.page_path is None
+                    else ingest_result.page_path.relative_to(root).as_posix()
+                ),
+            }
+        )
+
+    final_freshness = scan_source_freshness(root)
+    payload = {
+        "status": "failed" if failed else "succeeded",
+        "initial_freshness": _source_freshness_counts(freshness),
+        "final_freshness": _source_freshness_counts(final_freshness),
+        "missing": [],
+        "refreshed": refreshed_payloads,
+        "ingest": ingest_payloads,
+        "summary": {
+            "processed": processed,
+            "succeeded": succeeded,
+            "failed": failed,
+            "skipped": skipped,
+        },
+    }
+    if args.json_output:
+        print(json.dumps(payload, indent=2))
+    else:
+        print("Stale ingest")
+        print(_format_source_freshness_counts("Initial freshness", freshness))
+        for refreshed in refreshed_payloads:
+            if refreshed.get("status") == "failed":
+                print(f"- {refreshed['source_ref']}: refresh failed ({refreshed['message']})")
+                continue
+            print(
+                f"- {refreshed['source_ref']}: refreshed "
+                f"{refreshed['requested_source_id']} -> {refreshed['refreshed_source_id']}"
+            )
+        for item in ingest_payloads:
+            print(f"{item['source_id']}: {item['outcome']} ({item['message']})")
+        print(
+            "Stale ingest summary: "
+            f"processed={processed} "
+            f"succeeded={succeeded} "
+            f"failed={failed} "
+            f"skipped={skipped}"
+        )
+        print(_format_source_freshness_counts("Final freshness", final_freshness))
+        if succeeded == 1:
+            source_id = next(
+                item["source_id"] for item in ingest_payloads if item["outcome"] == "succeeded"
+            )
+            print(f"Next: splendor wiki suggest {source_id}")
+        elif succeeded > 1:
+            print("Next: splendor wiki status")
+        elif failed:
+            print("Next: splendor queue inspect")
+    return 1 if failed else 0
+
+
+def _source_freshness_counts(result) -> dict[str, int]:
+    return {
+        "total": result.total,
+        "unchanged": result.unchanged,
+        "changed": result.changed,
+        "missing": result.missing,
+        "unsupported": result.unsupported,
+        "historical": result.historical,
+    }
+
+
+def _format_source_freshness_counts(label: str, result) -> str:
+    counts = _source_freshness_counts(result)
+    return (
+        f"{label}: "
+        f"total={counts['total']} "
+        f"unchanged={counts['unchanged']} "
+        f"changed={counts['changed']} "
+        f"missing={counts['missing']} "
+        f"unsupported={counts['unsupported']} "
+        f"historical={counts['historical']}"
+    )
+
+
+def _freshness_item_payload(root: Path, item) -> dict[str, object]:
+    return {
+        "source_id": item.source.source_id,
+        "source_ref": item.canonical_path,
+        "manifest_path": item.manifest_path.relative_to(root).as_posix(),
+        "status": item.status,
+        "message": item.message,
+        "next_commands": item.next_commands,
+    }
 
 
 def handle_queue_inspect(args: argparse.Namespace) -> int:
@@ -2196,8 +2438,12 @@ def handle_question_create(args: argparse.Namespace) -> int:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    if args.command == "ingest" and bool(args.source_id) == bool(args.pending):
-        parser.error("ingest requires exactly one of <source_id> or --pending")
+    if args.command == "ingest":
+        mode_count = sum(bool(value) for value in [args.source_id, args.pending, args.changed])
+        if mode_count != 1:
+            parser.error("ingest requires exactly one of <source_id>, --pending, or --changed")
+        if args.json_output and not args.changed:
+            parser.error("ingest --json is currently supported only with --changed")
     return args.handler(args)
 
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -22,12 +22,7 @@ from splendor.commands.file_answer import (
     file_answer_from_last_query,
 )
 from splendor.commands.health import run_health_checks
-from splendor.commands.ingest import (
-    drain_pending_ingest_jobs,
-    enqueue_ingest_job,
-    ingest_source,
-    run_ingest_job,
-)
+from splendor.commands.ingest import drain_pending_ingest_jobs, enqueue_ingest_job, ingest_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.lint import run_lint_checks
 from splendor.commands.maintenance import execute_maintenance_command, render_report_json
@@ -67,12 +62,14 @@ from splendor.commands.repo_scan import (
 )
 from splendor.commands.source import (
     SourceLookupResult,
+    ingest_changed_sources,
     list_sources,
     lookup_sources,
     refresh_source,
     render_source_freshness_json,
     render_source_lookup_json,
     render_source_refresh_json,
+    render_stale_ingest_json,
     resolve_source_query_exact,
     scan_source_freshness,
     write_source_freshness_report,
@@ -1120,224 +1117,68 @@ def handle_ingest(args: argparse.Namespace) -> int:
 def _handle_ingest_changed(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     try:
-        freshness = scan_source_freshness(root)
+        result = ingest_changed_sources(root)
     except (FileNotFoundError, RuntimeError, ValueError) as exc:
         return _print_error(exc)
 
-    missing_items = [item for item in freshness.sources if item.status == "missing"]
-    if missing_items:
-        payload = {
-            "status": "blocked",
-            "initial_freshness": _source_freshness_counts(freshness),
-            "missing": [_freshness_item_payload(root, item) for item in missing_items],
-            "refreshed": [],
-            "ingest": [],
-            "summary": {"processed": 0, "succeeded": 0, "failed": 0, "skipped": 0},
-        }
-        if args.json_output:
-            print(json.dumps(payload, indent=2))
-        else:
-            print("Stale ingest blocked")
-            print(_format_source_freshness_counts("Freshness", freshness))
-            print("Missing curated sources:")
-            for item in missing_items:
-                print(f"- {item.canonical_path}: {item.message}")
-            print("Next: splendor source freshness")
-        return 1
-
-    changed_items = [item for item in freshness.sources if item.status == "changed"]
-    if not changed_items:
-        payload = {
-            "status": "no-op",
-            "initial_freshness": _source_freshness_counts(freshness),
-            "missing": [],
-            "refreshed": [],
-            "ingest": [],
-            "summary": {"processed": 0, "succeeded": 0, "failed": 0, "skipped": 0},
-        }
-        if args.json_output:
-            print(json.dumps(payload, indent=2))
-        else:
-            print("No changed curated workspace-backed sources found.")
-            print(_format_source_freshness_counts("Freshness", freshness))
-        return 0
-
-    refreshed_payloads: list[dict[str, object]] = []
-    ingest_payloads: list[dict[str, object]] = []
-    processed = 0
-    succeeded = 0
-    failed = 0
-    skipped = 0
-
-    for item in changed_items:
-        try:
-            refresh = refresh_source(root, item.source.source_id)
-        except (FileNotFoundError, RuntimeError, ValueError) as exc:
-            failed += 1
-            refreshed_payloads.append(
-                {
-                    "requested_source_id": item.source.source_id,
-                    "source_ref": item.canonical_path,
-                    "status": "failed",
-                    "message": str(exc),
-                }
-            )
-            continue
-
-        refreshed_payloads.append(
-            {
-                "requested_source_id": refresh.requested.source_id,
-                "refreshed_source_id": refresh.refreshed.record.source_id,
-                "source_ref": canonical_source_ref(refresh.refreshed.record),
-                "changed": refresh.changed,
-                "queued": refresh.queued,
-                "queue_path": (
-                    None
-                    if refresh.queue_path is None
-                    else refresh.queue_path.relative_to(root).as_posix()
-                ),
-                "message": refresh.message,
-            }
-        )
-
-        if refresh.queue_path is None:
-            skipped += 1
-            ingest_payloads.append(
-                {
-                    "source_id": refresh.refreshed.record.source_id,
-                    "outcome": "skipped",
-                    "message": refresh.message,
-                }
-            )
-            continue
-
-        try:
-            ingest_result = run_ingest_job(root, refresh.queue_path)
-        except (FileNotFoundError, RuntimeError, ValueError) as exc:
-            processed += 1
-            failed += 1
-            ingest_payloads.append(
-                {
-                    "source_id": refresh.refreshed.record.source_id,
-                    "queue_path": refresh.queue_path.relative_to(root).as_posix(),
-                    "outcome": "failed",
-                    "message": str(exc),
-                }
-            )
-            continue
-
-        if ingest_result.no_op:
-            skipped += 1
-            ingest_payloads.append(
-                {
-                    "source_id": ingest_result.source_id,
-                    "queue_path": refresh.queue_path.relative_to(root).as_posix(),
-                    "outcome": "skipped",
-                    "message": "already ingested for the current pipeline version",
-                }
-            )
-            continue
-
-        processed += 1
-        succeeded += 1
-        ingest_payloads.append(
-            {
-                "source_id": ingest_result.source_id,
-                "queue_path": refresh.queue_path.relative_to(root).as_posix(),
-                "outcome": "succeeded",
-                "message": f"run {ingest_result.run_id}",
-                "run_id": ingest_result.run_id,
-                "page_path": (
-                    None
-                    if ingest_result.page_path is None
-                    else ingest_result.page_path.relative_to(root).as_posix()
-                ),
-            }
-        )
-
-    final_freshness = scan_source_freshness(root)
-    payload = {
-        "status": "failed" if failed else "succeeded",
-        "initial_freshness": _source_freshness_counts(freshness),
-        "final_freshness": _source_freshness_counts(final_freshness),
-        "missing": [],
-        "refreshed": refreshed_payloads,
-        "ingest": ingest_payloads,
-        "summary": {
-            "processed": processed,
-            "succeeded": succeeded,
-            "failed": failed,
-            "skipped": skipped,
-        },
-    }
     if args.json_output:
-        print(json.dumps(payload, indent=2))
+        print(render_stale_ingest_json(root, result))
+    elif result.status == "no-op":
+        print("No changed curated workspace-backed sources found.")
+        print(_format_source_freshness_counts("Freshness", result.initial_freshness))
     else:
-        print("Stale ingest")
-        print(_format_source_freshness_counts("Initial freshness", freshness))
-        for refreshed in refreshed_payloads:
-            if refreshed.get("status") == "failed":
-                print(f"- {refreshed['source_ref']}: refresh failed ({refreshed['message']})")
+        if result.status == "blocked":
+            print("Stale ingest blocked")
+        elif result.status == "partial":
+            print("Stale ingest completed with unresolved sources")
+        else:
+            print("Stale ingest")
+        print(_format_source_freshness_counts("Initial freshness", result.initial_freshness))
+        if result.missing:
+            print("Missing curated sources:")
+            for item in result.missing:
+                print(f"- {item.canonical_path}: {item.message}")
+            print("Next: repair missing source paths or run splendor source freshness")
+        for refreshed in result.refreshed:
+            if refreshed.status == "failed":
+                print(f"- {refreshed.source_ref}: refresh failed ({refreshed.message})")
                 continue
             print(
-                f"- {refreshed['source_ref']}: refreshed "
-                f"{refreshed['requested_source_id']} -> {refreshed['refreshed_source_id']}"
+                f"- {refreshed.source_ref}: refreshed "
+                f"{refreshed.requested_source_id} -> {refreshed.refreshed_source_id}"
             )
-        for item in ingest_payloads:
-            print(f"{item['source_id']}: {item['outcome']} ({item['message']})")
+        for item in result.ingest:
+            print(f"{item.source_id}: {item.outcome} ({item.message})")
         print(
             "Stale ingest summary: "
-            f"processed={processed} "
-            f"succeeded={succeeded} "
-            f"failed={failed} "
-            f"skipped={skipped}"
+            f"processed={result.processed} "
+            f"succeeded={result.succeeded} "
+            f"failed={result.failed} "
+            f"skipped={result.skipped}"
         )
-        print(_format_source_freshness_counts("Final freshness", final_freshness))
-        if succeeded == 1:
+        print(_format_source_freshness_counts("Final freshness", result.final_freshness))
+        if result.succeeded == 1:
             source_id = next(
-                item["source_id"] for item in ingest_payloads if item["outcome"] == "succeeded"
+                item.source_id for item in result.ingest if item.outcome == "succeeded"
             )
             print(f"Next: splendor wiki suggest {source_id}")
-        elif succeeded > 1:
+        elif result.succeeded > 1:
             print("Next: splendor wiki status")
-        elif failed:
+        elif result.failed:
             print("Next: splendor queue inspect")
-    return 1 if failed else 0
-
-
-def _source_freshness_counts(result) -> dict[str, int]:
-    return {
-        "total": result.total,
-        "unchanged": result.unchanged,
-        "changed": result.changed,
-        "missing": result.missing,
-        "unsupported": result.unsupported,
-        "historical": result.historical,
-    }
+    return 1 if result.status in {"blocked", "failed", "partial"} else 0
 
 
 def _format_source_freshness_counts(label: str, result) -> str:
-    counts = _source_freshness_counts(result)
     return (
         f"{label}: "
-        f"total={counts['total']} "
-        f"unchanged={counts['unchanged']} "
-        f"changed={counts['changed']} "
-        f"missing={counts['missing']} "
-        f"unsupported={counts['unsupported']} "
-        f"historical={counts['historical']}"
+        f"total={result.total} "
+        f"unchanged={result.unchanged} "
+        f"changed={result.changed} "
+        f"missing={result.missing} "
+        f"unsupported={result.unsupported} "
+        f"historical={result.historical}"
     )
-
-
-def _freshness_item_payload(root: Path, item) -> dict[str, object]:
-    return {
-        "source_id": item.source.source_id,
-        "source_ref": item.canonical_path,
-        "manifest_path": item.manifest_path.relative_to(root).as_posix(),
-        "status": item.status,
-        "message": item.message,
-        "next_commands": item.next_commands,
-    }
 
 
 def handle_queue_inspect(args: argparse.Namespace) -> int:

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -7,7 +7,7 @@ import shlex
 from dataclasses import dataclass, replace
 from pathlib import Path
 
-from splendor.commands.ingest import enqueue_ingest_job, is_ingest_current
+from splendor.commands.ingest import enqueue_ingest_job, is_ingest_current, run_ingest_job
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import SourceRecord
@@ -68,6 +68,42 @@ class SourceFreshnessResult:
     historical: int
     sources: list[SourceFreshnessItem]
     report_path: str | None = None
+
+
+@dataclass(frozen=True)
+class StaleIngestRefresh:
+    requested_source_id: str
+    refreshed_source_id: str | None
+    source_ref: str
+    changed: bool | None
+    queued: bool
+    queue_path: Path | None
+    status: str
+    message: str
+
+
+@dataclass(frozen=True)
+class StaleIngestRun:
+    source_id: str
+    outcome: str
+    message: str
+    queue_path: Path | None = None
+    run_id: str | None = None
+    page_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class StaleIngestResult:
+    status: str
+    initial_freshness: SourceFreshnessResult
+    final_freshness: SourceFreshnessResult
+    missing: list[SourceFreshnessItem]
+    refreshed: list[StaleIngestRefresh]
+    ingest: list[StaleIngestRun]
+    processed: int
+    succeeded: int
+    failed: int
+    skipped: int
 
 
 def list_sources(root: Path) -> list[SourceLookupResult]:
@@ -263,6 +299,127 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
     )
 
 
+def ingest_changed_sources(root: Path) -> StaleIngestResult:
+    initial_freshness = scan_source_freshness(root)
+    missing_items = [item for item in initial_freshness.sources if item.status == "missing"]
+    changed_items = [item for item in initial_freshness.sources if item.status == "changed"]
+
+    refreshed_items: list[StaleIngestRefresh] = []
+    ingest_items: list[StaleIngestRun] = []
+    processed = 0
+    succeeded = 0
+    failed = 0
+    skipped = 0
+
+    for item in changed_items:
+        try:
+            refresh = refresh_source(root, item.source.source_id)
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            failed += 1
+            refreshed_items.append(
+                StaleIngestRefresh(
+                    requested_source_id=item.source.source_id,
+                    refreshed_source_id=None,
+                    source_ref=item.canonical_path,
+                    changed=None,
+                    queued=False,
+                    queue_path=None,
+                    status="failed",
+                    message=str(exc),
+                )
+            )
+            continue
+
+        refreshed_items.append(
+            StaleIngestRefresh(
+                requested_source_id=refresh.requested.source_id,
+                refreshed_source_id=refresh.refreshed.record.source_id,
+                source_ref=canonical_source_ref(refresh.refreshed.record),
+                changed=refresh.changed,
+                queued=refresh.queued,
+                queue_path=refresh.queue_path,
+                status="queued" if refresh.queued else "skipped",
+                message=refresh.message,
+            )
+        )
+
+        if refresh.queue_path is None:
+            skipped += 1
+            ingest_items.append(
+                StaleIngestRun(
+                    source_id=refresh.refreshed.record.source_id,
+                    outcome="skipped",
+                    message=refresh.message,
+                )
+            )
+            continue
+
+        try:
+            ingest_result = run_ingest_job(root, refresh.queue_path)
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            processed += 1
+            failed += 1
+            ingest_items.append(
+                StaleIngestRun(
+                    source_id=refresh.refreshed.record.source_id,
+                    queue_path=refresh.queue_path,
+                    outcome="failed",
+                    message=str(exc),
+                )
+            )
+            continue
+
+        if ingest_result.no_op:
+            skipped += 1
+            ingest_items.append(
+                StaleIngestRun(
+                    source_id=ingest_result.source_id,
+                    queue_path=refresh.queue_path,
+                    outcome="skipped",
+                    message="already ingested for the current pipeline version",
+                )
+            )
+            continue
+
+        processed += 1
+        succeeded += 1
+        ingest_items.append(
+            StaleIngestRun(
+                source_id=ingest_result.source_id,
+                queue_path=refresh.queue_path,
+                outcome="succeeded",
+                message=f"run {ingest_result.run_id}",
+                run_id=ingest_result.run_id,
+                page_path=ingest_result.page_path,
+            )
+        )
+
+    final_freshness = scan_source_freshness(root) if changed_items else initial_freshness
+    if failed:
+        status = "failed"
+    elif missing_items and (processed or succeeded or skipped):
+        status = "partial"
+    elif missing_items:
+        status = "blocked"
+    elif not changed_items:
+        status = "no-op"
+    else:
+        status = "succeeded"
+
+    return StaleIngestResult(
+        status=status,
+        initial_freshness=initial_freshness,
+        final_freshness=final_freshness,
+        missing=missing_items,
+        refreshed=refreshed_items,
+        ingest=ingest_items,
+        processed=processed,
+        succeeded=succeeded,
+        failed=failed,
+        skipped=skipped,
+    )
+
+
 def _select_refresh_candidate(
     source_query: str, candidates: list[SourceLookupResult]
 ) -> SourceLookupResult:
@@ -392,6 +549,21 @@ def render_source_freshness_json(root: Path, result: SourceFreshnessResult) -> s
             "historical": result.historical,
             "report_path": result.report_path,
             "sources": [_freshness_payload(root, item) for item in result.sources],
+        },
+        indent=2,
+    )
+
+
+def render_stale_ingest_json(root: Path, result: StaleIngestResult) -> str:
+    return json.dumps(
+        {
+            "status": result.status,
+            "initial_freshness": _freshness_counts(result.initial_freshness),
+            "final_freshness": _freshness_counts(result.final_freshness),
+            "missing": [_freshness_payload(root, item) for item in result.missing],
+            "refreshed": [_stale_ingest_refresh_payload(root, item) for item in result.refreshed],
+            "ingest": [_stale_ingest_run_payload(root, item) for item in result.ingest],
+            "summary": _stale_ingest_summary(result),
         },
         indent=2,
     )
@@ -595,6 +767,56 @@ def _freshness_payload(root: Path, item: SourceFreshnessItem) -> dict[str, objec
         "manifest_path": item.manifest_path.relative_to(root).as_posix(),
         "message": item.message,
         "next_commands": item.next_commands,
+    }
+
+
+def _freshness_counts(result: SourceFreshnessResult) -> dict[str, int]:
+    return {
+        "total": result.total,
+        "unchanged": result.unchanged,
+        "changed": result.changed,
+        "missing": result.missing,
+        "unsupported": result.unsupported,
+        "historical": result.historical,
+    }
+
+
+def _stale_ingest_summary(result: StaleIngestResult) -> dict[str, int]:
+    return {
+        "processed": result.processed,
+        "succeeded": result.succeeded,
+        "failed": result.failed,
+        "skipped": result.skipped,
+    }
+
+
+def _stale_ingest_refresh_payload(root: Path, item: StaleIngestRefresh) -> dict[str, object]:
+    return {
+        "requested_source_id": item.requested_source_id,
+        "refreshed_source_id": item.refreshed_source_id,
+        "source_ref": item.source_ref,
+        "changed": item.changed,
+        "queued": item.queued,
+        "queue_path": None
+        if item.queue_path is None
+        else item.queue_path.relative_to(root).as_posix(),
+        "status": item.status,
+        "message": item.message,
+    }
+
+
+def _stale_ingest_run_payload(root: Path, item: StaleIngestRun) -> dict[str, object]:
+    return {
+        "source_id": item.source_id,
+        "queue_path": None
+        if item.queue_path is None
+        else item.queue_path.relative_to(root).as_posix(),
+        "outcome": item.outcome,
+        "message": item.message,
+        "run_id": item.run_id,
+        "page_path": None
+        if item.page_path is None
+        else item.page_path.relative_to(root).as_posix(),
     }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ import splendor.cli as cli_module
 from splendor import __version__
 from splendor.cli import build_parser, main
 from splendor.commands.ingest import enqueue_ingest_job
-from splendor.commands.source import refresh_source
+from splendor.commands.source import ingest_changed_sources, refresh_source
 from splendor.config import load_config, write_config
 from splendor.layout import resolve_layout
 from splendor.schemas import KnowledgePageFrontmatter, MaintenanceIssue, MaintenanceReport
@@ -1905,17 +1905,45 @@ def test_cli_ingest_changed_noops_for_unchanged_workspace(tmp_path: Path, capsys
     assert sorted((tmp_path / "state" / "runs").glob("*.json")) == before_runs
 
 
-def test_cli_ingest_changed_reports_missing_sources_without_mutating(
+def test_ingest_changed_sources_returns_typed_noop_result(tmp_path: Path) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    main(["--root", str(tmp_path), "ingest", source_id])
+
+    result = ingest_changed_sources(tmp_path)
+
+    assert result.status == "no-op"
+    assert result.initial_freshness == result.final_freshness
+    assert result.processed == 0
+    assert result.succeeded == 0
+    assert result.failed == 0
+    assert result.skipped == 0
+
+
+def test_cli_ingest_changed_reports_missing_sources_and_continues_valid_refresh(
     tmp_path: Path, capsys
 ) -> None:
     main(["--root", str(tmp_path), "init"])
-    source = tmp_path / "missing.md"
-    source.write_text("# Missing\n", encoding="utf-8")
-    main(["--root", str(tmp_path), "add-source", str(source)])
-    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
-    source.unlink()
+    changed_source = tmp_path / "changed.md"
+    changed_source.write_text("# Changed\n\nOriginal.\n", encoding="utf-8")
+    missing_source = tmp_path / "missing.md"
+    missing_source.write_text("# Missing\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(changed_source)])
+    changed_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    main(["--root", str(tmp_path), "ingest", changed_id])
+    main(["--root", str(tmp_path), "add-source", str(missing_source)])
+    missing_id = next(
+        path.stem
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if path.stem != changed_id
+    )
+    changed_source.write_text("# Changed\n\nUpdated.\n", encoding="utf-8")
+    missing_source.unlink()
     before_manifest = (
-        tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
+        tmp_path / "state" / "manifests" / "sources" / f"{missing_id}.json"
     ).read_text(encoding="utf-8")
     capsys.readouterr()
 
@@ -1923,10 +1951,19 @@ def test_cli_ingest_changed_reports_missing_sources_without_mutating(
 
     assert exit_code == 1
     out = capsys.readouterr().out
-    assert "Stale ingest blocked" in out
+    assert "Stale ingest completed with unresolved sources" in out
     assert "- missing.md: canonical workspace source file is missing" in out
-    assert not list((tmp_path / "state" / "runs").glob("*.json"))
-    assert (tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json").read_text(
+    assert "Stale ingest summary: processed=1 succeeded=1 failed=0 skipped=0" in out
+    manifests = sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    assert len(manifests) == 3
+    refreshed_id = next(
+        path.stem for path in manifests if path.stem not in {changed_id, missing_id}
+    )
+    assert load_queue_item(tmp_path / "state" / "queue" / f"ingest-{refreshed_id}.json").status == (
+        "done"
+    )
+    assert (tmp_path / "wiki" / "sources" / f"{refreshed_id}.md").exists()
+    assert (tmp_path / "state" / "manifests" / "sources" / f"{missing_id}.json").read_text(
         encoding="utf-8"
     ) == before_manifest
 
@@ -1954,6 +1991,35 @@ def test_cli_ingest_changed_json_reports_refreshed_ingest(tmp_path: Path, capsys
     assert payload["ingest"][0]["source_id"] == refreshed_id
     assert payload["ingest"][0]["outcome"] == "succeeded"
     load_source_record(tmp_path / "state" / "manifests" / "sources" / f"{refreshed_id}.json")
+
+
+def test_cli_ingest_changed_json_includes_final_freshness_for_noop_and_blocked(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    main(["--root", str(tmp_path), "ingest", source_id])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--changed", "--json"])
+
+    assert exit_code == 0
+    noop_payload = json.loads(capsys.readouterr().out)
+    assert noop_payload["status"] == "no-op"
+    assert noop_payload["initial_freshness"] == noop_payload["final_freshness"]
+
+    source.unlink()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--changed", "--json"])
+
+    assert exit_code == 1
+    blocked_payload = json.loads(capsys.readouterr().out)
+    assert blocked_payload["status"] == "blocked"
+    assert blocked_payload["initial_freshness"] == blocked_payload["final_freshness"]
+    assert blocked_payload["missing"][0]["source_id"] == source_id
 
 
 def test_cli_ingest_command_reports_missing_source(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1848,6 +1848,114 @@ def test_cli_ingest_command_no_op(tmp_path: Path, capsys) -> None:
     assert "already ingested" in captured.out
 
 
+def test_cli_ingest_changed_refreshes_completed_queue_source(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    main(["--root", str(tmp_path), "ingest", original_id])
+    manual_page = tmp_path / "wiki" / "topics" / "manual.md"
+    manual_page.parent.mkdir(parents=True, exist_ok=True)
+    manual_content = (
+        "---\nschema_version: '1'\nkind: topic\ntitle: Manual\npage_id: manual\n---\nKept.\n"
+    )
+    manual_page.write_text(manual_content, encoding="utf-8")
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--changed"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Stale ingest" in out
+    assert "Stale ingest summary: processed=1 succeeded=1 failed=0 skipped=0" in out
+    manifests = sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    assert len(manifests) == 2
+    records = {path.stem: load_source_record(path) for path in manifests}
+    refreshed_id = next(source_id for source_id in records if source_id != original_id)
+    assert records[original_id].superseded_by == refreshed_id
+    assert records[refreshed_id].supersedes == [original_id]
+    assert load_queue_item(tmp_path / "state" / "queue" / f"ingest-{original_id}.json").status == (
+        "done"
+    )
+    assert load_queue_item(tmp_path / "state" / "queue" / f"ingest-{refreshed_id}.json").status == (
+        "done"
+    )
+    assert (tmp_path / "wiki" / "sources" / f"{refreshed_id}.md").exists()
+    assert manual_page.read_text(encoding="utf-8") == manual_content
+
+
+def test_cli_ingest_changed_noops_for_unchanged_workspace(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    main(["--root", str(tmp_path), "ingest", source_id])
+    before_manifests = sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    before_runs = sorted((tmp_path / "state" / "runs").glob("*.json"))
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--changed"])
+
+    assert exit_code == 0
+    assert "No changed curated workspace-backed sources found." in capsys.readouterr().out
+    assert sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json")) == before_manifests
+    assert sorted((tmp_path / "state" / "runs").glob("*.json")) == before_runs
+
+
+def test_cli_ingest_changed_reports_missing_sources_without_mutating(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "missing.md"
+    source.write_text("# Missing\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    source.unlink()
+    before_manifest = (
+        tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
+    ).read_text(encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--changed"])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "Stale ingest blocked" in out
+    assert "- missing.md: canonical workspace source file is missing" in out
+    assert not list((tmp_path / "state" / "runs").glob("*.json"))
+    assert (tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json").read_text(
+        encoding="utf-8"
+    ) == before_manifest
+
+
+def test_cli_ingest_changed_json_reports_refreshed_ingest(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    main(["--root", str(tmp_path), "ingest", original_id])
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--changed", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "succeeded"
+    assert payload["initial_freshness"]["changed"] == 1
+    assert payload["final_freshness"]["changed"] == 0
+    assert payload["summary"] == {"processed": 1, "succeeded": 1, "failed": 0, "skipped": 0}
+    assert payload["refreshed"][0]["requested_source_id"] == original_id
+    refreshed_id = payload["refreshed"][0]["refreshed_source_id"]
+    assert payload["ingest"][0]["source_id"] == refreshed_id
+    assert payload["ingest"][0]["outcome"] == "succeeded"
+    load_source_record(tmp_path / "state" / "manifests" / "sources" / f"{refreshed_id}.json")
+
+
 def test_cli_ingest_command_reports_missing_source(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
 
@@ -1864,6 +1972,12 @@ def test_cli_ingest_requires_exactly_one_target_mode() -> None:
 
     with pytest.raises(SystemExit):
         main(["ingest", "src-123", "--pending"])
+
+    with pytest.raises(SystemExit):
+        main(["ingest", "src-123", "--changed"])
+
+    with pytest.raises(SystemExit):
+        main(["ingest", "--pending", "--json"])
 
 
 def test_cli_ingest_pending_reports_no_jobs(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Implements `M14-P1.5` for issue #93 by adding an explicit stale-source ingestion path:

- add `splendor ingest --changed` for checksum-drifted curated workspace-backed sources
- compose existing source freshness, supersession-aware `source refresh`, and targeted queue ingestion
- avoid draining unrelated pending ingest work while allowing changed sources to ingest even when prior queue records are already `done`
- report clean no-op output for unchanged workspaces
- report missing curated sources as unresolved diagnostics while still processing valid changed sources
- add JSON output for stale-ingest handoff with consistent initial/final freshness counts, missing-source diagnostics, refreshed source IDs, targeted ingest outcomes, and summary counts
- move stale-ingest orchestration into the source command layer so the CLI only renders a typed result
- update planning/product/schema/handoff docs to move the active state from `M15-P1.1` to `M14-P1.5`, with `M14-P1.6` as the likely next Milestone 14 repair slice

Closes #93.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest` (`559 passed`)
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`

## Notes

This PR intentionally does not implement the broader missing/broken source tolerance from #90, path repair from #89, stable moved-file identity from #94, or health remediation hints from #95. Those remain separate source-lifecycle recovery follow-ups.
