### PR TITLE
M14-P1.8 Health remediation hints

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M14-P1.6`
-- Last action taken: `M14-P1.6` is implemented; the current PR adds explicit source path repair commands for moved or stale curated workspace-backed sources for #89.
-- Current planned slice: `Source path repair commands`
-- Current PR sub-slice: `M14-P1.7`
+- Previous completed PR sub-slice: `M14-P1.7`
+- Last action taken: `M14-P1.7` is implemented; the current PR adds actionable health remediation hints for #95.
+- Current planned slice: `Health remediation hints`
+- Current PR sub-slice: `M14-P1.8`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely health remediation hints`
-- Next planned PR sub-slice: `likely M14-P1.8`
+- Next planned slice: `likely source identity design review or M15 compile/update, depending on roadmap`
+- Next planned PR sub-slice: `likely M14-P1.9 only if #94 is narrowed; otherwise M15-P1.2 or next roadmap notation`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ outcomes, and the summary.
 exists. JSON, human stdout, and Markdown reports surface missing active workspace source paths with
 `source update-path` / `source freshness` guidance, checksum drift with `source refresh`,
 `ingest --pending`, or `ingest --changed`, and queue repair diagnostics with `queue retry` or
-`repair ingest`. Unknown provenance refs remain diagnostic-only rather than suggesting unsafe broad
-rewrites.
+`repair ingest`. Unknown source provenance refs remain diagnostic-only rather than suggesting
+unsafe broad rewrites.
 
 `splendor pr-summary --since main` is a read-only PR handoff command over local git state. It uses
 the merge base between `HEAD` and the base ref for PR-style diff semantics, then summarizes curated

--- a/README.md
+++ b/README.md
@@ -188,6 +188,13 @@ curated sources without preventing valid changed sources from being processed. `
 initial/final freshness counts, missing-source diagnostics, refreshed source IDs, targeted ingest
 outcomes, and the summary.
 
+`splendor health` now includes deterministic remediation hints where a narrow repair command
+exists. JSON, human stdout, and Markdown reports surface missing active workspace source paths with
+`source update-path` / `source freshness` guidance, checksum drift with `source refresh`,
+`ingest --pending`, or `ingest --changed`, and queue repair diagnostics with `queue retry` or
+`repair ingest`. Unknown provenance refs remain diagnostic-only rather than suggesting unsafe broad
+rewrites.
+
 `splendor pr-summary --since main` is a read-only PR handoff command over local git state. It uses
 the merge base between `HEAD` and the base ref for PR-style diff semantics, then summarizes curated
 source manifests added, refreshed, superseded, or invalid; generated source-summary pages added,
@@ -232,12 +239,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M14-P1.6`
-- Current planned slice: `Source path repair commands`
-- Current PR sub-slice: `M14-P1.7`
+- Previous completed PR sub-slice: `M14-P1.7`
+- Current planned slice: `Health remediation hints`
+- Current PR sub-slice: `M14-P1.8`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely health remediation hints`
-- Next planned PR sub-slice: `likely M14-P1.8`
+- Next planned slice: `likely source identity design review or M15 compile/update, depending on roadmap`
+- Next planned PR sub-slice: `likely M14-P1.9 only if #94 is narrowed; otherwise M15-P1.2 or next roadmap notation`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -488,8 +488,8 @@ has a known safe operator action: missing active workspace source paths point to
 update-path ... <new-path>` and `splendor source freshness`; checksum drift points to
 `splendor source refresh ...`, `splendor ingest --pending`, or `splendor ingest --changed`;
 failed/dead-letter queue diagnostics and expired leases point to queue retry or ingest repair
-commands. Unknown run/page/source provenance references stay diagnostic-only and explicitly avoid a
-broad rewrite command.
+commands. Unknown source provenance references stay diagnostic-only and explicitly avoid a broad
+rewrite command.
 
 ## Repo scan
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -471,6 +471,26 @@ Current runtime behavior:
 - failed runs retain only the source/input-side structured provenance that was actually known at
   failure time
 
+## Maintenance report records
+
+`splendor lint` and `splendor health` write timestamped JSON and Markdown reports under
+`reports/<command>/`. `MaintenanceIssue` carries:
+
+- `code`
+- `message`
+- `path`
+- `record_id`
+- `check_name`
+- `remediation_hint`
+
+`remediation_hint` is optional and deterministic. Health uses it only when the current diagnostic
+has a known safe operator action: missing active workspace source paths point to `splendor source
+update-path ... <new-path>` and `splendor source freshness`; checksum drift points to
+`splendor source refresh ...`, `splendor ingest --pending`, or `splendor ingest --changed`;
+failed/dead-letter queue diagnostics and expired leases point to queue retry or ingest repair
+commands. Unknown run/page/source provenance references stay diagnostic-only and explicitly avoid a
+broad rewrite command.
+
 ## Repo scan
 
 The CLI now includes `splendor repo scan` for deterministic repo-native discovery.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -980,7 +980,7 @@ rendered in JSON, human stdout, and Markdown reports. Active workspace source pa
 to `splendor source update-path ... <new-path>` and `splendor source freshness`; checksum drift
 points to `splendor source refresh ...`, `splendor ingest --pending`, or `splendor ingest
 --changed`; failed/dead-letter queue shape and expired lease diagnostics point to queue retry or
-ingest repair commands. Unknown provenance/source refs remain diagnostic-only and explicitly avoid
+ingest repair commands. Unknown source provenance refs remain diagnostic-only and explicitly avoid
 inventing unsafe broad repair commands.
 
 ## Candidate Milestone 15 — Post-v1 reviewed compile/update workflow

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M14-P1.6`
-- Current planned slice: `Source path repair commands`
-- Current PR sub-slice: `M14-P1.7`
+- Previous completed PR sub-slice: `M14-P1.7`
+- Current planned slice: `Health remediation hints`
+- Current PR sub-slice: `M14-P1.8`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely health remediation hints`
-- Next planned PR sub-slice: `likely M14-P1.8`
+- Next planned slice: `likely source identity design review or M15 compile/update, depending on roadmap`
+- Next planned PR sub-slice: `likely M14-P1.9 only if #94 is narrowed; otherwise M15-P1.2 or next roadmap notation`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -889,6 +889,7 @@ breaking the v1 file contracts.
 - `M14-P1.5` Stale-source ingestion for checksum-drifted curated sources
 - `M14-P1.6` Repo refresh missing/broken source tolerance
 - `M14-P1.7` Source path repair commands
