### PR TITLE
M14-P1.9 Record source identity disposition

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M14-P1.7`
-- Last action taken: `M14-P1.7` is implemented; the current PR adds actionable health remediation hints for #95.
-- Current planned slice: `Health remediation hints`
-- Current PR sub-slice: `M14-P1.8`
+- Previous completed PR sub-slice: `M14-P1.8`
+- Last action taken: `M14-P1.8` is implemented; the current PR records the source identity review/disposition for #94.
+- Current planned slice: `Source identity design review`
+- Current PR sub-slice: `M14-P1.9`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely source identity design review or M15 compile/update, depending on roadmap`
-- Next planned PR sub-slice: `likely M14-P1.9 only if #94 is narrowed; otherwise M15-P1.2 or next roadmap notation`
+- Next planned slice: `likely M15 compile/update expansion`
+- Next planned PR sub-slice: `likely M15-P1.2`
 - Current blockers: none
 
 ## Planning Notation
@@ -280,6 +280,16 @@
   - [x] Validate target paths as supported in-workspace files and reject ambiguous active curated targets
   - [x] Update active workspace-backed source refs, logical IDs, aliases, and compatibility paths without broad discovery
   - [x] Report manifest/current checksums, manifest path, and deterministic next commands in human and JSON output
+- [x] Implement `M14-P1.8`: Health remediation hints
+  - [x] Add deterministic remediation hints to health issues, JSON output, human stdout, and Markdown reports
+  - [x] Point active workspace path failures, checksum drift, queue failures, and expired leases at existing repair commands
+  - [x] Keep unknown provenance refs diagnostic-only instead of inventing unsafe broad repairs
+- [x] Implement `M14-P1.9`: Source identity design review
+  - [x] Audit #94 against stable logical IDs, supersession, source freshness, path repair, pruning, and topic-ref migration
+  - [x] Preserve stable logical selectors and old path aliases when `source update-path` repairs a moved source
+  - [x] Preserve canonical content-addressed `src-...` manifest IDs and schema version `1`
+  - [x] Record that #94 is materially addressed for curated workspace-backed sources
+  - [x] Keep #79/M15 compile/update expansion, #47 ingest timing, #37 web scaling, and #30 repo-scan optimization separate
 
 ## Context Pointers
 
@@ -348,6 +358,8 @@
 - `M14-P1.5` Stale-source ingestion for checksum-drifted curated sources
 - `M14-P1.6` Repo refresh missing/broken source tolerance
 - `M14-P1.7` Source path repair commands
+- `M14-P1.8` Health remediation hints
+- `M14-P1.9` Source identity design review
 - `M14-P2.1` PR summary and lower-noise generated-state review handoff
 - `M14-P3.1` Source-lifecycle re-evaluation gate
 - `M14-P4.1` Planning-doc authority and task-oriented agent briefs

--- a/README.md
+++ b/README.md
@@ -173,9 +173,10 @@ migration.
 path for moved active curated workspace sources. By default it requires the old workspace path to
 be missing; `--force` is available for deliberate reparenting while the old file still exists. It
 validates that the new path is a supported file inside the workspace, rejects targets already
-curated by another active source, updates the source manifest's workspace ref, logical ID, alias,
-and compatibility path fields, and reports manifest/current checksums plus next commands. Same-byte
-moves queue a re-ingest so generated source-summary provenance can refresh. Changed-byte moves are
+curated by another active source, updates the source manifest's workspace ref and compatibility
+path fields, preserves the stable logical ID and old path alias, adds the new path alias, and
+reports manifest/current checksums plus next commands. Same-byte moves queue a re-ingest so
+generated source-summary provenance can refresh. Changed-byte moves are
 reported as partial repairs with a non-zero exit and an explicit `source refresh` next command. The
 command does not discover/register uncurated files, rewrite historical run records, or mutate
 maintained synthesis pages.
@@ -239,12 +240,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M14-P1.7`
-- Current planned slice: `Health remediation hints`
-- Current PR sub-slice: `M14-P1.8`
+- Previous completed PR sub-slice: `M14-P1.8`
+- Current planned slice: `Source identity design review`
+- Current PR sub-slice: `M14-P1.9`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely source identity design review or M15 compile/update, depending on roadmap`
-- Next planned PR sub-slice: `likely M14-P1.9 only if #94 is narrowed; otherwise M15-P1.2 or next roadmap notation`
+- Next planned slice: `likely M15 compile/update expansion`
+- Next planned PR sub-slice: `likely M15-P1.2`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -365,6 +366,30 @@ against source manifests. Historical manifests and run records remain valid.
 them into current canonical source versions, and ingests only those refreshed queue jobs even when
 the previous queue item was already `done`. Missing curated sources are reported as unresolved
 diagnostics while valid changed sources continue through refresh and ingest.
