### PR TITLE
M15-P1.2 Compile target handoff commands

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M14-P1.8`
-- Last action taken: `M14-P1.8` is implemented; the current PR records the source identity review/disposition for #94.
-- Current planned slice: `Source identity design review`
-- Current PR sub-slice: `M14-P1.9`
+- Previous completed PR sub-slice: `M14-P1.9`
+- Last action taken: `M14-P1.9` is complete; issue #94 is closed after the source identity review/disposition.
+- Current planned slice: `Compile/update expansion after first reviewed page apply`
+- Current PR sub-slice: `M15-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely M15 compile/update expansion`
-- Next planned PR sub-slice: `likely M15-P1.2`
+- Next planned slice: `likely ingest run-duration precision or post-M15 issue triage`
+- Next planned PR sub-slice: `likely TBD, possibly issue #47`
 - Current blockers: none
 
 ## Planning Notation
@@ -290,6 +290,14 @@
   - [x] Preserve canonical content-addressed `src-...` manifest IDs and schema version `1`
   - [x] Record that #94 is materially addressed for curated workspace-backed sources
   - [x] Keep #79/M15 compile/update expansion, #47 ingest timing, #37 web scaling, and #30 repo-scan optimization separate
+- [x] Implement `M15-P1.1`: First reviewed compile/apply loop
+  - [x] Keep bare `wiki compile` non-mutating
+  - [x] Add one-page deterministic compile proposals with proposal hashes
+  - [x] Require `--apply --proposal-hash` before writing maintained synthesis pages
+- [x] Implement `M15-P1.2`: Compile/update expansion after first reviewed page apply
+  - [x] Include ranked maintained-page suggestions in bare `wiki compile`
+  - [x] Include ready-to-run compile preview commands in `wiki compile` and `wiki suggest`
+  - [x] Preserve explicit one-page apply semantics and avoid automatic multi-page mutation
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -240,12 +240,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M14-P1.8`
-- Current planned slice: `Source identity design review`
-- Current PR sub-slice: `M14-P1.9`
+- Previous completed PR sub-slice: `M14-P1.9`
+- Current planned slice: `Compile/update expansion after first reviewed page apply`
+- Current PR sub-slice: `M15-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely M15 compile/update expansion`
-- Next planned PR sub-slice: `likely M15-P1.2`
+- Next planned slice: `likely ingest run-duration precision or post-M15 issue triage`
+- Next planned PR sub-slice: `likely TBD, possibly issue #47`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -421,6 +421,14 @@ that maintained page when the current target and source-summary inputs still mat
 proposal. Applied output updates schema-bound frontmatter source refs/provenance links, writes a
 managed `Compiled Source Evidence` section, and refuses generated source-summary pages as compile
 targets.
+
+`M15-P1.2` makes the reviewed loop easier to run end to end without broadening mutation. Bare
+`splendor wiki compile <source-id|title|path>` now includes ranked maintained-page suggestions and
+ready-to-run `splendor wiki compile <source-id> --page <page>` preview commands. `splendor wiki
+suggest <source-id|title|path>` exposes the same compile-preview commands in text and JSON output.
+JSON output also includes structured `compile_preview_args` argv tokens so agents do not have to
+parse shell text. Actual writes still require the explicit one-page `--apply --proposal-hash
+<hash>` gate.
 
 ### v1 readiness checklist
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -239,15 +239,20 @@ Implemented fields:
   initial and final freshness counts, missing-source diagnostics, refreshed source IDs, targeted
   queue outcomes, and summary counts.
 - `splendor wiki compile <source-id|title|path>` remains non-mutating unless a maintained target
