### PR TITLE
M9-P3.1 Scale web document listing

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M10-P3.1`
-- Last action taken: `M10-P3.1` is complete; PR #103 corrected ingest run timing for issue #47.
-- Current planned slice: `Repo-scan registration overhead`
-- Current PR sub-slice: `M13-P3.3`
+- Previous completed PR sub-slice: `M13-P3.3`
+- Last action taken: `M13-P3.3` is complete; PR #104 reduced repo-scan registration overhead for issue #30.
+- Current planned slice: `Local web UI document-list scaling`
+- Current PR sub-slice: `M9-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely local web UI document-list scaling or issue #79 disposition`
-- Next planned PR sub-slice: `likely TBD, possibly #37 or a narrowed #79 follow-up`
+- Next planned slice: `likely issue #79 disposition or narrowed compile/update follow-up`
+- Next planned PR sub-slice: `likely TBD, possibly M15-P1.3 if a concrete #79 follow-up is defined`
 - Current blockers: none
 
 ## Planning Notation
@@ -141,6 +141,11 @@
   - [x] Keep web actions non-mutating and CLI-first
   - [x] Update focused tests and docs for the planning/runtime web surfaces
   - [x] Publish a non-draft GitHub PR for `M9-P2.1` with labels, milestone, and a detailed description
+- [x] Implement `M9-P3.1`: Local web UI document-list scaling
+  - [x] Build browse/home rows from lightweight markdown listing metadata
+  - [x] Keep document detail and search parsing complete
+  - [x] Update focused tests and planning state for issue #37
+  - [x] Publish a non-draft GitHub PR for `M9-P3.1` with labels, milestone, and a detailed description
 - [x] Implement `M10-P1.1`: Queue inspect/retry/repair commands
   - [x] Add CLI queue inspection with human and JSON output
   - [x] Add explicit failed ingest queue retry

--- a/README.md
+++ b/README.md
@@ -240,12 +240,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M10-P3.1`
-- Current planned slice: `Repo-scan registration overhead`
-- Current PR sub-slice: `M13-P3.3`
+- Previous completed PR sub-slice: `M13-P3.3`
+- Current planned slice: `Local web UI document-list scaling`
+- Current PR sub-slice: `M9-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely local web UI document-list scaling or issue #79 disposition`
-- Next planned PR sub-slice: `likely TBD, possibly #37 or a narrowed #79 follow-up`
+- Next planned slice: `likely issue #79 disposition or narrowed compile/update follow-up`
+- Next planned PR sub-slice: `likely TBD, possibly M15-P1.3 if a concrete #79 follow-up is defined`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M10-P3.1`
-- Current planned slice: `Repo-scan registration overhead`
-- Current PR sub-slice: `M13-P3.3`
+- Previous completed PR sub-slice: `M13-P3.3`
+- Current planned slice: `Local web UI document-list scaling`
+- Current PR sub-slice: `M9-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely local web UI document-list scaling or issue #79 disposition`
-- Next planned PR sub-slice: `likely TBD, possibly #37 or a narrowed #79 follow-up`
+- Next planned slice: `likely issue #79 disposition or narrowed compile/update follow-up`
+- Next planned PR sub-slice: `likely TBD, possibly M15-P1.3 if a concrete #79 follow-up is defined`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -555,6 +555,7 @@ Provide a modest but useful human UI without changing the system’s center of g
 - `M10-P0.2` Project briefing and compile-loop contract
 - `M10-P0.3` Dogfood workflow polish and web status surfaces
 - `M9-P2.1` Planning/runs UI views
+- `M9-P3.1` Local web UI document-list scaling
 
 ### Milestone 9 status
 
@@ -570,7 +571,9 @@ work. `M10-P0.2` adds project briefing and a documented, non-mutating review-gat
 contract. `M10-P0.3` polishes the visible dogfood workflow with query snippet improvements,
 restrained next-action hints, and read-only web status/source-detail surfaces. `M9-P2.1` adds
 read-only planning record lists plus queue and run inspection views to the same local web shell.
-Mutating web actions and add-source forms remain deferred to later `M9` slices.
+`M9-P3.1` keeps browse and home listing lightweight by deriving rows from paths plus cheap markdown
+metadata while deferring full document parsing to detail and search. Mutating web actions and
+add-source forms remain deferred to later `M9` slices.
 
 ---
 

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -11,6 +11,7 @@ from urllib.parse import quote
 
 import bleach
 import markdown as markdown_lib
+import yaml
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse
 from pydantic import ValidationError
@@ -716,14 +717,68 @@ def _empty_workspace_panel() -> str:
 
 
 def _document_summary(root: Path, layout: ResolvedLayout, path: Path) -> _DocumentSummary:
-    detail = _document_detail(root, layout, path)
+    relative_path = path.relative_to(root).as_posix()
+    metadata = _read_listing_metadata(path)
+    if path.is_relative_to(layout.wiki_dir):
+        document_class = "wiki"
+        default_kind = None
+    else:
+        document_class = "planning"
+        default_kind = _planning_kind(layout, path)
     return _DocumentSummary(
-        path=detail.path,
-        title=detail.title,
-        document_class=detail.document_class,
-        kind=detail.kind,
-        status=detail.status,
+        path=relative_path,
+        title=metadata.get("title") or _title_from_path(relative_path),
+        document_class=document_class,
+        kind=metadata.get("kind") or default_kind,
+        status=metadata.get("status"),
     )
+
+
+def _read_listing_metadata(path: Path) -> dict[str, str | None]:
+    """Read only frontmatter and the first heading needed for browse rows."""
+    frontmatter_lines: list[str] = []
+    heading: str | None = None
+    frontmatter: dict[str, object] = {}
+    frontmatter_closed = False
+
+    with path.open("r", encoding="utf-8") as handle:
+        first_line = handle.readline()
+        if first_line.replace("\r\n", "\n").replace("\r", "\n") == "---\n":
+            for line in handle:
+                normalized = line.replace("\r\n", "\n").replace("\r", "\n")
+                if normalized == "---\n":
+                    frontmatter_closed = True
+                    break
+                frontmatter_lines.append(normalized)
+            if frontmatter_closed:
+                frontmatter = _load_listing_frontmatter(frontmatter_lines)
+        else:
+            heading = _heading_from_line(first_line)
+
+        if heading is None and not _frontmatter_string(frontmatter, "title"):
+            for line in handle:
+                heading = _heading_from_line(line)
+                if heading is not None:
+                    break
+
+    return {
+        "title": _frontmatter_string(frontmatter, "title") or heading,
+        "kind": _frontmatter_string(frontmatter, "kind"),
+        "status": _frontmatter_string(frontmatter, "status"),
+    }
+
+
+def _load_listing_frontmatter(frontmatter_lines: list[str]) -> dict[str, object]:
+    try:
+        loaded = yaml.safe_load("".join(frontmatter_lines))
+    except yaml.YAMLError:
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _frontmatter_string(frontmatter: dict[str, object], key: str) -> str | None:
+    value = frontmatter.get(key)
+    return value if isinstance(value, str) and value else None
 
 
 def _document_detail(root: Path, layout: ResolvedLayout, path: Path) -> _DocumentDetail:
@@ -840,10 +895,23 @@ def _render_markdown(markdown_text: str) -> str:
 
 def _title_from_markdown(markdown_text: str, fallback: str) -> str:
     for line in markdown_text.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("# "):
-            return stripped.removeprefix("# ").strip() or fallback
+        heading = _heading_from_line(line)
+        if heading is not None:
+            return heading or fallback
     return fallback
+
+
+def _heading_from_line(line: str) -> str | None:
+    stripped = line.strip()
+    if stripped.startswith("# "):
+        return stripped.removeprefix("# ").strip()
+    return None
+
+
+def _title_from_path(path: str) -> str:
+    stem = PurePosixPath(path).stem
+    title = stem.replace("-", " ").replace("_", " ").strip()
+    return title.title() if title else path
 
 
 def _document_row(document: _DocumentSummary) -> str:

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -62,6 +62,10 @@ _ALLOWED_MARKDOWN_ATTRIBUTES = {
     "code": ["class"],
     "span": ["class"],
 }
+_LISTING_FRONTMATTER_LINE_LIMIT = 200
+_LISTING_FRONTMATTER_CHAR_LIMIT = 64 * 1024
+_LISTING_HEADING_LINE_LIMIT = 40
+_LISTING_HEADING_CHAR_LIMIT = 16 * 1024
 
 
 @dataclass(frozen=True)
@@ -736,36 +740,58 @@ def _document_summary(root: Path, layout: ResolvedLayout, path: Path) -> _Docume
 
 def _read_listing_metadata(path: Path) -> dict[str, str | None]:
     """Read only frontmatter and the first heading needed for browse rows."""
-    frontmatter_lines: list[str] = []
     heading: str | None = None
     frontmatter: dict[str, object] = {}
-    frontmatter_closed = False
 
     with path.open("r", encoding="utf-8") as handle:
         first_line = handle.readline()
         if first_line.replace("\r\n", "\n").replace("\r", "\n") == "---\n":
-            for line in handle:
-                normalized = line.replace("\r\n", "\n").replace("\r", "\n")
-                if normalized == "---\n":
-                    frontmatter_closed = True
-                    break
-                frontmatter_lines.append(normalized)
-            if frontmatter_closed:
+            frontmatter_lines = _read_bounded_frontmatter_lines(handle)
+            if frontmatter_lines is not None:
                 frontmatter = _load_listing_frontmatter(frontmatter_lines)
         else:
             heading = _heading_from_line(first_line)
 
         if heading is None and not _frontmatter_string(frontmatter, "title"):