+- `M14-P1.8` Health remediation hints
 - `M14-P2.1` PR summary and lower-noise generated-state review handoff
 - `M14-P3.1` Source-lifecycle re-evaluation gate
 - `M14-P4.1` Planning-doc authority and task-oriented agent briefs
@@ -917,7 +918,9 @@ loop is substantially implemented and re-evaluated. The intended sequence before
    skipping them with diagnostics while continuing valid refresh work.
 8. `M14-P1.7` adds explicit `splendor source update-path` repair for moved active curated
    workspace-backed source paths without broad discovery or manual manifest JSON edits.
-9. `M14-P2.1` adds `splendor pr-summary --since main`, a read-only PR-oriented summary with
+9. `M14-P1.8` adds deterministic health remediation hints that point diagnostics at existing
+   repair commands without implementing broad source-identity redesign or provenance rewriting.
+10. `M14-P2.1` adds `splendor pr-summary --since main`, a read-only PR-oriented summary with
    lower-noise generated-state review guidance over local git state.
 
 After those slices land, the gate should use a comparable planning or repo-maintenance workflow and
@@ -969,8 +972,16 @@ and reporting manifest/current checksums plus next commands. Same-byte moves que
 existing source ID so generated source-summary provenance can refresh; changed-byte moves return a
 partial repair status and point to `source refresh`. It does not implement the broader #94
 source-identity redesign, discover/register uncurated files, rewrite historical run records, or
-mutate maintained synthesis pages. #95 can build on this by adding health remediation hints that
-point at the new repair surface.
+mutate maintained synthesis pages.
+
+`M14-P1.8` addresses issue #95 by making `splendor health` an operational repair guide for the
+repair commands that now exist. Maintenance issues can carry an optional `remediation_hint` field,
+rendered in JSON, human stdout, and Markdown reports. Active workspace source path failures point
+to `splendor source update-path ... <new-path>` and `splendor source freshness`; checksum drift
+points to `splendor source refresh ...`, `splendor ingest --pending`, or `splendor ingest
+--changed`; failed/dead-letter queue shape and expired lease diagnostics point to queue retry or
+ingest repair commands. Unknown provenance/source refs remain diagnostic-only and explicitly avoid
+inventing unsafe broad repair commands.
 
 ## Candidate Milestone 15 — Post-v1 reviewed compile/update workflow
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1184,6 +1184,13 @@ Not all maintenance should use LLMs.
 - stale run references
 - unresolved source references
 
