### PR TITLE
M14-P1.7 Add source path repair command

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M14-P1.5`
-- Last action taken: `M14-P1.5` is implemented; the current PR makes workspace refresh tolerate unresolved curated sources while continuing valid changed-source work for #90.
-- Current planned slice: `Repo refresh missing/broken source tolerance`
-- Current PR sub-slice: `M14-P1.6`
+- Previous completed PR sub-slice: `M14-P1.6`
+- Last action taken: `M14-P1.6` is implemented; the current PR adds explicit source path repair commands for moved or stale curated workspace-backed sources for #89.
+- Current planned slice: `Source path repair commands`
+- Current PR sub-slice: `M14-P1.7`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely source path repair commands`
-- Next planned PR sub-slice: `likely M14-P1.7`
+- Next planned slice: `likely health remediation hints`
+- Next planned PR sub-slice: `likely M14-P1.8`
 - Current blockers: none
 
 ## Planning Notation
@@ -270,6 +270,16 @@
   - [x] Compose source freshness, supersession-aware source refresh, and targeted queue ingestion
   - [x] Report missing curated sources without rewriting manifests or draining unrelated queue work
   - [x] Add human and JSON output plus focused stale/no-op/error tests
+- [x] Implement `M14-P1.6`: Repo refresh missing/broken source tolerance
+  - [x] Let `workspace refresh --changed` skip unresolved active curated workspace sources
+  - [x] Continue valid changed-source refresh and targeted ingest work after unrelated unresolved sources
+  - [x] Summarize skipped and failed source diagnostics in human and JSON output
+  - [x] Exit non-zero while unresolved skipped sources, failed refreshes, or targeted ingest failures remain
+- [x] Implement `M14-P1.7`: Source path repair commands
+  - [x] Add `splendor source update-path <source-id|logical-id|title|path> <new-path>`
+  - [x] Validate target paths as supported in-workspace files and reject ambiguous active curated targets
+  - [x] Update active workspace-backed source refs, logical IDs, aliases, and compatibility paths without broad discovery
+  - [x] Report manifest/current checksums, manifest path, and deterministic next commands in human and JSON output
 
 ## Context Pointers
 
@@ -337,6 +347,7 @@
 - `M14-P1.4` Superseded-state pruning and topic-ref migration
 - `M14-P1.5` Stale-source ingestion for checksum-drifted curated sources
 - `M14-P1.6` Repo refresh missing/broken source tolerance
+- `M14-P1.7` Source path repair commands
 - `M14-P2.1` PR summary and lower-noise generated-state review handoff
 - `M14-P3.1` Source-lifecycle re-evaluation gate
 - `M14-P4.1` Planning-doc authority and task-oriented agent briefs

--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ Implemented today:
 - `splendor init`
 - `splendor add-source <path>`, `splendor add-source --glob "pattern"`, and
   `splendor add-source --dir path`
-- `splendor source list`, `splendor source lookup [query]`, `splendor source freshness`, and
-  `splendor source refresh <source-id|title|path>`
+- `splendor source list`, `splendor source lookup [query]`, `splendor source freshness`,
+  `splendor source refresh <source-id|title|path>`, and
+  `splendor source update-path <source-id|logical-id|title|path> <new-path>`
 - `splendor workspace refresh --changed` with optional `--ingest`, `--rebuild-index`,
   `--prune-superseded`, and `--update-topic-refs`
 - `splendor ingest <source-id>`, `splendor ingest --pending`, and `splendor ingest --changed`
@@ -168,6 +169,12 @@ list bullets from superseded source IDs to the active source version ID. Prune J
 unsafe candidates with reasons rather than deleting ambiguous state. The command does not discover
 or register uncurated files or mutate maintained synthesis content beyond that explicit source-ref
 migration.
+`splendor source update-path <source-id|logical-id|title|path> <new-path>` is the explicit repair
+path for moved active curated workspace sources. It validates that the new path is a supported file
+inside the workspace, rejects targets already curated by another active source, updates the source
+manifest's workspace ref, logical ID, alias, and compatibility path fields, and reports
+manifest/current checksums plus next commands. It does not discover/register uncurated files,
+rewrite run records, or mutate maintained synthesis pages.
 
 `splendor ingest --changed` is the narrower stale-ingest repair path for checksum-drifted curated
 workspace-backed sources when old ingest queue records are already `done`. It refreshes changed
@@ -221,12 +228,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M14-P1.5`
-- Current planned slice: `Repo refresh missing/broken source tolerance`
-- Current PR sub-slice: `M14-P1.6`
+- Previous completed PR sub-slice: `M14-P1.6`
+- Current planned slice: `Source path repair commands`
+- Current PR sub-slice: `M14-P1.7`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely source path repair commands`
-- Next planned PR sub-slice: `likely M14-P1.7`
+- Next planned slice: `likely health remediation hints`
+- Next planned PR sub-slice: `likely M14-P1.8`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel

--- a/README.md
+++ b/README.md
@@ -170,11 +170,15 @@ unsafe candidates with reasons rather than deleting ambiguous state. The command
 or register uncurated files or mutate maintained synthesis content beyond that explicit source-ref
 migration.
 `splendor source update-path <source-id|logical-id|title|path> <new-path>` is the explicit repair
