### PR TITLE
M16-P1.1: Harden repo scan ignores

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `v0.2.0-release-tag-prep`
-- Last action taken: `v0.2.0` was tagged and published from main commit `a564cc1` after PR #107
-  prepared the evaluation release.
-- Current planned slice: `M16 v0.3 evaluation intake and roadmap decomposition`
-- Current PR sub-slice: `M16-P0.1`
+- Previous completed PR sub-slice: `M16-P0.1`
+- Last action taken: `M16-P0.1` was squash-merged into main as commit `1dc7766`,
+  recording v0.3 evaluation intake and roadmap decomposition.
+- Current planned slice: `M16-P1 source hygiene and registry recovery`
+- Current PR sub-slice: `M16-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P1 source hygiene and registry recovery`
-- Next planned PR sub-slice: `M16-P1.1`
+- Next planned PR sub-slice: `M16-P1.2`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -148,7 +148,10 @@ Not implemented yet:
 - mutating web UI actions such as add-source forms
 
 `splendor repo scan` is safe by default: it previews candidates without writing manifests or
-derived state. Registration requires `repo scan --apply` plus `--class ...` or `--all`.
+derived state. Registration requires `repo scan --apply` plus `--class ...` or `--all`. Scan
+previews honor `.gitignore`, root `.splendorignore`, Splendor-managed paths, dependency
+directories, local-agent directories, and transient cache/build directories before class filtering
+or apply registration.
 `splendor source freshness` is also non-mutating by default: it compares workspace-backed curated
 source files to their manifest checksums, reports unchanged/changed/missing/unsupported sources,
 and prints exact `source refresh`/`ingest --pending` next commands for stale paths. `--json` emits
@@ -241,12 +244,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `v0.2.0-release-tag-prep`
-- Current planned slice: `M16 v0.3 evaluation intake and roadmap decomposition`
-- Current PR sub-slice: `M16-P0.1`
+- Previous completed PR sub-slice: `M16-P0.1`
+- Current planned slice: `M16-P1 source hygiene and registry recovery`
+- Current PR sub-slice: `M16-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P1 source hygiene and registry recovery`
-- Next planned PR sub-slice: `M16-P1.1`
+- Next planned PR sub-slice: `M16-P1.2`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -465,7 +468,7 @@ rewritten.
 
 ### v0.3 recovery readiness checklist
 
-- [ ] Repo scan ignores and `.splendorignore` prevent cache/local-agent source pollution.
+- [x] Repo scan ignores and `.splendorignore` prevent cache/local-agent source pollution.
 - [ ] `splendor source forget` provides safe single and bulk source-registry recovery.
 - [ ] Duplicate canonical source versions can be reconciled without manual manifest edits.
 - [ ] Health resolves existing manifest source IDs without false unknown-source diagnostics.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -548,8 +548,9 @@ Current runtime behavior:
 - candidates include repo-relative paths, source classes, labels, status, and already-curated
   source identity when a workspace-backed source manifest already tracks the path
 - ignored paths include a deterministic reason such as `managed_or_transient`, `gitignore`,
-  `splendorignore`, `include_patterns`, `exclude_patterns`, or `class_filter`; pruned ignored
-  directories are reported with trailing slash paths
+  `splendorignore`, `scan_control`, `include_patterns`, `exclude_patterns`, or `class_filter`;
+  pruned ignored directories are reported with trailing slash paths when they represent populated
+  non-layout trees
 - mutating registration requires `--apply` plus `--class ...` or `--all`
 - large apply runs require `--allow-large-apply` after preview review
 - scan honors `sources.include_patterns`, `sources.exclude_patterns`, and

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -548,11 +548,13 @@ Current runtime behavior:
 - candidates include repo-relative paths, source classes, labels, status, and already-curated
   source identity when a workspace-backed source manifest already tracks the path
 - ignored paths include a deterministic reason such as `managed_or_transient`, `gitignore`,