-  page is selected and `--apply --proposal-hash <hash>` is supplied. `--page <maintained-page>`
-  proposes a deterministic update from the generated source-summary page into one maintained
-  topic, concept, entity, architecture, or glossary page. Proposed output includes a unified diff,
-  target/source-summary SHA-256 hashes, and a proposal hash derived from those inputs plus the
-  proposed page hash. Proposed and applied updates add the source ID to frontmatter `source_refs`,
-  add provenance links with `supports` and `generated-from` roles, append a managed
-  `Compiled Source Evidence` section to the markdown body, and validate the resulting
-  `KnowledgePageFrontmatter` before reporting or writing. Generated source-summary pages are not
-  valid compile targets.
+  page is selected and `--apply --proposal-hash <hash>` is supplied. Without `--page`, it reports
+  the review-gated contract plus ranked maintained-page suggestions and ready-to-run
+  `splendor wiki compile <source-id> --page <page>` preview commands. JSON suggestions include
+  both the rendered `compile_preview_command` string for human handoff and `compile_preview_args`
+  argv tokens for tools that should not parse shell text. `splendor wiki suggest
+  <source-id|title|path>` emits the same preview command and args in human and JSON output.
+  `--page <maintained-page>` proposes a deterministic update from the generated source-summary
+  page into one maintained topic, concept, entity, architecture, or glossary page. Proposed output
+  includes a unified diff, target/source-summary SHA-256 hashes, and a proposal hash derived from
+  those inputs plus the proposed page hash. Proposed and applied updates add the source ID to
+  frontmatter `source_refs`, add provenance links with `supports` and `generated-from` roles,
+  append a managed `Compiled Source Evidence` section to the markdown body, and validate the
+  resulting `KnowledgePageFrontmatter` before reporting or writing. Generated source-summary pages
+  are not valid compile targets.
 - `splendor pr-summary --since main` is a read-only PR handoff view over local git diff/status and
   existing report files. It diffs from the merge base between `HEAD` and the base ref, respects
   configured workspace layout directories, and groups curated source manifests, generated

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M14-P1.8`
-- Current planned slice: `Source identity design review`
-- Current PR sub-slice: `M14-P1.9`
+- Previous completed PR sub-slice: `M14-P1.9`
+- Current planned slice: `Compile/update expansion after first reviewed page apply`
+- Current PR sub-slice: `M15-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely M15 compile/update expansion`
-- Next planned PR sub-slice: `likely M15-P1.2`
+- Next planned slice: `likely ingest run-duration precision or post-M15 issue triage`
+- Next planned PR sub-slice: `likely TBD, possibly issue #47`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1036,6 +1036,18 @@ match the current target/source-summary inputs.
 The first slice intentionally does not choose multiple pages automatically, call an LLM, create a
 web UI, register new sources, refresh broad workspace state, or address #47 ingest timing, #37 web
 document-list scaling, or #30 repo-scan registration performance.
+
+### M15-P1.2 compile-target discovery expansion
+
+`M15-P1.2` connects the first reviewed compile/apply loop to existing source-impact suggestions.
+Bare `splendor wiki compile <source-id|title|path>` remains non-mutating, but now includes ranked
+maintained synthesis-page suggestions and ready-to-run
+`splendor wiki compile <source-id> --page <page>` preview commands. `splendor wiki suggest
+<source-id|title|path>` emits the same compile-preview commands for human and JSON agent handoff.
+JSON suggestions include structured `compile_preview_args` alongside the rendered command string
+so agents can execute the preview command without shell parsing. This slice does not add automatic
+multi-page apply, LLM synthesis, web mutation, source registration changes, broad workspace
+refresh, or performance/scaling work from #47, #37, or #30.
 
 ### Boundaries
 - Promote these candidates to committed roadmap slices only after the child issues and GitHub

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -747,9 +747,13 @@ contract is trustworthy.
 
 Current `splendor wiki compile <source-id>` support remains intentionally non-mutating when no
 target page is provided. It validates the source record and prints the review-gated contract:
-inspect the source summary, run source-impact suggestions, propose synthesis-page edits with
+inspect the source summary, review ranked maintained-page suggestions, run the ready-to-run
+`wiki compile <source-id> --page <page>` preview commands, propose synthesis-page edits with
 provenance/run state, keep generated source-summary pages separate from maintained synthesis pages,
-and require human review before wiki synthesis is changed.
+and require human review before wiki synthesis is changed. `wiki suggest` exposes the same preview
+commands in human and JSON output so agent handoffs do not have to stitch together command strings
+manually. JSON output also carries structured `compile_preview_args` argv tokens alongside the
+rendered `compile_preview_command`.
 
 The first mutating slice is deliberately narrow. `splendor wiki compile <source-id|title|path>
 --page <maintained-page>` proposes a deterministic one-page update from the generated
@@ -843,11 +847,14 @@ Current implementation:
   synthesis-follow-up counts, with optional JSON output.
 - `splendor wiki suggest <source-id|title|path>` deterministically ranks existing synthesis pages using source
   metadata, source-summary text, frontmatter source refs, tags, source refs, and page content, with