-path for moved active curated workspace sources. It validates that the new path is a supported file
-inside the workspace, rejects targets already curated by another active source, updates the source
-manifest's workspace ref, logical ID, alias, and compatibility path fields, and reports
-manifest/current checksums plus next commands. It does not discover/register uncurated files,
-rewrite run records, or mutate maintained synthesis pages.
+path for moved active curated workspace sources. By default it requires the old workspace path to
+be missing; `--force` is available for deliberate reparenting while the old file still exists. It
+validates that the new path is a supported file inside the workspace, rejects targets already
+curated by another active source, updates the source manifest's workspace ref, logical ID, alias,
+and compatibility path fields, and reports manifest/current checksums plus next commands. Same-byte
+moves queue a re-ingest so generated source-summary provenance can refresh. Changed-byte moves are
+reported as partial repairs with a non-zero exit and an explicit `source refresh` next command. The
+command does not discover/register uncurated files, rewrite historical run records, or mutate
+maintained synthesis pages.
 
 `splendor ingest --changed` is the narrower stale-ingest repair path for checksum-drifted curated
 workspace-backed sources when old ingest queue records are already `done`. It refreshes changed

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -184,6 +184,15 @@ Implemented fields:
   new canonical source version, preserves `source_commit_capture` intent, links the old and new
   versions with `supersedes` / `superseded_by`, and queues ingest through the same queue handoff
   used by `add-source`.
+- `splendor source update-path <source-id|logical-id|title|path> <new-path>` repairs the manifest
+  for an active curated workspace-backed source after an intentional file move. The first
+  implementation supports `storage_mode: none` and `storage_mode: copy` workspace sources. It
+  validates that the target is a supported file inside the workspace, rejects paths already curated
+  by another active source, updates `source_ref`, `logical_id`, `aliases`, `original_path`, and the
+  compatibility `path` field for `storage_mode: none`, then validates and rewrites the schema-bound
+  manifest. Human and JSON output report source ID, old path, new path, manifest/current
+  checksums, checksum match status, manifest path, and next commands. It does not discover or
+  register uncurated files, rewrite run records, or mutate maintained synthesis pages.
 - `splendor source freshness` is a non-mutating preview over curated source manifests. It reports
   path-first freshness state for workspace-backed canonical source refs, including unchanged,
   changed, missing, and unsupported statuses, manifest/current checksums where available, source

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -186,13 +186,18 @@ Implemented fields:
   used by `add-source`.
 - `splendor source update-path <source-id|logical-id|title|path> <new-path>` repairs the manifest
   for an active curated workspace-backed source after an intentional file move. The first
-  implementation supports `storage_mode: none` and `storage_mode: copy` workspace sources. It
-  validates that the target is a supported file inside the workspace, rejects paths already curated
-  by another active source, updates `source_ref`, `logical_id`, `aliases`, `original_path`, and the
-  compatibility `path` field for `storage_mode: none`, then validates and rewrites the schema-bound
-  manifest. Human and JSON output report source ID, old path, new path, manifest/current
-  checksums, checksum match status, manifest path, and next commands. It does not discover or
-  register uncurated files, rewrite run records, or mutate maintained synthesis pages.
+  implementation supports `storage_mode: none` and `storage_mode: copy` workspace sources. By
+  default it requires the old workspace path to be missing; `--force` allows explicit reparenting
+  while the old path still exists. It validates that the target is a supported file inside the
+  workspace, rejects paths already curated by another active source, updates `source_ref`,
+  `logical_id`, `aliases`, `original_path`, and the compatibility `path` field for
+  `storage_mode: none`, then validates and rewrites the schema-bound manifest. Same-byte repairs
+  mark previously ingested source records as needing ingest and queue the existing source ID so
+  generated source-summary provenance can refresh. Changed-byte repairs return `status: partial`,
+  do not queue ingest, and point operators to `splendor source refresh <new-path>`. Human and JSON
+  output report source ID, old path, new path, status, manifest/current checksums, checksum match
+  status, manifest path, queue path when present, and next commands. It does not discover or
+  register uncurated files, rewrite historical run records, or mutate maintained synthesis pages.
 - `splendor source freshness` is a non-mutating preview over curated source manifests. It reports
   path-first freshness state for workspace-backed canonical source refs, including unchanged,
   changed, missing, and unsupported statuses, manifest/current checksums where available, source

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -963,11 +963,14 @@ ingest failures remain.
 `M14-P1.7` addresses issue #89 with the narrow path-repair command:
 `splendor source update-path <source-id|logical-id|title|path> <new-path>`. The command repairs an
 active workspace-backed source manifest after an intentional file move by validating the target as a
-supported in-workspace file, rejecting paths already curated by another active source, updating the
-source-ref/logical-ID/alias fields, and reporting manifest/current checksums plus next commands. It
-does not implement the broader #94 source-identity redesign, discover/register uncurated files,
-rewrite historical run records, or mutate maintained synthesis pages. #95 can build on this by
-adding health remediation hints that point at the new repair surface.
+supported in-workspace file, rejecting paths already curated by another active source, requiring the
+old path to be missing unless `--force` is supplied, updating the source-ref/logical-ID/alias fields,
+and reporting manifest/current checksums plus next commands. Same-byte moves queue re-ingest for the
+existing source ID so generated source-summary provenance can refresh; changed-byte moves return a
+partial repair status and point to `source refresh`. It does not implement the broader #94
+source-identity redesign, discover/register uncurated files, rewrite historical run records, or
+mutate maintained synthesis pages. #95 can build on this by adding health remediation hints that
+point at the new repair surface.
 
 ## Candidate Milestone 15 — Post-v1 reviewed compile/update workflow
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M14-P1.5`
-- Current planned slice: `Repo refresh missing/broken source tolerance`
-- Current PR sub-slice: `M14-P1.6`
+- Previous completed PR sub-slice: `M14-P1.6`
+- Current planned slice: `Source path repair commands`
+- Current PR sub-slice: `M14-P1.7`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely source path repair commands`
-- Next planned PR sub-slice: `likely M14-P1.7`
+- Next planned slice: `likely health remediation hints`
+- Next planned PR sub-slice: `likely M14-P1.8`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -888,6 +888,7 @@ breaking the v1 file contracts.
 - `M14-P1.4` Superseded-state pruning and topic-ref migration
 - `M14-P1.5` Stale-source ingestion for checksum-drifted curated sources
 - `M14-P1.6` Repo refresh missing/broken source tolerance