+
+`M14-P1.6` makes workspace refresh continue past unrelated unresolved curated sources: missing or
+unsupported active workspace-backed sources are reported as skipped diagnostics, valid changed
+sources still refresh and ingest, and the command exits non-zero while unresolved source or targeted
+ingest failures remain.
+
+`M14-P1.7` adds `splendor source update-path <source-id|logical-id|title|path> <new-path>` for
+intentional file moves. It updates active workspace-backed source refs, logical IDs, aliases, and
+compatibility paths without broad discovery, queues same-byte repairs for re-ingest, and points
+changed-byte moves to `source refresh`.
+
+`M14-P1.8` adds health remediation hints for the concrete source lifecycle commands now available:
+missing active source paths point to `source update-path` plus freshness checks, checksum drift
+points to source refresh or `ingest --changed`, and queue/runtime state points to queue retry or
+ingest repair.
+
+`M14-P1.9` records the source identity review for issue #94. The disposition is that the current
+M14 source-lifecycle contract materially addresses #94 for curated workspace-backed sources without
+renaming canonical `src-...` manifests or changing schema version `1`: logical IDs and aliases
+provide stable selectors, source refresh records content edits as superseded versions, freshness
+keeps checksum state separate from identity, `source update-path` preserves the stable logical
+selector while adding the new path alias for intentional moves, and workspace refresh can migrate
+maintained topic refs after refreshed versions exist. Remaining work should be a specific
+regression or non-workspace extension, not a broad identity redesign.
 
 `M14-P2.1` adds the read-only PR handoff surface:
 `splendor pr-summary --since main` groups merge-base changes into curated source lifecycle records,

--- a/docs/m14_synthbanshee_reevaluation.md
+++ b/docs/m14_synthbanshee_reevaluation.md
@@ -135,6 +135,9 @@ starting.
 Keep the following issues separate unless a future re-evaluation directly proves one has become
 urgent:
 
+- #94: source identity review. `M14-P1.9` audits this separately and records the disposition that
+  curated workspace-backed identity is materially addressed by logical IDs, supersession, freshness
+  state, path repair, and topic-ref migration without changing canonical `src-...` IDs.
 - #79: mutating compile/update workflow.
 - #47: ingest run-duration precision.
 - #37: web document-list scaling.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -189,9 +189,10 @@ Implemented fields:
   implementation supports `storage_mode: none` and `storage_mode: copy` workspace sources. By
   default it requires the old workspace path to be missing; `--force` allows explicit reparenting
   while the old path still exists. It validates that the target is a supported file inside the
-  workspace, rejects paths already curated by another active source, updates `source_ref`,
-  `logical_id`, `aliases`, `original_path`, and the compatibility `path` field for
-  `storage_mode: none`, then validates and rewrites the schema-bound manifest. Same-byte repairs
+  workspace, rejects paths already curated by another active source, preserves the stable
+  `logical_id` and original-path alias, adds the new path alias, updates `source_ref`, and updates
+  the compatibility `path` field for `storage_mode: none`, then validates and rewrites the
+  schema-bound manifest. Same-byte repairs
   mark previously ingested source records as needing ingest and queue the existing source ID so
   generated source-summary provenance can refresh. Changed-byte repairs return `status: partial`,
   do not queue ingest, and point operators to `splendor source refresh <new-path>`. Human and JSON
@@ -229,6 +230,7 @@ Implemented fields:
   source IDs to the active content-addressed source version, leaving prose and code-fence mentions
   untouched. The command does not perform broad repo discovery, register uncurated files, or run
   mutating synthesis compile/update workflows.
+
 - `splendor ingest --changed` is the narrow stale-source ingestion path for checksum-drifted
   curated workspace-backed sources. It scans source freshness, reports missing active curated
   workspace sources as unresolved diagnostics, refreshes each changed source through the existing
@@ -269,6 +271,39 @@ Implemented fields:
   optional and explicitly configured; successful OCR-derived text is recorded in
   `derived_artifacts` without changing the canonical source identity. Sidecar OCR inputs are
   tracked through metadata artifacts so no-op ingest can detect sidecar checksum drift.
