### PR TITLE
M13-P3.3: Optimize repo scan registration overhead

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M15-P1.2`
-- Last action taken: `M15-P1.2` is complete; PR #102 connected compile-target discovery to preview handoff for issue #79.
-- Current planned slice: `Ingest run-duration precision`
-- Current PR sub-slice: `M10-P3.1`
+- Previous completed PR sub-slice: `M10-P3.1`
+- Last action taken: `M10-P3.1` is complete; PR #103 corrected ingest run timing for issue #47.
+- Current planned slice: `Repo-scan registration overhead`
+- Current PR sub-slice: `M13-P3.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely post-M15 issue triage or performance follow-up`
-- Next planned PR sub-slice: `likely TBD, possibly #30 or #37 after #47`
+- Next planned slice: `likely local web UI document-list scaling or issue #79 disposition`
+- Next planned PR sub-slice: `likely TBD, possibly #37 or a narrowed #79 follow-up`
 - Current blockers: none
 
 ## Planning Notation
@@ -303,6 +303,10 @@
   - [x] Preserve sub-second `finished_at` only when the run reaches terminal success or failure
   - [x] Add deterministic regression coverage without relying on sleeps
   - [x] Keep historical run records and schema version unchanged
+- [x] Implement `M13-P3.3`: Repo-scan registration overhead
+  - [x] Reuse preloaded config/layout during repo-scan apply registration
+  - [x] Preserve repo-scan preview/apply gates and source registration behavior
+  - [x] Add deterministic regression coverage without timing assertions
 
 ## Context Pointers
 
@@ -364,6 +368,7 @@
 - `M13-P2.5` Source-summary policy and path-first UX
 - `M13-P3.1` Release hardening and v1 readiness
 - `M13-P3.2` Final release checklist and post-v1 handoff
+- `M13-P3.3` Repo-scan registration overhead
 - `M14-P0.1` Split post-v1 source-lifecycle and workflow follow-ups
 - `M14-P1.1` Stable logical source identities
 - `M14-P1.2` Supersession-aware source refresh

--- a/README.md
+++ b/README.md
@@ -240,12 +240,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M15-P1.2`
-- Current planned slice: `Ingest run-duration precision`
-- Current PR sub-slice: `M10-P3.1`
+- Previous completed PR sub-slice: `M10-P3.1`
+- Current planned slice: `Repo-scan registration overhead`
+- Current PR sub-slice: `M13-P3.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely post-M15 issue triage or performance follow-up`
-- Next planned PR sub-slice: `likely TBD, possibly #30 or #37 after #47`
+- Next planned slice: `likely local web UI document-list scaling or issue #79 disposition`
+- Next planned PR sub-slice: `likely TBD, possibly #37 or a narrowed #79 follow-up`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M15-P1.2`
-- Current planned slice: `Ingest run-duration precision`
-- Current PR sub-slice: `M10-P3.1`
+- Previous completed PR sub-slice: `M10-P3.1`
+- Current planned slice: `Repo-scan registration overhead`
+- Current PR sub-slice: `M13-P3.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely post-M15 issue triage or performance follow-up`
-- Next planned PR sub-slice: `likely TBD, possibly #30 or #37 after #47`
+- Next planned slice: `likely local web UI document-list scaling or issue #79 disposition`
+- Next planned PR sub-slice: `likely TBD, possibly #37 or a narrowed #79 follow-up`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -791,6 +791,7 @@ freshness, contested knowledge, planning state, and next actions rather than mos
 - `M13-P2.5` Source-summary policy and path-first UX
 - `M13-P3.1` Release hardening and v1 readiness
 - `M13-P3.2` Final release checklist and post-v1 handoff
+- `M13-P3.3` Repo-scan registration overhead
 
 ### Deliverables
 - v1 schema versions
@@ -830,6 +831,11 @@ adds the concise release handoff in `docs/v1_release_handoff.md`, and makes the 
 explicit: #72 owns source lifecycle and agent workflow follow-up; #79 owns the deferred mutating
 compile/update path from #41; #47 owns ingest run durations and is targeted by `M10-P3.1`; #30 and
 #37 remain independent performance/scaling follow-ups.
+
+`M13-P3.3` handles issue #30 as a focused repo-scan apply performance/refactor slice. It preserves
+safe non-mutating scan previews, explicit apply gates, source IDs, manifest validation, and queue
+handoff behavior while avoiding repeated config loading and layout resolution during bulk
+registration.
 
 ### M13-P3 v1 release-readiness checklist
 