+- `M14-P1.7` Source path repair commands
 - `M14-P2.1` PR summary and lower-noise generated-state review handoff
 - `M14-P3.1` Source-lifecycle re-evaluation gate
 - `M14-P4.1` Planning-doc authority and task-oriented agent briefs
@@ -912,9 +913,11 @@ loop is substantially implemented and re-evaluated. The intended sequence before
 6. `M14-P1.5` adds explicit stale-source ingestion with `splendor ingest --changed`, so
    checksum-drifted curated sources can be refreshed and ingested even when previous queue jobs are
    already `done`.
-7. `M14-P1.6` should make repo/workspace refresh tolerate missing or broken curated sources by
+7. `M14-P1.6` makes repo/workspace refresh tolerate missing or broken curated sources by
    skipping them with diagnostics while continuing valid refresh work.
-8. `M14-P2.1` adds `splendor pr-summary --since main`, a read-only PR-oriented summary with
+8. `M14-P1.7` adds explicit `splendor source update-path` repair for moved active curated
+   workspace-backed source paths without broad discovery or manual manifest JSON edits.
+9. `M14-P2.1` adds `splendor pr-summary --since main`, a read-only PR-oriented summary with
    lower-noise generated-state review guidance over local git state.
 
 After those slices land, the gate should use a comparable planning or repo-maintenance workflow and
@@ -956,6 +959,15 @@ reported as skipped unresolved diagnostics, per-source refresh failures are summ
 aborting the whole command, valid changed sources still refresh, `--ingest` remains limited to
 refreshed-source queue jobs, and the command exits non-zero while unresolved sources or targeted
 ingest failures remain.
+
+`M14-P1.7` addresses issue #89 with the narrow path-repair command:
+`splendor source update-path <source-id|logical-id|title|path> <new-path>`. The command repairs an
+active workspace-backed source manifest after an intentional file move by validating the target as a
+supported in-workspace file, rejecting paths already curated by another active source, updating the
+source-ref/logical-ID/alias fields, and reporting manifest/current checksums plus next commands. It
+does not implement the broader #94 source-identity redesign, discover/register uncurated files,
+rewrite historical run records, or mutate maintained synthesis pages. #95 can build on this by
+adding health remediation hints that point at the new repair surface.
 
 ## Candidate Milestone 15 — Post-v1 reviewed compile/update workflow
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -787,6 +787,12 @@ Current implementation:
   those content-addressed versions. Refresh also links changed versions with `supersedes` and
   `superseded_by` so health treats older workspace-backed manifests as historical records instead
   of active current-byte targets.
+- `splendor source update-path <source-id|logical-id|title|path> <new-path>` repairs an active
+  `none`/`copy` storage workspace-backed source manifest after a curated file moves. It validates
+  that the target is a supported in-workspace file, rejects targets already curated by another
+  active source, updates the manifest's path/logical identity fields, and reports manifest/current
+  checksums plus next commands. It does not perform broad discovery, register uncurated files,
+  rewrite historical run records, or mutate maintained synthesis pages.
 - `splendor workspace refresh --changed` safely refreshes only changed curated workspace-backed
   sources by composing `source freshness` with the supersession-aware `source refresh` path. It
   reports missing or unsupported active curated workspace sources as skipped unresolved diagnostics,

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -789,10 +789,13 @@ Current implementation:
   of active current-byte targets.
 - `splendor source update-path <source-id|logical-id|title|path> <new-path>` repairs an active
   `none`/`copy` storage workspace-backed source manifest after a curated file moves. It validates
-  that the target is a supported in-workspace file, rejects targets already curated by another
-  active source, updates the manifest's path/logical identity fields, and reports manifest/current
-  checksums plus next commands. It does not perform broad discovery, register uncurated files,
-  rewrite historical run records, or mutate maintained synthesis pages.
+  that the old path is missing unless `--force` is supplied, validates that the target is a
+  supported in-workspace file, rejects targets already curated by another active source, updates
+  the manifest's path/logical identity fields, and reports manifest/current checksums plus next
+  commands. Same-byte moves queue re-ingest for the existing source ID so generated provenance can
+  refresh; changed-byte moves are reported as partial repairs and point to `source refresh`. It
+  does not perform broad discovery, register uncurated files, rewrite historical run records, or
+  mutate maintained synthesis pages.
 - `splendor workspace refresh --changed` safely refreshes only changed curated workspace-backed
   sources by composing `source freshness` with the supersession-aware `source refresh` path. It
   reports missing or unsupported active curated workspace sources as skipped unresolved diagnostics,

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -64,8 +64,7 @@ These items are intentionally not v1 release blockers:
 - richer post-M14 authority lifecycle policy after the initial planning-doc authority briefs have
   been exercised in real repositories
 - ingest run-duration precision for #47
-- repo refresh tolerance for missing or broken curated sources after the narrower #93 stale-ingest
-  repair
+- health remediation hints after source path repair commands exist
 - repo-scan bulk registration optimization for #30
 - web document-list scaling for #37
 
@@ -85,8 +84,12 @@ The conservative next queue after the `M14-P3.1` gate is:
 5. `M14-P1.6` handles issue #90: workspace refresh skips missing curated sources and summarizes
    per-source refresh failures with diagnostics while continuing valid refresh work, then exits
    non-zero while unresolved sources remain.
