### PR TITLE
M10-P3.1 Fix ingest run timing precision

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M14-P1.9`
-- Last action taken: `M14-P1.9` is complete; issue #94 is closed after the source identity review/disposition.
-- Current planned slice: `Compile/update expansion after first reviewed page apply`
-- Current PR sub-slice: `M15-P1.2`
+- Previous completed PR sub-slice: `M15-P1.2`
+- Last action taken: `M15-P1.2` is complete; PR #102 connected compile-target discovery to preview handoff for issue #79.
+- Current planned slice: `Ingest run-duration precision`
+- Current PR sub-slice: `M10-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely ingest run-duration precision or post-M15 issue triage`
-- Next planned PR sub-slice: `likely TBD, possibly issue #47`
+- Next planned slice: `likely post-M15 issue triage or performance follow-up`
+- Next planned PR sub-slice: `likely TBD, possibly #30 or #37 after #47`
 - Current blockers: none
 
 ## Planning Notation
@@ -298,6 +298,11 @@
   - [x] Include ranked maintained-page suggestions in bare `wiki compile`
   - [x] Include ready-to-run compile preview commands in `wiki compile` and `wiki suggest`
   - [x] Preserve explicit one-page apply semantics and avoid automatic multi-page mutation
+- [x] Implement `M10-P3.1`: Ingest run-duration precision
+  - [x] Capture ingest run `started_at` before source resolution/dispatch work begins
+  - [x] Preserve sub-second `finished_at` only when the run reaches terminal success or failure
+  - [x] Add deterministic regression coverage without relying on sleeps
+  - [x] Keep historical run records and schema version unchanged
 
 ## Context Pointers
 
@@ -333,6 +338,7 @@
 - `M14-P3` Source-lifecycle re-evaluation gate
 - `M14-P4` Planning-doc authority and task-oriented agent briefs
 - `M15-P1` Post-v1 mutating compile/update workflow
+- `M10-P3` Ingest run-duration precision
 
 ## PR Sub-slice Queue
 
@@ -373,3 +379,4 @@
 - `M14-P4.1` Planning-doc authority and task-oriented agent briefs
 - `M15-P1.1` First reviewed compile/apply loop
 - `M15-P1.2` Compile/update expansion after first reviewed page apply
+- `M10-P3.1` Ingest run-duration precision

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ ingest handoff, #44's query snippets, #45's web status/source detail pages, and 
 visibility as represented in current behavior. `M15-P1.1` now starts #41's deferred mutating
 compile/update workflow through #79 with explicit one-page proposal/apply semantics. `M15-P1.2`
 is implemented: bare compile/suggest output now includes ranked compile-target previews while
-preserving the explicit apply gate. Issue #47 is handled next by `M10-P3.1` as a focused
+preserving the explicit apply gate. Issue #47 is targeted next by `M10-P3.1` as a focused
 ingest/run-state timing follow-up. Issues #30 and #37
 remain post-v1 performance work. Issue #70 is closed after the M13-P2/M13-P3.1 response. Issue #72
 is the parent feedback loop for the M14 source-lifecycle sequence; stable logical source

--- a/README.md
+++ b/README.md
@@ -240,12 +240,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M14-P1.9`
-- Current planned slice: `Compile/update expansion after first reviewed page apply`
-- Current PR sub-slice: `M15-P1.2`
+- Previous completed PR sub-slice: `M15-P1.2`
+- Current planned slice: `Ingest run-duration precision`
+- Current PR sub-slice: `M10-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely ingest run-duration precision or post-M15 issue triage`
-- Next planned PR sub-slice: `likely TBD, possibly issue #47`
+- Next planned slice: `likely post-M15 issue triage or performance follow-up`
+- Next planned PR sub-slice: `likely TBD, possibly #30 or #37 after #47`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -332,8 +332,10 @@ CLI, clarifies generated-state review policy, and records the v1 readiness audit
 issue #41's briefing and non-mutating compile contract, #42's next-action hints, #43's pending
 ingest handoff, #44's query snippets, #45's web status/source detail pages, and #46's page-state
 visibility as represented in current behavior. `M15-P1.1` now starts #41's deferred mutating
-compile/update workflow through #79 with explicit one-page proposal/apply semantics. Issue #47
-remains an ingest/run-state timing follow-up. Issues #30 and #37
+compile/update workflow through #79 with explicit one-page proposal/apply semantics. `M15-P1.2`
+is implemented: bare compile/suggest output now includes ranked compile-target previews while
+preserving the explicit apply gate. Issue #47 is handled next by `M10-P3.1` as a focused
+ingest/run-state timing follow-up. Issues #30 and #37
 remain post-v1 performance work. Issue #70 is closed after the M13-P2/M13-P3.1 response. Issue #72
 is the parent feedback loop for the M14 source-lifecycle sequence; stable logical source
 identities, supersession lifecycle, safe workspace refresh, superseded summary pruning, topic-ref