-            for line in handle:
-                heading = _heading_from_line(line)
-                if heading is not None:
-                    break
+            heading = _read_bounded_heading(handle)
 
     return {
         "title": _frontmatter_string(frontmatter, "title") or heading,
         "kind": _frontmatter_string(frontmatter, "kind"),
         "status": _frontmatter_string(frontmatter, "status"),
     }
+
+
+def _read_bounded_frontmatter_lines(handle) -> list[str] | None:
+    lines: list[str] = []
+    char_count = 0
+    for _ in range(_LISTING_FRONTMATTER_LINE_LIMIT):
+        line = handle.readline()
+        if not line:
+            return None
+        normalized = line.replace("\r\n", "\n").replace("\r", "\n")
+        if normalized == "---\n":
+            return lines
+        char_count += len(normalized)
+        if char_count > _LISTING_FRONTMATTER_CHAR_LIMIT:
+            return None
+        lines.append(normalized)
+    return None
+
+
+def _read_bounded_heading(handle) -> str | None:
+    char_count = 0
+    for _ in range(_LISTING_HEADING_LINE_LIMIT):
+        line = handle.readline()
+        if not line:
+            return None
+        char_count += len(line)
+        if char_count > _LISTING_HEADING_CHAR_LIMIT:
+            return None
+        heading = _heading_from_line(line)
+        if heading is not None:
+            return heading
+    return None
 
 
 def _load_listing_frontmatter(frontmatter_lines: list[str]) -> dict[str, object]:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import yaml
 from fastapi.testclient import TestClient
 
+import splendor.web as web
 from splendor.cli import main
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
@@ -93,6 +94,91 @@ def test_browse_page_lists_wiki_and_planning_documents(tmp_path: Path) -> None:
     assert "Ship web shell" in response.text
     assert "wiki/concepts/web-shell.md" in response.text
     assert "planning/tasks/task-ship-web-shell.md" in response.text
+
+
+def test_home_and_browse_listing_do_not_parse_full_documents(tmp_path: Path, monkeypatch) -> None:
+    initialize_workspace(tmp_path)
+    wiki_path = tmp_path / "wiki" / "concepts" / "large-web-shell.md"
+    write_wiki_page(
+        wiki_path,
+        title="Large web shell",
+        page_id="concept-large-web-shell",
+        body="# Large web shell\n\n" + ("Body text that listing should not parse.\n" * 500),
+    )
+    create_task(
+        tmp_path,
+        "Track web scaling",
+        record_id="task-track-web-scaling",
+        status="todo",
+        priority="medium",
+        owner=None,
+        milestone_refs=[],
+        decision_refs=[],
+        question_refs=[],
+        depends_on=[],
+        source_refs=[],
+    )
+    planning_path = tmp_path / "planning" / "tasks" / "task-track-web-scaling.md"
+
+    def fail_detail(*args, **kwargs):
+        raise AssertionError("listing should not use full document detail parsing")
+
+    def fail_wiki_parse(*args, **kwargs):
+        raise AssertionError("listing should not parse full wiki documents")
+
+    def fail_planning_parse(*args, **kwargs):
+        raise AssertionError("listing should not parse full planning documents")
+
+    monkeypatch.setattr(web, "_document_detail", fail_detail)
+    monkeypatch.setattr(web, "parse_wiki_markdown", fail_wiki_parse)
+    monkeypatch.setattr(web, "parse_planning_document", fail_planning_parse)
+    real_open = Path.open
+    guarded_paths = {wiki_path.resolve(), planning_path.resolve()}
+
+    class FrontmatterOnlyGuard:
+        def __init__(self, handle):
+            self._handle = handle
+            self._frontmatter_closed = False
+
+        def __enter__(self):
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._handle.__exit__(*args)
+
+        def readline(self, *args, **kwargs):
+            return self._handle.readline(*args, **kwargs)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self._frontmatter_closed:
+                raise AssertionError("listing should not read document bodies")
+            line = next(self._handle)
+            if line.replace("\r\n", "\n").replace("\r", "\n") == "---\n":
+                self._frontmatter_closed = True
+            return line
+
+    def guarded_open(path, *args, **kwargs):
+        handle = real_open(path, *args, **kwargs)
+        if Path(path).resolve() in guarded_paths:
+            return FrontmatterOnlyGuard(handle)
+        return handle
+
+    monkeypatch.setattr(Path, "open", guarded_open)
+    client = TestClient(create_app(tmp_path))
+
+    home = client.get("/")
+    browse = client.get("/browse")
+
+    assert home.status_code == 200
+    assert browse.status_code == 200
+    assert "Large web shell" in browse.text
+    assert "Track web scaling" in browse.text
+    assert "wiki/concepts/large-web-shell.md" in browse.text
+    assert "planning/tasks/task-track-web-scaling.md" in browse.text
 
 
 def test_browse_page_separates_index_and_log_as_special_files(tmp_path: Path) -> None:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,3 +1,4 @@
