### PR TITLE
Prepare v0.2.0 evaluation release tagging

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M9-P3.1`
-- Last action taken: `M9-P3.1` is complete; PR #105 scaled local web UI document lists for issue #37.
-- Current planned slice: `Issue #79 compile/update disposition`
-- Current PR sub-slice: `M15-P1.3`
+- Previous completed PR sub-slice: `M15-P1.3`
+- Last action taken: `M15-P1.3` is complete; PR #106 recorded the issue #79 compile/update
+  disposition and closed the remaining open issue queue.
+- Current planned slice: `v0.2.0 evaluation release tagging readiness`
+- Current PR sub-slice: `v0.2.0-release-tag-prep`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely no open issue after #79 closes; release/tagging readiness`
-- Next planned PR sub-slice: `TBD`
+- Next planned slice: `post-v0.2.0 SynthBanshee/Claude Code evaluation`
+- Next planned PR sub-slice: `TBD after evaluation feedback`
 - Current blockers: none
 
 ## Planning Notation
@@ -317,6 +318,11 @@
   - [x] Reuse preloaded config/layout during repo-scan apply registration
   - [x] Preserve repo-scan preview/apply gates and source registration behavior
   - [x] Add deterministic regression coverage without timing assertions
+- [x] Prepare `v0.2.0-release-tag-prep`: Evaluation release tagging readiness
+  - [x] Update package version metadata to `0.2.0`
+  - [x] Add concise `v0.2.0` release notes for SynthBanshee/Claude Code evaluation
+  - [x] Reframe stale v1-tagging handoff language around the immediate `v0.2.0` tag target
+  - [x] Keep schema version `1` and runtime behavior unchanged
 
 ## Context Pointers
 

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -318,11 +318,12 @@
   - [x] Reuse preloaded config/layout during repo-scan apply registration
   - [x] Preserve repo-scan preview/apply gates and source registration behavior
   - [x] Add deterministic regression coverage without timing assertions
-- [x] Prepare `v0.2.0-release-tag-prep`: Evaluation release tagging readiness
+- [ ] Prepare `v0.2.0-release-tag-prep`: Evaluation release tagging readiness
   - [x] Update package version metadata to `0.2.0`
   - [x] Add concise `v0.2.0` release notes for SynthBanshee/Claude Code evaluation
   - [x] Reframe stale v1-tagging handoff language around the immediate `v0.2.0` tag target
   - [x] Keep schema version `1` and runtime behavior unchanged
+  - [ ] Merge the release-prep PR and verify green `main` before tagging
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -240,12 +240,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M9-P3.1`
-- Current planned slice: `Issue #79 compile/update disposition`
-- Current PR sub-slice: `M15-P1.3`
+- Previous completed PR sub-slice: `M15-P1.3`
+- Current planned slice: `v0.2.0 evaluation release tagging readiness`
+- Current PR sub-slice: `v0.2.0-release-tag-prep`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely no open issue after #79 closes; release/tagging readiness`
-- Next planned PR sub-slice: `TBD`
+- Next planned slice: `post-v0.2.0 SynthBanshee/Claude Code evaluation`
+- Next planned PR sub-slice: `TBD after evaluation feedback`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -342,6 +342,12 @@ frontmatter validation, and focused regression coverage. The detailed dispositio
 Issue #79 should close with the `M15-P1.3` disposition PR unless maintainers identify a new narrow
 follow-up outside the current reviewed one-page compile/apply contract.
 
+The current release-prep PR is not an issue-backed milestone slice. It prepares the `v0.2.0`
+evaluation release by updating package version metadata, adding versioned release notes, and
+reframing stale v1-tagging language so the next concrete action after merge and green `main` is the
+`v0.2.0` tag. The product follow-up after that tag is a fresh SynthBanshee/Claude Code evaluation
+run.
+
 `M14-P1.1` adds the first stable logical source identity layer above content-addressed source IDs:
 workspace-backed manifests now persist `source:<workspace-path>` logical IDs and path aliases while
 keeping `src-...` IDs as the compatibility contract.