@@ -429,6 +431,11 @@ suggest <source-id|title|path>` exposes the same compile-preview commands in tex
 JSON output also includes structured `compile_preview_args` argv tokens so agents do not have to
 parse shell text. Actual writes still require the explicit one-page `--apply --proposal-hash
 <hash>` gate.
+
+`M10-P3.1` handles issue #47 as a narrow runtime-ledger bugfix. New ingest run records capture
+`started_at` with sub-second precision before source resolution/dispatch work begins and preserve
+`finished_at` only when the run reaches terminal success or failure. Historical run records are not
+rewritten.
 
 ### v1 readiness checklist
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -479,6 +479,9 @@ The runtime contracts are now used by deterministic single-source ingestion.
 - `QueueItemRecord` captures item lifecycle, retries, backoff scheduling, dead-letter state, and
   leases.
 - `RunRecord` captures pipeline inputs, outputs, warnings, and failures.
+- Ingest run records capture `started_at` with sub-second precision before source
+  resolution/dispatch work begins, and set `finished_at` only when the run reaches terminal
+  success or failure. Historical run records are not rewritten.
 
 Current persisted locations:
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M14-P1.9`
-- Current planned slice: `Compile/update expansion after first reviewed page apply`
-- Current PR sub-slice: `M15-P1.2`
+- Previous completed PR sub-slice: `M15-P1.2`
+- Current planned slice: `Ingest run-duration precision`
+- Current PR sub-slice: `M10-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely ingest run-duration precision or post-M15 issue triage`
-- Next planned PR sub-slice: `likely TBD, possibly issue #47`
+- Next planned slice: `likely post-M15 issue triage or performance follow-up`
+- Next planned PR sub-slice: `likely TBD, possibly #30 or #37 after #47`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -827,9 +827,9 @@ adding SQLite, vector search, background workers, mutating web UI, or broad refr
 
 `M13-P3.2` is the final release checklist and post-v1 handoff. It keeps runtime behavior stable,
 adds the concise release handoff in `docs/v1_release_handoff.md`, and makes the post-v1 queue
-explicit: #72 owns source lifecycle and agent workflow follow-up; #47 owns ingest run durations;
-#79 owns the deferred mutating compile/update path from #41; #30 and #37 remain independent
-performance/scaling follow-ups.
+explicit: #72 owns source lifecycle and agent workflow follow-up; #79 owns the deferred mutating
+compile/update path from #41; #47 owns ingest run durations and is handled by `M10-P3.1`; #30 and
+#37 remain independent performance/scaling follow-ups.
 
 ### M13-P3 v1 release-readiness checklist
 
@@ -1048,6 +1048,13 @@ JSON suggestions include structured `compile_preview_args` alongside the rendere
 so agents can execute the preview command without shell parsing. This slice does not add automatic
 multi-page apply, LLM synthesis, web mutation, source registration changes, broad workspace
 refresh, or performance/scaling work from #47, #37, or #30.
+
+### M10-P3.1 ingest run-duration precision
+
+`M10-P3.1` handles issue #47 as a focused runtime-ledger correction. Ingest run records capture
+`started_at` with sub-second precision before source resolution and dispatch begin, then preserve a
+terminal `finished_at` only when the run succeeds or fails. The persisted run-record shape and
+schema version remain unchanged, and historical run records are not rewritten.
 
 ### Boundaries
 - Promote these candidates to committed roadmap slices only after the child issues and GitHub

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -828,7 +828,7 @@ adding SQLite, vector search, background workers, mutating web UI, or broad refr
 `M13-P3.2` is the final release checklist and post-v1 handoff. It keeps runtime behavior stable,
 adds the concise release handoff in `docs/v1_release_handoff.md`, and makes the post-v1 queue
 explicit: #72 owns source lifecycle and agent workflow follow-up; #79 owns the deferred mutating
-compile/update path from #41; #47 owns ingest run durations and is handled by `M10-P3.1`; #30 and
+compile/update path from #41; #47 owns ingest run durations and is targeted by `M10-P3.1`; #30 and
 #37 remain independent performance/scaling follow-ups.
 
 ### M13-P3 v1 release-readiness checklist

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -207,6 +207,8 @@ Examples:
 - repair attempts
 
 This layer exists to support idempotency, trust, debugging, and recovery.
+Ingest run records preserve distinct start and terminal finish timestamps with sub-second
+precision for new runs, without rewriting historical ledger entries.
 
 ### 4.7 Planning Objects
 

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -46,7 +46,7 @@ For this handoff:
 - #72 remains open as the parent source-refresh lifecycle and agent-workflow feedback loop
 - #41-#46 are closed as completed v1 dogfood issues after closing comments named the shipped scope
   and any deferred work; #79 tracks the deferred mutating compile/update path from #41
