### PR TITLE
M14-P1.6 tolerate unresolved sources during workspace refresh

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M15-P1.1`
-- Last action taken: `M15-P1.1` is implemented; the next PR returns to open Milestone 14 source-lifecycle repair by adding an explicit stale-source ingest path for #93.
-- Current planned slice: `Post-v1 source lifecycle repair: stale-source ingestion`
-- Current PR sub-slice: `M14-P1.5`
+- Previous completed PR sub-slice: `M14-P1.5`
+- Last action taken: `M14-P1.5` is implemented; the current PR makes workspace refresh tolerate unresolved curated sources while continuing valid changed-source work for #90.
+- Current planned slice: `Repo refresh missing/broken source tolerance`
+- Current PR sub-slice: `M14-P1.6`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `Repo refresh missing/broken source tolerance`
-- Next planned PR sub-slice: `M14-P1.6`
+- Next planned slice: `likely source path repair commands`
+- Next planned PR sub-slice: `likely M14-P1.7`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -157,13 +157,17 @@ Relative report paths use the current working directory.
 supersession-aware refresh path for changed curated workspace-backed sources. Add `--ingest` to
 ingest only queue jobs created or reused for the refreshed sources, and add `--rebuild-index` to
 regenerate `wiki/index.md` after that targeted ingest succeeds. JSON output reports both initial
-and final freshness counts. Add `--prune-superseded` to delete superseded generated
+and final freshness counts, skipped unresolved curated sources, and failed changed-source refreshes.
+Missing, unsupported, or refresh-failed active curated sources are reported as unresolved
+diagnostics while valid changed sources still refresh; the command exits non-zero when those
+unresolved sources remain. Add `--prune-superseded` to delete superseded generated
 `wiki/sources/<source-id>.md` summaries once a current successor summary exists, while keeping
-historical source manifests and run records. Add `--update-topic-refs` to rewrite maintained wiki
-page `source_refs` and generated source-reference list bullets from superseded source IDs to the
-active source version ID. Prune JSON reports skipped unsafe candidates with reasons rather than
-deleting ambiguous state. The command does not discover or register uncurated files or mutate
-maintained synthesis content beyond that explicit source-ref migration.
+historical source manifests and run records. Add
+`--update-topic-refs` to rewrite maintained wiki page `source_refs` and generated source-reference
+list bullets from superseded source IDs to the active source version ID. Prune JSON reports skipped
+unsafe candidates with reasons rather than deleting ambiguous state. The command does not discover
+or register uncurated files or mutate maintained synthesis content beyond that explicit source-ref
+migration.
 
 `splendor ingest --changed` is the narrower stale-ingest repair path for checksum-drifted curated
 workspace-backed sources when old ingest queue records are already `done`. It refreshes changed
@@ -217,12 +221,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M15-P1.1`
-- Current planned slice: `Post-v1 source lifecycle repair: stale-source ingestion`
-- Current PR sub-slice: `M14-P1.5`
+- Previous completed PR sub-slice: `M14-P1.5`
+- Current planned slice: `Repo refresh missing/broken source tolerance`
+- Current PR sub-slice: `M14-P1.6`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `Repo refresh missing/broken source tolerance`
-- Next planned PR sub-slice: `M14-P1.6`
+- Next planned slice: `likely source path repair commands`
+- Next planned PR sub-slice: `likely M14-P1.7`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -197,20 +197,24 @@ Implemented fields:
   still require `splendor queue retry <job-id>` or `splendor repair ingest <source-id>`.
 - `splendor workspace refresh --changed` is the safe workspace-level mutating path over curated
   workspace-backed source manifests. It uses `source freshness` to select changed active manifests,