@@ -436,7 +442,7 @@ parse shell text. Actual writes still require the explicit one-page `--apply --p
 `finished_at` only when the run reaches terminal success or failure. Historical run records are not
 rewritten.
 
-### v1 readiness checklist
+### v0.2.0 evaluation readiness checklist
 
 - [x] Safe repo discovery is non-mutating by default and requires explicit apply flags.
 - [x] Curated source manifests remain the durable registry instead of a broad file mirror.
@@ -447,3 +453,5 @@ rewritten.
 - [x] Final release handoff names validation, issue state, GitHub metadata, known non-blockers,
   and the post-v1 queue.
 - [x] PR-summary tooling gives reviewers a lower-noise generated-state handoff.
+- [ ] `v0.2.0` package metadata, release notes, local validation, and green `main` CI are confirmed
+  before tagging.

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -314,18 +314,19 @@ Required secrets:
 - `pre-commit.ci autofix trigger` bridges bot PRs and `pre-commit.ci` label-based autofix behavior.
 - `weekly-repo-review` is scheduled maintenance, not a merge gate.
 
-## v1 release-hardening boundaries
+## v0.2.0 / v1 release-hardening boundaries
 
 The current automation layer supports CI, maintenance reports, generated-change PRs, PR context
-refresh, review automation, and optional weekly repo review. It does not yet provide stable logical
-source identities, supersession-aware pruning, a one-command full workspace refresh, or
-`splendor pr-summary --since main`. Those belong to later source-lifecycle or PR-summary slices,
-not the M13-P3.1 release-hardening pass.
+refresh, review automation, and optional weekly repo review. Source lifecycle, workspace refresh,
+and `splendor pr-summary --since main` remain local CLI contracts; GitHub workflows can report or
+package their output, but they do not replace the operator-reviewed local validation path.
 
-For the M13-P3.2 release handoff, `docs/v1_release_handoff.md` is the checklist that connects local
-validation, GitHub PR metadata, issue state, and known non-blockers. GitHub automation remains
-supporting infrastructure around the local CLI, not a substitute for the explicit validation
-commands named in that handoff.
+For the current `v0.2.0` evaluation-release prep, `docs/v1_release_handoff.md` remains the
+historical v1-style checklist that connects local validation, GitHub PR metadata, issue state, and
+known non-blockers, while `docs/v0_2_0_release_notes.md` names the immediate tag target and
+post-release SynthBanshee/Claude Code evaluation step. GitHub automation remains supporting
+infrastructure around the local CLI, not a substitute for the explicit validation commands named in
+that handoff.
 
 ## Planning update rule for PRs
 

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -78,6 +78,8 @@ Use `source freshness`, `brief --agent-context`, and `suggest-next` before decid
 workspace needs ingest, synthesis review, queue repair, or planning follow-up.
 
 The current workflow now provides stable logical source identities, source supersession, explicit
-workspace refresh, and explicit superseded-summary pruning/topic-ref migration. Do not expect
-PR-summary generation yet; it remains tracked from issue #72 as later lifecycle work. For v1 release work, use
-`docs/v1_release_handoff.md` to separate release-blocking validation from the post-v1 dogfood queue.
+workspace refresh, explicit superseded-summary pruning/topic-ref migration, and
+`splendor pr-summary --since main` for local PR handoff. Issue #72 is no longer the active
+source-lifecycle queue. For `v0.2.0` evaluation-release work, use `docs/v1_release_handoff.md`
+together with `docs/v0_2_0_release_notes.md` to separate release-blocking validation from
+post-release dogfood or SynthBanshee/Claude Code evaluation feedback.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -217,9 +217,10 @@ directory.
 Refresh does not override active ingest leases or dead-letter protections; use `queue retry` or
 `repair ingest` for those recovery cases.
 
-For release verification, use `docs/v1_release_handoff.md` as the checklist. It keeps the
-quickstart focused on normal operator workflow while the handoff records validation commands,
-GitHub metadata expectations, issue state, and post-v1 follow-up boundaries.
+For release verification, use `docs/v1_release_handoff.md` together with
+`docs/v0_2_0_release_notes.md`. The handoff keeps the quickstart focused on normal operator
+workflow while the release notes name the immediate `v0.2.0` evaluation tag target, validation
+commands, issue state, and post-release SynthBanshee/Claude Code evaluation step.
 
 For a read-only browser view over the same status and source-detail contracts:
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -570,7 +570,7 @@ Current runtime behavior:
 - mutating scan registration requires `repo refresh --apply-scan` plus `--class ...` or `--all`;
   large apply runs also require `--allow-large-apply`
 
-## v1 readiness notes
+## v0.2.0 / v1 readiness notes
 
 - The current schema version remains `1`; M13-P3.1 does not introduce a migration or rewrite
   existing manifests.
@@ -584,9 +584,9 @@ Current runtime behavior:
 - Lint validates present workspace-backed logical identity fields: `logical_id` must match
   `source:<source_ref>`, persisted aliases must stay scoped to the canonical workspace path, and
   exact identities must not point at conflicting canonical source refs.
-- The final v1 handoff in `docs/v1_release_handoff.md` treats schema version `1`, legacy manifest
-  compatibility, and deferred source-lifecycle fields as release checklist items rather than
-  implicit assumptions.
+- The current `v0.2.0` evaluation release keeps schema version `1`; the final v1-style handoff in
+  `docs/v1_release_handoff.md` treats schema version `1`, legacy manifest compatibility, and
+  deferred source-lifecycle fields as release checklist items rather than implicit assumptions.
 
 ## Review config
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M9-P3.1`
-- Current planned slice: `Issue #79 compile/update disposition`
-- Current PR sub-slice: `M15-P1.3`
+- Previous completed PR sub-slice: `M15-P1.3`
+- Current planned slice: `v0.2.0 evaluation release tagging readiness`
+- Current PR sub-slice: `v0.2.0-release-tag-prep`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `likely no open issue after #79 closes; release/tagging readiness`
-- Next planned PR sub-slice: `TBD`
+- Next planned slice: `post-v0.2.0 SynthBanshee/Claude Code evaluation`
+- Next planned PR sub-slice: `TBD after evaluation feedback`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -840,7 +840,7 @@ safe non-mutating scan previews, explicit apply gates, source IDs, manifest vali
 handoff behavior while avoiding repeated config loading and layout resolution during bulk
 registration.
 