-6. Continue #79 through `M15-P1.2` after the open Milestone 14 P1 repair issues are handled.
-7. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
+6. `M14-P1.7` handles issue #89: `splendor source update-path` repairs moved active curated
+   workspace-backed source paths without manual manifest JSON edits or broad discovery.
+7. Use #95 as the likely next Milestone 14 repair slice so health diagnostics can point at the
+   concrete `source update-path`, source refresh, and stale-ingest commands now available.
+8. Continue #79 through `M15-P1.2` after the open Milestone 14 P1 repair issues are handled.
+9. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
    either one urgent.
 
 The internal source-lifecycle re-evaluation gate is now complete in `M14-P3.1`. The completed retry

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -68,10 +68,12 @@ from splendor.commands.source import (
     refresh_source,
     render_source_freshness_json,
     render_source_lookup_json,
+    render_source_path_update_json,
     render_source_refresh_json,
     render_stale_ingest_json,
     resolve_source_query_exact,
     scan_source_freshness,
+    update_source_path,
     write_source_freshness_report,
 )
 from splendor.commands.wiki import (
@@ -233,6 +235,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     source_refresh_parser.set_defaults(handler=handle_source_refresh)
+    source_update_path_parser = source_subparsers.add_parser(
+        "update-path", help="Repair a workspace-backed source manifest after a file move"
+    )
+    source_update_path_parser.add_argument(
+        "query", help="Source ID, logical ID, title, or current path to repair"
+    )
+    source_update_path_parser.add_argument(
+        "new_path",
+        type=Path,
+        help="New workspace path for the curated source file",
+    )
+    source_update_path_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    source_update_path_parser.set_defaults(handler=handle_source_update_path)
     source_freshness_parser = source_subparsers.add_parser(
         "freshness", help="Preview changed workspace-backed source content without mutating"
     )
@@ -1002,6 +1022,35 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
     else:
         print(f"Refresh skipped: {result.message}")
         print(f"Next: splendor wiki suggest {result.refreshed.record.source_id}")
+    return 0
+
+
+def handle_source_update_path(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = update_source_path(root, args.query, args.new_path)
+    except (FileNotFoundError, IsADirectoryError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_source_path_update_json(root, result))
+        return 0
+
+    print(f"Updated source path for {result.source.source_id}")
+    print(f"Old path: {result.old_path}")
+    print(f"New path: {result.new_path}")
+    logical_id = effective_logical_id(result.source)
+    if logical_id is not None:
+        print(f"Logical ID: {logical_id}")
+    print(f"Manifest: {result.manifest_path}")
+    print(f"Manifest checksum: {result.manifest_checksum}")
+    print(f"Current checksum: {result.current_checksum}")
+    if result.checksum_matches:
+        print("Checksum: matches manifest")
+    else:
+        print("Checksum: differs from manifest")
+    for command in result.next_commands:
+        print(f"Next: {command}")
     return 0
 
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -252,6 +252,11 @@ def build_parser() -> argparse.ArgumentParser:
         dest="json_output",
         help="Emit machine-readable JSON output.",
     )
+    source_update_path_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow updating a source path even when the current path still exists.",
+    )
     source_update_path_parser.set_defaults(handler=handle_source_update_path)
     source_freshness_parser = source_subparsers.add_parser(
         "freshness", help="Preview changed workspace-backed source content without mutating"
@@ -1028,15 +1033,16 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
 def handle_source_update_path(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     try:
-        result = update_source_path(root, args.query, args.new_path)
-    except (FileNotFoundError, IsADirectoryError, ValueError) as exc:
+        result = update_source_path(root, args.query, args.new_path, force=args.force)
+    except (FileNotFoundError, IsADirectoryError, RuntimeError, ValueError) as exc:
         return _print_error(exc)
 
     if args.json_output:
         print(render_source_path_update_json(root, result))
-        return 0
+        return 0 if result.status == "repaired" else 1
 
     print(f"Updated source path for {result.source.source_id}")
+    print(f"Status: {result.status}")
     print(f"Old path: {result.old_path}")
     print(f"New path: {result.new_path}")
     logical_id = effective_logical_id(result.source)
@@ -1047,11 +1053,14 @@ def handle_source_update_path(args: argparse.Namespace) -> int:
     print(f"Current checksum: {result.current_checksum}")
     if result.checksum_matches:
         print("Checksum: matches manifest")
+        if result.queue_path is not None:
+            print(f"Queued ingest: {result.queue_path}")
     else:
         print("Checksum: differs from manifest")
+        print("Path was updated, but content refresh is still required.")
     for command in result.next_commands:
         print(f"Next: {command}")
-    return 0
+    return 0 if result.status == "repaired" else 1
 
 
 def handle_source_freshness(args: argparse.Namespace) -> int:

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from splendor.commands.ingest import enqueue_ingest_job, is_ingest_current, run_ingest_job
 from splendor.config import load_config
+from splendor.ingest_dispatch import SUPPORTED_SOURCE_TYPES
 from splendor.layout import resolve_layout
 from splendor.schemas import SourceRecord
 from splendor.state.paths import resolve_workspace_path
@@ -19,6 +20,7 @@ from splendor.state.source_compat import (
     effective_logical_id,
     effective_materialized_path,
     effective_storage_mode,
+    logical_source_id_for_ref,
 )
 from splendor.state.source_registry import (
     RegisteredSource,
@@ -44,6 +46,19 @@ class SourceRefreshResult:
     queued: bool
     queue_path: Path | None
     message: str
+
+
+@dataclass(frozen=True)
+class SourcePathUpdateResult:
+    source: SourceRecord
+    manifest_path: Path
+    old_path: str
+    new_path: str
+    manifest_checksum: str
+    current_checksum: str
+    checksum_matches: bool
+    updated: bool
+    next_commands: list[str]
 
 
 @dataclass(frozen=True)
@@ -299,6 +314,89 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
     )
 
 
+def update_source_path(root: Path, source_query: str, new_path: Path) -> SourcePathUpdateResult:
+    source_match = resolve_source_query_exact(root, source_query)
+    source = source_match.source
+    old_path = canonical_source_ref(source)
+
+    if source.superseded_by is not None:
+        msg = (
+            "Cannot update the path for a superseded source version: "
+            f"{source.source_id}. Select the active source version instead."
+        )
+        raise ValueError(msg)
+    if source.source_ref_kind != "workspace_path" or source.source_ref is None:
+        msg = (
+            "source update-path supports only workspace-backed curated sources in this release: "
+            f"{source.source_id}"
+        )
+        raise ValueError(msg)
+    storage_mode = effective_storage_mode(source)
+    if storage_mode not in {"none", "copy"}:
+        msg = (
+            "source update-path supports only none/copy storage for workspace-backed sources in "
+            f"this release; got {storage_mode!r}"
+        )
+        raise ValueError(msg)
+
+    target = _source_path_update_target(root, new_path)
+    source_type = target.suffix.lstrip(".") or "file"
+    if source_type not in SUPPORTED_SOURCE_TYPES:
+        msg = f"Target source type is not supported for ingestion: {source_type}"
+        raise ValueError(msg)
+    if source_type != source.source_type:
+        msg = (
+            "Target source type must match the existing source manifest: "
+            f"expected {source.source_type}, got {source_type}"
+        )
+        raise ValueError(msg)
+
+    new_ref = target.relative_to(root.resolve()).as_posix()
+    _ensure_update_path_target_is_unambiguous(
+        root,
+        source_id=source.source_id,
+        new_ref=new_ref,
+    )
+
+    current_checksum = sha256_file(target)
+    logical_id = logical_source_id_for_ref(new_ref, "workspace_path")
+    updated_fields: dict[str, object] = {
+        "source_ref": new_ref,
+        "source_ref_kind": "workspace_path",
+        "logical_id": logical_id,
+        "aliases": [new_ref],
+        "original_path": new_ref,
+    }
+    if storage_mode == "none":
+        updated_fields["path"] = new_ref
+
+    updated_source = SourceRecord.model_validate(source.model_dump(mode="json") | updated_fields)
+    updated = updated_source != source
+    if updated:
+        write_source_record(source_match.manifest_path, updated_source)
+
+    checksum_matches = current_checksum == updated_source.checksum
+    next_commands = (
+        ["splendor source freshness", f"splendor ingest {updated_source.source_id}"]
+        if checksum_matches
+        else [
+            f"splendor source refresh {shlex.quote(new_ref)}",
+            "splendor ingest --pending",
+        ]
+    )
+    return SourcePathUpdateResult(
+        source=updated_source,
+        manifest_path=source_match.manifest_path,
+        old_path=old_path,
+        new_path=new_ref,
+        manifest_checksum=updated_source.checksum,
+        current_checksum=current_checksum,
+        checksum_matches=checksum_matches,
+        updated=updated,
+        next_commands=next_commands,
+    )
+
+
 def ingest_changed_sources(root: Path) -> StaleIngestResult:
     initial_freshness = scan_source_freshness(root)
     missing_items = [item for item in initial_freshness.sources if item.status == "missing"]
@@ -520,6 +618,26 @@ def render_source_refresh_json(root: Path, result: SourceRefreshResult) -> str:
     )
 
 
+def render_source_path_update_json(root: Path, result: SourcePathUpdateResult) -> str:
+    return json.dumps(
+        {
+            "source_id": result.source.source_id,
+            "logical_id": effective_logical_id(result.source),
+            "old_path": result.old_path,
+            "new_path": result.new_path,
+            "source_ref": result.source.source_ref,
+            "aliases": result.source.aliases,
+            "manifest_checksum": result.manifest_checksum,
+            "current_checksum": result.current_checksum,
+            "checksum_matches": result.checksum_matches,
+            "manifest_path": result.manifest_path.relative_to(root).as_posix(),
+            "updated": result.updated,
+            "next_commands": result.next_commands,
+        },
+        indent=2,
+    )
+
+
 def write_source_freshness_report(
     root: Path, result: SourceFreshnessResult, report_path: Path
 ) -> SourceFreshnessResult:
@@ -607,6 +725,40 @@ def _refreshable_source_path(root: Path, source: SourceRecord) -> Path:
         "with `splendor add-source <path>` to create a refreshable source_ref."
     )
     raise ValueError(msg)