+Current health output is also a repair guide where Splendor has a narrow, existing command for the
+problem. Maintenance issues may include a `remediation_hint` in JSON, human stdout, and Markdown
+reports. Missing active workspace source paths point to `source update-path` plus `source
+freshness`; checksum drift points to `source refresh`, `ingest --pending`, or `ingest --changed`;
+queue failure diagnostics point to `queue retry` or `repair ingest`. Unknown provenance references
+remain diagnostic-only until a safe provenance repair design exists.
+
 ### 22.2 LLM-assisted maintenance
 
 - contradiction detection

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1188,8 +1188,8 @@ Current health output is also a repair guide where Splendor has a narrow, existi
 problem. Maintenance issues may include a `remediation_hint` in JSON, human stdout, and Markdown
 reports. Missing active workspace source paths point to `source update-path` plus `source
 freshness`; checksum drift points to `source refresh`, `ingest --pending`, or `ingest --changed`;
-queue failure diagnostics point to `queue retry` or `repair ingest`. Unknown provenance references
-remain diagnostic-only until a safe provenance repair design exists.
+queue failure diagnostics point to `queue retry` or `repair ingest`. Unknown source provenance
+references remain diagnostic-only until a safe provenance repair design exists.
 
 ### 22.2 LLM-assisted maintenance
 

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -64,7 +64,7 @@ These items are intentionally not v1 release blockers:
 - richer post-M14 authority lifecycle policy after the initial planning-doc authority briefs have
   been exercised in real repositories
 - ingest run-duration precision for #47
-- health remediation hints after source path repair commands exist
+- broader source identity design after the narrow health remediation hints in #95
 - repo-scan bulk registration optimization for #30
 - web document-list scaling for #37
 
@@ -86,9 +86,10 @@ The conservative next queue after the `M14-P3.1` gate is:
    non-zero while unresolved sources remain.
 6. `M14-P1.7` handles issue #89: `splendor source update-path` repairs moved active curated
    workspace-backed source paths without manual manifest JSON edits or broad discovery.
-7. Use #95 as the likely next Milestone 14 repair slice so health diagnostics can point at the
-   concrete `source update-path`, source refresh, and stale-ingest commands now available.
-8. Continue #79 through `M15-P1.2` after the open Milestone 14 P1 repair issues are handled.
+7. `M14-P1.8` handles issue #95: health diagnostics include deterministic remediation hints for
+   the concrete `source update-path`, source refresh, stale-ingest, queue retry, and repair ingest
+   commands now available.
+8. Continue #79 through `M15-P1.2` after any narrowed #94 source identity review follow-up.
 9. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
    either one urgent.
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -1769,6 +1769,8 @@ def _print_maintenance_stdout(command: str, report, *, json_output: bool) -> Non
     for issue in report.issues:
         subject = issue.record_id or issue.path or issue.check_name or issue.code
         print(f"- {subject}: {issue.message}")
+        if issue.remediation_hint:
+            print(f"  Hint: {issue.remediation_hint}")
 
 
 def handle_lint(args: argparse.Namespace) -> int:

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -135,12 +135,19 @@ def _source_health_remediation_hint(source: SourceRecord | None, message: str) -
     storage_mode = effective_storage_mode(source)
     selector = _source_selector(source)
     if source.source_ref_kind == "workspace_path" and source.superseded_by is None:
-        if "Workspace source is missing:" in message:
+        source_is_missing = "Workspace source is missing:" in message
+        source_checksum_mismatch = "checksum mismatch for ingestion" in message
+        if source_is_missing and storage_mode in {"none", "copy"}:
             return (
                 f"Run splendor source update-path {selector} <new-path>; inspect current "
                 "freshness first with splendor source freshness."
             )
