### PR TITLE
M15-P1.3: record issue 79 compile/update disposition

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M13-P3.3`
-- Last action taken: `M13-P3.3` is complete; PR #104 reduced repo-scan registration overhead for issue #30.
-- Current planned slice: `Local web UI document-list scaling`
-- Current PR sub-slice: `M9-P3.1`
+- Previous completed PR sub-slice: `M9-P3.1`
+- Last action taken: `M9-P3.1` is complete; PR #105 scaled local web UI document lists for issue #37.
+- Current planned slice: `Issue #79 compile/update disposition`
+- Current PR sub-slice: `M15-P1.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely issue #79 disposition or narrowed compile/update follow-up`
-- Next planned PR sub-slice: `likely TBD, possibly M15-P1.3 if a concrete #79 follow-up is defined`
+- Next planned slice: `likely no open issue after #79 closes; release/tagging readiness`
+- Next planned PR sub-slice: `TBD`
 - Current blockers: none
 
 ## Planning Notation
@@ -146,6 +146,11 @@
   - [x] Keep document detail and search parsing complete
   - [x] Update focused tests and planning state for issue #37
   - [x] Publish a non-draft GitHub PR for `M9-P3.1` with labels, milestone, and a detailed description
+- [x] Implement `M15-P1.3`: Issue #79 compile/update disposition
+  - [x] Audit the reviewed compile/update behavior against issue #79
+  - [x] Confirm proposed diffs, proposal-hash apply, deterministic output, schema validation, and generated/maintained page separation are represented
+  - [x] Keep scope to docs/planning disposition because `M15-P1.1` and `M15-P1.2` already carry the behavior and regression coverage
+  - [x] Record the issue-closing disposition evidence for `M15-P1.3` in versioned planning docs
 - [x] Implement `M10-P1.1`: Queue inspect/retry/repair commands
   - [x] Add CLI queue inspection with human and JSON output
   - [x] Add explicit failed ingest queue retry

--- a/README.md
+++ b/README.md
@@ -240,12 +240,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M13-P3.3`
-- Current planned slice: `Local web UI document-list scaling`
-- Current PR sub-slice: `M9-P3.1`
+- Previous completed PR sub-slice: `M9-P3.1`
+- Current planned slice: `Issue #79 compile/update disposition`
+- Current PR sub-slice: `M15-P1.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely issue #79 disposition or narrowed compile/update follow-up`
-- Next planned PR sub-slice: `likely TBD, possibly M15-P1.3 if a concrete #79 follow-up is defined`
+- Next planned slice: `likely no open issue after #79 closes; release/tagging readiness`
+- Next planned PR sub-slice: `TBD`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -334,14 +334,13 @@ ingest handoff, #44's query snippets, #45's web status/source detail pages, and 
 visibility as represented in current behavior. `M15-P1.1` now starts #41's deferred mutating
 compile/update workflow through #79 with explicit one-page proposal/apply semantics. `M15-P1.2`
 is implemented: bare compile/suggest output now includes ranked compile-target previews while