+
+
+def _source_path_update_target(root: Path, new_path: Path) -> Path:
+    expanded = new_path.expanduser()
+    candidate = expanded.resolve() if expanded.is_absolute() else (root / expanded).resolve()
+    workspace_root = root.resolve()
+    try:
+        candidate.relative_to(workspace_root)
+    except ValueError as exc:
+        msg = f"Target source path must stay inside the workspace: {new_path}"
+        raise ValueError(msg) from exc
+    if not candidate.exists():
+        msg = f"Target source path does not exist: {new_path}"
+        raise FileNotFoundError(msg)
+    if not candidate.is_file():
+        msg = f"Target source path must be a file: {new_path}"
+        raise IsADirectoryError(msg)
+    return candidate
+
+
+def _ensure_update_path_target_is_unambiguous(root: Path, *, source_id: str, new_ref: str) -> None:
+    conflicting = [
+        result.source
+        for result in list_sources(root)
+        if result.source.source_id != source_id
+        and result.source.superseded_by is None
+        and result.source.source_ref_kind == "workspace_path"
+        and result.source.source_ref == new_ref
+    ]
+    if conflicting:
+        ids = ", ".join(source.source_id for source in conflicting[:5])
+        suffix = "" if len(conflicting) <= 5 else ", ..."
+        msg = f"Target source path is already curated by another active source: {ids}{suffix}"
+        raise ValueError(msg)
 
 
 def _freshness_item(root: Path, result: SourceLookupResult) -> SourceFreshnessItem:

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -54,10 +54,12 @@ class SourcePathUpdateResult:
     manifest_path: Path
     old_path: str
     new_path: str