--- a/src/splendor/commands/repo_scan.py
+++ b/src/splendor/commands/repo_scan.py
@@ -9,11 +9,15 @@ from dataclasses import dataclass, replace
 from fnmatch import fnmatchcase
 from pathlib import Path
 
-from splendor.config import load_config
+from splendor.config import SplendorConfig, load_config
 from splendor.ingest_dispatch import IMAGE_SOURCE_TYPES, SUPPORTED_SOURCE_TYPES
 from splendor.layout import ResolvedLayout, resolve_layout
 from splendor.schemas.types import SourceClass
-from splendor.state.source_registry import load_source_record, register_source
+from splendor.state.source_registry import (
+    SourceRegistrationContext,
+    load_source_record,
+    register_source,
+)
 from splendor.utils.hashing import sha256_file
 
 _CONFIG_EXTENSIONS = {"json", "yaml", "yml"}
@@ -109,6 +113,23 @@ def scan_repo(
 ) -> RepoScanResult:
     config = load_config(root)
     layout = resolve_layout(root, config)
+    return _scan_repo_with_context(
+        root,
+        config=config,
+        layout=layout,
+        class_filters=class_filters,
+        all_classes=all_classes,
+    )
+
+
+def _scan_repo_with_context(
+    root: Path,
+    *,
+    config: SplendorConfig,
+    layout: ResolvedLayout,
+    class_filters: list[SourceClass] | None = None,
+    all_classes: bool = False,
+) -> RepoScanResult:
     selected_classes = _selected_classes(
         configured_default_classes=config.sources.repo_scan_default_classes,
         class_filters=class_filters,
@@ -221,7 +242,16 @@ def apply_repo_scan(
     if not class_filters and not all_classes:
         msg = "repo scan --apply requires at least one --class filter or --all"
         raise ValueError(msg)
-    preview = scan_repo(root, class_filters=class_filters, all_classes=all_classes)
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    registration_context = SourceRegistrationContext(config=config, layout=layout)
+    preview = _scan_repo_with_context(
+        root,
+        config=config,
+        layout=layout,
+        class_filters=class_filters,
+        all_classes=all_classes,
+    )
     if preview.candidates > LARGE_APPLY_CANDIDATE_LIMIT and not allow_large_apply:
         msg = (
             "repo scan --apply refused "
@@ -241,6 +271,7 @@ def apply_repo_scan(
             source_labels=candidate.source_labels,
             discovered_by="repo_scan",
             refresh_existing_metadata=True,
+            context=registration_context,
         )
         status = "already_registered" if registered_source.already_registered else "registered"
         if registered_source.already_registered:

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -8,8 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from splendor import __version__
-from splendor.config import load_config
-from splendor.layout import resolve_layout
+from splendor.config import SplendorConfig, load_config
+from splendor.layout import ResolvedLayout, resolve_layout
 from splendor.schemas import SourcePointerArtifact, SourceRecord
 from splendor.schemas.types import SourceClass, SourceDiscoveryMode, StorageMode
 from splendor.state.paths import resolve_workspace_path
@@ -50,6 +50,18 @@ class MaterializedSource:
     stored_path: Path
     storage_mode: StorageMode
     source_ref: str
+
+
+@dataclass(frozen=True)
+class SourceRegistrationContext:
+    config: SplendorConfig
+    layout: ResolvedLayout
+
+
+def source_registration_context(root: Path) -> SourceRegistrationContext:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    return SourceRegistrationContext(config=config, layout=layout)
 
 
 def manifest_path_for(root: Path, source_id: str) -> Path:
@@ -432,6 +444,7 @@ def register_source(
     source_labels: list[str] | None = None,
     discovered_by: SourceDiscoveryMode | None = None,
     refresh_existing_metadata: bool = False,
+    context: SourceRegistrationContext | None = None,
 ) -> RegisteredSource:
     candidate = source_path.expanduser().resolve()
     if not candidate.exists():
@@ -441,8 +454,13 @@ def register_source(
         msg = f"Source path must be a file: {source_path}"
         raise IsADirectoryError(msg)
 
-    config = load_config(root)
-    layout = resolve_layout(root, config)
+    if context is None:
+        context = source_registration_context(root)
+    config = context.config
+    layout = context.layout
+    if layout.root.resolve() != root.resolve():
+        msg = f"Source registration context root does not match workspace root: {layout.root}"
+        raise ValueError(msg)
     ensure_directory(layout.source_records_dir)
     ensure_directory(layout.raw_sources_dir)
 

--- a/tests/test_repo_scan.py
+++ b/tests/test_repo_scan.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+import splendor.commands.repo_scan as repo_scan_module
+import splendor.state.source_registry as source_registry_module
 from conftest import write_text_pdf
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
@@ -101,6 +103,66 @@ def test_repo_scan_apply_registers_and_classifies_supported_workspace_files(
     assert manifest_by_ref["AGENTS.md"].source_class == "documentation"
     assert manifest_by_ref["AGENTS.md"].source_labels == ["agent-instructions"]
     assert manifest_by_ref["src/main.py"].source_class == "code"
+
+
+def test_repo_scan_apply_reuses_config_and_layout_for_bulk_registration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initialize_workspace(tmp_path)
+    config_path = tmp_path / "splendor.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["layout"]["state_dir"] = "custom-state"
+    config["layout"]["source_records_dir"] = "custom-state/manifests/sources"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    for index in range(3):
+        (tmp_path / f"doc-{index}.md").write_text(f"# Doc {index}\n", encoding="utf-8")
+
+    load_config_calls = 0
+    resolve_layout_calls = 0
+    real_load_config = repo_scan_module.load_config
+    real_resolve_layout = repo_scan_module.resolve_layout
+
+    def counting_load_config(root: Path):
+        nonlocal load_config_calls
+        load_config_calls += 1
+        return real_load_config(root)
+
+    def counting_resolve_layout(root: Path, config):
+        nonlocal resolve_layout_calls
+        resolve_layout_calls += 1
+        return real_resolve_layout(root, config)
+
+    def fail_source_registry_load_config(root: Path):
+        raise AssertionError(f"unexpected per-source config load for {root}")
+
+    def fail_source_registry_resolve_layout(root: Path, config):
+        raise AssertionError(f"unexpected per-source layout resolution for {root}")
+
+    monkeypatch.setattr(repo_scan_module, "load_config", counting_load_config)
+    monkeypatch.setattr(repo_scan_module, "resolve_layout", counting_resolve_layout)
+    monkeypatch.setattr(source_registry_module, "load_config", fail_source_registry_load_config)
+    monkeypatch.setattr(
+        source_registry_module,
+        "resolve_layout",
+        fail_source_registry_resolve_layout,
+    )
+
+    result = repo_scan_module.apply_repo_scan(tmp_path, class_filters=["documentation"])
+
+    assert result.registered == 3
+    assert load_config_calls == 1
+    assert resolve_layout_calls == 1
+    assert _manifest_paths(tmp_path) == []
+    custom_manifest_paths = sorted(
+        (tmp_path / "custom-state" / "manifests" / "sources").glob("*.json")
+    )
+    assert len(custom_manifest_paths) == 3
+    assert {load_source_record(path).source_ref for path in custom_manifest_paths} == {
+        "doc-0.md",
+        "doc-1.md",
+        "doc-2.md",
+    }
 
 
 def test_repo_scan_classifies_image_sources_as_other(tmp_path: Path) -> None:


### PR DESCRIPTION
## Planning notation

- Concrete PR sub-slice: `M13-P3.3`
- Parent milestone slice: `M13-P3` Extension/performance/release finalization
- Plan source: `.agent-plan.md`, README `What Comes Next`, and `docs/splendor_mvp_to_v1_roadmap.md`

## Summary

- Add optional preloaded `SplendorConfig` and `ResolvedLayout` parameters to `register_source()` while preserving the existing default single-file behavior.
- Reuse the config/layout pair loaded by `apply_repo_scan()` for both preview selection and each `repo_scan` registration.
- Add deterministic repo-scan apply coverage that proves the apply loop avoids source-registry config/layout reloads without relying on timing assertions.
- Update planning-state lines and the roadmap entry for `M13-P3.3`.

## Why

Issue #30 identified that `scan_repo --apply` reused `register_source()` once per discovered file, which kept behavior consistent but paid repeated `load_config()` and `resolve_layout()` overhead for bulk repo-scan workloads. This PR keeps registration behavior centralized and backward-compatible while giving repo-scan apply a narrow way to reuse the already-loaded workspace context.

## Behavior and compatibility

- Public CLI behavior is unchanged.
- Bare `splendor repo scan` remains non-mutating.
- `repo scan --apply` still requires explicit class/all opt-in and keeps the large-set refusal gate.
- Source IDs, manifest validation, metadata backfill, storage-mode behavior, and queue handoff semantics stay on the existing `register_source()` path.
- No durable caches, background workers, broad source lifecycle changes, candidate classification changes, or web UI behavior are added.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`

Closes #30