-  optional JSON output.
+  optional JSON output. Human and JSON output include the matching
+  `splendor wiki compile <source-id> --page <page>` preview command for each suggestion, and JSON
+  suggestions include structured `compile_preview_args` for agent handoff.
 - `splendor wiki compile <source-id|title|path>` exposes the review-gated compile-loop contract
-  when no target page is supplied. With `--page <maintained-page>`, it proposes a deterministic
-  source-summary evidence update and unified diff for one maintained synthesis page, and
-  `--apply --proposal-hash <hash>` explicitly accepts and writes that page after frontmatter and
+  when no target page is supplied, including ranked maintained-page suggestions and ready-to-run
+  preview commands. With `--page <maintained-page>`, it proposes a deterministic source-summary
+  evidence update and unified diff for one maintained synthesis page, and `--apply
+  --proposal-hash <hash>` explicitly accepts and writes that page after frontmatter and
   proposal-hash validation.
 - `splendor wiki rebuild-index` rewrites `wiki/index.md` from validated wiki page frontmatter,
   including maintained synthesis pages and generated source-summary pages, without mutating the

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -58,7 +58,8 @@ For this handoff:
   `M14-P1.1` through `M14-P1.9`; future work should be a specific non-workspace extension or
   regression, not a broad canonical source-ID redesign
 - #79 now owns the M15 reviewed compile/update sequence; `M15-P1.1` starts with explicit
-  one-page diff/proposal-hash/apply semantics rather than broad automatic synthesis updates
+  one-page diff/proposal-hash/apply semantics and `M15-P1.2` connects bare compile output to
+  ranked page suggestions without broad automatic synthesis updates
 
 ## Known Non-Blockers
 
@@ -97,8 +98,10 @@ The conservative next queue after the `M14-P3.1` gate is:
    canonical `src-...` IDs immutable as version/provenance records while logical IDs, supersession,
    freshness, path repair, and topic-ref migration cover ordinary curated workspace edits and
    moves.
-9. Continue #79 through `M15-P1.2` after #94 is closed or narrowed.
-10. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
+9. Continue #79 after `M15-P1.2` only through deliberately narrowed follow-ups, because compile
+   target discovery and one-page reviewed apply are now represented.
+10. Keep #47 as the likely next focused post-M15 follow-up for ingest run-duration precision.
+11. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
    either one urgent.
 
 The internal source-lifecycle re-evaluation gate is now complete in `M14-P3.1`. The completed retry