-  refuses to continue when active curated workspace sources are missing, refreshes each changed
-  source through the supersession-aware source refresh path, and can ingest only the queue records
-  created or reused for those refreshed sources with `--ingest`.
+  reports missing or unsupported active curated workspace sources as skipped unresolved diagnostics,
+  refreshes each changed source through the supersession-aware source refresh path, records
+  per-source refresh failures instead of aborting the whole command, and can ingest only the queue
+  records created or reused for successful refreshed sources with `--ingest`. The command exits
+  non-zero when unresolved skipped sources, failed source refreshes, or targeted ingest failures
+  remain, while preserving successful refresh and ingest work.
 - `splendor workspace refresh --changed --ingest --rebuild-index` rebuilds `wiki/index.md` only
   after the targeted refreshed-source ingest succeeds. JSON output reports both initial and final
-  freshness counts. `--prune-superseded` deletes superseded generated source-summary pages after a
-  current successor summary exists, removes the pruned generated-page link from the superseded
-  source manifest, and preserves historical source manifests and run records. Health treats run
-  page refs for those exact pruned superseded workspace summaries as valid historical provenance
-  without exempting unrelated broken run refs. Prune JSON reports skipped unsafe candidates with
-  reasons. `--update-topic-refs` rewrites maintained wiki page `source_refs` and generated
-  source-reference list bullets from superseded source IDs to the active content-addressed source
-  version, leaving prose and code-fence mentions untouched. The command does not perform broad repo
-  discovery, register uncurated files, or run mutating synthesis compile/update workflows.
+  freshness counts plus skipped-source and failed-refresh diagnostics. `--prune-superseded` deletes
+  superseded generated source-summary pages after a current successor summary exists, removes the pruned
+  generated-page link from the superseded source manifest, and preserves historical source
+  manifests and run records. Health treats run page refs for those exact pruned superseded
+  workspace summaries as valid historical provenance without exempting unrelated broken run refs.
+  Prune JSON reports skipped unsafe candidates with reasons. `--update-topic-refs` rewrites
+  maintained wiki page `source_refs` and generated source-reference list bullets from superseded
+  source IDs to the active content-addressed source version, leaving prose and code-fence mentions
+  untouched. The command does not perform broad repo discovery, register uncurated files, or run
+  mutating synthesis compile/update workflows.
 - `splendor ingest --changed` is the narrow stale-source ingestion path for checksum-drifted
   curated workspace-backed sources. It scans source freshness, reports missing active curated
   workspace sources as unresolved diagnostics, refreshes each changed source through the existing

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M15-P1.1`
-- Current planned slice: `Post-v1 source lifecycle repair: stale-source ingestion`
-- Current PR sub-slice: `M14-P1.5`
+- Previous completed PR sub-slice: `M14-P1.5`
+- Current planned slice: `Repo refresh missing/broken source tolerance`
+- Current PR sub-slice: `M14-P1.6`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `Repo refresh missing/broken source tolerance`
-- Next planned PR sub-slice: `M14-P1.6`
+- Next planned slice: `likely source path repair commands`
+- Next planned PR sub-slice: `likely M14-P1.7`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -949,6 +949,13 @@ Milestone 14 MVP source-lifecycle repair. It adds `splendor ingest --changed` as
 from source freshness to supersession-aware source refresh and targeted ingest. The command does
 not discover uncurated files, does not drain unrelated pending jobs, and reports missing curated
 sources as unresolved diagnostics while continuing valid changed-source repair work.
+
+`M14-P1.6` addresses issue #90 by making `splendor workspace refresh --changed` use the same
+partial-progress recovery posture: missing or unsupported active curated workspace sources are
+reported as skipped unresolved diagnostics, per-source refresh failures are summarized without
+aborting the whole command, valid changed sources still refresh, `--ingest` remains limited to
+refreshed-source queue jobs, and the command exits non-zero while unresolved sources or targeted
+ingest failures remain.
 
 ## Candidate Milestone 15 — Post-v1 reviewed compile/update workflow
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -789,9 +789,13 @@ Current implementation:
   of active current-byte targets.
 - `splendor workspace refresh --changed` safely refreshes only changed curated workspace-backed
   sources by composing `source freshness` with the supersession-aware `source refresh` path. It
-  fails before mutating when active curated workspace sources are missing, can ingest only refreshed
+  reports missing or unsupported active curated workspace sources as skipped unresolved diagnostics,
+  records per-source refresh failures without aborting the whole command, can ingest only refreshed
   sources' queue jobs with `--ingest`, and can rebuild `wiki/index.md` after successful targeted
-  ingest with `--rebuild-index`. JSON output reports both initial and final freshness counts.
+  ingest with `--rebuild-index`. Valid changed sources still refresh and ingest even when unrelated
+  curated sources are unresolved; the command exits non-zero while skipped sources, failed refreshes,
+  or targeted ingest failures remain. JSON output reports both initial and final freshness counts
+  plus skipped-source and failed-refresh diagnostics.
   `--prune-superseded` deletes old generated source-summary pages only after a current successor
   summary exists, removes stale generated-page links from the superseded source manifest, and keeps
   historical source manifests and run records valid. Unsafe prune candidates are reported with

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -82,8 +82,9 @@ The conservative next queue after the `M14-P3.1` gate is:
 4. Use `M14-P1.5` for issue #93 before continuing post-MVP expansion: add an explicit
    `splendor ingest --changed` path for checksum-drifted curated sources whose old queue items are
    already done.
-5. Use `M14-P1.6` for issue #90 after #93: repo/workspace refresh should skip missing or broken
-   curated sources with diagnostics while continuing valid refresh work.
+5. `M14-P1.6` handles issue #90: workspace refresh skips missing curated sources and summarizes
+   per-source refresh failures with diagnostics while continuing valid refresh work, then exits
+   non-zero while unresolved sources remain.
 6. Continue #79 through `M15-P1.2` after the open Milestone 14 P1 repair issues are handled.
 7. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
    either one urgent.

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -1503,7 +1503,13 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
 
     if args.json_output:
         print(render_workspace_refresh_json(root, result))
-        return 1 if result.ingest is not None and result.ingest.failed else 0
+        if (
+            result.skipped_sources
+            or result.failed_sources
+            or (result.ingest is not None and result.ingest.failed)
+        ):
+            return 1
+        return 0
 
     print("Workspace refresh")
     print(
@@ -1516,7 +1522,15 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
         f"historical={result.initial_freshness.historical}"
     )
     if not result.refreshed:
-        print("No changed curated workspace-backed sources found.")
+        print("No changed curated workspace-backed sources were refreshed.")
+    if result.skipped_sources:
+        print("Skipped unresolved curated workspace sources:")
+        for item in result.skipped_sources:
+            print(f"- {item.canonical_path}: {item.status} ({item.message})")
+            print(f"  Source ID: {item.source.source_id}")
+            logical_id = effective_logical_id(item.source)
+            if logical_id is not None:
+                print(f"  Logical ID: {logical_id}")
     for refresh in result.refreshed:
         source_ref = canonical_source_ref(refresh.refreshed.record)
         print(f"- {source_ref}: refreshed source_id={refresh.refreshed.record.source_id}")
@@ -1528,6 +1542,13 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
             print(f"  Queued ingest: {refresh.queue_path}")
         else:
             print(f"  Refresh skipped: {refresh.message}")
+    if result.failed_sources:
+        print("Failed changed-source refreshes:")
+        for item in result.failed_sources:
+            print(f"- {item.path}: failed ({item.reason})")
+            print(f"  Source ID: {item.source_id}")
+            if item.logical_id is not None:
+                print(f"  Logical ID: {item.logical_id}")
 
     if result.ingest is not None:
         for item in result.ingest.items:
@@ -1573,6 +1594,10 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
 
     if result.ingest is not None and result.ingest.failed:
         print("Next: splendor queue inspect")
+        return 1
+    if result.skipped_sources or result.failed_sources:
+        print("Workspace refresh completed with unresolved curated sources.")
+        print("Next: splendor source freshness")
         return 1
     if result.index is None and result.ingest is None and result.refreshed:
         print("Next: splendor ingest --pending")

--- a/src/splendor/commands/workspace.py
+++ b/src/splendor/commands/workspace.py
@@ -61,9 +61,22 @@ class TopicRefMigrationResult:
 
 
 @dataclass(frozen=True)
+class FailedWorkspaceRefreshSource:
+    path: str
+    source_id: str
+    logical_id: str | None
+    title: str
+    manifest_path: str
+    phase: str
+    reason: str
+
+
+@dataclass(frozen=True)
 class WorkspaceRefreshResult:
     initial_freshness: SourceFreshnessResult
     final_freshness: SourceFreshnessResult
+    skipped_sources: list[SourceFreshnessItem]
+    failed_sources: list[FailedWorkspaceRefreshSource]
     refreshed: list[SourceRefreshResult]
     ingest: DrainResult | None
     index: WikiIndexRebuildResult | None
@@ -88,9 +101,9 @@ def refresh_workspace(
         raise ValueError(msg)
 
     initial_freshness = scan_source_freshness(root)
-    _raise_if_missing_active_workspace_sources(initial_freshness)
+    skipped_sources = _unresolved_active_workspace_sources(initial_freshness)
     changed_items = [item for item in initial_freshness.sources if item.status == "changed"]
-    refreshed = [_refresh_changed_item(root, item) for item in changed_items]
+    refreshed, failed_sources = _refresh_changed_items(root, changed_items)
 
     ingest_result = _drain_refreshed_ingest_jobs(root, refreshed) if ingest else None
     index_result = None
@@ -112,6 +125,8 @@ def refresh_workspace(
     return WorkspaceRefreshResult(
         initial_freshness=initial_freshness,
         final_freshness=final_freshness,
+        skipped_sources=skipped_sources,
+        failed_sources=failed_sources,
         refreshed=refreshed,
         ingest=ingest_result,
         index=index_result,
@@ -279,6 +294,10 @@ def render_workspace_refresh_json(root: Path, result: WorkspaceRefreshResult) ->
         {
             "initial_freshness": _freshness_counts(result.initial_freshness),
             "final_freshness": _freshness_counts(result.final_freshness),
+            "skipped_sources": [
+                _skipped_source_payload(root, item) for item in result.skipped_sources
+            ],
+            "failed_sources": [asdict(item) for item in result.failed_sources],
             "refreshed": [_refresh_payload(root, item) for item in result.refreshed],
             "ingest": None if result.ingest is None else _ingest_payload(root, result.ingest),
             "index": None if result.index is None else asdict(result.index),
@@ -440,19 +459,42 @@ def _refresh_changed_item(root: Path, item: SourceFreshnessItem) -> SourceRefres
     return refresh_source(root, item.canonical_path)
 
 
-def _raise_if_missing_active_workspace_sources(result: SourceFreshnessResult) -> None:
-    missing_paths = sorted(
-        {
-            item.canonical_path
-            for item in result.sources
-            if item.status == "missing" and item.source.superseded_by is None
-        }
+def _refresh_changed_items(
+    root: Path, items: list[SourceFreshnessItem]
+) -> tuple[list[SourceRefreshResult], list[FailedWorkspaceRefreshSource]]:
+    refreshed: list[SourceRefreshResult] = []
+    failed: list[FailedWorkspaceRefreshSource] = []
+    for item in items:
+        try:
+            refreshed.append(_refresh_changed_item(root, item))
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            failed.append(_failed_refresh_source(root, item=item, reason=str(exc)))
+    return refreshed, failed
+
+
+def _unresolved_active_workspace_sources(
+    result: SourceFreshnessResult,
+) -> list[SourceFreshnessItem]:
+    return [
+        item
+        for item in result.sources
+        if item.status in {"missing", "unsupported"} and item.source.superseded_by is None
+    ]
+
+
+def _failed_refresh_source(
+    root: Path, *, item: SourceFreshnessItem, reason: str
+) -> FailedWorkspaceRefreshSource:
+    source = item.source
+    return FailedWorkspaceRefreshSource(
+        path=item.canonical_path,
+        source_id=source.source_id,
+        logical_id=effective_logical_id(source),
+        title=source.title,
+        manifest_path=item.manifest_path.relative_to(root).as_posix(),
+        phase="refresh",
+        reason=reason,
     )
-    if not missing_paths:
-        return
-    joined = ", ".join(missing_paths)
-    msg = f"workspace refresh cannot continue with missing curated sources: {joined}"
-    raise FileNotFoundError(msg)
 
 
 def _drain_refreshed_ingest_jobs(root: Path, refreshed: list[SourceRefreshResult]) -> DrainResult:
@@ -542,6 +584,22 @@ def _refresh_payload(root: Path, result: SourceRefreshResult) -> dict[str, objec
         "queued": result.queued,
         "queue_path": queue_path,
         "message": result.message,
+    }
+
+
+def _skipped_source_payload(root: Path, item: SourceFreshnessItem) -> dict[str, object]:
+    source = item.source
+    return {
+        "path": item.canonical_path,
+        "status": item.status,
+        "source_id": source.source_id,
+        "logical_id": effective_logical_id(source),
+        "title": source.title,
+        "source_ref": canonical_source_ref(source),
+        "source_ref_kind": source.source_ref_kind,
+        "manifest_path": item.manifest_path.relative_to(root).as_posix(),
+        "message": item.message,
+        "next_commands": item.next_commands,
     }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 
 import splendor.cli as cli_module
+import splendor.commands.workspace as workspace_module
 from splendor import __version__
 from splendor.cli import build_parser, main
 from splendor.commands.ingest import enqueue_ingest_job
@@ -1331,9 +1332,7 @@ def test_cli_workspace_refresh_ingests_only_refreshed_sources(tmp_path: Path, ca
     assert not (tmp_path / "wiki" / "sources" / f"{pending_id}.md").exists()
 
 
-def test_cli_workspace_refresh_fails_when_active_curated_source_is_missing(
-    tmp_path: Path, capsys
-) -> None:
+def test_cli_workspace_refresh_reports_missing_source_as_unresolved(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     source = tmp_path / "missing.md"
     source.write_text("# Missing\n", encoding="utf-8")
@@ -1344,10 +1343,229 @@ def test_cli_workspace_refresh_fails_when_active_curated_source_is_missing(
     exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed"])
 
     assert exit_code == 1
-    assert (
-        "Error: workspace refresh cannot continue with missing curated sources: missing.md"
-        in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "Workspace refresh" in out
+    assert "No changed curated workspace-backed sources were refreshed." in out
+    assert "Skipped unresolved curated workspace sources:" in out
+    assert "- missing.md: missing (canonical workspace source file is missing)" in out
+    assert "Workspace refresh completed with unresolved curated sources." in out
+
+
+def test_cli_workspace_refresh_continues_valid_changed_source_when_another_source_is_missing(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    changed_source = tmp_path / "changed.md"
+    missing_source = tmp_path / "missing.md"
+    changed_source.write_text("# Changed\n\nOriginal.\n", encoding="utf-8")
+    missing_source.write_text("# Missing\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(changed_source)])
+    main(["--root", str(tmp_path), "add-source", str(missing_source)])
+    changed_id = next(
+        load_source_record(path).source_id
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if load_source_record(path).source_ref == "changed.md"
     )
+    changed_source.write_text("# Changed\n\nUpdated.\n", encoding="utf-8")
+    missing_source.unlink()
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed"])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "Initial freshness: total=2 unchanged=0 changed=1 missing=1" in out
+    assert "Final freshness: total=3 unchanged=1 changed=0 missing=1" in out
+    assert "- missing.md: missing (canonical workspace source file is missing)" in out
+    assert re.search(r"- changed\.md: refreshed source_id=src-[a-f0-9]{16}", out)
+    assert f"Previous source ID: {changed_id}" in out
+    refreshed_records = [
+        load_source_record(path)
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if load_source_record(path).source_ref == "changed.md"
+        and load_source_record(path).superseded_by is None
+    ]
+    assert len(refreshed_records) == 1
+    assert refreshed_records[0].source_id != changed_id
+    assert not (tmp_path / "wiki" / "topics").exists() or not list(
+        (tmp_path / "wiki" / "topics").glob("*.md")
+    )
+
+
+def test_cli_workspace_refresh_json_reports_skipped_missing_and_final_freshness(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    changed_source = tmp_path / "changed.md"
+    missing_source = tmp_path / "missing.md"
+    changed_source.write_text("# Changed\n\nOriginal.\n", encoding="utf-8")
+    missing_source.write_text("# Missing\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(changed_source)])
+    main(["--root", str(tmp_path), "add-source", str(missing_source)])
+    changed_source.write_text("# Changed\n\nUpdated.\n", encoding="utf-8")
+    missing_source.unlink()
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed", "--json"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["initial_freshness"] == {
+        "total": 2,
+        "unchanged": 0,
+        "changed": 1,
+        "missing": 1,
+        "unsupported": 0,
+        "historical": 0,
+    }
+    assert payload["final_freshness"]["total"] == 3
+    assert payload["final_freshness"]["changed"] == 0
+    assert payload["final_freshness"]["missing"] == 1
+    assert payload["skipped_sources"][0]["path"] == "missing.md"
+    assert payload["skipped_sources"][0]["status"] == "missing"
+    assert payload["refreshed"][0]["path"] == "changed.md"
+    assert payload["ingest"] is None
+
+
+def test_cli_workspace_refresh_ingests_refreshed_valid_sources_despite_missing_source(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    changed_source = tmp_path / "changed.md"
+    missing_source = tmp_path / "missing.md"
+    pending_source = tmp_path / "pending.md"
+    changed_source.write_text("# Changed\n\nOriginal.\n", encoding="utf-8")
+    missing_source.write_text("# Missing\n\nOriginal.\n", encoding="utf-8")
+    pending_source.write_text("# Pending\n\nQueued separately.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(changed_source)])
+    main(["--root", str(tmp_path), "add-source", str(missing_source)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "add-source", str(pending_source)])
+    pending_id = next(
+        load_source_record(path).source_id
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if load_source_record(path).source_ref == "pending.md"
+    )
+    changed_source.write_text("# Changed\n\nUpdated.\n", encoding="utf-8")
+    missing_source.unlink()
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "workspace", "refresh", "--changed", "--ingest", "--json"]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["skipped_sources"][0]["path"] == "missing.md"
+    assert payload["ingest"]["total"] == 1
+    assert payload["ingest"]["succeeded"] == 1
+    assert load_queue_item(tmp_path / "state" / "queue" / f"ingest-{pending_id}.json").status == (
+        "pending"
+    )
+    refreshed_id = payload["refreshed"][0]["source_id"]
+    assert (tmp_path / "wiki" / "sources" / f"{refreshed_id}.md").exists()
+    assert not (tmp_path / "wiki" / "sources" / f"{pending_id}.md").exists()
+
+
+def test_cli_workspace_refresh_continues_after_changed_source_refresh_failure(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    ok_source = tmp_path / "ok.md"
+    broken_source = tmp_path / "broken.md"
+    ok_source.write_text("# OK\n\nOriginal.\n", encoding="utf-8")
+    broken_source.write_text("# Broken\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(ok_source)])
+    main(["--root", str(tmp_path), "add-source", str(broken_source)])
+    broken_id = next(
+        load_source_record(path).source_id
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if load_source_record(path).source_ref == "broken.md"
+    )
+    ok_source.write_text("# OK\n\nUpdated.\n", encoding="utf-8")
+    broken_source.write_text("# Broken\n\nUpdated.\n", encoding="utf-8")
+
+    def fail_one_source(root: Path, query: str):
+        if query == "broken.md":
+            raise RuntimeError("simulated refresh failure")
+        return refresh_source(root, query)
+
+    monkeypatch.setattr(workspace_module, "refresh_source", fail_one_source)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed"])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert re.search(r"- ok\.md: refreshed source_id=src-[a-f0-9]{16}", out)
+    assert "Failed changed-source refreshes:" in out
+    assert "- broken.md: failed (simulated refresh failure)" in out
+    assert f"Source ID: {broken_id}" in out
+    assert "Final freshness: total=3 unchanged=1 changed=1 missing=0" in out
+    assert "Workspace refresh completed with unresolved curated sources." in out
+
+
+def test_cli_workspace_refresh_json_reports_failed_refresh_and_ingests_successes(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    ok_source = tmp_path / "ok.md"
+    broken_source = tmp_path / "broken.md"
+    pending_source = tmp_path / "pending.md"
+    ok_source.write_text("# OK\n\nOriginal.\n", encoding="utf-8")
+    broken_source.write_text("# Broken\n\nOriginal.\n", encoding="utf-8")
+    pending_source.write_text("# Pending\n\nQueued separately.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(ok_source)])
+    main(["--root", str(tmp_path), "add-source", str(broken_source)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "add-source", str(pending_source)])
+    pending_id = next(
+        load_source_record(path).source_id
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if load_source_record(path).source_ref == "pending.md"
+    )
+    ok_source.write_text("# OK\n\nUpdated.\n", encoding="utf-8")
+    broken_source.write_text("# Broken\n\nUpdated.\n", encoding="utf-8")
+
+    def fail_one_source(root: Path, query: str):
+        if query == "broken.md":
+            raise ValueError("simulated refresh failure")
+        return refresh_source(root, query)
+
+    monkeypatch.setattr(workspace_module, "refresh_source", fail_one_source)
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "workspace", "refresh", "--changed", "--ingest", "--json"]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["initial_freshness"]["changed"] == 2
+    assert payload["final_freshness"]["changed"] == 1
+    assert payload["skipped_sources"] == []
+    assert payload["failed_sources"] == [
+        {
+            "path": "broken.md",
+            "source_id": payload["failed_sources"][0]["source_id"],
+            "logical_id": "source:broken.md",
+            "title": "broken",
+            "manifest_path": (
+                f"state/manifests/sources/{payload['failed_sources'][0]['source_id']}.json"
+            ),
+            "phase": "refresh",
+            "reason": "simulated refresh failure",
+        }
+    ]
+    assert payload["refreshed"][0]["path"] == "ok.md"
+    assert payload["ingest"]["total"] == 1
+    assert payload["ingest"]["succeeded"] == 1
+    assert load_queue_item(tmp_path / "state" / "queue" / f"ingest-{pending_id}.json").status == (
+        "pending"
+    )
+    refreshed_id = payload["refreshed"][0]["source_id"]
+    assert (tmp_path / "wiki" / "sources" / f"{refreshed_id}.md").exists()
+    assert not (tmp_path / "wiki" / "sources" / f"{pending_id}.md").exists()
 
 
 def test_cli_workspace_refresh_human_output_is_path_first(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Closes #90.

This PR implements `M14-P1.6` for the remaining Milestone 14 P1 refresh recovery issue. The historical issue uses `repo refresh` wording, but the current source-lifecycle refresh path is `splendor workspace refresh --changed`; `splendor repo refresh` remains a deterministic repo-scan/wiki-page refresh and does not perform curated source lifecycle work.

## What changed

- Change `workspace refresh --changed` so missing or unsupported active curated workspace sources are reported as skipped unresolved diagnostics instead of aborting before mutation.
- Continue refreshing valid changed curated workspace sources even when another curated source is missing or unsupported.
- Record per-source changed-source refresh failures instead of aborting the whole command.
- Preserve targeted `--ingest` behavior: only queue jobs created or reused for successfully refreshed sources are drained, and unrelated pending jobs stay pending.
- Add skipped-source and failed-refresh diagnostics to human and JSON output, including initial/final freshness counts.
- Return non-zero when unresolved skipped sources, failed refreshes, or targeted ingest failures remain, while preserving successful refresh and ingest work.
- Update planning state and CLI contract docs for `M14-P1.6`.

## Scope boundaries

- Does not register uncurated files or add broad discovery.
- Does not repair moved source paths automatically; that remains a likely `M14-P1.7` follow-up.
- Does not mutate maintained synthesis pages beyond existing explicit workspace-refresh options.
- Does not add caches, SQLite, background workers, web UI changes, vector search, or performance work.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`