+
+### Source identity disposition
+
+Issue #94's stable source-identity concern is handled in schema version `1` by layering stable
+logical selectors and lifecycle links over immutable content-addressed records, rather than by
+renaming canonical IDs:
+
+- Canonical source manifests, queue payloads, generated source-summary pages, and run provenance
+  continue to use content-addressed `src-...` IDs for compatibility.
+- Workspace-backed curated sources persist or derive `source:<workspace-path>` logical IDs and path
+  aliases so operators can select the logical source across ordinary content edits. After an
+  explicit path repair, the original logical ID remains a stable selector and the new path is added
+  as a path alias.
+- Changed content is represented as a new canonical source version linked to the previous version
+  with `supersedes` / `superseded_by`; historical manifests and run records remain valid.
+- Checksum/freshness state stays on each source version and in explicit freshness reports; it is not
+  the logical identity.
+- Intentional file moves are handled by `splendor source update-path`, which updates the active
+  source ref and compatibility path fields while preserving the stable logical ID and old path
+  alias, without discovering uncurated files or rewriting historical run records.
+- Maintained topic/source refs can be migrated from superseded source IDs to active versions with
+  `workspace refresh --update-topic-refs` after refreshed successor summaries exist.
+
+This disposition keeps schema version `1` stable. Future identity work should name a specific
+remaining gap, such as non-workspace source lifecycle semantics, rather than replacing the canonical
+`src-...` compatibility contract.
+
+Legacy SHA/content-addressed manifests remain compatible. If a workspace-backed record has
+`source_ref_kind: workspace_path` but lacks `logical_id` or aliases, lookup/freshness derives the
+effective logical ID from the recorded workspace path and re-registration or path repair backfills
+the persisted selector fields. Older copied/stored-artifact records that do not carry
+workspace-backed source refs keep their canonical `src-...` identity until an operator explicitly
+re-registers or otherwise curates them as workspace-backed sources.
 
 ### Derived artifacts
 

--- a/docs/source_resolution_refactor_plan.md
+++ b/docs/source_resolution_refactor_plan.md
@@ -199,6 +199,17 @@ Optional stable lookup aliases for source resolution. Workspace-backed registrat
 repo-relative path alias; lookup and freshness payloads also expose the effective logical ID as an
 alias for agent handoff.
 
+### Source identity compatibility
+
+The stable-identity layer is intentionally additive. Canonical manifest filenames, generated
+source-summary pages, queue payloads, and run provenance continue to use content-addressed
+`src-...` IDs. Workspace-backed logical IDs and aliases are selectors above those version IDs;
+source refresh records content edits with `supersedes` / `superseded_by`; source freshness keeps
+checksum drift separate from identity; and `source update-path` repairs intentional path moves for
+active curated workspace-backed sources while preserving the original logical selector and adding
+the new path alias. Issue #94 should not require schema version `1` to replace canonical `src-...`
+IDs unless a future, narrower gap is identified outside that contract.
+
 ### `source_commit_capture`
 
 Nullable intent flag controlling whether refresh should attempt source commit capture again:

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M14-P1.7`
-- Current planned slice: `Health remediation hints`
-- Current PR sub-slice: `M14-P1.8`
+- Previous completed PR sub-slice: `M14-P1.8`
+- Current planned slice: `Source identity design review`
+- Current PR sub-slice: `M14-P1.9`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely source identity design review or M15 compile/update, depending on roadmap`
-- Next planned PR sub-slice: `likely M14-P1.9 only if #94 is narrowed; otherwise M15-P1.2 or next roadmap notation`
+- Next planned slice: `likely M15 compile/update expansion`
+- Next planned PR sub-slice: `likely M15-P1.2`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -890,6 +890,7 @@ breaking the v1 file contracts.
 - `M14-P1.6` Repo refresh missing/broken source tolerance
 - `M14-P1.7` Source path repair commands
 - `M14-P1.8` Health remediation hints
+- `M14-P1.9` Source identity design review
 - `M14-P2.1` PR summary and lower-noise generated-state review handoff
 - `M14-P3.1` Source-lifecycle re-evaluation gate
 - `M14-P4.1` Planning-doc authority and task-oriented agent briefs
