### PR TITLE
M16-P0.1: Record v0.3 evaluation intake

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -329,7 +329,7 @@
   - [x] Create Milestone 16, 17, and 18 GitHub issue tracks for v0.3, v1, and v2
   - [x] Record the sanitized SynthBanshee/Claude Code evaluation findings
   - [x] Synchronize README, roadmap, and planning state for the v0.3 recovery track
-  - [ ] Publish a non-draft PR with labels, milestone, and detailed validation
+  - [x] Publish a non-draft PR with labels, milestone, and detailed validation
 
 ## Context Pointers
 

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M15-P1.3`
-- Last action taken: `M15-P1.3` is complete; PR #106 recorded the issue #79 compile/update
-  disposition and closed the remaining open issue queue.
-- Current planned slice: `v0.2.0 evaluation release tagging readiness`
-- Current PR sub-slice: `v0.2.0-release-tag-prep`
+- Previous completed PR sub-slice: `v0.2.0-release-tag-prep`
+- Last action taken: `v0.2.0` was tagged and published from main commit `a564cc1` after PR #107
+  prepared the evaluation release.
+- Current planned slice: `M16 v0.3 evaluation intake and roadmap decomposition`
+- Current PR sub-slice: `M16-P0.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `post-v0.2.0 SynthBanshee/Claude Code evaluation`
-- Next planned PR sub-slice: `TBD after evaluation feedback`
+- Next planned slice: `M16-P1 source hygiene and registry recovery`
+- Next planned PR sub-slice: `M16-P1.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -318,12 +318,18 @@
   - [x] Reuse preloaded config/layout during repo-scan apply registration
   - [x] Preserve repo-scan preview/apply gates and source registration behavior
   - [x] Add deterministic regression coverage without timing assertions
-- [ ] Prepare `v0.2.0-release-tag-prep`: Evaluation release tagging readiness
+- [x] Prepare `v0.2.0-release-tag-prep`: Evaluation release tagging readiness
   - [x] Update package version metadata to `0.2.0`
   - [x] Add concise `v0.2.0` release notes for SynthBanshee/Claude Code evaluation
   - [x] Reframe stale v1-tagging handoff language around the immediate `v0.2.0` tag target
   - [x] Keep schema version `1` and runtime behavior unchanged
-  - [ ] Merge the release-prep PR and verify green `main` before tagging
+  - [x] Merge the release-prep PR and verify green `main` before tagging
+- [ ] Implement `M16-P0.1`: v0.3 evaluation intake and roadmap decomposition
+  - [x] Preserve the sanitized post-v0.2.0 fixture archive outside the repository
+  - [x] Create Milestone 16, 17, and 18 GitHub issue tracks for v0.3, v1, and v2
+  - [x] Record the sanitized SynthBanshee/Claude Code evaluation findings
+  - [x] Synchronize README, roadmap, and planning state for the v0.3 recovery track
+  - [ ] Publish a non-draft PR with labels, milestone, and detailed validation
 
 ## Context Pointers
 
@@ -360,6 +366,16 @@
 - `M14-P4` Planning-doc authority and task-oriented agent briefs
 - `M15-P1` Post-v1 mutating compile/update workflow
 - `M10-P3` Ingest run-duration precision
+- `M16-P0` v0.3 evaluation intake and roadmap decomposition
+- `M16-P1` v0.3 source hygiene and registry recovery
+- `M16-P2` v0.3 validation correctness
+- `M16-P3` v0.3 workflow polish
+- `M17-P1` Public mock client acceptance repository
+- `M17-P2` Planning authority lifecycle
+- `M17-P3` Agent handoff ranking
+- `M17-P4` Contradiction-review task noise reduction
+- `M18-P1` Advanced semantic search
+- `M18-P2` Mutating web review workflows
 
 ## PR Sub-slice Queue
 
@@ -402,3 +418,18 @@
 - `M15-P1.1` First reviewed compile/apply loop
 - `M15-P1.2` Compile/update expansion after first reviewed page apply
 - `M10-P3.1` Ingest run-duration precision
+- `M16-P0.1` v0.3 evaluation intake and roadmap decomposition
+- `M16-P1.1` Harden repo scan ignores and `.splendorignore`
+- `M16-P1.2` Add source forget recovery command
+- `M16-P1.3` Reconcile duplicate canonical source versions
+- `M16-P2.1` Fix source validation health false positives
+- `M16-P2.2` Align lint path checks with live source refs
+- `M16-P3.1` Loosen workspace maintenance flag coupling
+- `M16-P3.2` Add JSON output for pending ingest drains
+- `M16-P3.3` Publish release artifacts for easier trial installs
+- `M17-P1.1` Create public mock client acceptance repository
+- `M17-P2.1` Expand planning authority lifecycle
+- `M17-P3.1` Improve semantic ranking for agent handoff
+- `M17-P4.1` Reduce contradiction-review task noise
+- `M18-P1.1` Add advanced semantic search or vector index
+- `M18-P2.1` Explore mutating web review workflows

--- a/README.md
+++ b/README.md
@@ -237,15 +237,16 @@ the source manifest, and kept separate from parsed PDF artifacts.
 - [docs/ci_and_repo_automation.md](docs/ci_and_repo_automation.md)
 - [docs/v1_release_handoff.md](docs/v1_release_handoff.md)
 - [docs/m14_synthbanshee_reevaluation.md](docs/m14_synthbanshee_reevaluation.md)
+- [docs/v0_2_synthbanshee_evaluation.md](docs/v0_2_synthbanshee_evaluation.md)
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M15-P1.3`
-- Current planned slice: `v0.2.0 evaluation release tagging readiness`
-- Current PR sub-slice: `v0.2.0-release-tag-prep`
+- Previous completed PR sub-slice: `v0.2.0-release-tag-prep`
+- Current planned slice: `M16 v0.3 evaluation intake and roadmap decomposition`
+- Current PR sub-slice: `M16-P0.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `post-v0.2.0 SynthBanshee/Claude Code evaluation`
-- Next planned PR sub-slice: `TBD after evaluation feedback`
+- Next planned slice: `M16-P1 source hygiene and registry recovery`
+- Next planned PR sub-slice: `M16-P1.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -342,11 +343,17 @@ frontmatter validation, and focused regression coverage. The detailed dispositio
 Issue #79 should close with the `M15-P1.3` disposition PR unless maintainers identify a new narrow
 follow-up outside the current reviewed one-page compile/apply contract.
 