-        if "checksum mismatch for ingestion" in message:
+        if source_is_missing and storage_mode in {"pointer", "symlink"}:
+            return (
+                "Run splendor source freshness to inspect the missing curated source; "
+                f"{storage_mode}-backed sources are not supported by source update-path yet."
+            )
+        if source_checksum_mismatch:
             return (
                 f"Run splendor source refresh {selector}, then splendor ingest --pending; "
                 "for all changed curated workspace sources run splendor ingest --changed."
@@ -783,7 +790,6 @@ def _validate_run_record(
             path=run_relpath,
             record_id=canonical_run_id,
             check_name="run-provenance",
-            remediation_hint=_unknown_provenance_hint(),
         )
 
     for page_ref in run_record.page_refs:
@@ -797,7 +803,6 @@ def _validate_run_record(
                 path=run_relpath,
                 record_id=canonical_run_id,
                 check_name="run-provenance",
-                remediation_hint=_unknown_provenance_hint(),
             )
             continue
         if not resolved.is_file():
@@ -810,7 +815,6 @@ def _validate_run_record(
                 path=run_relpath,
                 record_id=canonical_run_id,
                 check_name="run-provenance",
-                remediation_hint=_unknown_provenance_hint(),
             )
 
     for link in run_record.provenance_links:
@@ -835,7 +839,6 @@ def _validate_run_record(
                     path=run_relpath,
                     record_id=canonical_run_id,
                     check_name="run-provenance",
-                    remediation_hint=_unknown_provenance_hint(),
                 )
         if (
             link.run_id is not None
@@ -849,7 +852,6 @@ def _validate_run_record(
                 path=run_relpath,
                 record_id=canonical_run_id,
                 check_name="run-provenance",
-                remediation_hint=_unknown_provenance_hint(),
             )
         if link.path_ref is None:
             continue
@@ -863,7 +865,6 @@ def _validate_run_record(
                 path=run_relpath,
                 record_id=canonical_run_id,
                 check_name="run-provenance",
-                remediation_hint=_unknown_provenance_hint(),
             )
             continue
         if not resolved.exists():
@@ -876,7 +877,6 @@ def _validate_run_record(
                 path=run_relpath,
                 record_id=canonical_run_id,
                 check_name="run-provenance",
-                remediation_hint=_unknown_provenance_hint(),
             )
 
     if run_record.status == "succeeded":

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -102,6 +103,7 @@ def _append_issue(
     path: str,
     record_id: str | None = None,
     check_name: str,
+    remediation_hint: str | None = None,
 ) -> None:
     issues.append(
         MaintenanceIssue(
@@ -110,7 +112,74 @@ def _append_issue(
             path=path,
             record_id=record_id,
             check_name=check_name,
+            remediation_hint=remediation_hint,
         )
+    )
+
+
+def _quote_command_arg(value: str) -> str:
+    return shlex.quote(value)
+
+
+def _source_selector(source: SourceRecord) -> str:
+    if source.source_ref:
+        return _quote_command_arg(source.source_ref)
+    if source.logical_id:
+        return _quote_command_arg(source.logical_id)
+    return _quote_command_arg(source.source_id)
+
+
+def _source_health_remediation_hint(source: SourceRecord | None, message: str) -> str | None:
+    if source is None:
+        return None
+    storage_mode = effective_storage_mode(source)
+    selector = _source_selector(source)
+    if source.source_ref_kind == "workspace_path" and source.superseded_by is None:
+        if "Workspace source is missing:" in message:
+            return (
+                f"Run splendor source update-path {selector} <new-path>; inspect current "
+                "freshness first with splendor source freshness."
+            )
+        if "checksum mismatch for ingestion" in message:
+            return (
+                f"Run splendor source refresh {selector}, then splendor ingest --pending; "
+                "for all changed curated workspace sources run splendor ingest --changed."
+            )
+    if storage_mode in {"copy", "pointer", "symlink"} and "checksum mismatch" in message:
+        return (
+            f"Run splendor source refresh {selector}, then splendor ingest --pending if a "
+            "new queue job is created."
+        )
+    return None
+
+
+def _queue_repair_hint(queue_record: QueueItemRecord, canonical_job_id: str) -> str:
+    source_id = _source_id_from_job_id(canonical_job_id)
+    if queue_record.status == "failed":
+        return (
+            f"Run splendor queue retry {_quote_command_arg(canonical_job_id)} or "
+            f"splendor repair ingest {_quote_command_arg(source_id)}."
+        )
+    if queue_record.status == "dead_letter":
+        return (
+            f"Run splendor repair ingest {_quote_command_arg(source_id)} or "
+            f"splendor queue retry {_quote_command_arg(canonical_job_id)} after reviewing "
+            "the dead-letter error."
+        )
+    if queue_record.status == "leased":
+        return (
+            f"Run splendor queue retry {_quote_command_arg(canonical_job_id)} after confirming "
+            "the lease owner is no longer active."
+        )
+    return (
+        f"Inspect queue state with splendor queue inspect {_quote_command_arg(canonical_job_id)}."
+    )
+
+
+def _unknown_provenance_hint() -> str:
+    return (
+        "Diagnostic only: inspect the referenced run/page/source records and file a follow-up; "
+        "no direct provenance rewrite command is available."
     )
 
 
@@ -161,6 +230,7 @@ def _load_source_records(
         checked_count += 1
         source_id = manifest_path.stem
         manifest_relpath = workspace_relative_path(root, manifest_path)
+        source: SourceRecord | None = None
         try:
             source = load_source_record(manifest_path)
             _validate_storage_policy(source)
@@ -175,6 +245,7 @@ def _load_source_records(
                 path=manifest_relpath,
                 record_id=source_id,
                 check_name="source-storage",
+                remediation_hint=_source_health_remediation_hint(source, str(exc)),
             )
             continue
         for artifact_ref in source.derived_artifacts:
@@ -417,6 +488,7 @@ def _validate_queue_record(
                         path=queue_relpath,
                         record_id=canonical_job_id,
                         check_name="queue-state",
+                        remediation_hint=_queue_repair_hint(queue_record, canonical_job_id),
                     )
     elif queue_record.lease_owner is not None or queue_record.lease_expires_at is not None:
         _append_issue(
@@ -440,6 +512,7 @@ def _validate_queue_record(
                 path=queue_relpath,
                 record_id=canonical_job_id,
                 check_name="queue-state",
+                remediation_hint=_queue_repair_hint(queue_record, canonical_job_id),
             )
     elif queue_record.last_error is not None:
         _append_issue(
@@ -460,6 +533,7 @@ def _validate_queue_record(
                 path=queue_relpath,
                 record_id=canonical_job_id,
                 check_name="queue-state",
+                remediation_hint=_queue_repair_hint(queue_record, canonical_job_id),
             )
         else:
             try:
@@ -690,6 +764,7 @@ def _validate_run_record(
             path=run_relpath,
             record_id=canonical_run_id,
             check_name="run-provenance",
+            remediation_hint=_unknown_provenance_hint(),
         )
 
     page_paths_by_id = {
@@ -708,6 +783,7 @@ def _validate_run_record(
             path=run_relpath,
             record_id=canonical_run_id,
             check_name="run-provenance",
+            remediation_hint=_unknown_provenance_hint(),
         )
 
     for page_ref in run_record.page_refs:
@@ -721,6 +797,7 @@ def _validate_run_record(
                 path=run_relpath,
                 record_id=canonical_run_id,
                 check_name="run-provenance",
+                remediation_hint=_unknown_provenance_hint(),
             )
             continue
         if not resolved.is_file():
@@ -733,6 +810,7 @@ def _validate_run_record(
                 path=run_relpath,
                 record_id=canonical_run_id,
                 check_name="run-provenance",
+                remediation_hint=_unknown_provenance_hint(),
             )
 
     for link in run_record.provenance_links:
@@ -744,6 +822,7 @@ def _validate_run_record(
                 path=run_relpath,
                 record_id=canonical_run_id,
                 check_name="run-provenance",
+                remediation_hint=_unknown_provenance_hint(),
             )
         if link.page_id is not None and link.page_id not in wiki_pages:
             if not _is_expected_pruned_source_summary_page_id(
@@ -756,6 +835,7 @@ def _validate_run_record(
                     path=run_relpath,
                     record_id=canonical_run_id,
                     check_name="run-provenance",
+                    remediation_hint=_unknown_provenance_hint(),
                 )
         if (
             link.run_id is not None
@@ -769,6 +849,7 @@ def _validate_run_record(
                 path=run_relpath,
                 record_id=canonical_run_id,
                 check_name="run-provenance",
+                remediation_hint=_unknown_provenance_hint(),
             )
         if link.path_ref is None:
             continue
@@ -782,6 +863,7 @@ def _validate_run_record(
                 path=run_relpath,
                 record_id=canonical_run_id,
                 check_name="run-provenance",
+                remediation_hint=_unknown_provenance_hint(),
             )
             continue
         if not resolved.exists():
@@ -794,6 +876,7 @@ def _validate_run_record(
                 path=run_relpath,
                 record_id=canonical_run_id,
                 check_name="run-provenance",
+                remediation_hint=_unknown_provenance_hint(),
             )
 
     if run_record.status == "succeeded":

--- a/src/splendor/commands/maintenance.py
+++ b/src/splendor/commands/maintenance.py
@@ -59,6 +59,8 @@ def render_report_markdown(report: MaintenanceReport) -> str:
                 detail_parts.append(f"path: `{issue.path}`")
             if issue.check_name:
                 detail_parts.append(f"check: `{issue.check_name}`")
+            if issue.remediation_hint:
+                detail_parts.append(f"hint: {issue.remediation_hint}")
             lines.append(f"- {'; '.join(detail_parts)}")
     return "\n".join(lines) + "\n"
 

--- a/src/splendor/schemas/maintenance.py
+++ b/src/splendor/schemas/maintenance.py
@@ -18,6 +18,7 @@ class MaintenanceIssue(StrictRecord):
     path: str | None = None
     record_id: str | None = None
     check_name: str | None = None
+    remediation_hint: str | None = None
 
 
 class MaintenanceReport(StrictRecord):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2691,6 +2691,32 @@ def test_cli_health_command_fails_for_invalid_sources(tmp_path: Path, capsys) ->
     assert "[source-health-check-failed]" in markdown
 
 
+def test_cli_health_command_renders_remediation_hints_in_stdout_and_reports(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source.unlink()
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "health"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    expected_hint = (
+        "Run splendor source update-path brief.md <new-path>; inspect current freshness first "
+        "with splendor source freshness."
+    )
+    assert f"Hint: {expected_hint}" in captured.out
+    json_report, markdown_report = latest_report_paths(tmp_path, "health")
+    payload = json.loads(json_report.read_text(encoding="utf-8"))
+    assert payload["issues"][0]["remediation_hint"] == expected_hint
+    markdown = markdown_report.read_text(encoding="utf-8")
+    assert f"hint: {expected_hint}" in markdown
+
+
 def test_cli_health_command_reports_top_level_errors(tmp_path: Path, capsys) -> None:
     (tmp_path / "splendor.yaml").write_text("sources: [\n", encoding="utf-8")
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -63,6 +63,24 @@ def test_run_health_checks_hints_missing_active_workspace_source_repair(
     )
 
 
+def test_run_health_checks_does_not_hint_update_path_for_pointer_source(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    add_source(tmp_path, source, storage_mode="pointer")
+    source.unlink()
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["source-health-check-failed"]
+    assert result.issues[0].remediation_hint == (
+        "Run splendor source freshness to inspect the missing curated source; "
+        "pointer-backed sources are not supported by source update-path yet."
+    )
+
+
 def test_run_health_checks_hints_checksum_mismatch_active_workspace_source(
     tmp_path: Path,
 ) -> None:
@@ -938,6 +956,43 @@ def test_run_health_checks_hints_unknown_source_refs_without_unsafe_repair(
     assert all(
         "source update-path" not in (issue.remediation_hint or "") for issue in result.issues
     )
+
+
+def test_run_health_checks_does_not_repeat_generic_hint_for_missing_page_refs(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    write_run_record(
+        layout.runs_dir / "run-missing-page.json",
+        RunRecord(
+            run_id="run-missing-page",
+            job_id="ingest-src-example",
+            job_type="ingest_source",
+            started_at="2026-04-20T09:00:00+00:00",
+            finished_at="2026-04-20T09:05:00+00:00",
+            status="failed",
+            input_refs=[],
+            errors=["page disappeared"],
+            pipeline_version=__version__,
+            page_ids=["missing-page"],
+            page_refs=["wiki/topics/missing.md"],
+            provenance_links=[
+                ProvenanceLink(page_id="missing-page", role="generated-page"),
+                ProvenanceLink(path_ref="wiki/topics/missing.md", role="generated-page"),
+            ],
+        ),
+    )
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == [
+        "missing-run-page-id",
+        "missing-run-page-ref",
+        "missing-run-provenance-page-ref",
+        "missing-run-provenance-path",
+    ]
+    assert all(issue.remediation_hint is None for issue in result.issues)
 
 
 def test_run_health_checks_reports_source_runtime_cross_reference_problems(tmp_path: Path) -> None:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -45,6 +45,42 @@ def test_run_health_checks_reports_missing_source_derived_artifact(tmp_path: Pat
     assert result.issues[0].path == added.manifest_path.relative_to(tmp_path).as_posix()
 
 
+def test_run_health_checks_hints_missing_active_workspace_source_repair(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    add_source(tmp_path, source)
+    source.unlink()
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["source-health-check-failed"]
+    assert result.issues[0].remediation_hint == (
+        "Run splendor source update-path brief.md <new-path>; inspect current freshness first "
+        "with splendor source freshness."
+    )
+
+
+def test_run_health_checks_hints_checksum_mismatch_active_workspace_source(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    add_source(tmp_path, source)
+    source.write_text("# Brief\n\nupdated\n", encoding="utf-8")
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["source-health-check-failed"]
+    assert result.issues[0].remediation_hint == (
+        "Run splendor source refresh brief.md, then splendor ingest --pending; for all changed "
+        "curated workspace sources run splendor ingest --changed."
+    )
+
+
 def test_run_health_checks_accepts_ocr_derived_artifact_links(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "diagram.png"
@@ -577,6 +613,25 @@ def test_run_health_checks_reports_invalid_failed_queue_and_run_shapes(tmp_path:
     }
 
 
+def test_run_health_checks_hints_dead_letter_queue_repair(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+    dead_letter = queue_record.model_copy(update={"status": "dead_letter", "last_error": None})
+    write_queue_item(queue_path, dead_letter)
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["invalid-queue-error-state"]
+    assert result.issues[0].remediation_hint == (
+        f"Run splendor repair ingest {added.source_id} or splendor queue retry "
+        f"ingest-{added.source_id} after reviewing the dead-letter error."
+    )
+
+
 def test_run_health_checks_reports_queue_and_run_shape_mismatches(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
@@ -846,6 +901,43 @@ def test_run_health_checks_reports_run_state_and_reference_problems(tmp_path: Pa
         "succeeded-run-missing-page-refs",
         "succeeded-run-missing-generated-page-provenance",
     }
+
+
+def test_run_health_checks_hints_unknown_source_refs_without_unsafe_repair(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    write_run_record(
+        layout.runs_dir / "run-unknown-source.json",
+        RunRecord(
+            run_id="run-unknown-source",
+            job_id="ingest-src-missing",
+            job_type="ingest_source",
+            started_at="2026-04-20T09:00:00+00:00",
+            finished_at="2026-04-20T09:05:00+00:00",
+            status="failed",
+            input_refs=[],
+            errors=["source disappeared"],
+            pipeline_version=__version__,
+            source_ids=["src-missing"],
+            provenance_links=[ProvenanceLink(source_id="src-missing", role="input")],
+        ),
+    )
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == [
+        "missing-run-source-id",
+        "missing-run-provenance-source-ref",
+    ]
+    assert {issue.remediation_hint for issue in result.issues} == {
+        "Diagnostic only: inspect the referenced run/page/source records and file a follow-up; "
+        "no direct provenance rewrite command is available."
+    }
+    assert all(
+        "source update-path" not in (issue.remediation_hint or "") for issue in result.issues
+    )
 
 
 def test_run_health_checks_reports_source_runtime_cross_reference_problems(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #95.

This PR implements `M14-P1.8` for Milestone 14 by making `splendor health` an operational repair guide now that the narrow repair commands exist.

## What changed

- Add an optional `remediation_hint` field to maintenance issues so health hints are machine-readable in JSON reports.
- Render remediation hints in human health output and generated Markdown maintenance reports.
- Add deterministic health hints for known-safe repair routes:
  - missing active workspace source paths point to `splendor source update-path ... <new-path>` and `splendor source freshness` only for storage modes supported by `source update-path`
  - pointer/symlink missing source paths point to `splendor source freshness` and explicitly avoid suggesting unsupported `source update-path` repair
  - checksum drift points to `splendor source refresh ...`, `splendor ingest --pending`, and `splendor ingest --changed`
  - dead-letter/failed queue diagnostics and expired leases point to `splendor queue retry ...` or `splendor repair ingest ...`
  - unknown source provenance refs stay diagnostic-only and avoid unsafe broad rewrite guidance
- Update the planning state and docs for `M14-P1.8`.

## Scope boundaries

This intentionally does not implement #94 source identity redesign, #79 compile/update work, broad discovery, provenance rewriting, SQLite, background workers, web UI, vector search, or unrelated performance work.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`