@@ -920,7 +921,9 @@ loop is substantially implemented and re-evaluated. The intended sequence before
    workspace-backed source paths without broad discovery or manual manifest JSON edits.
 9. `M14-P1.8` adds deterministic health remediation hints that point diagnostics at existing
    repair commands without implementing broad source-identity redesign or provenance rewriting.
-10. `M14-P2.1` adds `splendor pr-summary --since main`, a read-only PR-oriented summary with
+10. `M14-P1.9` audits the implemented source identity behavior against #94 and records whether the
+   remaining gap is narrow enough to close or retarget without changing canonical `src-...` IDs.
+11. `M14-P2.1` adds `splendor pr-summary --since main`, a read-only PR-oriented summary with
    lower-noise generated-state review guidance over local git state.
 
 After those slices land, the gate should use a comparable planning or repo-maintenance workflow and
@@ -967,12 +970,12 @@ ingest failures remain.
 `splendor source update-path <source-id|logical-id|title|path> <new-path>`. The command repairs an
 active workspace-backed source manifest after an intentional file move by validating the target as a
 supported in-workspace file, rejecting paths already curated by another active source, requiring the
-old path to be missing unless `--force` is supplied, updating the source-ref/logical-ID/alias fields,
-and reporting manifest/current checksums plus next commands. Same-byte moves queue re-ingest for the
-existing source ID so generated source-summary provenance can refresh; changed-byte moves return a
-partial repair status and point to `source refresh`. It does not implement the broader #94
-source-identity redesign, discover/register uncurated files, rewrite historical run records, or
-mutate maintained synthesis pages.
+old path to be missing unless `--force` is supplied, updating the source ref and compatibility path,
+preserving the stable logical ID and old path alias, adding the new path alias, and reporting
+manifest/current checksums plus next commands. Same-byte moves queue re-ingest for the existing
+source ID so generated source-summary provenance can refresh; changed-byte moves return a partial
+repair status and point to `source refresh`. It does not discover/register uncurated files, rewrite
+historical run records, or mutate maintained synthesis pages.
 
 `M14-P1.8` addresses issue #95 by making `splendor health` an operational repair guide for the
 repair commands that now exist. Maintenance issues can carry an optional `remediation_hint` field,
@@ -982,6 +985,20 @@ points to `splendor source refresh ...`, `splendor ingest --pending`, or `splend
 --changed`; failed/dead-letter queue shape and expired lease diagnostics point to queue retry or
 ingest repair commands. Unknown source provenance refs remain diagnostic-only and explicitly avoid
 inventing unsafe broad repair commands.
+
+`M14-P1.9` addresses issue #94 as a focused identity review/disposition, not a redesign. The audit
+finds the #94 expected behavior materially covered for curated workspace-backed sources by the
+landed M14 sequence: `M14-P1.1` adds stable `source:<workspace-path>` logical IDs and path aliases;
+`M14-P1.2` keeps content edits as content-addressed versions linked by `supersedes` /
+`superseded_by`; source freshness reports checksum drift separately from identity; `M14-P1.7`
+repairs intentional moves by updating active source refs and compatibility paths while preserving
+the stable logical ID and old path alias; and `M14-P1.4` can migrate maintained topic refs after
+refreshed successor summaries exist. Schema version `1` and canonical `src-...` manifest/page/run
+provenance IDs remain the compatibility contract. Legacy workspace-backed manifests can derive
+logical identity from `source_ref`, while older non-workspace copied/stored-artifact records keep
+their canonical source IDs until explicitly re-curated. Any future #94 follow-up should be a
+specific regression or an explicit extension beyond curated workspace-backed sources, not a
+schema-breaking source-ID migration.
 
 ## Candidate Milestone 15 — Post-v1 reviewed compile/update workflow
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -904,6 +904,13 @@ Release-readiness boundary:
   The `ingest --changed` repair path handles checksum-drifted curated workspace sources whose
   previous queue records are already done, and the `pr-summary` surface provides a read-only local
   PR handoff over that generated-state churn.
+- issue #94's broader source-identity question is materially addressed for curated
+  workspace-backed sources by the same contract: logical IDs and aliases are stable selectors above
+  canonical `src-...` records, content edits become superseded source versions, freshness reports
+  keep checksum drift separate from identity, `source update-path` preserves the original logical
+  selector while adding the new path alias for intentional moves, and maintained topic refs can be
+  migrated after refreshed successor summaries exist. This does not require a schema-version change
+  or a canonical source-ID migration.
 - issue #79 tracks the reviewed mutating compile/update workflow from #41; v1 shipped briefing and
   the non-mutating compile contract, and `M15-P1.1` begins the explicit one-page proposal/apply
   path.

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -54,6 +54,9 @@ For this handoff:
   maintainers accept the gate result
 - #86 tracks the planning-document authority and task-oriented agent brief gap addressed by
   `M14-P4.1`