-The current release-prep PR is not an issue-backed milestone slice. It prepares the `v0.2.0`
+The `v0.2.0-release-tag-prep` PR was not an issue-backed milestone slice. It prepared the
 evaluation release by updating package version metadata, adding versioned release notes, and
-reframing stale v1-tagging language so the next concrete action after merge and green `main` is the
-`v0.2.0` tag. The product follow-up after that tag is a fresh SynthBanshee/Claude Code evaluation
-run.
+reframing stale v1-tagging language around the immediate `v0.2.0` tag. The tag is published, and
+the SynthBanshee/Claude Code evaluation has now become the input for `M16`.
+
+`M16-P0.1` records the post-`v0.2.0` SynthBanshee/Claude Code evaluation intake. The evaluation
+found that the source-refresh model and compact agent handoff are useful, but v0.3 must focus on
+source hygiene, registry recovery, and validation correctness before another trial release. The
+sanitized intake is in [docs/v0_2_synthbanshee_evaluation.md](docs/v0_2_synthbanshee_evaluation.md).
+Milestone 16 tracks v0.3 blockers and polish; Milestone 17 tracks public v1 readiness; Milestone
+18 tracks v2 product bets.
 
 `M14-P1.1` adds the first stable logical source identity layer above content-addressed source IDs:
 workspace-backed manifests now persist `source:<workspace-path>` logical IDs and path aliases while