-### M13-P3 v1 release-readiness checklist
+### M13-P3 / v0.2.0 evaluation release-readiness checklist
 
 - [x] M13-P2 safe discovery, source freshness, agent handoff, and path-first source-summary UX have
   landed.
@@ -857,8 +857,10 @@ registration.
   the shipped v1 briefing and non-mutating compile-contract scope.
 - [x] Final release handoff records validation commands, docs state, issue state, GitHub metadata,
   known non-blockers, and the post-v1 queue.
-- [ ] Tagging should happen only after the full validation suite, green CI on `main`, and release
-  notes that call out completed M13 work plus the explicit post-v1 queue.
+- [x] No GitHub issues remain open after the M15 disposition pass.
+- [ ] Tagging should happen only after the full validation suite, green CI on `main`, package
+  metadata set to `0.2.0`, and release notes that call out completed stabilization plus the next
+  SynthBanshee/Claude Code evaluation step.
 
 ### Exit criteria
 - the product is stable enough for sustained real-world use

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -848,13 +848,15 @@ registration.
   pages and explain which generated state is reviewer-significant.
 - [x] The quickstart demonstrates the queue-backed `add-source -> ingest --pending -> lookup`
   loop instead of requiring users to copy long IDs for the first ingest.
-- [x] Issue #70 is closed after the M13-P2/M13-P3.1 response for agent usefulness; release notes
-  identify that #72 now owns remaining source lifecycle and agent-workflow follow-up.
-- [x] Issue #72 remains the parent feedback loop for source-refresh lifecycle and agent workflow;
-  stable logical source identities, source supersession, safe workspace refresh, superseded
-  summary pruning, topic-ref migration, and `splendor pr-summary --since main` have landed.
-- [x] Issue #79 tracks the deferred mutating compile/update path from #41 so #41 can stay closed for
-  the shipped v1 briefing and non-mutating compile-contract scope.
+- [x] Issue #70 is closed after the M13-P2/M13-P3.1 response for agent usefulness; the later M14
+  and M15 follow-ups worked through the remaining source-lifecycle, agent-brief, timing, scaling,
+  identity, and compile/update issue queue.
+- [x] The former #72 source-refresh lifecycle feedback loop is closed or dispositioned: stable
+  logical source identities, source supersession, safe workspace refresh, superseded summary
+  pruning, topic-ref migration, and `splendor pr-summary --since main` have landed.
+- [x] The former #79 mutating compile/update follow-up from #41 is dispositioned by the reviewed
+  one-page proposal/apply workflow, compile-target suggestions, schema-bound validation, and
+  generated/maintained page separation.
 - [x] Final release handoff records validation commands, docs state, issue state, GitHub metadata,
   known non-blockers, and the post-v1 queue.
 - [x] No GitHub issues remain open after the M15 disposition pass.

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -897,7 +897,8 @@ M13-P2 repo-discovery contracts:
 
 Release-readiness boundary:
 