@@ -121,7 +124,9 @@ The retry result is captured in `docs/m14_synthbanshee_reevaluation.md`. After `
 work starts from #79 unless #86 review identifies a narrower follow-up or a new real-agent run
 reopens a source-lifecycle regression. The first #79 slice is `M15-P1.1`: keep bare compile
 non-mutating, require `--page` for a deterministic diff-backed proposal, and require
-`--apply --proposal-hash <hash>` for the explicit reviewed write.
+`--apply --proposal-hash <hash>` for the explicit reviewed write. `M15-P1.2` follows by adding
+ranked compile-target discovery, ready-to-run preview commands, and structured preview argv tokens
+to bare compile and `wiki suggest`, while preserving the one-page apply gate.
 
 ## Tagging Readiness
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -1450,6 +1450,7 @@ def handle_wiki_suggest(args: argparse.Namespace) -> int:
     for suggestion in result.suggestions:
         reasons = ", ".join(suggestion.reasons)
         print(f"- {suggestion.path} [{suggestion.kind}] score={suggestion.score} reasons={reasons}")
+        print(f"  Compile preview: {suggestion.compile_preview_command}")
     return 0
 
 
@@ -1518,6 +1519,17 @@ def handle_wiki_compile(args: argparse.Namespace) -> int:
     print("Mutates wiki: no")
     for item in result.contract:
         print(f"- {item}")
+    if result.suggested_pages:
+        print("Suggested compile targets:")
+        for suggestion in result.suggested_pages:
+            reasons = ", ".join(suggestion.reasons)
+            print(
+                f"- {suggestion.path} [{suggestion.kind}] score={suggestion.score} "
+                f"reasons={reasons}"
+            )
+            print(f"  Compile preview: {suggestion.compile_preview_command}")
+    else:
+        print("Suggested compile targets: none")
     print("Next steps:")
     for item in result.next_steps:
         print(f"- {item}")

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import posixpath
 import re
+import shlex
 from collections import Counter
 from dataclasses import asdict, dataclass, field
 from difflib import unified_diff
@@ -118,6 +119,8 @@ class WikiSuggestion:
     kind: str
     score: int
     reasons: list[str] = field(default_factory=list)
+    compile_preview_args: list[str] = field(default_factory=list)
+    compile_preview_command: str = ""
 
 
 @dataclass(frozen=True)
@@ -139,6 +142,7 @@ class WikiCompileContract:
     mutates: bool
     status: str
     contract: list[str]
+    suggested_pages: list[WikiSuggestion]
     next_steps: list[str]
 
 
@@ -635,6 +639,8 @@ def _score_page(
         kind=page.frontmatter.kind,
         score=score,
         reasons=reasons,
+        compile_preview_args=[],
+        compile_preview_command="",
     )
 
 
@@ -661,6 +667,8 @@ def _score_page_for_sources(
         kind=best.kind,
         score=max(suggestion.score for suggestion in scored),
         reasons=reasons,
+        compile_preview_args=[],
+        compile_preview_command="",
     )
 
 
@@ -685,6 +693,19 @@ def suggest_source_pages(root: Path, source_id: str) -> WikiSuggestResult:
         if suggestion is not None
     ]
     suggestions.sort(key=lambda suggestion: (-suggestion.score, suggestion.path))
+    suggestions = [
+        WikiSuggestion(
+            path=suggestion.path,
+            page_id=suggestion.page_id,
+            title=suggestion.title,
+            kind=suggestion.kind,
+            score=suggestion.score,
+            reasons=suggestion.reasons,
+            compile_preview_args=_compile_preview_args(source.source_id, suggestion.path),
+            compile_preview_command=_compile_preview_command(source.source_id, suggestion.path),
+        )
+        for suggestion in suggestions
+    ]
     return WikiSuggestResult(
         source_id=source.source_id,
         source_ids=[matched_source.source_id for matched_source in sources],
@@ -696,28 +717,48 @@ def suggest_source_pages(root: Path, source_id: str) -> WikiSuggestResult:
 
 
 def describe_wiki_compile_contract(root: Path, source_id: str) -> WikiCompileContract:
-    source = resolve_source_query(root, source_id).source
+    suggest_result = suggest_source_pages(root, source_id)
     return WikiCompileContract(
-        source_id=source.source_id,
-        source_title=source.title,
-        source_ref=canonical_source_ref(source),
-        source_status=source.status,
+        source_id=suggest_result.source_id,
+        source_title=suggest_result.source_title,
+        source_ref=suggest_result.source_ref,
+        source_status=suggest_result.source_status,
         mutates=False,
         status="contract-only",
         contract=[
             "Validate the source record and current source-summary page.",
-            "Use `splendor wiki suggest <source-id>` to identify affected synthesis pages.",
+            "Use ranked maintained-page suggestions to choose one explicit compile target.",
             "Propose synthesis-page edits with source refs, provenance links, run state, "
             "and review state.",
             "Keep generated source-summary pages separate from maintained synthesis pages.",
             "Require human review before mutating wiki synthesis pages.",
         ],
+        suggested_pages=suggest_result.suggestions,
         next_steps=[
-            f"Run `splendor wiki suggest {source.source_id}`.",
-            "Review suggested synthesis pages and apply changes through a reviewed future "
-            "compile loop.",
+            f"Run `splendor wiki suggest {suggest_result.source_id}` to inspect ranking reasons.",
+            *[
+                f"Preview `{suggestion.compile_preview_command}`."
+                for suggestion in suggest_result.suggestions[:3]
+            ],
+            *(
+                []
+                if suggest_result.suggestions
+                else [
+                    "Create or choose one maintained topic, concept, entity, architecture, "
+                    "or glossary page, then rerun `splendor wiki compile "
+                    f"{suggest_result.source_id} --page <page>`."
+                ]
+            ),
         ],
     )