+import io
 from pathlib import Path
 
 import yaml
@@ -118,7 +119,6 @@ def test_home_and_browse_listing_do_not_parse_full_documents(tmp_path: Path, mon
         depends_on=[],
         source_refs=[],
     )
-    planning_path = tmp_path / "planning" / "tasks" / "task-track-web-scaling.md"
 
     def fail_detail(*args, **kwargs):
         raise AssertionError("listing should not use full document detail parsing")
@@ -132,42 +132,6 @@ def test_home_and_browse_listing_do_not_parse_full_documents(tmp_path: Path, mon
     monkeypatch.setattr(web, "_document_detail", fail_detail)
     monkeypatch.setattr(web, "parse_wiki_markdown", fail_wiki_parse)
     monkeypatch.setattr(web, "parse_planning_document", fail_planning_parse)
-    real_open = Path.open
-    guarded_paths = {wiki_path.resolve(), planning_path.resolve()}
-
-    class FrontmatterOnlyGuard:
-        def __init__(self, handle):
-            self._handle = handle
-            self._frontmatter_closed = False
-
-        def __enter__(self):
-            self._handle.__enter__()
-            return self
-
-        def __exit__(self, *args):
-            return self._handle.__exit__(*args)
-
-        def readline(self, *args, **kwargs):
-            return self._handle.readline(*args, **kwargs)
-
-        def __iter__(self):
-            return self
-
-        def __next__(self):
-            if self._frontmatter_closed:
-                raise AssertionError("listing should not read document bodies")
-            line = next(self._handle)
-            if line.replace("\r\n", "\n").replace("\r", "\n") == "---\n":
-                self._frontmatter_closed = True
-            return line
-
-    def guarded_open(path, *args, **kwargs):
-        handle = real_open(path, *args, **kwargs)
-        if Path(path).resolve() in guarded_paths:
-            return FrontmatterOnlyGuard(handle)
-        return handle
-
-    monkeypatch.setattr(Path, "open", guarded_open)
     client = TestClient(create_app(tmp_path))
 
     home = client.get("/")
@@ -179,6 +143,45 @@ def test_home_and_browse_listing_do_not_parse_full_documents(tmp_path: Path, mon
     assert "Track web scaling" in browse.text
     assert "wiki/concepts/large-web-shell.md" in browse.text
     assert "planning/tasks/task-track-web-scaling.md" in browse.text
+
+
+def test_listing_metadata_stops_after_frontmatter_title(tmp_path: Path) -> None:
+    path = tmp_path / "listing.md"
+    path.write_text(
+        "---\n"
+        "title: Bounded listing\n"
+        "kind: concept\n"
+        "status: active\n"
+        "---\n"
+        "# Body heading that should not be needed\n" + ("body\n" * 100),
+        encoding="utf-8",
+    )
+
+    metadata = web._read_listing_metadata(path)
+
+    assert metadata == {
+        "title": "Bounded listing",
+        "kind": "concept",
+        "status": "active",
+    }
+
+
+def test_listing_frontmatter_scan_is_bounded_for_malformed_documents() -> None:
+    handle = io.StringIO("title: Never closed\n" * (web._LISTING_FRONTMATTER_LINE_LIMIT + 25))
+
+    metadata = web._read_bounded_frontmatter_lines(handle)
+
+    assert metadata is None
+    assert handle.readline() != ""
+
+
+def test_listing_heading_scan_is_bounded_for_frontmatter_light_documents() -> None:
+    handle = io.StringIO("body without heading\n" * (web._LISTING_HEADING_LINE_LIMIT + 25))
+
+    heading = web._read_bounded_heading(handle)
+
+    assert heading is None
+    assert handle.readline() != ""
 
 
 def test_browse_page_separates_index_and_log_as_special_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add a lightweight browse/home document-list metadata path that derives rows from markdown frontmatter, headings, and paths instead of full document detail parsing.
- Keep `/documents/...` detail rendering and `/search` behavior on the existing complete parsers.
- Update M9-P3.1 planning state in `.agent-plan.md`, the README What Comes Next block, and the roadmap.

## Issue

Closes #37.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`

## Notes

- This preserves the read-only web UI boundary.
- No durable cache, vector/search backend, SQLite, background worker, or mutating web action is added.
- Full markdown/body parsing remains deferred to document detail and search.