-- v1 treats content-addressed source IDs as the persisted compatibility contract.
+- `v0.2.0` evaluation release readiness treats content-addressed source IDs as the persisted
+  compatibility contract.
 - readable paths, titles, source refs, and logical IDs are lookup and display aids above that
   compatibility contract; generated source-summary pages and run provenance still use `src-...`
   identifiers.
@@ -920,11 +921,10 @@ Release-readiness boundary:
   selector while adding the new path alias for intentional moves, and maintained topic refs can be
   migrated after refreshed successor summaries exist. This does not require a schema-version change
   or a canonical source-ID migration.
-- issue #79 tracks the reviewed mutating compile/update workflow from #41; v1 shipped briefing and
-  the non-mutating compile contract, and `M15-P1.1` begins the explicit one-page proposal/apply
-  path.
-- `docs/v1_release_handoff.md` is the v1 handoff checklist for final validation, GitHub metadata,
-  issue state, known non-blockers, and the conservative post-v1 queue.
+- issue #79 tracked the reviewed mutating compile/update workflow from #41; `M15-P1.1`,
+  `M15-P1.2`, and `M15-P1.3` now represent and disposition the one-page proposal/apply path.
+- `docs/v1_release_handoff.md` remains the historical v1-style handoff checklist for validation
+  and GitHub metadata expectations, but the immediate evaluation release target is `v0.2.0`.
 
 Later optional support:
 - additional OCR providers

--- a/docs/v0_2_0_release_notes.md
+++ b/docs/v0_2_0_release_notes.md
@@ -28,13 +28,17 @@ Before tagging `v0.2.0` after this preparation PR merges, run the full local val
 the repository root and confirm green `main` CI:
 
 ```bash
-/Users/shaypalachy/.local/bin/uv run pytest
+env -u OPENAI_API_KEY /Users/shaypalachy/.local/bin/uv run pytest
 /Users/shaypalachy/.local/bin/uv run ruff format --check .
 /Users/shaypalachy/.local/bin/uv run ruff check .
 /Users/shaypalachy/.local/bin/uv run splendor lint
 /Users/shaypalachy/.local/bin/uv run splendor health
 /Users/shaypalachy/.local/bin/uv build
 ```
+
+The pytest command intentionally unsets `OPENAI_API_KEY`. Release validation should exercise the
+deterministic offline test path; configured OpenAI credentials can make contradiction-review tests
+attempt live network calls and turn release verification into an environment-dependent check.
 
 The package metadata for this preparation PR is `0.2.0` in both `pyproject.toml` and
 `src/splendor/__init__.py`. Do not create or push the `v0.2.0` tag from this PR; tag only after the