+- #94's source-identity concern is materially addressed for curated workspace-backed sources by
+  `M14-P1.1` through `M14-P1.9`; future work should be a specific non-workspace extension or
+  regression, not a broad canonical source-ID redesign
 - #79 now owns the M15 reviewed compile/update sequence; `M15-P1.1` starts with explicit
   one-page diff/proposal-hash/apply semantics rather than broad automatic synthesis updates
 
@@ -64,7 +67,8 @@ These items are intentionally not v1 release blockers:
 - richer post-M14 authority lifecycle policy after the initial planning-doc authority briefs have
   been exercised in real repositories
 - ingest run-duration precision for #47
-- broader source identity design after the narrow health remediation hints in #95
+- source identity extensions beyond curated workspace-backed source lifecycle semantics, if real
+  repository use identifies a concrete remaining gap after #94
 - repo-scan bulk registration optimization for #30
 - web document-list scaling for #37
 
@@ -89,8 +93,12 @@ The conservative next queue after the `M14-P3.1` gate is:
 7. `M14-P1.8` handles issue #95: health diagnostics include deterministic remediation hints for
    the concrete `source update-path`, source refresh, stale-ingest, queue retry, and repair ingest
    commands now available.
-8. Continue #79 through `M15-P1.2` after any narrowed #94 source identity review follow-up.
-9. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
+8. Close or explicitly narrow #94 through `M14-P1.9`; the current identity contract keeps
+   canonical `src-...` IDs immutable as version/provenance records while logical IDs, supersession,
+   freshness, path repair, and topic-ref migration cover ordinary curated workspace edits and
+   moves.
+9. Continue #79 through `M15-P1.2` after #94 is closed or narrowed.
+10. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
    either one urgent.
 
 The internal source-lifecycle re-evaluation gate is now complete in `M14-P3.1`. The completed retry

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -472,13 +472,14 @@ def _source_identity_issues(
     issues: list[MaintenanceIssue] = []
 
     if source.source_ref_kind == "workspace_path":
-        expected_logical_id = logical_source_id_for_ref(source.source_ref, source.source_ref_kind)
+        stable_identity_ref = source.original_path or source.source_ref
+        expected_logical_id = logical_source_id_for_ref(stable_identity_ref, source.source_ref_kind)
         if source.logical_id is not None and source.logical_id != expected_logical_id:
             issues.append(
                 MaintenanceIssue(
                     code="invalid-source-logical-id",
                     message=(
-                        "Workspace source logical_id must match source_ref: "
+                        "Workspace source logical_id must match the stable source identity ref: "
                         f"expected {expected_logical_id}, got {source.logical_id}"
                     ),
                     path=manifest_relpath,
@@ -486,7 +487,9 @@ def _source_identity_issues(
                     check_name="source-identity",
                 )
             )
-        allowed_aliases = {source.source_ref} if source.source_ref is not None else set()
+        allowed_aliases = {
+            alias for alias in (source.original_path, source.source_ref) if alias is not None
+        }
     else:
         allowed_aliases = set()
 

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -123,6 +123,16 @@ class StaleIngestResult:
     skipped: int
 
 
+def _dedupe_aliases(aliases: list[str | None]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for alias in aliases:
+        if alias and alias not in seen:
+            seen.add(alias)
+            deduped.append(alias)
+    return deduped
+
+
 def list_sources(root: Path) -> list[SourceLookupResult]:
     layout = resolve_layout(root, load_config(root))
     results = [
@@ -371,13 +381,16 @@ def update_source_path(
     )
 
     current_checksum = sha256_file(target)
-    logical_id = logical_source_id_for_ref(new_ref, "workspace_path")
+    stable_identity_ref = source.original_path or old_path
+    logical_id = source.logical_id or logical_source_id_for_ref(
+        stable_identity_ref, "workspace_path"
+    )
+    aliases = _dedupe_aliases([*source.aliases, old_path, new_ref])
     updated_fields: dict[str, object] = {
         "source_ref": new_ref,
         "source_ref_kind": "workspace_path",
         "logical_id": logical_id,
-        "aliases": [new_ref],
-        "original_path": new_ref,
+        "aliases": aliases,
     }
     if storage_mode == "none":
         updated_fields["path"] = new_ref

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -857,7 +857,7 @@ def test_cli_source_update_path_repairs_missing_workspace_source(tmp_path: Path,
     assert "Old path: docs/brief.md" in out
     assert "New path: moved/brief.md" in out
     assert "Status: repaired" in out
-    assert "Logical ID: source:moved/brief.md" in out
+    assert "Logical ID: source:docs/brief.md" in out
     assert "Checksum: matches manifest" in out
     assert f"Queued ingest: {tmp_path / 'state' / 'queue' / f'ingest-{source_id}.json'}" in out
     assert "Next: splendor ingest --pending" in out
@@ -865,9 +865,17 @@ def test_cli_source_update_path_repairs_missing_workspace_source(tmp_path: Path,
     assert updated.source_id == source_id
     assert updated.source_ref == "moved/brief.md"
     assert updated.path == "moved/brief.md"
-    assert updated.logical_id == "source:moved/brief.md"
-    assert updated.aliases == ["moved/brief.md"]
+    assert updated.original_path == "docs/brief.md"
+    assert updated.logical_id == "source:docs/brief.md"
+    assert updated.aliases == ["docs/brief.md", "moved/brief.md"]
     assert len(list((tmp_path / "state" / "manifests" / "sources").glob("*.json"))) == 1
+
+    lookup_code = main(
+        ["--root", str(tmp_path), "source", "lookup", "source:docs/brief.md", "--json"]
+    )
+    assert lookup_code == 0
+    lookup_payload = json.loads(capsys.readouterr().out)
+    assert lookup_payload["sources"][0]["source_id"] == source_id
 
     freshness_code = main(["--root", str(tmp_path), "source", "freshness", "--json"])
     assert freshness_code == 0
@@ -898,12 +906,12 @@ def test_cli_source_update_path_json_reports_deterministic_payload(tmp_path: Pat
     payload = json.loads(capsys.readouterr().out)
     assert payload == {
         "source_id": manifest.source_id,
-        "logical_id": "source:new.md",
+        "logical_id": "source:old.md",
         "old_path": "old.md",
         "new_path": "new.md",
         "status": "repaired",
         "source_ref": "new.md",
-        "aliases": ["new.md"],
+        "aliases": ["old.md", "new.md"],
         "manifest_checksum": manifest.checksum,
         "current_checksum": manifest.checksum,
         "checksum_matches": True,


### PR DESCRIPTION
## Summary

This PR records the focused `M14-P1.9` source identity review for issue #94. The audit finds #94 materially addressed for curated workspace-backed sources by the existing M14 source-lifecycle sequence, with one targeted behavior fix so the implementation now matches the documented move-stability claim.

What changed:

- Preserves the stable logical selector and old path alias when `splendor source update-path` repairs an intentional move, while adding the new path alias and updating the current `source_ref`/compatibility path.
- Updates lint identity validation so moved workspace-backed sources validate against the stable original identity ref while still rejecting unrelated stale logical IDs and aliases.
- Adds regression coverage showing a moved source remains findable by its original logical ID and JSON output reports both old/new aliases.
- Updates `.agent-plan.md`, the README "What Comes Next" block, and the roadmap planning state to move from completed `M14-P1.8` into `M14-P1.9`.
- Documents the source identity disposition in the roadmap, schema contracts, product spec, source-resolution plan, v1 handoff, and M14 re-evaluation note.
- Makes the compatibility boundary explicit: canonical `src-...` manifest IDs, generated source-summary pages, queue payloads, and run provenance remain the schema-version-1 version/provenance contract.
- Maps #94 expected behavior to the current implementation: stable logical IDs and aliases, supersession links for edited content, freshness/checksum state separate from identity, `source update-path` for intentional moves, maintained topic-ref migration after refreshed successors exist, and legacy manifest compatibility behavior.
- Keeps #79/M15 compile/update expansion, #47 ingest timing, #37 web scaling, and #30 repo-scan registration optimization out of scope.

## Issue disposition

Closes #94 as materially addressed for curated workspace-backed sources. Any future identity work should be a specific regression or explicit non-workspace/source-class extension, not a broad canonical source-ID migration.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`