-- #47 is handled by `M10-P3.1` as the focused ingest run-duration precision bug
+- #47 is targeted by `M10-P3.1` as the focused ingest run-duration precision bug
 - #30 remains open as post-v1 repo-scan registration performance work
 - #37 remains open as post-v1 web document-list scaling work
 - #72 is unblocked after `M14-P2.1`; the `M14-P3.1` source-lifecycle re-evaluation gate records
@@ -101,8 +101,8 @@ The conservative next queue after the `M14-P3.1` gate is:
    moves.
 9. Continue #79 after `M15-P1.2` only through deliberately narrowed follow-ups, because compile
    target discovery and one-page reviewed apply are now represented.
-10. Complete #47 through `M10-P3.1` for ingest run-duration precision without rewriting historical
-    runtime records.
+10. Complete #47 through `M10-P3.1` once the focused ingest run-duration precision PR merges,
+    without rewriting historical runtime records.
 11. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
    either one urgent.
 

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -46,7 +46,7 @@ For this handoff:
 - #72 remains open as the parent source-refresh lifecycle and agent-workflow feedback loop
 - #41-#46 are closed as completed v1 dogfood issues after closing comments named the shipped scope
   and any deferred work; #79 tracks the deferred mutating compile/update path from #41
-- #47 remains open as the real ingest run-duration bug
+- #47 is handled by `M10-P3.1` as the focused ingest run-duration precision bug
 - #30 remains open as post-v1 repo-scan registration performance work
 - #37 remains open as post-v1 web document-list scaling work
 - #72 is unblocked after `M14-P2.1`; the `M14-P3.1` source-lifecycle re-evaluation gate records
@@ -67,7 +67,8 @@ These items are intentionally not v1 release blockers:
 
 - richer post-M14 authority lifecycle policy after the initial planning-doc authority briefs have
   been exercised in real repositories
-- ingest run-duration precision for #47
+- historical ingest run records may still show zero duration because `M10-P3.1` does not rewrite
+  old runtime ledger entries
 - source identity extensions beyond curated workspace-backed source lifecycle semantics, if real
   repository use identifies a concrete remaining gap after #94
 - repo-scan bulk registration optimization for #30
@@ -100,7 +101,8 @@ The conservative next queue after the `M14-P3.1` gate is:
    moves.
 9. Continue #79 after `M15-P1.2` only through deliberately narrowed follow-ups, because compile
    target discovery and one-page reviewed apply are now represented.
-10. Keep #47 as the likely next focused post-M15 follow-up for ingest run-duration precision.
+10. Complete #47 through `M10-P3.1` for ingest run-duration precision without rewriting historical
+    runtime records.
 11. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
    either one urgent.
 

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -120,6 +120,10 @@ def _utc_now() -> datetime:
     return datetime.now(UTC).replace(microsecond=0)
 
 
+def _run_timestamp_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="microseconds")
+
+
 def _relative_to_root(root: Path, path: Path) -> str:
     return path.relative_to(root).as_posix()
 