--- a/docs/v0_2_0_release_notes.md
+++ b/docs/v0_2_0_release_notes.md
@@ -1,0 +1,49 @@
+# v0.2.0 Evaluation Release Notes
+
+`v0.2.0` is the next evaluation release for sending Splendor back through the
+SynthBanshee/Claude Code agent workflow. It is not the v1 tag. The release packages the completed
+post-MVP stabilization, source-lifecycle, planning-authority, and reviewed compile/update work that
+landed after the original alpha metadata.
+
+## Release Purpose
+
+This release is intended to give a coding agent using Splendor in a real companion repository a
+cleaner, lower-noise operating loop:
+
+- curated source manifests remain the durable source registry instead of broad automatic mirrors
+- source discovery is non-mutating by default and produces candidate reports before registration
+- source freshness, workspace refresh, supersession, pruning, and topic-ref migration cover the
+  changed-source lifecycle without requiring manual manifest cleanup
+- `splendor pr-summary --since main` gives reviewers a local generated-state handoff before PR
+  publication
+- planning-document authority metadata and task-oriented briefs rank the docs most relevant to a
+  requested goal
+- reviewed wiki compile/update work now has one-page proposal diffs, proposal hashes, explicit
+  apply semantics, ranked target suggestions, and generated/maintained page separation
+- health diagnostics point at concrete repair commands for known source, queue, and run problems
+
+## Validation Expectations
+
+Before tagging `v0.2.0` after this preparation PR merges, run the full local validation suite from
+the repository root and confirm green `main` CI:
+
+```bash
+/Users/shaypalachy/.local/bin/uv run pytest
+/Users/shaypalachy/.local/bin/uv run ruff format --check .
+/Users/shaypalachy/.local/bin/uv run ruff check .
+/Users/shaypalachy/.local/bin/uv run splendor lint
+/Users/shaypalachy/.local/bin/uv run splendor health
+/Users/shaypalachy/.local/bin/uv build
+```
+
+The package metadata for this preparation PR is `0.2.0` in both `pyproject.toml` and
+`src/splendor/__init__.py`. Do not create or push the `v0.2.0` tag from this PR; tag only after the
+release-prep PR merges and `main` is green.
+
+## Current Issue State
+
+As of this handoff, GitHub has no open issues for `splendor-dev/splendor`. The previously tracked
+stabilization and agent-workflow issues, including #72, #47, #30, #37, #79, #86, #94, and the
+related M14/M15 follow-ups, are closed or dispositioned in merged PRs. The next product step after
+publishing `v0.2.0` is a fresh SynthBanshee/Claude Code evaluation run, not another pre-tag issue
+slice.

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -4,9 +4,18 @@ This checklist is the release handoff for `M13-P3.2`. It does not add runtime be
 the final v1 verification path, issue state, GitHub metadata expectations, known non-blockers, and
 post-v1 queue after the `M13-P2` redesign and `M13-P3.1` release-hardening audit.
 
+## v0.2.0 Evaluation Release Note
+
+The immediate tag target after the post-M15 issue-disposition pass is `v0.2.0`, not `v1.0.0`.
+This document remains the historical v1-style handoff and validation checklist, but the current
+release-prep PR uses it only to avoid stale release-state claims. The `v0.2.0` tag should be
+created only after the release-prep PR merges, `main` is green, and the version metadata plus
+`docs/v0_2_0_release_notes.md` are present on `main`.
+
 ## Release Validation
 