+
+
+def _compile_preview_args(source_id: str, page_path: str) -> list[str]:
+    return ["splendor", "wiki", "compile", source_id, "--page", page_path]
+
+
+def _compile_preview_command(source_id: str, page_path: str) -> str:
+    return shlex.join(_compile_preview_args(source_id, page_path))
 
 
 def compile_source_into_page(

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -436,6 +436,18 @@ def test_wiki_suggest_ranks_source_impact_pages(tmp_path: Path, capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["source_id"] == added.source_id
     assert payload["suggestions"][0]["path"] == "wiki/topics/wiki-maintenance.md"
+    assert (
+        payload["suggestions"][0]["compile_preview_command"]
+        == f"splendor wiki compile {added.source_id} --page wiki/topics/wiki-maintenance.md"
+    )
+    assert payload["suggestions"][0]["compile_preview_args"] == [
+        "splendor",
+        "wiki",
+        "compile",
+        added.source_id,
+        "--page",
+        "wiki/topics/wiki-maintenance.md",
+    ]
     assert "frontmatter-source-ref" in payload["suggestions"][0]["reasons"]
     assert all(
         suggestion["path"] != "wiki/architecture/unrelated.md"
@@ -470,6 +482,10 @@ def test_wiki_suggest_text_output_reports_top_suggestion(tmp_path: Path, capsys)
     assert f"Source ID: {added.source_id}" in out
     assert "Suggested pages:" in out
     assert "wiki/topics/wiki-maintenance.md" in out
+    assert (
+        f"Compile preview: splendor wiki compile {added.source_id} "
+        "--page wiki/topics/wiki-maintenance.md"
+    ) in out
 
 
 def test_wiki_suggest_path_includes_all_versions_for_that_path(tmp_path: Path, capsys) -> None:
@@ -634,7 +650,12 @@ def test_wiki_compile_reports_review_gated_contract_without_mutating(
     assert payload["source_id"] == added.source_id
     assert payload["mutates"] is False
     assert payload["status"] == "contract-only"
+    assert payload["suggested_pages"] == []
     assert "Run `splendor wiki suggest" in payload["next_steps"][0]
+    assert (
+        "Create or choose one maintained topic, concept, entity, architecture, or glossary page"
+        in payload["next_steps"][1]
+    )
     assert page_path.read_text(encoding="utf-8") == before
 
 
@@ -658,9 +679,67 @@ def test_wiki_compile_text_reports_review_gated_contract_without_mutating(
     assert f"Source ID: {added.source_id}" in out
     assert "Compile contract" in out
     assert "Mutates wiki: no" in out
+    assert "Suggested compile targets: none" in out
     assert "Next steps:" in out
     assert "Run `splendor wiki suggest" in out
+    assert "Create or choose one maintained topic" in out
     assert page_path.read_text(encoding="utf-8") == before
+
+
+def test_wiki_compile_contract_includes_suggested_page_preview_commands(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "compile-contract.md"
+    source.write_text(
+        "# Compile contract\n\nSynthesis remains review-gated for wiki maintenance.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "compile contract.md",
+        kind="topic",
+        title="Compile contract",
+        page_id="topic-compile-contract",
+        source_refs=[added.source_id],
+        body="Maintained compile contract synthesis.",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "compile", added.source_id, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mutates"] is False
+    assert payload["suggested_pages"][0]["path"] == "wiki/topics/compile contract.md"
+    assert (
+        payload["suggested_pages"][0]["compile_preview_command"]
+        == f"splendor wiki compile {added.source_id} --page 'wiki/topics/compile contract.md'"
+    )
+    assert payload["suggested_pages"][0]["compile_preview_args"] == [
+        "splendor",
+        "wiki",
+        "compile",
+        added.source_id,
+        "--page",
+        "wiki/topics/compile contract.md",
+    ]
+    assert (
+        f"Preview `splendor wiki compile {added.source_id} "
+        "--page 'wiki/topics/compile contract.md'`."
+    ) in payload["next_steps"]
+
+    exit_code = main(["--root", str(tmp_path), "wiki", "compile", added.source_id])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Suggested compile targets:" in out
+    assert "wiki/topics/compile contract.md [topic]" in out
+    assert (
+        f"Compile preview: splendor wiki compile {added.source_id} "
+        "--page 'wiki/topics/compile contract.md'"
+    ) in out
 
 
 def test_wiki_compile_reports_unknown_source(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

- Add deterministic compile preview commands to `splendor wiki suggest` human and JSON suggestions.
- Make bare `splendor wiki compile <source>` include ranked maintained-page suggestions plus ready-to-run `wiki compile <source> --page <page>` preview commands.
- Keep actual writes behind the existing explicit one-page `--apply --proposal-hash <hash>` gate.
- Update planning state and command-contract docs for M15-P1.2.

## Issue linkage

Refs #79. This narrows #79 by completing compile-target discovery and handoff after M15-P1.1; it does not add multi-page apply, LLM synthesis, mutating web UI, source registration changes, or #47/#37/#30 follow-ups.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`