-  `include_patterns`, `exclude_patterns`, or `class_filter`
+  `splendorignore`, `include_patterns`, `exclude_patterns`, or `class_filter`; pruned ignored
+  directories are reported with trailing slash paths
 - mutating registration requires `--apply` plus `--class ...` or `--all`
 - large apply runs require `--allow-large-apply` after preview review
 - scan honors `sources.include_patterns`, `sources.exclude_patterns`, and
-  `sources.repo_scan_default_classes` from `splendor.yaml`
+  `sources.repo_scan_default_classes` from `splendor.yaml`, plus optional root `.splendorignore`
+  project-specific ignore patterns
 - scan skips Git-ignored files, Splendor-managed directories, dependency directories, and
   transient cache/build directories by default
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `v0.2.0-release-tag-prep`
-- Current planned slice: `M16 v0.3 evaluation intake and roadmap decomposition`
-- Current PR sub-slice: `M16-P0.1`
+- Previous completed PR sub-slice: `M16-P0.1`
+- Current planned slice: `M16-P1 source hygiene and registry recovery`
+- Current PR sub-slice: `M16-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P1 source hygiene and registry recovery`
-- Next planned PR sub-slice: `M16-P1.1`
+- Next planned PR sub-slice: `M16-P1.2`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1130,8 +1130,8 @@ is preserved outside the repository at
 - `M16-P3.3` Publish release artifacts for easier trial installs (#120).
 
 ### Minimum v0.3 retry bar
-- Repo scan honors `.gitignore` and project-specific ignore rules across documentation scans,
-  `--all`, class-filtered scans, and apply paths.
+- Repo scan honors `.gitignore`, `.splendorignore`, and safe built-in ignore rules across
+  documentation scans, `--all`, class-filtered scans, and apply paths.
 - Operators can clean polluted registries through `source forget` without deleting manifests by
   hand.
 - Duplicate active source versions for the same canonical source ref can be reconciled through a

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -876,9 +876,10 @@ M13-P2 repo-discovery contracts:
   requires `--report PATH`, and that path writes only report JSON.
 - Mutating registration from scan requires `--apply` plus either `--class ...` or `--all`; the bare
   command says it is preview-only and prints the explicit apply command.
-- Repo scan supports class filters, include/exclude patterns from `splendor.yaml`, and large
-  candidate-set guards before registration. Exclude patterns win over include patterns, and class
-  filters apply after include/exclude filtering.
+- Repo scan supports class filters, include/exclude patterns from `splendor.yaml`, optional root
+  `.splendorignore` project-specific ignore patterns, and large candidate-set guards before
+  registration. Exclude patterns win over include patterns, and class filters apply after
+  include/exclude filtering.
 - Broad registration refuses large candidate sets unless the operator passes
   `--allow-large-apply` after reviewing the preview/report.
 - `splendor.yaml` supports `sources.include_patterns`, `sources.exclude_patterns`, and
@@ -1331,11 +1332,12 @@ Current source settings:
 - `sources.repo_scan_default_classes`: class policy for non-mutating candidate discovery, applied
   after include/exclude filtering, default `["documentation"]`
 
-Repo scan should skip Git-ignored files, Splendor state/output directories, dependency directories,
-build artifacts, and other generated paths by default unless a future explicit override flag
-documents the extra churn. Class filters narrow the already-filtered candidate set; they should not
-override excludes. The default class policy should bias toward documentation and curated knowledge
-over all supported files.
+Repo scan should skip Git-ignored files, root `.splendorignore` project-specific ignores, Splendor
+state/output directories, dependency directories, build artifacts, local-agent directories, and
+other generated paths by default unless a future explicit override flag documents the extra churn.
+Class filters narrow the already-filtered candidate set; they should not override excludes. The
+default class policy should bias toward documentation and curated knowledge over all supported
+files.
 
 ## 28. Minimum Opinionated Core
 

--- a/src/splendor/commands/repo_scan.py
+++ b/src/splendor/commands/repo_scan.py
@@ -41,6 +41,7 @@ _IGNORED_DIR_NAMES = {
     "generated",
     "node_modules",
 }
+_SCAN_CONTROL_FILENAMES = {".splendorignore"}
 _SOURCE_CLASSES: tuple[SourceClass, ...] = ("code", "documentation", "configuration", "other")
 LARGE_APPLY_CANDIDATE_LIMIT = 200
 
@@ -403,10 +404,11 @@ def _discover_supported_paths(
             if reason is None:
                 reason = _splendorignore_dir_reason(path, root, splendorignore)
             if reason is not None:
-                ignored_paths_by_path[relative_dir_path] = RepoScanIgnoredPath(
-                    path=relative_dir_path,
-                    reason=reason,
-                )
+                if _should_report_pruned_directory(path, reason, root, layout):
+                    ignored_paths_by_path[relative_dir_path] = RepoScanIgnoredPath(
+                        path=relative_dir_path,
+                        reason=reason,
+                    )
                 continue
             repo_relative = _repo_relative_path(path, gitignore, is_dir=True)
             if repo_relative is not None:
@@ -418,10 +420,11 @@ def _discover_supported_paths(
                 dirname = gitignore_dir_candidates[repo_path]
                 path = current_dir / dirname
                 relative_dir_path = f"{path.relative_to(root).as_posix()}/"
-                ignored_paths_by_path[relative_dir_path] = RepoScanIgnoredPath(
-                    path=relative_dir_path,
-                    reason="gitignore",
-                )
+                if _should_report_pruned_directory(path, "gitignore", root, layout):
+                    ignored_paths_by_path[relative_dir_path] = RepoScanIgnoredPath(
+                        path=relative_dir_path,
+                        reason="gitignore",
+                    )
             filtered_dirnames = [
                 dirname
                 for dirname in filtered_dirnames
@@ -493,6 +496,8 @@ def _ignored_path_reason(path: Path, root: Path, layout: ResolvedLayout) -> str 
     relative = path.relative_to(root)
     if not relative.parts:
         return None
+    if len(relative.parts) == 1 and relative.name in _SCAN_CONTROL_FILENAMES:
+        return "scan_control"
     if _is_managed_layout_path(relative, root, layout) or _has_ignored_dir_name(
         relative.parts, is_dir=False
     ):
@@ -537,6 +542,28 @@ def _parts_start_with(parts: tuple[str, ...], prefix: tuple[str, ...]) -> bool:
 def _has_ignored_dir_name(parts: tuple[str, ...], *, is_dir: bool) -> bool:
     directory_parts = parts if is_dir else parts[:-1]
     return any(part in _IGNORED_DIR_NAMES for part in directory_parts)
+
+
+def _should_report_pruned_directory(
+    path: Path,
+    reason: str,
+    root: Path,
+    layout: ResolvedLayout,
+) -> bool:
+    relative = path.relative_to(root)
+    if reason == "managed_or_transient" and _is_managed_layout_path(relative, root, layout):
+        return False
+    return _directory_has_entries(path)
+
+
+def _directory_has_entries(path: Path) -> bool:
+    try:
+        next(path.iterdir())
+    except StopIteration:
+        return False
+    except OSError:
+        return True
+    return True
 
 
 def _git_ignore_context(root: Path) -> GitIgnoreContext:

--- a/src/splendor/commands/repo_scan.py
+++ b/src/splendor/commands/repo_scan.py
@@ -27,6 +27,7 @@ _CODE_EXTENSIONS = (
 )
 _IGNORED_DIR_NAMES = {
     ".cache",
+    ".claude",
     ".git",
     ".mypy_cache",
     ".pytest_cache",
@@ -75,6 +76,12 @@ class RepoScanIgnoredPath:
 class GitIgnoreContext:
     repo_root: Path | None
     workspace_root: Path
+
+
+@dataclass(frozen=True)
+class SplendorIgnoreRules:
+    file_patterns: tuple[str, ...]
+    directory_patterns: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -383,6 +390,7 @@ def _discover_supported_paths(
     ignored_paths_by_path: dict[str, RepoScanIgnoredPath] = {}
     unsupported = 0
     gitignore = _git_ignore_context(root)
+    splendorignore = _load_splendorignore(root)
 
     for dirpath, dirnames, filenames in os.walk(root, topdown=True):
         current_dir = Path(dirpath)
@@ -390,8 +398,15 @@ def _discover_supported_paths(
         gitignore_dir_candidates: dict[str, str] = {}
         for dirname in sorted(dirnames):
             path = current_dir / dirname
+            relative_dir_path = f"{path.relative_to(root).as_posix()}/"
             reason = _ignored_dir_reason(path, root, layout)
+            if reason is None:
+                reason = _splendorignore_dir_reason(path, root, splendorignore)
             if reason is not None:
+                ignored_paths_by_path[relative_dir_path] = RepoScanIgnoredPath(
+                    path=relative_dir_path,
+                    reason=reason,
+                )
                 continue
             repo_relative = _repo_relative_path(path, gitignore, is_dir=True)
             if repo_relative is not None:
@@ -399,6 +414,14 @@ def _discover_supported_paths(
             filtered_dirnames.append(dirname)
         gitignored_dirs = _git_ignored_repo_paths(gitignore_dir_candidates, gitignore)
         if gitignored_dirs:
+            for repo_path in gitignored_dirs:
+                dirname = gitignore_dir_candidates[repo_path]
+                path = current_dir / dirname
+                relative_dir_path = f"{path.relative_to(root).as_posix()}/"
+                ignored_paths_by_path[relative_dir_path] = RepoScanIgnoredPath(
+                    path=relative_dir_path,
+                    reason="gitignore",
+                )
             filtered_dirnames = [
                 dirname
                 for dirname in filtered_dirnames
@@ -410,6 +433,13 @@ def _discover_supported_paths(
             path = current_dir / filename
             relative_path = path.relative_to(root).as_posix()
             reason = _ignored_path_reason(path, root, layout)
+            if reason is not None:
+                ignored_paths_by_path[relative_path] = RepoScanIgnoredPath(
+                    path=relative_path,
+                    reason=reason,
+                )
+                continue
+            reason = _splendorignore_file_reason(path, root, splendorignore)
             if reason is not None:
                 ignored_paths_by_path[relative_path] = RepoScanIgnoredPath(
                     path=relative_path,
@@ -525,6 +555,62 @@ def _git_ignore_context(root: Path) -> GitIgnoreContext:
         repo_root=Path(top_level.stdout.strip()).resolve(),
         workspace_root=root.resolve(),
     )
+
+
+def _load_splendorignore(root: Path) -> SplendorIgnoreRules:
+    ignore_path = root / ".splendorignore"
+    if not ignore_path.is_file():
+        return SplendorIgnoreRules(file_patterns=(), directory_patterns=())
+    file_patterns: list[str] = []
+    directory_patterns: list[str] = []
+    for raw_line in ignore_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.endswith("/"):
+            normalized = _normalize_pattern(line)
+            if normalized:
+                directory_patterns.append(normalized)
+            continue
+        normalized = _normalize_pattern(line)
+        if normalized:
+            file_patterns.append(normalized)
+    return SplendorIgnoreRules(
+        file_patterns=tuple(file_patterns),
+        directory_patterns=tuple(directory_patterns),
+    )
+
+
+def _splendorignore_dir_reason(path: Path, root: Path, rules: SplendorIgnoreRules) -> str | None:
+    if not rules.directory_patterns:
+        return None
+    relative_path = path.relative_to(root).as_posix()
+    if _matches_any_pattern(relative_path, list(rules.directory_patterns)):
+        return "splendorignore"
+    return None
+
+
+def _splendorignore_file_reason(path: Path, root: Path, rules: SplendorIgnoreRules) -> str | None:
+    relative_path = path.relative_to(root).as_posix()
+    if _matches_any_pattern(relative_path, list(rules.file_patterns)):
+        return "splendorignore"
+    if rules.directory_patterns and _matches_directory_pattern_parent(
+        relative_path,
+        rules.directory_patterns,
+    ):
+        return "splendorignore"
+    return None
+
+
+def _matches_directory_pattern_parent(
+    relative_path: str, directory_patterns: tuple[str, ...]
+) -> bool:
+    parts = tuple(part for part in relative_path.split("/") if part)
+    for index in range(1, len(parts)):
+        parent = "/".join(parts[:index])
+        if _matches_any_pattern(parent, list(directory_patterns)):
+            return True
+    return False
 
 
 def _git_ignored_paths(root: Path, paths: list[Path], gitignore: GitIgnoreContext) -> set[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -345,6 +345,49 @@ def test_cli_repo_scan_preview_shows_source_id_for_new_version_candidate(
     assert f"source_id={source_id}" in captured.out
 
 
+def test_cli_repo_scan_json_repeated_class_filters_honor_ignored_dirs(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    (tmp_path / "splendor.yaml").unlink()
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "main.py").write_text("print('hi')\n", encoding="utf-8")
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    (claude_dir / "settings.local.json").write_text("{}\n", encoding="utf-8")
+    cache_dir = tmp_path / ".mypy_cache"
+    cache_dir.mkdir()
+    (cache_dir / "module.py").write_text("print('ignored')\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "repo",
+            "scan",
+            "--class",
+            "documentation",
+            "--class",
+            "code",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [item["path"] for item in payload["candidate_sources"]] == [
+        "README.md",
+        "src/main.py",
+    ]
+    assert payload["class_filters"] == ["documentation", "code"]
+    ignored = {item["path"]: item["reason"] for item in payload["ignored_paths"]}
+    assert ignored[".claude/"] == "managed_or_transient"
+    assert ignored[".mypy_cache/"] == "managed_or_transient"
+
+
 def test_cli_add_source_command_reports_workspace_backed_registration(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_repo_scan.py
+++ b/tests/test_repo_scan.py
@@ -51,6 +51,23 @@ def _write_mixed_repo(root: Path) -> None:
     (workflows_dir / "ci.yml").write_text("name: CI\n", encoding="utf-8")
 
 
+def _write_populated_ignored_dirs(root: Path) -> None:
+    ignored_sources = {
+        ".claude/settings.local.json": "{}\n",
+        ".mypy_cache/module.data.json": "{}\n",
+        ".pytest_cache/v/cache/nodeids": "[]\n",
+        ".ruff_cache/0.11.0/file.py": "print('ignored')\n",
+        ".venv/lib/site-packages/pkg.py": "print('ignored')\n",
+        "build/lib/generated.py": "print('ignored')\n",
+        "dist/package.json": "{}\n",
+        "src/__pycache__/main.py": "print('ignored')\n",
+    }
+    for relative_path, contents in ignored_sources.items():
+        path = root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+
+
 def test_repo_scan_previews_and_classifies_supported_workspace_files(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     _remove_workspace_config(tmp_path)
@@ -210,6 +227,96 @@ def test_repo_scan_ignores_managed_and_transient_directories(tmp_path: Path) -> 
     assert result.scanned == 1
     assert result.registered == 0
     assert [item.path for item in result.candidate_sources] == ["README.md"]
+
+
+def test_repo_scan_default_excludes_populated_local_tooling_dirs(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "main.py").write_text("print('hi')\n", encoding="utf-8")
+    _write_populated_ignored_dirs(tmp_path)
+
+    result = scan_repo(tmp_path)
+
+    assert [item.path for item in result.candidate_sources] == [
+        "README.md",
+        "docs/guide.md",
+    ]
+    ignored = {item.path: item.reason for item in result.ignored_paths}
+    assert ignored[".claude/"] == "managed_or_transient"
+    assert ignored[".mypy_cache/"] == "managed_or_transient"
+    assert ignored[".pytest_cache/"] == "managed_or_transient"
+    assert ignored[".ruff_cache/"] == "managed_or_transient"
+    assert ignored[".venv/"] == "managed_or_transient"
+    assert ignored["build/"] == "managed_or_transient"
+    assert ignored["dist/"] == "managed_or_transient"
+    assert ignored["src/__pycache__/"] == "managed_or_transient"
+
+
+def test_repo_scan_all_and_class_filters_exclude_populated_local_tooling_dirs(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "main.py").write_text("print('hi')\n", encoding="utf-8")
+    _write_populated_ignored_dirs(tmp_path)
+
+    all_result = scan_repo(tmp_path, all_classes=True)
+    class_filtered_result = scan_repo(tmp_path, class_filters=["documentation", "code"])
+
+    assert [item.path for item in all_result.candidate_sources] == [
+        "README.md",
+        "src/main.py",
+    ]
+    assert [item.path for item in class_filtered_result.candidate_sources] == [
+        "README.md",
+        "src/main.py",
+    ]
+    assert all(
+        not item.path.startswith((".claude", ".mypy_cache", ".pytest_cache", ".ruff_cache"))
+        for item in all_result.candidate_sources
+    )
+
+
+def test_repo_scan_apply_excludes_populated_local_tooling_dirs(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "main.py").write_text("print('hi')\n", encoding="utf-8")
+    _write_populated_ignored_dirs(tmp_path)
+
+    result = apply_repo_scan(tmp_path, all_classes=True)
+
+    assert [item.path for item in result.touched_sources] == ["README.md", "src/main.py"]
+    manifest_refs = {load_source_record(path).source_ref for path in _manifest_paths(tmp_path)}
+    assert manifest_refs == {"README.md", "src/main.py"}
+
+
+def test_render_repo_scan_json_reports_pruned_ignored_directories(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+    _write_populated_ignored_dirs(tmp_path)
+
+    payload = json.loads(render_repo_scan_json(scan_repo(tmp_path, all_classes=True)))
+
+    ignored = {item["path"]: item["reason"] for item in payload["ignored_paths"]}
+    assert ignored[".claude/"] == "managed_or_transient"
+    assert ignored[".mypy_cache/"] == "managed_or_transient"
+    assert ignored[".pytest_cache/"] == "managed_or_transient"
+    assert ignored[".ruff_cache/"] == "managed_or_transient"
+    assert ignored[".venv/"] == "managed_or_transient"
+    assert ignored["build/"] == "managed_or_transient"
+    assert ignored["dist/"] == "managed_or_transient"
 
 
 def test_repo_scan_reports_unsupported_files(tmp_path: Path) -> None:
@@ -571,6 +678,55 @@ def test_repo_scan_prunes_gitignored_directories_before_walking(tmp_path: Path) 
 
     assert [item.path for item in result.candidate_sources] == ["README.md"]
     assert "vendor/skip.md" not in {item.path for item in result.ignored_paths}
+    assert {item.path: item.reason for item in result.ignored_paths}["vendor/"] == "gitignore"
+
+
+def test_repo_scan_respects_splendorignore_file_patterns(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    (tmp_path / ".splendorignore").write_text(
+        "# local scan policy\nsecret.md\ndocs/private/*.md\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+    (tmp_path / "secret.md").write_text("# Secret\n", encoding="utf-8")
+    private_dir = tmp_path / "docs" / "private"
+    private_dir.mkdir(parents=True)
+    (private_dir / "note.md").write_text("# Private\n", encoding="utf-8")
+    (private_dir / "keep.txt").write_text("Keep\n", encoding="utf-8")
+
+    result = scan_repo(tmp_path, all_classes=True)
+
+    assert [item.path for item in result.candidate_sources] == [
+        "README.md",
+        "docs/private/keep.txt",
+    ]
+    ignored = {item.path: item.reason for item in result.ignored_paths}
+    assert ignored["secret.md"] == "splendorignore"
+    assert ignored["docs/private/note.md"] == "splendorignore"
+
+
+def test_repo_scan_respects_splendorignore_directory_patterns(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    (tmp_path / ".splendorignore").write_text(
+        "local-agent/\ndocs/private-cache/\n", encoding="utf-8"
+    )
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+    local_agent_dir = tmp_path / "local-agent"
+    local_agent_dir.mkdir()
+    (local_agent_dir / "settings.json").write_text("{}\n", encoding="utf-8")
+    private_cache_dir = tmp_path / "docs" / "private-cache"
+    private_cache_dir.mkdir(parents=True)
+    (private_cache_dir / "skip.md").write_text("# Skip\n", encoding="utf-8")
+
+    result = scan_repo(tmp_path, all_classes=True)
+
+    assert [item.path for item in result.candidate_sources] == ["README.md"]
+    ignored = {item.path: item.reason for item in result.ignored_paths}
+    assert ignored["local-agent/"] == "splendorignore"
+    assert ignored["docs/private-cache/"] == "splendorignore"
+    assert "local-agent/settings.json" not in ignored
 
 
 def test_repo_scan_apply_requires_explicit_class_or_all(tmp_path: Path) -> None:

--- a/tests/test_repo_scan.py
+++ b/tests/test_repo_scan.py
@@ -467,6 +467,18 @@ def test_render_repo_scan_json_matches_expected_shape(tmp_path: Path) -> None:
     assert payload["candidate_sources"][0]["status"] == "candidate"
 
 
+def test_repo_scan_reports_quiet_preview_for_initialized_workspace(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    _remove_workspace_config(tmp_path)
+    (tmp_path / "README.md").write_text("# Readme\n", encoding="utf-8")
+
+    result = scan_repo(tmp_path, all_classes=True)
+
+    assert result.unsupported == 0
+    assert result.ignored == 0
+    assert result.ignored_paths == []
+
+
 def test_repo_scan_defaults_to_configured_default_classes(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     _remove_workspace_config(tmp_path)
@@ -702,8 +714,10 @@ def test_repo_scan_respects_splendorignore_file_patterns(tmp_path: Path) -> None
         "docs/private/keep.txt",
     ]
     ignored = {item.path: item.reason for item in result.ignored_paths}
+    assert ignored[".splendorignore"] == "scan_control"
     assert ignored["secret.md"] == "splendorignore"
     assert ignored["docs/private/note.md"] == "splendorignore"
+    assert result.unsupported == 0
 
 
 def test_repo_scan_respects_splendorignore_directory_patterns(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- harden `splendor repo scan` so built-in local/tooling excludes include `.claude/` and are reported as deterministic ignored directory entries when populated
- add lightweight root `.splendorignore` support for workspace-relative file globs and trailing-slash directory pruning, with `.splendorignore` treated as scan-control input rather than an unsupported source
- keep fresh initialized workspace previews quiet by suppressing empty/Splendor-managed layout directory noise
- cover default, `--all`, repeated class-filter CLI JSON, JSON report, and `--apply` paths with populated ignored-directory regression tests
- update M16-P1.1 planning state and repo-scan docs

Closes #111

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest` - 594 passed
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .` - passed
- `/Users/shaypalachy/.local/bin/uv run ruff check .` - passed
- `/Users/shaypalachy/.local/bin/uv run splendor lint` - passed
- `/Users/shaypalachy/.local/bin/uv run splendor health` - passed

## Evidence Context

Preserved evaluation fixture remains local at `/Users/shaypalachy/archive/splendor-fixtures/splendor-fixture-2026-05-05.tar.gz` with SHA-256 `8b2fea5e3cd04c99d52d79398347ff7a38b41a30c410a3a1ab1985fbe63b162c`. This PR does not commit the fixture.

## Boundaries

- No schema version change.
- `.splendorignore` is intentionally root-only and lightweight; advanced gitignore-compatible semantics are deferred.
- Source forget (#109), duplicate canonical reconciliation (#110), validation fixes (#112/#113), and broader recovery workflows remain out of scope.