-Run these commands from the repository root before tagging or publishing a v1 release:
+Run these commands from the repository root before tagging or publishing the `v0.2.0` evaluation
+release:
 
 ```bash
 uv run pytest
@@ -37,33 +46,25 @@ Release PRs should be non-draft and should carry:
 
 - a detailed body covering changes, validation, limitations, and follow-up work
 - focused labels such as `type/docs`, `area/docs`, `area/planning`, and `release/post-mvp`
-- the `Milestone 13` milestone when it exists
+- the most relevant milestone when one exists; this `v0.2.0` release-prep PR has no issue-backed
+  milestone unless maintainers create a dedicated evaluation-release milestone
 - explicit issue linkage for issues that are closed or intentionally kept open
 
-For this handoff:
+For the current `v0.2.0` evaluation-release handoff:
 
-- #70 is closed and should remain the completed parent feedback loop for the `M13-P2` redesign
-- #72 remains open as the parent source-refresh lifecycle and agent-workflow feedback loop
-- #41-#46 are closed as completed v1 dogfood issues after closing comments named the shipped scope
-  and any deferred work; #79 tracks the deferred mutating compile/update path from #41
-- #47 is targeted by `M10-P3.1` as the focused ingest run-duration precision bug
-- #30 remains open as post-v1 repo-scan registration performance work
-- #37 remains open as post-v1 web document-list scaling work
-- #72 is unblocked after `M14-P2.1`; the `M14-P3.1` source-lifecycle re-evaluation gate records
-  that the source-refresh lifecycle pain is materially addressed and recommends closing #72 once
-  maintainers accept the gate result
-- #86 tracks the planning-document authority and task-oriented agent brief gap addressed by
-  `M14-P4.1`
-- #94's source-identity concern is materially addressed for curated workspace-backed sources by
-  `M14-P1.1` through `M14-P1.9`; future work should be a specific non-workspace extension or
-  regression, not a broad canonical source-ID redesign
-- #79 now owns the M15 reviewed compile/update sequence; `M15-P1.1` starts with explicit
-  one-page diff/proposal-hash/apply semantics and `M15-P1.2` connects bare compile output to
-  ranked page suggestions without broad automatic synthesis updates
+- GitHub has no open issues as of the release-prep handoff.
+- #70 remains the completed parent feedback loop for the `M13-P2` redesign.
+- #72, #86, #94, #47, #30, #37, and #79 are closed or dispositioned by merged M14/M15 follow-ups.
+- #79's reviewed compile/update scope is represented by `M15-P1.1`, `M15-P1.2`, and the
+  `M15-P1.3` disposition: one-page proposal diffs, proposal hashes, explicit apply semantics,
+  ranked compile-target suggestions, schema-bound frontmatter validation, and generated/maintained
+  page separation.
+- No new issue-backed implementation slice is required before the `v0.2.0` tag unless the
+  release-prep validation suite finds a concrete blocker.
 
 ## Known Non-Blockers
 
-These items are intentionally not v1 release blockers:
+These items are intentionally not `v0.2.0` release blockers:
 
 - richer post-M14 authority lifecycle policy after the initial planning-doc authority briefs have
   been exercised in real repositories
@@ -71,40 +72,17 @@ These items are intentionally not v1 release blockers:
   old runtime ledger entries
 - source identity extensions beyond curated workspace-backed source lifecycle semantics, if real
   repository use identifies a concrete remaining gap after #94
-- repo-scan bulk registration optimization for #30
-- web document-list scaling for #37
+- repo-scan and web-listing work beyond the closed #30 and #37 follow-ups, if renewed evaluation
+  identifies a concrete scaling gap
 
 ## Post-v1 Queue
 
-The conservative next queue after the `M14-P3.1` gate is:
-
-1. Close #72 once maintainers accept the gate PR, because its broad source-refresh lifecycle and PR
-   handoff asks have landed and been re-evaluated.
-2. Review #86 through `M14-P4.1`, which adds initial planning-document authority metadata and
-   task-oriented authority brief ranking.
-3. Keep using `splendor pr-summary --since main` during review handoff to explain source
-   lifecycle, maintained wiki, source-summary, and mechanical generated-state changes.
-4. Use `M14-P1.5` for issue #93 before continuing post-MVP expansion: add an explicit
-   `splendor ingest --changed` path for checksum-drifted curated sources whose old queue items are
-   already done.
-5. `M14-P1.6` handles issue #90: workspace refresh skips missing curated sources and summarizes
-   per-source refresh failures with diagnostics while continuing valid refresh work, then exits
-   non-zero while unresolved sources remain.
-6. `M14-P1.7` handles issue #89: `splendor source update-path` repairs moved active curated
-   workspace-backed source paths without manual manifest JSON edits or broad discovery.
-7. `M14-P1.8` handles issue #95: health diagnostics include deterministic remediation hints for
-   the concrete `source update-path`, source refresh, stale-ingest, queue retry, and repair ingest
-   commands now available.
-8. Close or explicitly narrow #94 through `M14-P1.9`; the current identity contract keeps
-   canonical `src-...` IDs immutable as version/provenance records while logical IDs, supersession,
-   freshness, path repair, and topic-ref migration cover ordinary curated workspace edits and
-   moves.
-9. Continue #79 after `M15-P1.2` only through deliberately narrowed follow-ups, because compile
-   target discovery and one-page reviewed apply are now represented.
-10. Complete #47 through `M10-P3.1` once the focused ingest run-duration precision PR merges,
-    without rewriting historical runtime records.
-11. Keep #30 and #37 as independent performance/scaling follow-ups unless real repository use makes
-   either one urgent.
+The historical post-v1 queue recorded by `M13-P3.2` has now been worked down through the M14 and
+M15 follow-ups. The current queue before tagging `v0.2.0` is release validation only: confirm local
+tests, formatting, lint, Splendor lint/health, build output, green `main` CI, package metadata
+`0.2.0`, release notes, and no open GitHub issues. After `v0.2.0` is released, the next product
+step is sending Splendor back to evaluation by the Claude Code agent user developing
+SynthBanshee.
 
 The internal source-lifecycle re-evaluation gate is now complete in `M14-P3.1`. The completed retry
 bundle is:
@@ -122,33 +100,32 @@ bundle is:
    including a controlled changed-source exercise, and record the close-or-split recommendation for
    #72.
 
-The retry result is captured in `docs/m14_synthbanshee_reevaluation.md`. After `M14-P4.1`, future
-work starts from #79 unless #86 review identifies a narrower follow-up or a new real-agent run
-reopens a source-lifecycle regression. The first #79 slice is `M15-P1.1`: keep bare compile
-non-mutating, require `--page` for a deterministic diff-backed proposal, and require
-`--apply --proposal-hash <hash>` for the explicit reviewed write. `M15-P1.2` follows by adding
-ranked compile-target discovery, ready-to-run preview commands, and structured preview argv tokens
-to bare compile and `wiki suggest`, while preserving the one-page apply gate.
+The retry result is captured in `docs/m14_synthbanshee_reevaluation.md`. The subsequent
+`M14-P4.1`, `M15-P1.1`, `M15-P1.2`, and `M15-P1.3` work is also complete: planning-authority
+briefs landed, the reviewed one-page compile/apply loop landed, compile-target discovery landed,
+and #79 was dispositioned. Future work should now come from the post-`v0.2.0`
+SynthBanshee/Claude Code evaluation rather than from the closed historical issue queue.
 
 ## Tagging Readiness
 
-After the release PR merges, v1 tagging is ready when `main` has:
+After the release-prep PR merges, `v0.2.0` tagging is ready when `main` has:
 
-- package version metadata updated for the intended v1 tag in both `pyproject.toml` and
+- package version metadata updated to `0.2.0` in both `pyproject.toml` and
   `src/splendor/__init__.py`
-- a release-notes entry or GitHub release draft that names completed M13 work, validation, and the
-  explicit post-v1 queue
+- `docs/v0_2_0_release_notes.md` or a GitHub release draft that names completed stabilization,
+  validation, current no-open-issues state, and the post-release SynthBanshee/Claude Code
+  evaluation step
 - green CI for formatting, linting, tests, and coverage
 - a passing `splendor lint` planning-state check
-- no open issue mislabeled as a v1 blocker
+- no open GitHub issues unless a newly found release blocker has been deliberately filed
 
 Use this final tagging sequence after those checks pass:
 
 ```bash
 git switch main
 git pull --ff-only origin main