@@ -453,5 +460,13 @@ rewritten.
 - [x] Final release handoff names validation, issue state, GitHub metadata, known non-blockers,
   and the post-v1 queue.
 - [x] PR-summary tooling gives reviewers a lower-noise generated-state handoff.
-- [ ] `v0.2.0` package metadata, release notes, local validation, and green `main` CI are confirmed
+- [x] `v0.2.0` package metadata, release notes, local validation, and green `main` CI are confirmed
   before tagging.
+
+### v0.3 recovery readiness checklist
+
+- [ ] Repo scan ignores and `.splendorignore` prevent cache/local-agent source pollution.
+- [ ] `splendor source forget` provides safe single and bulk source-registry recovery.
+- [ ] Duplicate canonical source versions can be reconciled without manual manifest edits.
+- [ ] Health resolves existing manifest source IDs without false unknown-source diagnostics.
+- [ ] Lint validates live source refs after path repair and supersession.

--- a/README.md
+++ b/README.md
@@ -340,8 +340,8 @@ desired reviewed compile/update follow-up is materially represented by the exist
 proposal/apply workflow, generated/maintained page separation, deterministic output, schema-bound
 frontmatter validation, and focused regression coverage. The detailed disposition matrix lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md#completed-disposition-m15-p13-issue-79-disposition).
-Issue #79 should close with the `M15-P1.3` disposition PR unless maintainers identify a new narrow
-follow-up outside the current reviewed one-page compile/apply contract.
+Issue #79 closed with the `M15-P1.3` disposition PR. Any future compile/update follow-up should be
+a new narrow issue outside the current reviewed one-page compile/apply contract.
 
 The `v0.2.0-release-tag-prep` PR was not an issue-backed milestone slice. It prepared the
 evaluation release by updating package version metadata, adding versioned release notes, and

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -1079,8 +1079,8 @@ and `M15-P1.2`.
 
 Remaining deliberate non-goals are automatic multi-page mutation, LLM synthesis, mutating web UI
 actions, search/index redesign, source lifecycle work, and broad roadmap expansion. Unless