@@ -683,7 +687,7 @@ def _mark_attempt_failed(
     failed_run = run.model_copy(
         update={
             "source_ids": failed_run.source_ids,
-            "finished_at": utc_now_iso(),
+            "finished_at": _run_timestamp_iso(),
             "status": "failed",
             "errors": [error_message],
             "provenance_links": failed_run.provenance_links,
@@ -894,7 +898,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
         run_id=run_id,
         job_id=queue_item.job_id,
         job_type="ingest_source",
-        started_at=utc_now_iso(),
+        started_at=_run_timestamp_iso(),
         status="running",
         input_refs=[
             _relative_to_root(root, manifest_path),
@@ -978,7 +982,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
         page_path = _page_path_for(layout.wiki_sources_dir, source.source_id)
         page_relpath = _relative_to_root(root, page_path)
         registered_path = canonical_source_ref(source)
-        finished_at = utc_now_iso()
+        finished_at = _run_timestamp_iso()
         frontmatter = KnowledgePageFrontmatter(
             kind="source-summary",
             title=source.title,

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -982,7 +982,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
         page_path = _page_path_for(layout.wiki_sources_dir, source.source_id)
         page_relpath = _relative_to_root(root, page_path)
         registered_path = canonical_source_ref(source)
-        finished_at = _run_timestamp_iso()
+        generated_at = _run_timestamp_iso()
         frontmatter = KnowledgePageFrontmatter(
             kind="source-summary",
             title=source.title,
@@ -991,7 +991,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
             review_state="machine-generated",
             source_refs=[source.source_id],
             generated_by_run_ids=[run_id],
-            last_generated_at=finished_at,
+            last_generated_at=generated_at,
             confidence=1.0,
             tags=["source-summary", source.source_type],
             provenance_links=_page_provenance_links(
@@ -1022,7 +1022,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
             f"Checksum: `{source.checksum}`",
             f"Source ref: `{canonical_source_ref(source)}`",
             f"Added at: `{source.added_at}`",
-            f"Ingested at: `{finished_at}`",
+            f"Ingested at: `{generated_at}`",
             *_build_content_key_facts(source_text),
         ]
         provenance_lines = [
@@ -1110,6 +1110,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
                 ),
             }
         )
+        finished_at = _run_timestamp_iso()
         success_run = run.model_copy(
             update={
                 "finished_at": finished_at,

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 from pypdf import PdfWriter
 
+import splendor.commands.ingest as ingest_module
 import splendor.utils.contradictions as contradictions_module
 from conftest import write_text_pdf
 from splendor.commands.add_source import add_source
@@ -137,6 +138,33 @@ def test_ingest_source_happy_path(tmp_path: Path) -> None:
     log_content = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
     assert added.source_id in log_content
     assert result.run_id in log_content
+
+
+def test_ingest_source_records_distinct_start_and_finish_timestamps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source, storage_mode="copy")
+    timestamps = iter(
+        [
+            "2026-05-04T10:00:00.000100+00:00",
+            "2026-05-04T10:00:00.000900+00:00",
+        ]
+    )
+
+    monkeypatch.setattr(ingest_module, "_run_timestamp_iso", lambda: next(timestamps))
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.run_path is not None
+    run_record = load_run_record(result.run_path)
+    assert run_record.started_at == "2026-05-04T10:00:00.000100+00:00"
+    assert run_record.finished_at == "2026-05-04T10:00:00.000900+00:00"
+    assert datetime.fromisoformat(run_record.started_at) <= datetime.fromisoformat(
+        run_record.finished_at
+    )
 
 
 def test_ingest_source_is_idempotent_when_current_pipeline_already_succeeded(

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -147,14 +147,44 @@ def test_ingest_source_records_distinct_start_and_finish_timestamps(
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
     added = add_source(tmp_path, source, storage_mode="copy")
+    events: list[str] = []
     timestamps = iter(
         [
             "2026-05-04T10:00:00.000100+00:00",
+            "2026-05-04T10:00:00.000500+00:00",
             "2026-05-04T10:00:00.000900+00:00",
         ]
     )
 
-    monkeypatch.setattr(ingest_module, "_run_timestamp_iso", lambda: next(timestamps))
+    def next_run_timestamp() -> str:
+        timestamp = next(timestamps)
+        events.append(f"timestamp:{timestamp}")
+        return timestamp
+
+    def review_after_initial_page_render(**kwargs):
+        events.append("review")
+        return contradictions_module.ContradictionReviewResult(
+            frontmatter=kwargs["current_snapshot"].frontmatter,
+            task_updates=[],
+            page_updates=[],
+            contradiction_ids=[],
+            task_ids=[],
+            warnings=[],
+        )
+
+    original_commit_success = ingest_module._commit_success
+
+    def commit_success_after_terminal_run(**kwargs):
+        events.append(f"commit:{kwargs['success_run'].finished_at}")
+        original_commit_success(**kwargs)
+
+    monkeypatch.setattr(ingest_module, "_run_timestamp_iso", next_run_timestamp)
+    monkeypatch.setattr(
+        ingest_module,
+        "review_source_summary_contradictions",
+        review_after_initial_page_render,
+    )
+    monkeypatch.setattr(ingest_module, "_commit_success", commit_success_after_terminal_run)
 
     result = ingest_source(tmp_path, added.source_id)
 
@@ -165,6 +195,13 @@ def test_ingest_source_records_distinct_start_and_finish_timestamps(
     assert datetime.fromisoformat(run_record.started_at) <= datetime.fromisoformat(
         run_record.finished_at
     )
+    assert events == [
+        "timestamp:2026-05-04T10:00:00.000100+00:00",
+        "timestamp:2026-05-04T10:00:00.000500+00:00",
+        "review",
+        "timestamp:2026-05-04T10:00:00.000900+00:00",
+        "commit:2026-05-04T10:00:00.000900+00:00",
+    ]
 
 
 def test_ingest_source_is_idempotent_when_current_pipeline_already_succeeded(


### PR DESCRIPTION
## Summary

- Capture new ingest run `started_at` timestamps with sub-second precision before source resolution and dispatch work begins.
- Preserve terminal `finished_at` timestamps with sub-second precision for both successful and failed ingest runs without changing the run-record schema version.
- Update planning/runtime docs for `M10-P3.1` and keep historical run records unchanged.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`

Closes #47