-git tag -a v1.0.0 -m "Splendor v1.0.0"
-git push origin v1.0.0
+git tag -a v0.2.0 -m "Splendor v0.2.0"
+git push origin v0.2.0
 uv build
 ```
 

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -18,16 +18,22 @@ Run these commands from the repository root before tagging or publishing the `v0
 release:
 
 ```bash
-uv run pytest
+env -u OPENAI_API_KEY uv run pytest
 uv run ruff format --check .
 uv run ruff check .
 uv run splendor lint
+uv run splendor health
+uv build
 ```
 
-For a CI-equivalent test job with coverage:
+The pytest command intentionally unsets `OPENAI_API_KEY` so release validation uses the
+deterministic offline path instead of attempting live contradiction-review calls when local
+credentials are configured.
+
+For a CI-equivalent test job with coverage, also use the deterministic offline path:
 
 ```bash
-uv run pytest --cov=splendor --cov-report=term-missing --cov-report=xml
+env -u OPENAI_API_KEY uv run pytest --cov=splendor --cov-report=term-missing --cov-report=xml
 ```
 
 Before publishing release notes, verify that:
@@ -124,15 +130,12 @@ Use this final tagging sequence after those checks pass:
 ```bash
 git switch main
 git pull --ff-only origin main
-git tag -a v0.2.0 -m "Splendor v0.2.0"
-git push origin v0.2.0
 uv build
-```
-
-Before publishing artifacts outside GitHub, verify the built wheel/sdist from `dist/` in a clean
-environment with:
-
-```bash
 uv pip install dist/splendor-*.whl
 splendor --version
+git tag -a v0.2.0 -m "Splendor v0.2.0"
+git push origin v0.2.0
 ```