-preserving the explicit apply gate. Issue #47 is targeted next by `M10-P3.1` as a focused
-ingest/run-state timing follow-up. Issues #30 and #37
-remain post-v1 performance work. Issue #70 is closed after the M13-P2/M13-P3.1 response. Issue #72
-is the parent feedback loop for the M14 source-lifecycle sequence; stable logical source
-identities, supersession lifecycle, safe workspace refresh, superseded summary pruning, topic-ref
-migration, and PR-summary support have landed. `M14-P3.1` recommends closing #72 once maintainers
-accept the gate result, with the narrower remaining handoff gap tracked by #86.
-Issue #79 tracks the reviewed compile/update sequence that started in `M15-P1.1`.
+preserving the explicit apply gate. `M15-P1.3` audits #79 and records the disposition that the
+desired reviewed compile/update follow-up is materially represented by the existing one-page
+proposal/apply workflow, generated/maintained page separation, deterministic output, schema-bound
+frontmatter validation, and focused regression coverage. The detailed disposition matrix lives in
+[docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md#completed-disposition-m15-p13-issue-79-disposition).
+Issue #79 should close with the `M15-P1.3` disposition PR unless maintainers identify a new narrow
+follow-up outside the current reviewed one-page compile/apply contract.
 
 `M14-P1.1` adds the first stable logical source identity layer above content-addressed source IDs:
 workspace-backed manifests now persist `source:<workspace-path>` logical IDs and path aliases while

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M13-P3.3`
-- Current planned slice: `Local web UI document-list scaling`
-- Current PR sub-slice: `M9-P3.1`
+- Previous completed PR sub-slice: `M9-P3.1`
+- Current planned slice: `Issue #79 compile/update disposition`
+- Current PR sub-slice: `M15-P1.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely issue #79 disposition or narrowed compile/update follow-up`
-- Next planned PR sub-slice: `likely TBD, possibly M15-P1.3 if a concrete #79 follow-up is defined`
+- Next planned slice: `likely no open issue after #79 closes; release/tagging readiness`
+- Next planned PR sub-slice: `TBD`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1057,6 +1057,26 @@ JSON suggestions include structured `compile_preview_args` alongside the rendere
 so agents can execute the preview command without shell parsing. This slice does not add automatic
 multi-page apply, LLM synthesis, web mutation, source registration changes, broad workspace
 refresh, or performance/scaling work from #47, #37, or #30.
+
+### Completed disposition: M15-P1.3 issue #79 disposition
+
+`M15-P1.3` is a focused disposition/audit PR for issue #79. It does not add another mutating
+surface. The audit records that the desired #79 follow-up is materially represented by `M15-P1.1`
+and `M15-P1.2`.
+
+| #79 requirement | Current disposition | Evidence |
+| --- | --- | --- |
+| Proposed diffs before mutation | `splendor wiki compile <source-id|title|path> --page <maintained-page>` returns a one-page proposal with `proposed_diff`, target/source-summary hashes, `proposal_hash`, and `proposed_markdown`; preview mode does not write the target page. | `src/splendor/commands/wiki.py` `compile_source_into_page`; `tests/test_wiki_commands.py` `test_wiki_compile_proposes_maintained_page_update_without_mutating`; `test_wiki_compile_text_proposal_prints_reviewable_diff_and_hash` |
+| Explicit accept/apply semantics | The only write path is `--apply --proposal-hash <hash>`. The hash is recomputed from source ID, target path, target hash, source-summary path/hash, and proposed markdown hash so stale previews are rejected. | `src/splendor/commands/wiki.py` `_compile_proposal_hash`; `tests/test_wiki_commands.py` `test_wiki_compile_apply_updates_only_maintained_target_page`; `test_wiki_compile_apply_rejects_stale_proposal_hash`; `test_wiki_compile_apply_requires_page`; `test_wiki_compile_apply_requires_proposal_hash` |
+| Deterministic output | Compile evidence is extracted deterministically from generated source-summary sections, fenced content and generated key-fact boilerplate are skipped, output includes stable hashes, and repeated accepted compiles become no-ops. | `src/splendor/commands/wiki.py` `_compile_evidence_lines`; `_render_compile_diff`; `tests/test_wiki_commands.py` `test_wiki_compile_skips_fenced_extract_contents`; `test_wiki_compile_apply_updates_only_maintained_target_page` |
+| Schema-bound frontmatter validation | Compiled markdown is validated through `KnowledgePageFrontmatter` before proposal/apply output is accepted, and invalid wiki pages block compile. | `src/splendor/commands/wiki.py` `_validate_compiled_markdown`; `tests/test_wiki_commands.py` `test_wiki_compile_rejects_invalid_wiki_pages` |
+| Generated source-summary versus maintained synthesis separation | Compile targets must be maintained synthesis pages (`architecture`, `concept`, `entity`, `glossary`, or `topic`); generated `source-summary` pages are rejected as targets and are only used as evidence. | `src/splendor/commands/wiki.py` `SYNTHESIS_KINDS`; `compile_source_into_page`; `tests/test_wiki_commands.py` `test_wiki_compile_rejects_generated_source_summary_target`; `test_wiki_compile_apply_updates_only_maintained_target_page` |
+| Docs/tests for mutating command behavior | Product docs describe the non-mutating contract, one-page proposal, and explicit reviewed apply gate; focused wiki command tests cover preview, apply, stale hash, invalid input, generated-target rejection, and suggestion preview arguments. | `docs/splendor_product_spec.md` section 14.6; `README.md` current MVP surface; `tests/test_wiki_commands.py` compile and suggest coverage |
+
+Remaining deliberate non-goals are automatic multi-page mutation, LLM synthesis, mutating web UI
+actions, search/index redesign, source lifecycle work, and broad roadmap expansion. Unless
+maintainers identify a newly scoped gap, #79 should close with this disposition rather than
+expanding the parent issue beyond the reviewed one-page compile/apply contract.
 
 ### M10-P3.1 ingest run-duration precision
 


### PR DESCRIPTION
## Summary

- records M15-P1.3 as the focused disposition/audit PR for issue #79
- updates synchronized planning-state lines in `.agent-plan.md`, `README.md`, and `docs/splendor_mvp_to_v1_roadmap.md`
- documents that #79 is materially complete through M15-P1.1 and M15-P1.2: reviewed one-page diffs, explicit `--apply --proposal-hash` accept semantics, deterministic evidence extraction, schema-bound frontmatter validation, generated/maintained page separation, and focused regression coverage

## Audit Notes

The existing compile/update implementation already satisfies the issue #79 follow-up without broadening scope:

- bare `splendor wiki compile <source-id|title|path>` remains non-mutating and exposes ranked maintained-page suggestions
- `splendor wiki compile <source-id|title|path> --page <maintained-page>` proposes a deterministic one-page update with a unified diff and proposal hash
- writes require explicit `--apply --proposal-hash <hash>` and are bound to the current target/source-summary inputs
- generated source-summary pages are rejected as compile targets
- frontmatter validation is schema-bound before proposal/apply output is accepted
- text and JSON outputs include reviewable details and structured preview arguments

No new code or test change was needed for this disposition PR because the behavior and regression coverage already landed in M15-P1.1 and M15-P1.2.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`

Closes #79