+    status: str
     manifest_checksum: str
     current_checksum: str
     checksum_matches: bool
     updated: bool
+    queue_path: Path | None
     next_commands: list[str]
 
 
@@ -314,7 +316,9 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
     )
 
 
-def update_source_path(root: Path, source_query: str, new_path: Path) -> SourcePathUpdateResult:
+def update_source_path(
+    root: Path, source_query: str, new_path: Path, *, force: bool = False
+) -> SourcePathUpdateResult:
     source_match = resolve_source_query_exact(root, source_query)
     source = source_match.source
     old_path = canonical_source_ref(source)
@@ -336,6 +340,14 @@ def update_source_path(root: Path, source_query: str, new_path: Path) -> SourceP
         msg = (
             "source update-path supports only none/copy storage for workspace-backed sources in "
             f"this release; got {storage_mode!r}"
+        )
+        raise ValueError(msg)
+
+    old_target = resolve_workspace_path(root, source.source_ref, context="Current workspace source")
+    if old_target.exists() and not force:
+        msg = (
+            "Current workspace source path still exists; refusing to reparent a healthy source "
+            f"without --force: {source.source_ref}"
         )
         raise ValueError(msg)
 
@@ -370,29 +382,38 @@ def update_source_path(root: Path, source_query: str, new_path: Path) -> SourceP
     if storage_mode == "none":
         updated_fields["path"] = new_ref
 
+    checksum_matches = current_checksum == source.checksum
+    if checksum_matches and source.status == "ingested":
+        updated_fields["status"] = "registered"
+
     updated_source = SourceRecord.model_validate(source.model_dump(mode="json") | updated_fields)
     updated = updated_source != source
     if updated:
         write_source_record(source_match.manifest_path, updated_source)
 