-maintainers identify a newly scoped gap, #79 should close with this disposition rather than
-expanding the parent issue beyond the reviewed one-page compile/apply contract.
+maintainers identify a newly scoped gap, any future compile/update follow-up should be a new narrow
+issue beyond the reviewed one-page compile/apply contract.
 
 ### M10-P3.1 ingest run-duration precision
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M15-P1.3`
-- Current planned slice: `v0.2.0 evaluation release tagging readiness`
-- Current PR sub-slice: `v0.2.0-release-tag-prep`
+- Previous completed PR sub-slice: `v0.2.0-release-tag-prep`
+- Current planned slice: `M16 v0.3 evaluation intake and roadmap decomposition`
+- Current PR sub-slice: `M16-P0.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `post-v0.2.0 SynthBanshee/Claude Code evaluation`
-- Next planned PR sub-slice: `TBD after evaluation feedback`
+- Next planned slice: `M16-P1 source hygiene and registry recovery`
+- Next planned PR sub-slice: `M16-P1.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -829,11 +829,11 @@ threads. Later M14 slices added stable logical source identities, supersedes/sup
 semantics, safe workspace refresh, pruning, topic-ref migration, and PR-summary tooling without
 adding SQLite, vector search, background workers, mutating web UI, or broad refresh discovery.
 
-`M13-P3.2` is the final release checklist and post-v1 handoff. It keeps runtime behavior stable,
-adds the concise release handoff in `docs/v1_release_handoff.md`, and makes the post-v1 queue
-explicit: #72 owns source lifecycle and agent workflow follow-up; #79 owns the deferred mutating
-compile/update path from #41; #47 owns ingest run durations and is targeted by `M10-P3.1`; #30 and
-#37 remain independent performance/scaling follow-ups.
+`M13-P3.2` is the final release checklist and historical post-v1 handoff. It keeps runtime
+behavior stable and adds the concise release handoff in `docs/v1_release_handoff.md`. Its original
+post-v1 queue was later worked through by the M14/M15 follow-ups: #72 covered source lifecycle and
+agent workflow work, #79 covered the deferred mutating compile/update path from #41, #47 was
+targeted by `M10-P3.1`, and #30/#37 were dispositioned independently.
 
 `M13-P3.3` handles issue #30 as a focused repo-scan apply performance/refactor slice. It preserves
 safe non-mutating scan previews, explicit apply gates, source IDs, manifest validation, and queue
@@ -859,10 +859,10 @@ registration.
   generated/maintained page separation.
 - [x] Final release handoff records validation commands, docs state, issue state, GitHub metadata,
   known non-blockers, and the post-v1 queue.
-- [x] No GitHub issues remain open after the M15 disposition pass.
-- [ ] Tagging should happen only after the full validation suite, green CI on `main`, package
-  metadata set to `0.2.0`, and release notes that call out completed stabilization plus the next
-  SynthBanshee/Claude Code evaluation step.
+- [x] No GitHub issues remained open after the M15 disposition pass and before the post-`v0.2.0`
+  evaluation reopened the roadmap with M16/M17/M18 follow-ups.
+- [x] The `v0.2.0` tag was published from green `main` after PR #107, and the follow-up
+  SynthBanshee/Claude Code evaluation was captured as the input for the v0.3 roadmap.
 
 ### Exit criteria
 - the product is stable enough for sustained real-world use
@@ -1096,6 +1096,88 @@ schema version remain unchanged, and historical run records are not rewritten.
 - Preserve curated source manifests as the durable registry.
 - Keep #30 and #37 independent performance/scaling follow-ups unless real repository use makes
   either one urgent.
+
+---
+
+## Milestone 16 — v0.3 source hygiene and registry recovery
+
+### Goal
+Make Splendor safe to retry on a real external agent workflow after the post-`v0.2.0`
+SynthBanshee/Claude Code evaluation. The release target is not broader product surface; it is
+recoverability, source-registration hygiene, and trustworthy validation.
+
+### Input signal
+The sanitized evaluation intake lives in `docs/v0_2_synthbanshee_evaluation.md`. A fixture archive
+is preserved outside the repository at
+`/Users/shaypalachy/archive/splendor-fixtures/splendor-fixture-2026-05-05.tar.gz` with SHA-256
+`8b2fea5e3cd04c99d52d79398347ff7a38b41a30c410a3a1ab1985fbe63b162c`.
+
+### Planned PR slices
+- `M16-P0` Evaluation intake and roadmap decomposition.
+- `M16-P1` Source hygiene and registry recovery.
+- `M16-P2` Validation correctness.
+- `M16-P3` Workflow polish and trial-install polish.
+
+### Planned PR sub-slices
+- `M16-P0.1` Record v0.3 evaluation intake and issue decomposition.
+- `M16-P1.1` Harden repo scan ignores and `.splendorignore` (#111).
+- `M16-P1.2` Add `splendor source forget` recovery command (#109).
+- `M16-P1.3` Reconcile duplicate canonical source versions (#110).
+- `M16-P2.1` Fix source validation health false positives (#112).
+- `M16-P2.2` Align lint path checks with live source refs (#113).
+- `M16-P3.1` Loosen workspace maintenance flag coupling (#121).
+- `M16-P3.2` Add JSON output for pending ingest drains (#122).
+- `M16-P3.3` Publish release artifacts for easier trial installs (#120).
+
+### Minimum v0.3 retry bar
+- Repo scan honors `.gitignore` and project-specific ignore rules across documentation scans,
+  `--all`, class-filtered scans, and apply paths.
+- Operators can clean polluted registries through `source forget` without deleting manifests by
+  hand.
+- Duplicate active source versions for the same canonical source ref can be reconciled through a
+  documented command or automatic scan reconciliation.
+- Lint reads the live source model after source refresh, path repair, and supersession repair.
+- Health resolves run source IDs against the manifest store without false unknown-source errors.
+
+### Exit criteria
+- `splendor lint` and `splendor health` are trustworthy diagnostics on the acceptance fixture.
+- A polluted registry has a documented, tested recovery path.
+- The same Claude Code evaluator can retry Splendor on SynthBanshee without manual manifest
+  surgery.
+
+## Milestone 17 — v1 public readiness
+
+### Goal
+Prepare Splendor for public v1 evaluation after v0.3 proves safe on the real SynthBanshee workflow.
+This milestone is about acceptance fixtures, external evaluator ergonomics, and higher-signal agent
+handoff.
+
+### Planned PR slices
+- `M17-P1.1` Create a public mock client acceptance repository (#114).
+- `M17-P2.1` Expand planning authority lifecycle (#116).
+- `M17-P3.1` Improve semantic ranking for agent handoff (#115).
+- `M17-P4.1` Reduce contradiction-review task noise (#117).
+
+### Public mock client guidance
+The public mock client should model a realistic small CLI/data project with human-authored specs,
+implementation plans, decision records, research notes that contain real contradictions, a
+non-trivial PR history, populated ignored cache directories in local scenarios, and dedicated
+failure branches or fixtures for polluted manifests, dangling active sources, and renamed-file
+repairs. Healthy `main` should be useful for first-run evaluation; intentionally broken states
+belong in scenario branches or fixtures.
+
+## Milestone 18 — v2 advanced product track
+
+### Goal
+Keep larger product bets visible without pulling them into the v0.3 recovery release or the public
+v1 readiness gate.
+
+### Candidate PR slices
+- `M18-P1.1` Add advanced semantic search or a vector index (#118).
+- `M18-P2.1` Explore mutating web review workflows (#119).
+
+These remain post-v1 unless a later external evaluation shows they are more important than the
+source hygiene, recovery, validation, and public-readiness work above.
 
 ---
 

--- a/docs/v0_2_synthbanshee_evaluation.md
+++ b/docs/v0_2_synthbanshee_evaluation.md
@@ -1,0 +1,101 @@
+# v0.2.0 SynthBanshee Evaluation Intake
+
+## Purpose
+
+This document records the sanitized post-`v0.2.0` external-agent evaluation that followed the
+`v0.2.0` tag. The evaluator was a Claude Code agent working in a public companion project. The
+private project-specific details are intentionally omitted because they are not needed to explain
+the Splendor product findings.
+
+The evaluation replaces the previous internal-only `M14-P3.1` source-lifecycle gate as the current
+external workflow signal. Its conclusion is blunt: Splendor's core model is understandable and some
+handoff surfaces are useful, but v0.2.0 is not ready as a daily-driver agent companion until source
+registration hygiene, registry recovery, and validation correctness are fixed.
+
+## Preserved Fixture
+
+A sanitized fixture bundle was captured outside the repository:
+
+- Local path: `/Users/shaypalachy/archive/splendor-fixtures/splendor-fixture-2026-05-05.tar.gz`
+- SHA-256: `8b2fea5e3cd04c99d52d79398347ff7a38b41a30c410a3a1ab1985fbe63b162c`
+- Contents: one representative run record, five source manifests, command output captures, and a
+  `repo scan --json` preview
+
+The fixture is not committed in this PR. It should be treated as a local regression source for the
+v0.3 issues below. Do not publish raw project-specific details unless they have been sanitized.
+
+## What Worked
+
+- `brief --agent-context` produced a useful top-level handoff block with wiki status, source/run
+  state, and recent source/run context.
+- Curated topic pages contained real project value and surfaced recommendations that were not
+  obvious from a git log alone.
+- `splendor source update-path` repaired a renamed workspace source enough for the live manifest
+  path/source ref to point at the new file.
+- The source-refresh model was understandable: changed bytes create a new content-addressed source
+  version, ingest writes a successor source-summary page, pruning can remove old generated state,
+  and topic refs can migrate to the active version.
+
+## Blocking Failures
+
+### Historical repo-scan pollution
+
+The evaluated workspace contained thousands of untracked source manifests produced by a historical
+`repo_scan` run under Splendor `0.1.0a0`. Those manifests registered cache and local-agent files
+such as `.mypy_cache/*` and `.claude/settings.local.json` as curated workspace sources.
+
+The evaluator's v0.2.0 `repo scan --json` check suggests default documentation scans now honor
+`.gitignore`, but `--all`, class-filtered scans, and `--apply` still need direct regression
+coverage before this can be called fixed.
+
+### No source-registry recovery command
+
+Once a registry is polluted, v0.2.0 has no first-class cleanup command. Operators must manually
+delete JSON manifests under `state/manifests/sources/`, which is not acceptable for an
+agent-facing system.
+
+### Duplicate canonical source refs
+
+The fixture shows a source originally registered through `add-source`, later re-registered by repo
+scan under a different source ID, and then refreshed into a third source ID. The refresh only
+linked the repo-scan version to its successor. The original `add-source` manifest stayed active,
+so lint correctly reported multiple active source versions for the same canonical source ref.
+
+The missing primitive is a documented reconciliation path, such as `source supersede` or
+`source reconcile`, plus scan behavior that does not create new active duplicates for already
+curated canonical refs.
+
+### Health false positives
+
+`splendor health` reported `Run references unknown source_id` for run records whose `source_ids`
+field exactly matched existing manifest filenames. Health must resolve run source IDs against the
+manifest store directly and avoid duplicate provenance diagnostics for the same bad ref.
+
+### Lint uses historical path fields as live paths
+
+After `source update-path`, live `path` and `source_ref` fields pointed at the new file, but lint
+still reported a missing old path from historical fields such as `original_path` or `logical_id`.
+Historical registration identity should not make a deliberately repaired source fail the live
+path-existence check.
+
+## v0.3 Minimum Retry Bar
+
+The same evaluator is willing to retry Splendor seriously on the companion project when these
+v0.3 items land:
+
+1. `repo scan`, including `--all`, class-filtered, and `--apply` paths, honors `.gitignore` and
+   project-specific ignore rules.
+2. `splendor source forget` supports safe single-source and bulk registry cleanup.
+3. Duplicate canonical source versions can be reconciled through `source supersede`,
+   `source reconcile`, or equivalent scan behavior.
+4. Lint reads the live source model correctly after source refresh and path repair.
+5. Health resolves source IDs against the manifest store without false unknown-source errors.
+
+Lower-priority v0.3 polish includes standalone workspace maintenance actions, JSON output for
+pending ingest drains, and easier release artifacts for trial installs.
+
+## Roadmap Consequence
+
+The next product direction is not broader synthesis, a mutating web UI, or advanced search. The
+next track is v0.3 source hygiene and registry recovery. Public v1 work should start after the
+v0.3 recovery loop is safe enough for another external trial.

--- a/docs/v0_2_synthbanshee_evaluation.md
+++ b/docs/v0_2_synthbanshee_evaluation.md
@@ -94,6 +94,30 @@ v0.3 items land:
 Lower-priority v0.3 polish includes standalone workspace maintenance actions, JSON output for
 pending ingest drains, and easier release artifacts for trial installs.
 
+## Public Mock Client Acceptance Workflows
+
+The evaluation reinforced the need for a public mock client repository before public v1. The mock
+repo should not replace real SynthBanshee trials, but it should give external evaluators and CI a
+safe, realistic place to exercise the failure modes found here.
+
+Healthy `main` should model a small project that is already several months old: human-authored
+specs, implementation plans, decision records, research notes with a few real contradictions, a
+non-trivial merged PR history, an `AGENTS.md` or equivalent agent instruction file, and realistic
+ignored cache/local-agent directories that appear in working trees after normal tool use.
+
+Failure scenarios should live outside healthy `main`, preferably as dedicated scenario branches or
+fixtures. The first public acceptance suite should force three workflows:
+
+1. Source refresh after a real PR changes several curated sources. The expected result is one
+   active manifest per changed source, pruned superseded source-summary pages, migrated maintained
+   topic refs, and passing `splendor lint` plus `splendor health`.
+2. Agent handoff on a planning question that spans multiple authorities. `brief --agent-context`
+   should surface the implementation plan, current decision record, and relevant contradicting
+   research note, with current authority ranked above stale or merely token-similar material.
+3. Recovery from polluted source state. A seeded polluted registry should be recoverable through a
+   documented Splendor command, ending with ignored cache/local-agent manifests removed, duplicate
+   active source refs reconciled, and no manual deletion under `state/manifests/sources/`.
+
 ## Roadmap Consequence
 
 The next product direction is not broader synthesis, a mutating web UI, or advanced search. The


### PR DESCRIPTION
## Summary

Records the post-v0.2.0 SynthBanshee/Claude Code evaluation as the input for the next Splendor roadmap slice.

This PR:
- adds `docs/v0_2_synthbanshee_evaluation.md` with sanitized findings, fixture location/hash, useful surfaces, blocking failures, and the minimum v0.3 retry bar
- synchronizes `.agent-plan.md`, README "What Comes Next", and `docs/splendor_mvp_to_v1_roadmap.md` around `M16-P0.1`
- decomposes the roadmap into three layers: Milestone 16 for v0.3 recovery blockers, Milestone 17 for public v1 readiness, and Milestone 18 for post-v1 product bets
- preserves the v0.2.0 release/tagging state as historical and makes M16 source hygiene/registry recovery the next concrete track

## Planning notation

- Previous completed PR sub-slice: `v0.2.0-release-tag-prep`
- Current planned slice: `M16 v0.3 evaluation intake and roadmap decomposition`
- Current PR sub-slice: `M16-P0.1`
- Current PR lifecycle: `branch=in-progress; main=merged`
- Next planned slice: `M16-P1 source hygiene and registry recovery`
- Next planned PR sub-slice: `M16-P1.1`

## Issue and milestone linkage

This is a planning/intake PR rather than an issue-backed implementation slice, so it does not close a product bug/feature issue directly.

It creates and links the follow-up issue decomposition:

- v0.3 / Milestone 16: #111, #109, #110, #112, #113, #121, #122, #120
- v1 / Milestone 17: #114, #116, #115, #117
- v2 / Milestone 18: #118, #119

This PR is assigned to Milestone 16 because it opens the `M16-P0` evaluation-intake track that feeds the v0.3 recovery release.

## Preserved fixture

The sanitized evaluation fixture is preserved outside the repository:

- Path: `/Users/shaypalachy/archive/splendor-fixtures/splendor-fixture-2026-05-05.tar.gz`
- SHA-256: `8b2fea5e3cd04c99d52d79398347ff7a38b41a30c410a3a1ab1985fbe63b162c`

The tarball is intentionally not committed.

## Validation

- [x] `env -u OPENAI_API_KEY /Users/shaypalachy/.local/bin/uv run pytest`
- [x] `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- [x] `/Users/shaypalachy/.local/bin/uv run ruff check .`
- [x] `/Users/shaypalachy/.local/bin/uv run splendor lint`
- [x] `/Users/shaypalachy/.local/bin/uv run splendor health`
- [x] `/Users/shaypalachy/.local/bin/uv build`