+
+The build and wheel smoke test must pass before the tag is pushed. If either fails, fix the release
+prep on a PR branch instead of publishing and then repairing a bad tag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "splendor"
-version = "0.1.0a0"
+version = "0.2.0"
 description = "Local-first, git-native, schema-driven knowledge compiler for code-and-research repositories."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/splendor/__init__.py
+++ b/src/splendor/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0a0"
+__version__ = "0.2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "splendor"
-version = "0.1.0a0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "bleach" },


### PR DESCRIPTION
## Summary

Prepare the repository for a `v0.2.0` evaluation release tag after the M15 issue-disposition pass.

This PR does not create or push the tag. Tagging should happen only after this PR merges, `main` is green, the deterministic release validation commands pass on `main`, and build/install smoke verification succeeds before the tag is pushed.

## Changes

- Update package metadata from `0.1.0a0` to `0.2.0` in `pyproject.toml`, `src/splendor/__init__.py`, and `uv.lock`.
- Add `docs/v0_2_0_release_notes.md` with release purpose, validation expectations, and current no-open-issues state.
- Reframe the historical v1 handoff and readiness language so it no longer implies this PR prepares a `v1.0.0` tag.
- Synchronize planning-state lines across `.agent-plan.md`, the README What Comes Next block, and `docs/splendor_mvp_to_v1_roadmap.md` using the non-milestone label `v0.2.0-release-tag-prep`.
- Harden release instructions so pytest uses the deterministic offline path with `OPENAI_API_KEY` unset.
- Move build and wheel-install smoke verification before publishing the annotated `v0.2.0` tag.
- Clear stale roadmap and dogfooding claims that #72/#79 work or PR-summary support remained pending.
- Keep runtime behavior and schema version `1` unchanged.

## Issue and milestone linkage

There are currently no open GitHub issues, and this is not an issue-backed implementation slice. PR #106 closed/dispositioned the remaining #79 work before this release-prep pass.

No GitHub milestone is assigned because the repository does not currently have a dedicated `v0.2.0` or evaluation-release milestone; assigning this to a v1/post-v1 implementation milestone would be misleading.

## Validation

- `env -u OPENAI_API_KEY /Users/shaypalachy/.local/bin/uv run pytest` passed: `586 passed`.
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .` passed.
- `/Users/shaypalachy/.local/bin/uv run ruff check .` passed.
- `/Users/shaypalachy/.local/bin/uv run splendor lint` passed: `Checked items: 268`.
- `/Users/shaypalachy/.local/bin/uv run splendor health` passed: `Checked records: 42`.
- `/Users/shaypalachy/.local/bin/uv build` passed and built `dist/splendor-0.2.0.tar.gz` plus `dist/splendor-0.2.0-py3-none-any.whl`.
- `git diff --check` passed.

Note: an earlier exact `/Users/shaypalachy/.local/bin/uv run pytest` attempt failed because the local environment exposed `OPENAI_API_KEY`, causing tests that exercise contradiction review to attempt live OpenAI calls and hit network/name-resolution timeouts. The release checklist now documents the deterministic offline pytest command explicitly.

## Follow-up

After this PR merges and `main` is green, create and push the annotated `v0.2.0` tag from updated `main` only after build and wheel smoke verification pass. The next product step after release is sending Splendor back to evaluation by the Claude Code agent user developing SynthBanshee.