-    checksum_matches = current_checksum == updated_source.checksum
-    next_commands = (
-        ["splendor source freshness", f"splendor ingest {updated_source.source_id}"]
-        if checksum_matches
-        else [
+    queue_path = enqueue_ingest_job(root, updated_source.source_id) if checksum_matches else None
+    status = "repaired" if checksum_matches else "partial"
+    next_commands = [
+        "splendor ingest --pending",
+        "splendor source freshness",
+    ]
+    if not checksum_matches:
+        next_commands = [
             f"splendor source refresh {shlex.quote(new_ref)}",
             "splendor ingest --pending",
+            "splendor source freshness",
         ]
-    )
     return SourcePathUpdateResult(
         source=updated_source,
         manifest_path=source_match.manifest_path,
         old_path=old_path,
         new_path=new_ref,
+        status=status,
         manifest_checksum=updated_source.checksum,
         current_checksum=current_checksum,
         checksum_matches=checksum_matches,
         updated=updated,
+        queue_path=queue_path,
         next_commands=next_commands,
     )
 
@@ -625,6 +646,7 @@ def render_source_path_update_json(root: Path, result: SourcePathUpdateResult) -
             "logical_id": effective_logical_id(result.source),
             "old_path": result.old_path,
             "new_path": result.new_path,
+            "status": result.status,
             "source_ref": result.source.source_ref,
             "aliases": result.source.aliases,
             "manifest_checksum": result.manifest_checksum,
@@ -632,6 +654,9 @@ def render_source_path_update_json(root: Path, result: SourcePathUpdateResult) -
             "checksum_matches": result.checksum_matches,
             "manifest_path": result.manifest_path.relative_to(root).as_posix(),
             "updated": result.updated,
+            "queue_path": None
+            if result.queue_path is None
+            else result.queue_path.relative_to(root).as_posix(),
             "next_commands": result.next_commands,
         },
         indent=2,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,7 +97,7 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     lookup = parser.parse_args(["source", "lookup", "brief", "--json"])
     refresh = parser.parse_args(["source", "refresh", "docs/brief.md", "--json"])
     update_path = parser.parse_args(
-        ["source", "update-path", "docs/old.md", "docs/new.md", "--json"]
+        ["source", "update-path", "docs/old.md", "docs/new.md", "--force", "--json"]
     )
     freshness = parser.parse_args(
         ["source", "freshness", "--report", "reports/freshness.json", "--json"]
@@ -113,6 +113,7 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     assert update_path.source_command == "update-path"
     assert update_path.query == "docs/old.md"
     assert update_path.new_path == Path("docs/new.md")
+    assert update_path.force is True
     assert update_path.json_output is True
     assert freshness.source_command == "freshness"
     assert freshness.report == Path("reports/freshness.json")
@@ -855,9 +856,11 @@ def test_cli_source_update_path_repairs_missing_workspace_source(tmp_path: Path,
     assert f"Updated source path for {source_id}" in out
     assert "Old path: docs/brief.md" in out
     assert "New path: moved/brief.md" in out
+    assert "Status: repaired" in out
     assert "Logical ID: source:moved/brief.md" in out
     assert "Checksum: matches manifest" in out
-    assert "Next: splendor source freshness" in out
+    assert f"Queued ingest: {tmp_path / 'state' / 'queue' / f'ingest-{source_id}.json'}" in out
+    assert "Next: splendor ingest --pending" in out
     updated = load_source_record(manifest_path)
     assert updated.source_id == source_id
     assert updated.source_ref == "moved/brief.md"
@@ -898,6 +901,7 @@ def test_cli_source_update_path_json_reports_deterministic_payload(tmp_path: Pat
         "logical_id": "source:new.md",
         "old_path": "old.md",
         "new_path": "new.md",
+        "status": "repaired",
         "source_ref": "new.md",
         "aliases": ["new.md"],
         "manifest_checksum": manifest.checksum,
@@ -905,9 +909,10 @@ def test_cli_source_update_path_json_reports_deterministic_payload(tmp_path: Pat
         "checksum_matches": True,
         "manifest_path": f"state/manifests/sources/{manifest.source_id}.json",
         "updated": True,
+        "queue_path": f"state/queue/ingest-{manifest.source_id}.json",
         "next_commands": [
+            "splendor ingest --pending",
             "splendor source freshness",
-            f"splendor ingest {manifest.source_id}",
         ],
     }
 
@@ -930,6 +935,7 @@ def test_cli_source_update_path_rejects_invalid_targets(
     source = tmp_path / "old.md"
     source.write_text("# Brief\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", "old.md"])
+    source.unlink()
     if target_content is not None:
         (tmp_path / target_name).write_bytes(target_content)
     capsys.readouterr()
@@ -946,6 +952,7 @@ def test_cli_source_update_path_rejects_directory_and_ambiguous_target(
     main(["--root", str(tmp_path), "init"])
     first = tmp_path / "first.md"
     second = tmp_path / "second.md"
+    moved = tmp_path / "moved.md"
     first.write_text("# First\n", encoding="utf-8")
     second.write_text("# Second\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", "first.md"])
@@ -953,6 +960,13 @@ def test_cli_source_update_path_rejects_directory_and_ambiguous_target(
     main(["--root", str(tmp_path), "add-source", "second.md"])
     capsys.readouterr()
 
+    existing_exit = main(
+        ["--root", str(tmp_path), "source", "update-path", "first.md", "second.md"]
+    )
+    assert existing_exit == 1
+    assert "still exists" in capsys.readouterr().out
+
+    first.rename(moved)
     directory_exit = main(["--root", str(tmp_path), "source", "update-path", "first.md", "."])
     assert directory_exit == 1
     assert "Target source path must be a file" in capsys.readouterr().out
@@ -965,6 +979,7 @@ def test_cli_source_update_path_rejects_directory_and_ambiguous_target(
             "update-path",
             first_manifest.stem,
             "second.md",
+            "--force",
         ]
     )
     assert target_exit == 1
@@ -989,6 +1004,69 @@ def test_cli_source_update_path_does_not_mutate_maintained_synthesis(
 
     assert exit_code == 0
     assert topic.read_text(encoding="utf-8") == topic_before
+
+
+def test_cli_source_update_path_reingests_same_byte_move_to_refresh_provenance(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "old.md"
+    replacement = tmp_path / "new.md"
+    source.write_text("# Brief\n\nSame bytes.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "old.md"])
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source_id = manifest_path.stem
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    page_path = tmp_path / "wiki" / "sources" / f"{source_id}.md"
+    assert "old.md" in page_path.read_text(encoding="utf-8")
+    source.rename(replacement)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "update-path", "old.md", "new.md"])
+
+    assert exit_code == 0
+    updated = load_source_record(manifest_path)
+    assert updated.status == "registered"
+    assert updated.last_run_id is not None
+    assert (tmp_path / "state" / "queue" / f"ingest-{source_id}.json").exists()
+
+    ingest_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+
+    assert ingest_code == 0
+    page_text = page_path.read_text(encoding="utf-8")
+    assert "new.md" in page_text
+
+
+def test_cli_source_update_path_changed_bytes_reports_partial_repair(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "old.md"
+    replacement = tmp_path / "new.md"
+    source.write_text("# Brief\n\nOld bytes.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "old.md"])
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source.rename(replacement)
+    replacement.write_text("# Brief\n\nNew bytes.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "source", "update-path", "old.md", "new.md", "--json"]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "partial"
+    assert payload["checksum_matches"] is False
+    assert payload["queue_path"] is None
+    assert payload["next_commands"] == [
+        "splendor source refresh new.md",
+        "splendor ingest --pending",
+        "splendor source freshness",
+    ]
+    updated = load_source_record(manifest_path)
+    assert updated.source_ref == "new.md"
+    assert updated.status == "registered"
 
 
 def test_cli_source_freshness_reports_changed_workspace_sources_without_mutating(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,6 +96,9 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
 
     lookup = parser.parse_args(["source", "lookup", "brief", "--json"])
     refresh = parser.parse_args(["source", "refresh", "docs/brief.md", "--json"])
+    update_path = parser.parse_args(
+        ["source", "update-path", "docs/old.md", "docs/new.md", "--json"]
+    )
     freshness = parser.parse_args(
         ["source", "freshness", "--report", "reports/freshness.json", "--json"]
     )
@@ -107,6 +110,10 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     assert refresh.source_command == "refresh"
     assert refresh.query == "docs/brief.md"
     assert refresh.json_output is True
+    assert update_path.source_command == "update-path"
+    assert update_path.query == "docs/old.md"
+    assert update_path.new_path == Path("docs/new.md")
+    assert update_path.json_output is True
     assert freshness.source_command == "freshness"
     assert freshness.report == Path("reports/freshness.json")
     assert freshness.json_output is True
@@ -822,6 +829,166 @@ def test_cli_source_refresh_by_path_uses_latest_matching_source_ref(tmp_path: Pa
     out = capsys.readouterr().out
     assert "ambiguous" not in out
     assert "No source content change detected" in out
+
+
+def test_cli_source_update_path_repairs_missing_workspace_source(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    moved = tmp_path / "moved"
+    moved.mkdir()
+    old_source = docs / "brief.md"
+    new_source = moved / "brief.md"
+    old_source.write_text("# Brief\n\nSame bytes.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "docs/brief.md"])
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source_id = manifest_path.stem
+    old_source.rename(new_source)
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "source", "update-path", "docs/brief.md", "moved/brief.md"]
+    )
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert f"Updated source path for {source_id}" in out
+    assert "Old path: docs/brief.md" in out
+    assert "New path: moved/brief.md" in out
+    assert "Logical ID: source:moved/brief.md" in out
+    assert "Checksum: matches manifest" in out
+    assert "Next: splendor source freshness" in out
+    updated = load_source_record(manifest_path)
+    assert updated.source_id == source_id
+    assert updated.source_ref == "moved/brief.md"
+    assert updated.path == "moved/brief.md"
+    assert updated.logical_id == "source:moved/brief.md"
+    assert updated.aliases == ["moved/brief.md"]
+    assert len(list((tmp_path / "state" / "manifests" / "sources").glob("*.json"))) == 1
+
+    freshness_code = main(["--root", str(tmp_path), "source", "freshness", "--json"])
+    assert freshness_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["unchanged"] == 1
+    assert payload["missing"] == 0
+
+    health_code = main(["--root", str(tmp_path), "health"])
+    assert health_code == 0
+
+
+def test_cli_source_update_path_json_reports_deterministic_payload(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    old_source = tmp_path / "old.md"
+    new_source = tmp_path / "new.md"
+    old_source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "old.md"])
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    manifest = load_source_record(manifest_path)
+    old_source.rename(new_source)
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "source", "update-path", manifest.source_id, "new.md", "--json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "source_id": manifest.source_id,
+        "logical_id": "source:new.md",
+        "old_path": "old.md",
+        "new_path": "new.md",
+        "source_ref": "new.md",
+        "aliases": ["new.md"],
+        "manifest_checksum": manifest.checksum,
+        "current_checksum": manifest.checksum,
+        "checksum_matches": True,
+        "manifest_path": f"state/manifests/sources/{manifest.source_id}.json",
+        "updated": True,
+        "next_commands": [
+            "splendor source freshness",
+            f"splendor ingest {manifest.source_id}",
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    ("target_name", "target_content", "expected_message"),
+    [
+        ("missing.md", None, "Target source path does not exist"),
+        ("unsupported.bin", b"binary", "Target source type is not supported"),
+    ],
+)
+def test_cli_source_update_path_rejects_invalid_targets(
+    tmp_path: Path,
+    capsys,
+    target_name: str,
+    target_content: bytes | None,
+    expected_message: str,
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "old.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "old.md"])
+    if target_content is not None:
+        (tmp_path / target_name).write_bytes(target_content)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "update-path", "old.md", target_name])
+
+    assert exit_code == 1
+    assert expected_message in capsys.readouterr().out
+
+
+def test_cli_source_update_path_rejects_directory_and_ambiguous_target(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    first = tmp_path / "first.md"
+    second = tmp_path / "second.md"
+    first.write_text("# First\n", encoding="utf-8")
+    second.write_text("# Second\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "first.md"])
+    first_manifest = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    main(["--root", str(tmp_path), "add-source", "second.md"])
+    capsys.readouterr()
+
+    directory_exit = main(["--root", str(tmp_path), "source", "update-path", "first.md", "."])
+    assert directory_exit == 1
+    assert "Target source path must be a file" in capsys.readouterr().out
+
+    target_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "source",
+            "update-path",
+            first_manifest.stem,
+            "second.md",
+        ]
+    )
+    assert target_exit == 1
+    assert "already curated by another active source" in capsys.readouterr().out
+
+
+def test_cli_source_update_path_does_not_mutate_maintained_synthesis(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    topic = tmp_path / "wiki" / "topics" / "briefing.md"
+    topic.write_text("# Maintained Topic\n\nSource refs stay manual.\n", encoding="utf-8")
+    source = tmp_path / "old.md"
+    replacement = tmp_path / "new.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "old.md"])
+    source.rename(replacement)
+    topic_before = topic.read_text(encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "update-path", "old.md", "new.md"])
+
+    assert exit_code == 0
+    assert topic.read_text(encoding="utf-8") == topic_before
 
 
 def test_cli_source_freshness_reports_changed_workspace_sources_without_mutating(


### PR DESCRIPTION
## Summary

Implements M14-P1.7 for issue #89 by adding an explicit source path repair workflow for moved curated workspace-backed sources.

Changes:
- Add `splendor source update-path <source-id|logical-id|title|path> <new-path>` with human and JSON output.
- Require the old workspace path to be missing by default so the command repairs moves rather than silently reparenting healthy sources; `--force` is available for deliberate reparenting.
- Validate repair targets as supported in-workspace files and reject nonexistent paths, directories, unsupported source types, superseded sources, non-workspace sources, unsupported storage modes, and targets already curated by another active source.
- Update the active source manifest's `source_ref`, logical ID, alias, `original_path`, and `storage_mode: none` compatibility `path` without broad discovery, uncurated registration, historical run-record rewrites, or maintained synthesis mutation.
- Queue re-ingest for same-byte moves so generated source-summary provenance refreshes for the existing source ID.
- Return a `partial` status and non-zero exit for changed-byte moves, with an explicit `splendor source refresh <new-path>` next command before ingest.
- Report source ID, old path, new path, repair status, manifest/current checksums, checksum match status, manifest path, queue path when present, and deterministic next commands.
- Update planning state and docs for the M14-P1.7 command contract and likely #95 health-remediation follow-up.

## Self-review Changes

After a hostile self-review, this PR was tightened to avoid three bad behaviors:
- It no longer allows accidental reparenting of a healthy source without `--force`.
- It no longer leaves same-byte moves with stale generated source-summary provenance; the command queues re-ingest.
- It no longer reports changed-byte moves as fully repaired; it returns partial/non-zero and points to source refresh.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest` (`572 passed`)
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`

## Scope Notes

This intentionally does not implement the broader #94 source identity redesign, broad auto-discovery, source removal, hidden caches, SQLite, background workers, web UI changes, vector search, historical run rewrites, or mutating synthesis updates.

Closes #89
