### PR TITLE
M16-P1.2: Add source forget recovery command

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M16-P0.1`
-- Last action taken: `M16-P0.1` was squash-merged into main as commit `1dc7766`,
-  recording v0.3 evaluation intake and roadmap decomposition.
+- Previous completed PR sub-slice: `M16-P1.1`
+- Last action taken: `M16-P1.1` was squash-merged into main as commit `ad0d1c4`,
+  hardening repo scan ignores and `.splendorignore`.
 - Current planned slice: `M16-P1 source hygiene and registry recovery`
-- Current PR sub-slice: `M16-P1.1`
+- Current PR sub-slice: `M16-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P1 source hygiene and registry recovery`
-- Next planned PR sub-slice: `M16-P1.2`
+- Next planned PR sub-slice: `M16-P1.3`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Implemented today:
 - `splendor source list`, `splendor source lookup [query]`, `splendor source freshness`,
   `splendor source refresh <source-id|title|path>`, and
   `splendor source update-path <source-id|logical-id|title|path> <new-path>`
+- `splendor source forget <source-id|logical-id|title|path>` and
+  `splendor source forget --matching "glob"` for preview-first registry cleanup
 - `splendor workspace refresh --changed` with optional `--ingest`, `--rebuild-index`,
   `--prune-superseded`, and `--update-topic-refs`
 - `splendor ingest <source-id>`, `splendor ingest --pending`, and `splendor ingest --changed`
@@ -184,6 +186,15 @@ reported as partial repairs with a non-zero exit and an explicit `source refresh
 command does not discover/register uncurated files, rewrite historical run records, or mutate
 maintained synthesis pages.
 
+`splendor source forget` is the explicit polluted-registry recovery path. It previews by default
+and requires `--apply` before deleting anything. Single-source cleanup accepts exact source IDs,
+logical IDs, path aliases/source refs, or unambiguous titles. Bulk cleanup uses
+`--matching <workspace-relative-glob>`, such as `--matching ".mypy_cache/**"`, against curated
+workspace refs and aliases in deterministic order. Apply removes selected manifests plus
+source-owned generated summaries, queue records, ingest run records, and safe generated artifacts;
+maintained wiki/planning references and unsafe mixed historical state are reported as residual
+references for review instead of rewritten.
+
 `splendor ingest --changed` is the narrower stale-ingest repair path for checksum-drifted curated
 workspace-backed sources when old ingest queue records are already `done`. It refreshes changed
 source versions through the same supersession-aware source lifecycle, ingests only those refreshed
@@ -244,12 +255,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M16-P0.1`
+- Previous completed PR sub-slice: `M16-P1.1`
 - Current planned slice: `M16-P1 source hygiene and registry recovery`
-- Current PR sub-slice: `M16-P1.1`
+- Current PR sub-slice: `M16-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P1 source hygiene and registry recovery`
-- Next planned PR sub-slice: `M16-P1.2`
+- Next planned PR sub-slice: `M16-P1.3`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -469,7 +480,7 @@ rewritten.
 ### v0.3 recovery readiness checklist
 
 - [x] Repo scan ignores and `.splendorignore` prevent cache/local-agent source pollution.
-- [ ] `splendor source forget` provides safe single and bulk source-registry recovery.
+- [x] `splendor source forget` provides safe single and bulk source-registry recovery.
 - [ ] Duplicate canonical source versions can be reconciled without manual manifest edits.
 - [ ] Health resolves existing manifest source IDs without false unknown-source diagnostics.
 - [ ] Lint validates live source refs after path repair and supersession.

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -387,3 +387,8 @@ lint/health reports to explain curated source changes, maintained wiki edits, so
 changes, and mechanical queue/run/report churn for reviewers. It labels lint/health status as
 latest local report state; it does not replace the required validation commands or GitHub metadata
 checks.
+
+For source-registry recovery PRs, use `splendor source forget` in preview mode before applying any
+cleanup. Applied recovery changes should be reviewed as intentional source-registry maintenance:
+selected manifests and source-owned generated state may be removed, while residual maintained
+wiki/planning references should remain visible in the command output and PR description.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -199,6 +199,17 @@ Implemented fields:
   output report source ID, old path, new path, status, manifest/current checksums, checksum match
   status, manifest path, queue path when present, and next commands. It does not discover or
   register uncurated files, rewrite historical run records, or mutate maintained synthesis pages.
+- `splendor source forget <source-id|logical-id|title|path>` and
+  `splendor source forget --matching <workspace-relative-glob>` provide preview-first registry
+  cleanup for polluted source manifests. The command requires exactly one selection mode, previews
+  by default, and requires `--apply` before deletion. Single-source selectors use the same strict
+  exact source resolution as mutating source commands. `--matching` compares the glob against
+  workspace source refs, original paths, aliases, logical IDs, and compatibility paths in
+  deterministic order. Apply removes selected manifests plus source-owned generated source-summary
+  pages, ingest queue records, source-owned ingest run records, safe derived artifacts, and
+  materialized artifacts under the source-owned raw artifact directory. Maintained wiki/planning
+  references, malformed generated pages, mixed run records, and unsafe artifacts are reported as
+  residual or skipped references rather than rewritten.
 - `splendor source freshness` is a non-mutating preview over curated source manifests. It reports
   path-first freshness state for workspace-backed canonical source refs, including unchanged,
   changed, missing, and unsupported statuses, manifest/current checksums where available, source

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M16-P0.1`
+- Previous completed PR sub-slice: `M16-P1.1`
 - Current planned slice: `M16-P1 source hygiene and registry recovery`
-- Current PR sub-slice: `M16-P1.1`
+- Current PR sub-slice: `M16-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P1 source hygiene and registry recovery`
-- Next planned PR sub-slice: `M16-P1.2`
+- Next planned PR sub-slice: `M16-P1.3`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -802,6 +802,16 @@ Current implementation:
   refresh; changed-byte moves are reported as partial repairs and point to `source refresh`. It
   does not perform broad discovery, register uncurated files, rewrite historical run records, or
   mutate maintained synthesis pages.
+- `splendor source forget <source-id|logical-id|title|path>` and
+  `splendor source forget --matching <workspace-relative-glob>` are the CLI-first recovery path for
+  polluted source registries. They preview by default and require `--apply` for destructive
+  cleanup. Single-source selection uses strict exact source resolution; bulk selection matches the
+  glob against curated workspace refs, original paths, logical IDs, aliases, and compatibility
+  paths. Apply removes selected manifests and source-owned generated state where deterministic:
+  generated source-summary pages, ingest queue records, source-owned ingest run records, safe
+  derived artifacts, and source-owned materialized artifacts. Maintained wiki/planning references,
+  malformed generated pages, mixed historical records, and unsafe artifact paths are reported for
+  operator review rather than rewritten.
 - `splendor workspace refresh --changed` safely refreshes only changed curated workspace-backed
   sources by composing `source freshness` with the supersession-aware `source refresh` path. It
   reports missing or unsupported active curated workspace sources as skipped unresolved diagnostics,

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -76,6 +76,11 @@ from splendor.commands.source import (
     update_source_path,
     write_source_freshness_report,
 )
+from splendor.commands.source_forget import (
+    SourceForgetResult,
+    forget_sources,
+    render_source_forget_json,
+)
 from splendor.commands.wiki import (
     add_topic_page,
     build_wiki_status,
@@ -258,6 +263,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="Allow updating a source path even when the current path still exists.",
     )
     source_update_path_parser.set_defaults(handler=handle_source_update_path)
+    source_forget_parser = source_subparsers.add_parser(
+        "forget", help="Preview or apply source registry cleanup"
+    )
+    source_forget_parser.add_argument(
+        "selector",
+        nargs="?",
+        help="Exact source ID, logical ID, title, path, or source ref to forget",
+    )
+    source_forget_parser.add_argument(
+        "--matching",
+        help="Workspace-relative glob for safe bulk source registry cleanup.",
+    )
+    source_forget_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the planned cleanup. Without this flag, source forget only previews.",
+    )
+    source_forget_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    source_forget_parser.set_defaults(handler=handle_source_forget)
     source_freshness_parser = source_subparsers.add_parser(
         "freshness", help="Preview changed workspace-backed source content without mutating"
     )
@@ -1063,6 +1092,26 @@ def handle_source_update_path(args: argparse.Namespace) -> int:
     return 0 if result.status == "repaired" else 1
 
 
+def handle_source_forget(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = forget_sources(
+            root,
+            selector=args.selector,
+            matching=args.matching,
+            apply=args.apply,
+        )
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_source_forget_json(root, result))
+        return 0
+
+    _print_source_forget_result(result)
+    return 0
+
+
 def handle_source_freshness(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     try:
@@ -1370,6 +1419,61 @@ def _print_source_lookup_results(results: list[SourceLookupResult]) -> None:
         )
         print(f"  Manifest: {result.manifest_path}")
     print("Next: splendor source refresh <source-id|title|path>")
+
+
+def _print_source_forget_result(result: SourceForgetResult) -> None:
+    mode = "applied" if result.applied else "preview"
+    print(f"Source forget {mode}")
+    print(
+        "Summary: "
+        f"candidates={len(result.candidates)} "
+        f"actions={len(result.actions)} "
+        f"skipped={len(result.skipped)} "
+        f"residual_references={len(result.residual_references)}"
+    )
+    if not result.candidates:
+        print("No matching sources.")
+        return
+    print("Sources:")
+    for candidate in result.candidates:
+        source = candidate.source
+        print(
+            f"- {canonical_source_ref(source)} title={source.title} "
+            f"logical_id={effective_logical_id(source) or '-'} source_id={source.source_id}"
+        )
+        print(f"  Manifest: {candidate.manifest_path}")
+    if result.actions:
+        print("Actions:")
+        for action in result.actions:
+            print(f"- {action.status}: {action.kind} {action.path} source_id={action.source_id}")
+    if result.skipped:
+        print("Skipped:")
+        for action in result.skipped:
+            print(
+                f"- {action.kind} {action.path} source_id={action.source_id}: "
+                f"{action.reason or 'not safe to remove'}"
+            )
+    if result.residual_references:
+        print("Residual references:")
+        for residual in result.residual_references:
+            ref_suffix = f" ref_id={residual.ref_id}" if residual.ref_id is not None else ""
+            print(
+                f"- {residual.kind} {residual.path} source_id={residual.source_id}: "
+                f"{residual.reason}{ref_suffix}"
+            )
+    if result.applied:
+        if result.residual_references:
+            print("Next: review reported residual references")
+        print("Next: splendor lint")
+        print("Next: splendor health")
+    else:
+        if result.selector is not None:
+            print(f"Next: splendor source forget {shlex.quote(result.selector)} --apply")
+        else:
+            print(
+                "Next: "
+                f"splendor source forget --matching {shlex.quote(result.matching or '')} --apply"
+            )
 
 
 def handle_wiki_status(args: argparse.Namespace) -> int:

--- a/src/splendor/commands/source_forget.py
+++ b/src/splendor/commands/source_forget.py
@@ -1,0 +1,867 @@
+"""Source registry forget/recovery command helpers."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import dataclass, replace
+from fnmatch import fnmatchcase
+from pathlib import Path
+from typing import Literal
+
+from splendor.commands.source import (
+    SourceLookupResult,
+    list_sources,
+    resolve_source_query_exact,
+)
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import SourceRecord
+from splendor.state.paths import resolve_workspace_path
+from splendor.state.runtime import ingest_job_id, load_queue_item, load_run_record
+from splendor.state.source_compat import (
+    canonical_source_ref,
+    effective_aliases,
+    effective_logical_id,
+    effective_materialized_path,
+)
+from splendor.utils.fs import write_text_atomic
+from splendor.utils.wiki import parse_wiki_markdown
+
+SourceForgetActionKind = Literal[
+    "source_manifest",
+    "source_summary_page",
+    "queue_record",
+    "run_record",
+    "derived_artifact",
+    "materialized_artifact",
+    "artifact",
+    "wiki_index_entry",
+]
+SourceForgetActionStatus = Literal["planned", "removed", "skipped"]
+SourceForgetResidualKind = Literal[
+    "source_run_ref",
+    "source_provenance_run",
+    "wiki_source_ref",
+    "wiki_provenance",
+    "wiki_generated_by_run",
+    "wiki_run_provenance",
+    "wiki_text",
+    "planning_text",
+    "run_provenance",
+]
+
+
+@dataclass(frozen=True)
+class SourceForgetAction:
+    kind: SourceForgetActionKind
+    path: str
+    source_id: str
+    status: SourceForgetActionStatus
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class SourceForgetResidualReference:
+    kind: SourceForgetResidualKind
+    path: str
+    source_id: str
+    reason: str
+    ref_id: str | None = None
+
+
+@dataclass(frozen=True)
+class SourceForgetResult:
+    applied: bool
+    selector: str | None
+    matching: str | None
+    candidates: list[SourceLookupResult]
+    actions: list[SourceForgetAction]
+    skipped: list[SourceForgetAction]
+    residual_references: list[SourceForgetResidualReference]
+
+
+def forget_sources(
+    root: Path,
+    *,
+    selector: str | None = None,
+    matching: str | None = None,
+    apply: bool = False,
+) -> SourceForgetResult:
+    if (selector is None) == (matching is None):
+        msg = "source forget requires exactly one of selector or --matching"
+        raise ValueError(msg)
+
+    candidates = (
+        [resolve_source_query_exact(root, selector)]
+        if selector is not None
+        else _matching_forget_candidates(root, matching or "")
+    )
+    actions, skipped, residuals = _plan_source_forget(root, candidates)
+    if apply:
+        _apply_source_forget(root, actions)
+        actions = [replace(action, status="removed") for action in actions]
+    return SourceForgetResult(
+        applied=apply,
+        selector=selector,
+        matching=matching,
+        candidates=candidates,
+        actions=actions,
+        skipped=skipped,
+        residual_references=residuals,
+    )
+
+
+def render_source_forget_json(root: Path, result: SourceForgetResult) -> str:
+    return json.dumps(
+        {
+            "applied": result.applied,
+            "selector": result.selector,
+            "matching": result.matching,
+            "summary": {
+                "candidates": len(result.candidates),
+                "actions": len(result.actions),
+                "skipped": len(result.skipped),
+                "residual_references": len(result.residual_references),
+            },
+            "sources": [_source_payload(root, candidate) for candidate in result.candidates],
+            "actions": [_forget_action_payload(action) for action in result.actions],
+            "skipped": [_forget_action_payload(action) for action in result.skipped],
+            "residual_references": [
+                _residual_reference_payload(residual) for residual in result.residual_references
+            ],
+            "next_commands": forget_next_commands(result),
+        },
+        indent=2,
+    )
+
+
+def forget_next_commands(result: SourceForgetResult) -> list[str]:
+    if not result.applied:
+        base = "splendor source forget"
+        if result.selector is not None:
+            command = f"{base} {shlex.quote(result.selector)} --apply"
+        else:
+            command = f"{base} --matching {shlex.quote(result.matching or '')} --apply"
+        return [command]
+    commands = ["splendor lint", "splendor health"]
+    if result.residual_references:
+        commands.insert(0, "review reported residual references")
+    return commands
+
+
+def _matching_forget_candidates(root: Path, pattern: str) -> list[SourceLookupResult]:
+    normalized = pattern.strip()
+    if not normalized:
+        msg = "--matching requires a non-empty workspace-relative glob"
+        raise ValueError(msg)
+    if Path(normalized).is_absolute() or ".." in Path(normalized).parts:
+        msg = "--matching must be a workspace-relative glob that does not escape the workspace"
+        raise ValueError(msg)
+
+    candidates = [
+        result
+        for result in list_sources(root)
+        if any(fnmatchcase(value, normalized) for value in _forget_match_values(result.source))
+    ]
+    return sorted(candidates, key=lambda result: result.source.source_id)
+
+
+def _forget_match_values(source: SourceRecord) -> list[str]:
+    return _dedupe_values(
+        [
+            canonical_source_ref(source),
+            source.path,
+            source.original_path,
+            source.source_ref,
+            effective_logical_id(source),
+            *effective_aliases(source),
+        ]
+    )
+
+
+def _plan_source_forget(
+    root: Path, candidates: list[SourceLookupResult]
+) -> tuple[
+    list[SourceForgetAction],
+    list[SourceForgetAction],
+    list[SourceForgetResidualReference],
+]:
+    layout = resolve_layout(root, load_config(root))
+    selected_ids = {candidate.source.source_id for candidate in candidates}
+    remaining_sources = [
+        result.source
+        for result in list_sources(root)
+        if result.source.source_id not in selected_ids
+    ]
+    actions: list[SourceForgetAction] = []
+    skipped: list[SourceForgetAction] = []
+    residuals: list[SourceForgetResidualReference] = []
+
+    for candidate in candidates:
+        source = candidate.source
+        source_id = source.source_id
+        manifest_ref = candidate.manifest_path.relative_to(root).as_posix()
+        actions.append(
+            SourceForgetAction(
+                kind="source_manifest",
+                path=manifest_ref,
+                source_id=source_id,
+                status="planned",
+            )
+        )
+        _plan_source_summary_forget(root, layout, source, actions, skipped)
+        _plan_source_queue_forget(root, layout, source_id, actions, skipped)
+        _plan_source_run_forget(root, layout, source_id, actions, skipped)
+        _plan_source_artifact_forget(
+            root,
+            layout,
+            source=source,
+            remaining_sources=remaining_sources,
+            actions=actions,
+            skipped=skipped,
+        )
+        residuals.extend(_source_residual_references(root, layout, source_id))
+
+    _plan_index_cleanup(root, layout, selected_ids, actions)
+    actions, skipped, run_residuals = _protect_referenced_run_records(
+        root, layout, actions, skipped, remaining_sources
+    )
+    residuals.extend(run_residuals)
+    actions = _dedupe_forget_actions(actions)
+    skipped = _dedupe_forget_actions(skipped)
+    residuals = _dedupe_residuals(residuals)
+    return actions, skipped, residuals
+
+
+def _plan_source_summary_forget(
+    root: Path,
+    layout,
+    source: SourceRecord,
+    actions: list[SourceForgetAction],
+    skipped: list[SourceForgetAction],
+) -> None:
+    source_id = source.source_id
+    expected_ref = f"wiki/sources/{source_id}.md"
+    page_refs = _dedupe_values([expected_ref, *source.linked_pages])
+    for page_ref in page_refs:
+        try:
+            page_path = resolve_workspace_path(root, page_ref, context="Linked source page")
+        except ValueError as exc:
+            skipped.append(
+                SourceForgetAction(
+                    kind="source_summary_page",
+                    path=page_ref,
+                    source_id=source_id,
+                    status="skipped",
+                    reason=str(exc),
+                )
+            )
+            continue
+        if not page_path.is_file():
+            continue
+        page_relpath = page_path.relative_to(root).as_posix()
+        if not _is_safe_source_summary_page(page_path, source_id):
+            skipped.append(
+                SourceForgetAction(
+                    kind="source_summary_page",
+                    path=page_relpath,
+                    source_id=source_id,
+                    status="skipped",
+                    reason="wiki page is not the expected generated source-summary page",
+                )
+            )
+            continue
+        if not _path_is_within(page_path, layout.wiki_sources_dir):
+            skipped.append(
+                SourceForgetAction(
+                    kind="source_summary_page",
+                    path=page_relpath,
+                    source_id=source_id,
+                    status="skipped",
+                    reason="source summary page is outside wiki/sources",
+                )
+            )
+            continue
+        actions.append(
+            SourceForgetAction(
+                kind="source_summary_page",
+                path=page_relpath,
+                source_id=source_id,
+                status="planned",
+            )
+        )
+
+
+def _is_safe_source_summary_page(page_path: Path, source_id: str) -> bool:
+    try:
+        parsed = parse_wiki_markdown(page_path)
+    except ValueError:
+        return False
+    return (
+        parsed.frontmatter.kind == "source-summary"
+        and parsed.frontmatter.page_id == source_id
+        and source_id in parsed.frontmatter.source_refs
+    )
+
+
+def _plan_source_queue_forget(
+    root: Path,
+    layout,
+    source_id: str,
+    actions: list[SourceForgetAction],
+    skipped: list[SourceForgetAction],
+) -> None:
+    queue_path = layout.queue_dir / f"{ingest_job_id(source_id)}.json"
+    if not queue_path.is_file():
+        return
+    queue_ref = queue_path.relative_to(root).as_posix()
+    try:
+        queue = load_queue_item(queue_path)
+    except ValueError as exc:
+        skipped.append(
+            SourceForgetAction(
+                kind="queue_record",
+                path=queue_ref,
+                source_id=source_id,
+                status="skipped",
+                reason=f"queue record is invalid: {exc}",
+            )
+        )
+        return
+    if queue.job_id != ingest_job_id(source_id) or queue.job_type != "ingest_source":
+        skipped.append(
+            SourceForgetAction(
+                kind="queue_record",
+                path=queue_ref,
+                source_id=source_id,
+                status="skipped",
+                reason="queue record is not the expected source-owned ingest job",
+            )
+        )
+        return
+    actions.append(
+        SourceForgetAction(
+            kind="queue_record",
+            path=queue_ref,
+            source_id=source_id,
+            status="planned",
+        )
+    )
+
+
+def _plan_source_run_forget(
+    root: Path,
+    layout,
+    source_id: str,
+    actions: list[SourceForgetAction],
+    skipped: list[SourceForgetAction],
+) -> None:
+    for run_path in sorted(layout.runs_dir.glob("*.json")):
+        if not run_path.is_file():
+            continue
+        try:
+            run = load_run_record(run_path)
+        except ValueError:
+            continue
+        if source_id not in run.source_ids:
+            continue
+        run_ref = run_path.relative_to(root).as_posix()
+        if (
+            run.job_type == "ingest_source"
+            and run.job_id == ingest_job_id(source_id)
+            and set(run.source_ids) == {source_id}
+        ):
+            actions.append(
+                SourceForgetAction(
+                    kind="run_record",
+                    path=run_ref,
+                    source_id=source_id,
+                    status="planned",
+                )
+            )
+            continue
+        skipped.append(
+            SourceForgetAction(
+                kind="run_record",
+                path=run_ref,
+                source_id=source_id,
+                status="skipped",
+                reason="run also references other state or is not a source-owned ingest run",
+            )
+        )
+
+
+def _plan_source_artifact_forget(
+    root: Path,
+    layout,
+    *,
+    source: SourceRecord,
+    remaining_sources: list[SourceRecord],
+    actions: list[SourceForgetAction],
+    skipped: list[SourceForgetAction],
+) -> None:
+    source_id = source.source_id
+    artifact_refs = _dedupe_values([*source.derived_artifacts, effective_materialized_path(source)])
+    remaining_refs = {
+        ref
+        for remaining in remaining_sources
+        for ref in [*remaining.derived_artifacts, effective_materialized_path(remaining)]
+        if ref is not None
+    }
+    for artifact_ref in artifact_refs:
+        if artifact_ref is None or artifact_ref in remaining_refs:
+            continue
+        try:
+            artifact_path = resolve_workspace_path(root, artifact_ref, context="Source artifact")
+        except ValueError as exc:
+            skipped.append(
+                SourceForgetAction(
+                    kind="artifact",
+                    path=artifact_ref,
+                    source_id=source_id,
+                    status="skipped",
+                    reason=str(exc),
+                )
+            )
+            continue
+        if not artifact_path.exists() and not artifact_path.is_symlink():
+            continue
+        artifact_relpath = artifact_path.relative_to(root).as_posix()
+        if _path_is_within(artifact_path, layout.derived_dir):
+            kind: SourceForgetActionKind = "derived_artifact"
+        elif _path_is_within(artifact_path, layout.raw_sources_dir / source_id):
+            kind = "materialized_artifact"
+        else:
+            skipped.append(
+                SourceForgetAction(
+                    kind="artifact",
+                    path=artifact_relpath,
+                    source_id=source_id,
+                    status="skipped",
+                    reason="artifact is outside source-owned generated directories",
+                )
+            )
+            continue
+        actions.append(
+            SourceForgetAction(
+                kind=kind,
+                path=artifact_relpath,
+                source_id=source_id,
+                status="planned",
+            )
+        )
+
+
+def _plan_index_cleanup(
+    root: Path,
+    layout,
+    selected_ids: set[str],
+    actions: list[SourceForgetAction],
+) -> None:
+    if not layout.index_file.is_file():
+        return
+    index_text = layout.index_file.read_text(encoding="utf-8")
+    for source_id in sorted(selected_ids):
+        if f"(`{source_id}`)" in index_text:
+            actions.append(
+                SourceForgetAction(
+                    kind="wiki_index_entry",
+                    path=layout.index_file.relative_to(root).as_posix(),
+                    source_id=source_id,
+                    status="planned",
+                )
+            )
+
+
+def _source_residual_references(
+    root: Path, layout, source_id: str
+) -> list[SourceForgetResidualReference]:
+    residuals: list[SourceForgetResidualReference] = []
+    for wiki_path in sorted(layout.wiki_dir.rglob("*.md")):
+        if wiki_path.name == ".gitkeep" or wiki_path in {layout.index_file, layout.log_file}:
+            continue
+        page_ref = wiki_path.relative_to(root).as_posix()
+        if page_ref == f"wiki/sources/{source_id}.md":
+            continue
+        try:
+            parsed = parse_wiki_markdown(wiki_path)
+        except ValueError:
+            text = wiki_path.read_text(encoding="utf-8")
+            if source_id in text:
+                residuals.append(
+                    SourceForgetResidualReference(
+                        kind="wiki_text",
+                        path=page_ref,
+                        source_id=source_id,
+                        reason="wiki page text contains source ID",
+                    )
+                )
+            continue
+        if source_id in parsed.frontmatter.source_refs:
+            residuals.append(
+                SourceForgetResidualReference(
+                    kind="wiki_source_ref",
+                    path=page_ref,
+                    source_id=source_id,
+                    reason="maintained wiki page source_refs contains source ID",
+                )
+            )
+        if any(link.source_id == source_id for link in parsed.frontmatter.provenance_links):
+            residuals.append(
+                SourceForgetResidualReference(
+                    kind="wiki_provenance",
+                    path=page_ref,
+                    source_id=source_id,
+                    reason="maintained wiki page provenance contains source ID",
+                )
+            )
+        if source_id in parsed.body:
+            residuals.append(
+                SourceForgetResidualReference(
+                    kind="wiki_text",
+                    path=page_ref,
+                    source_id=source_id,
+                    reason="wiki page text contains source ID",
+                )
+            )
+
+    for planning_path in sorted(layout.planning_dir.rglob("*.md")):
+        if planning_path.name == ".gitkeep" or not planning_path.is_file():
+            continue
+        if source_id not in planning_path.read_text(encoding="utf-8"):
+            continue
+        residuals.append(
+            SourceForgetResidualReference(
+                kind="planning_text",
+                path=planning_path.relative_to(root).as_posix(),
+                source_id=source_id,
+                reason="planning record contains source ID",
+            )
+        )
+    return residuals
+
+
+def _protect_referenced_run_records(
+    root: Path,
+    layout,
+    actions: list[SourceForgetAction],
+    skipped: list[SourceForgetAction],
+    remaining_sources: list[SourceRecord],
+) -> tuple[
+    list[SourceForgetAction],
+    list[SourceForgetAction],
+    list[SourceForgetResidualReference],
+]:
+    kept_actions: list[SourceForgetAction] = []
+    run_residuals: list[SourceForgetResidualReference] = []
+    deleted_page_refs = {action.path for action in actions if action.kind == "source_summary_page"}
+    for action in actions:
+        if action.kind != "run_record":
+            kept_actions.append(action)
+            continue
+        run_id = Path(action.path).stem
+        residuals = _run_residual_references(
+            root,
+            layout,
+            source_id=action.source_id,
+            run_id=run_id,
+            deleted_page_refs=deleted_page_refs,
+            remaining_sources=remaining_sources,
+        )
+        if not residuals:
+            kept_actions.append(action)
+            continue
+        skipped.append(
+            replace(
+                action,
+                status="skipped",
+                reason="run record is referenced by remaining workspace state",
+            )
+        )
+        run_residuals.extend(residuals)
+    return kept_actions, skipped, run_residuals
+
+
+def _run_residual_references(
+    root: Path,
+    layout,
+    *,
+    source_id: str,
+    run_id: str,
+    deleted_page_refs: set[str],
+    remaining_sources: list[SourceRecord],
+) -> list[SourceForgetResidualReference]:
+    residuals: list[SourceForgetResidualReference] = []
+    for source in sorted(remaining_sources, key=lambda item: item.source_id):
+        source_path = layout.source_records_dir / f"{source.source_id}.json"
+        source_ref = source_path.relative_to(root).as_posix()
+        if source.last_run_id == run_id or run_id in source.generated_by_run_ids:
+            residuals.append(
+                SourceForgetResidualReference(
+                    kind="source_run_ref",
+                    path=source_ref,
+                    source_id=source_id,
+                    ref_id=run_id,
+                    reason="remaining source manifest references run ID",
+                )
+            )
+        if any(link.run_id == run_id for link in source.provenance_links):
+            residuals.append(
+                SourceForgetResidualReference(
+                    kind="source_provenance_run",
+                    path=source_ref,
+                    source_id=source_id,
+                    ref_id=run_id,
+                    reason="remaining source manifest provenance references run ID",
+                )
+            )
+
+    for wiki_path in sorted(layout.wiki_dir.rglob("*.md")):
+        if wiki_path.name == ".gitkeep" or wiki_path in {layout.index_file, layout.log_file}:
+            continue
+        page_ref = wiki_path.relative_to(root).as_posix()
+        if page_ref in deleted_page_refs:
+            continue
+        try:
+            parsed = parse_wiki_markdown(wiki_path)
+        except ValueError:
+            text = wiki_path.read_text(encoding="utf-8")
+            if run_id in text:
+                residuals.append(
+                    SourceForgetResidualReference(
+                        kind="wiki_text",
+                        path=page_ref,
+                        source_id=source_id,
+                        ref_id=run_id,
+                        reason="wiki page text contains run ID",
+                    )
+                )
+            continue
+        if run_id in parsed.frontmatter.generated_by_run_ids:
+            residuals.append(
+                SourceForgetResidualReference(
+                    kind="wiki_generated_by_run",
+                    path=page_ref,
+                    source_id=source_id,
+                    ref_id=run_id,
+                    reason="maintained wiki page generated_by_run_ids contains run ID",
+                )
+            )
+        if any(link.run_id == run_id for link in parsed.frontmatter.provenance_links):
+            residuals.append(
+                SourceForgetResidualReference(
+                    kind="wiki_run_provenance",
+                    path=page_ref,
+                    source_id=source_id,
+                    ref_id=run_id,
+                    reason="maintained wiki page provenance contains run ID",
+                )
+            )
+        if run_id in parsed.body:
+            residuals.append(
+                SourceForgetResidualReference(
+                    kind="wiki_text",
+                    path=page_ref,
+                    source_id=source_id,
+                    ref_id=run_id,
+                    reason="wiki page text contains run ID",
+                )
+            )
+
+    for planning_path in sorted(layout.planning_dir.rglob("*.md")):
+        if planning_path.name == ".gitkeep" or not planning_path.is_file():
+            continue
+        if run_id not in planning_path.read_text(encoding="utf-8"):
+            continue
+        residuals.append(
+            SourceForgetResidualReference(
+                kind="planning_text",
+                path=planning_path.relative_to(root).as_posix(),
+                source_id=source_id,
+                ref_id=run_id,
+                reason="planning record contains run ID",
+            )
+        )
+
+    for run_path in sorted(layout.runs_dir.glob("*.json")):
+        if run_path.stem == run_id or not run_path.is_file():
+            continue
+        try:
+            run = load_run_record(run_path)
+        except ValueError:
+            continue
+        if not any(link.run_id == run_id for link in run.provenance_links):
+            continue
+        residuals.append(
+            SourceForgetResidualReference(
+                kind="run_provenance",
+                path=run_path.relative_to(root).as_posix(),
+                source_id=source_id,
+                ref_id=run_id,
+                reason="remaining run record provenance references run ID",
+            )
+        )
+    return residuals
+
+
+def _apply_source_forget(root: Path, actions: list[SourceForgetAction]) -> None:
+    layout = resolve_layout(root, load_config(root))
+    _preflight_source_forget_targets(root, actions)
+    for action in actions:
+        if action.kind == "wiki_index_entry":
+            continue
+        target = resolve_workspace_path(root, action.path, context="Forget target")
+        if target.exists() or target.is_symlink():
+            target.unlink()
+            _remove_empty_source_artifact_parents(layout.raw_sources_dir, target)
+
+    if any(action.kind == "wiki_index_entry" for action in actions):
+        _apply_index_cleanup(
+            layout,
+            {action.source_id for action in actions if action.kind == "wiki_index_entry"},
+        )
+
+
+def _preflight_source_forget_targets(root: Path, actions: list[SourceForgetAction]) -> None:
+    for action in actions:
+        if action.kind == "wiki_index_entry":
+            continue
+        target = resolve_workspace_path(root, action.path, context="Forget target")
+        if target.is_dir() and not target.is_symlink():
+            msg = f"Forget target is not a removable file: {action.path}"
+            raise ValueError(msg)
+
+
+def _apply_index_cleanup(layout, selected_ids: set[str]) -> None:
+    index_path = layout.index_file
+    if not index_path.is_file():
+        return
+    lines = index_path.read_text(encoding="utf-8").splitlines()
+    cleaned = [
+        line
+        for line in lines
+        if not any(
+            line.startswith("- [") and f"(`{source_id}`)" in line for source_id in selected_ids
+        )
+    ]
+    write_text_atomic(index_path, "\n".join(cleaned).rstrip() + "\n")
+
+
+def _remove_empty_source_artifact_parents(raw_sources_dir: Path, target: Path) -> None:
+    raw_sources_root = raw_sources_dir.resolve()
+    current = target.parent
+    while current != raw_sources_root:
+        try:
+            current.relative_to(raw_sources_root)
+        except ValueError:
+            return
+        try:
+            current.rmdir()
+        except OSError:
+            return
+        current = current.parent
+
+
+def _path_is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _dedupe_values(values: list[str | None]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            deduped.append(value)
+    return deduped
+
+
+def _dedupe_forget_actions(actions: list[SourceForgetAction]) -> list[SourceForgetAction]:
+    deduped: list[SourceForgetAction] = []
+    seen: set[tuple[str, str, str]] = set()
+    for action in sorted(actions, key=lambda item: (item.kind, item.path, item.source_id)):
+        key = (action.kind, action.path, action.source_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(action)
+    return deduped
+
+
+def _dedupe_residuals(
+    residuals: list[SourceForgetResidualReference],
+) -> list[SourceForgetResidualReference]:
+    deduped: list[SourceForgetResidualReference] = []
+    seen: set[tuple[str, str, str, str, str | None]] = set()
+    for residual in sorted(
+        residuals,
+        key=lambda item: (
+            item.kind,
+            item.path,
+            item.source_id,
+            item.reason,
+            item.ref_id or "",
+        ),
+    ):
+        key = (
+            residual.kind,
+            residual.path,
+            residual.source_id,
+            residual.reason,
+            residual.ref_id,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(residual)
+    return deduped
+
+
+def _forget_action_payload(action: SourceForgetAction) -> dict[str, object]:
+    return {
+        "kind": action.kind,
+        "path": action.path,
+        "source_id": action.source_id,
+        "status": action.status,
+        "reason": action.reason,
+    }
+
+
+def _residual_reference_payload(
+    residual: SourceForgetResidualReference,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "kind": residual.kind,
+        "path": residual.path,
+        "source_id": residual.source_id,
+        "reason": residual.reason,
+    }
+    if residual.ref_id is not None:
+        payload["ref_id"] = residual.ref_id
+    return payload
+
+
+def _source_payload(root: Path, result: SourceLookupResult) -> dict[str, object]:
+    source = result.source
+    return {
+        "source_id": source.source_id,
+        "logical_id": effective_logical_id(source),
+        "aliases": effective_aliases(source),
+        "title": source.title,
+        "source_type": source.source_type,
+        "status": source.status,
+        "supersedes": source.supersedes,
+        "superseded_by": source.superseded_by,
+        "source_ref": canonical_source_ref(source),
+        "source_ref_kind": source.source_ref_kind,
+        "original_path": source.original_path,
+        "checksum": source.checksum,
+        "manifest_path": result.manifest_path.relative_to(root).as_posix(),
+        "queue_job_id": ingest_job_id(source.source_id),
+        "linked_pages": source.linked_pages,
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,9 +16,16 @@ from splendor.commands.ingest import enqueue_ingest_job
 from splendor.commands.source import ingest_changed_sources, refresh_source
 from splendor.config import load_config, write_config
 from splendor.layout import resolve_layout
-from splendor.schemas import KnowledgePageFrontmatter, MaintenanceIssue, MaintenanceReport
+from splendor.schemas import (
+    KnowledgePageFrontmatter,
+    MaintenanceIssue,
+    MaintenanceReport,
+    ProvenanceLink,
+    QueueItemRecord,
+    RunRecord,
+)
 from splendor.state.query_snapshot import last_query_path_for, load_query_snapshot
-from splendor.state.runtime import load_queue_item
+from splendor.state.runtime import load_queue_item, write_queue_item, write_run_record
 from splendor.state.source_registry import load_source_record, write_source_record
 
 
@@ -102,6 +109,9 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     freshness = parser.parse_args(
         ["source", "freshness", "--report", "reports/freshness.json", "--json"]
     )
+    forget = parser.parse_args(
+        ["source", "forget", "--matching", ".mypy_cache/**", "--apply", "--json"]
+    )
 
     assert lookup.command == "source"
     assert lookup.source_command == "lookup"
@@ -118,6 +128,430 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     assert freshness.source_command == "freshness"
     assert freshness.report == Path("reports/freshness.json")
     assert freshness.json_output is True
+    assert forget.source_command == "forget"
+    assert forget.matching == ".mypy_cache/**"
+    assert forget.apply is True
+    assert forget.json_output is True
+
+
+def test_cli_source_forget_preview_is_non_mutating(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("# Brief\n\nKeep preview safe.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source_path)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    manifest_path = tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
+    summary_path = tmp_path / "wiki" / "sources" / f"{source_id}.md"
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    source_record = load_source_record(manifest_path)
+    run_path = tmp_path / "state" / "runs" / f"{source_record.last_run_id}.json"
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "forget", source_id, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["applied"] is False
+    assert payload["summary"]["candidates"] == 1
+    assert {action["status"] for action in payload["actions"]} == {"planned"}
+    assert manifest_path.exists()
+    assert summary_path.exists()
+    assert queue_path.exists()
+    assert run_path.exists()
+
+
+def test_cli_source_forget_apply_removes_source_owned_state(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("# Brief\n\nRemove generated state.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source_path)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    manifest_path = tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
+    summary_path = tmp_path / "wiki" / "sources" / f"{source_id}.md"
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    derived_path = tmp_path / "derived" / "parsed" / f"{source_id}.txt"
+    derived_path.parent.mkdir(parents=True, exist_ok=True)
+    derived_path.write_text("derived text\n", encoding="utf-8")
+    source_record = load_source_record(manifest_path)
+    run_path = tmp_path / "state" / "runs" / f"{source_record.last_run_id}.json"
+    write_source_record(
+        manifest_path,
+        source_record.model_copy(
+            update={"derived_artifacts": [derived_path.relative_to(tmp_path).as_posix()]}
+        ),
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "forget", source_id, "--apply", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["applied"] is True
+    assert {action["status"] for action in payload["actions"]} == {"removed"}
+    assert not manifest_path.exists()
+    assert not summary_path.exists()
+    assert not queue_path.exists()
+    assert not run_path.exists()
+    assert not derived_path.exists()
+    assert f"`{source_id}`" not in (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+
+
+def test_cli_source_forget_matching_removes_only_globbed_sources(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    polluted = tmp_path / ".mypy_cache" / "cache.py"
+    keep = tmp_path / "docs" / "keep.md"
+    polluted.parent.mkdir()
+    keep.parent.mkdir()
+    polluted.write_text("cache\n", encoding="utf-8")
+    keep.write_text("keep\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(polluted)])
+    main(["--root", str(tmp_path), "add-source", str(keep)])
+    sources = {
+        load_source_record(path).source_ref: path
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+    }
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "source",
+            "forget",
+            "--matching",
+            ".mypy_cache/**",
+            "--apply",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [source["source_ref"] for source in payload["sources"]] == [".mypy_cache/cache.py"]
+    assert not sources[".mypy_cache/cache.py"].exists()
+    assert sources["docs/keep.md"].exists()
+
+
+@pytest.mark.parametrize("selector", ["docs/brief.md", "source:docs/brief.md", "brief"])
+def test_cli_source_forget_resolves_exact_selectors(tmp_path: Path, capsys, selector: str) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "docs" / "brief.md"
+    source_path.parent.mkdir()
+    source_path.write_text("# Brief\n\nSelector test.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source_path)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "forget", selector, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [source["source_id"] for source in payload["sources"]] == [source_id]
+
+
+def test_cli_source_forget_reports_residual_maintained_refs(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("# Brief\n\nReferenced by a topic.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source_path)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    main(["--root", str(tmp_path), "add-topic", "Brief Notes", "--source-refs", source_id])
+    topic_path = tmp_path / "wiki" / "topics" / "brief-notes.md"
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "forget", source_id, "--apply", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["residual_references"] == [
+        {
+            "kind": "wiki_source_ref",
+            "path": "wiki/topics/brief-notes.md",
+            "source_id": source_id,
+            "reason": "maintained wiki page source_refs contains source ID",
+        },
+        {
+            "kind": "wiki_text",
+            "path": "wiki/topics/brief-notes.md",
+            "source_id": source_id,
+            "reason": "wiki page text contains source ID",
+        },
+    ]
+    assert source_id in topic_path.read_text(encoding="utf-8")
+
+
+def test_cli_source_forget_rejects_ambiguous_titles(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    first = tmp_path / "a" / "brief.md"
+    second = tmp_path / "b" / "brief.md"
+    first.parent.mkdir()
+    second.parent.mkdir()
+    first.write_text("first\n", encoding="utf-8")
+    second.write_text("second\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(first)])
+    main(["--root", str(tmp_path), "add-source", str(second)])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "forget", "brief"])
+
+    assert exit_code == 1
+    assert "Source lookup is ambiguous" in capsys.readouterr().out
+
+
+def test_cli_source_forget_rejects_missing_or_duplicate_selection_modes(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+
+    no_selector = main(["--root", str(tmp_path), "source", "forget"])
+    both_selectors = main(
+        [
+            "--root",
+            str(tmp_path),
+            "source",
+            "forget",
+            "src-123",
+            "--matching",
+            "docs/**",
+        ]
+    )
+    empty_matching = main(["--root", str(tmp_path), "source", "forget", "--matching", ""])
+    absolute_matching = main(["--root", str(tmp_path), "source", "forget", "--matching", "/tmp/**"])
+
+    output = capsys.readouterr().out
+    assert no_selector == 1
+    assert both_selectors == 1
+    assert empty_matching == 1
+    assert absolute_matching == 1
+    assert "requires exactly one" in output
+    assert "requires a non-empty workspace-relative glob" in output
+    assert "must be a workspace-relative glob" in output
+
+
+def test_cli_source_forget_matching_can_preview_no_matches(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "source", "forget", "--matching", ".mypy_cache/**", "--json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"] == {
+        "candidates": 0,
+        "actions": 0,
+        "skipped": 0,
+        "residual_references": 0,
+    }
+    assert payload["sources"] == []
+
+
+def test_cli_source_forget_reports_skipped_unsafe_cleanup(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("# Brief\n\nUnsafe cleanup branches.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source_path)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    manifest_path = tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
+    source_summary = tmp_path / "wiki" / "sources" / f"{source_id}.md"
+    source_summary.parent.mkdir(parents=True, exist_ok=True)
+    source_summary.write_text("not frontmatter\n", encoding="utf-8")
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    queue_path.write_text("{bad json}\n", encoding="utf-8")
+    unsafe_artifact = tmp_path / "scratch" / f"{source_id}.txt"
+    unsafe_artifact.parent.mkdir()
+    unsafe_artifact.write_text("unsafe\n", encoding="utf-8")
+    source_record = load_source_record(manifest_path)
+    write_source_record(
+        manifest_path,
+        source_record.model_copy(
+            update={
+                "derived_artifacts": [
+                    "../outside.txt",
+                    unsafe_artifact.relative_to(tmp_path).as_posix(),
+                ],
+                "linked_pages": [
+                    source_summary.relative_to(tmp_path).as_posix(),
+                    "../bad.md",
+                ],
+            }
+        ),
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "forget", source_id, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    skipped = {(item["kind"], item["path"]) for item in payload["skipped"]}
+    assert ("source_summary_page", f"wiki/sources/{source_id}.md") in skipped
+    assert ("source_summary_page", "../bad.md") in skipped
+    assert ("queue_record", f"state/queue/ingest-{source_id}.json") in skipped
+    assert ("artifact", "../outside.txt") in skipped
+    assert ("artifact", f"scratch/{source_id}.txt") in skipped
+
+
+def test_cli_source_forget_reports_valid_but_unsupported_queue_records(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("# Brief\n\nQueue mismatch.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source_path)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    queue = QueueItemRecord.model_validate_json(queue_path.read_text(encoding="utf-8"))
+    write_queue_item(queue_path, queue.model_copy(update={"job_type": "other"}))
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "forget", source_id, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert {(item["kind"], item["path"], item["reason"]) for item in payload["skipped"]} == {
+        (
+            "queue_record",
+            f"state/queue/ingest-{source_id}.json",
+            "queue record is not the expected source-owned ingest job",
+        )
+    }
+
+
+def test_cli_source_forget_reports_mixed_run_and_provenance_residuals(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("# Brief\n\nMixed references.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source_path)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    mixed_run_path = layout.runs_dir / "run-mixed.json"
+    write_run_record(
+        mixed_run_path,
+        RunRecord(
+            run_id="run-mixed",
+            job_id="custom-job",
+            job_type="ingest_source",
+            started_at="2026-05-05T00:00:00Z",
+            finished_at="2026-05-05T00:00:01Z",
+            status="succeeded",
+            pipeline_version=__version__,
+            source_ids=[source_id, "src-other"],
+        ),
+    )
+    invalid_run_path = layout.runs_dir / "run-invalid.json"
+    invalid_run_path.write_text("{bad json}\n", encoding="utf-8")
+    other_run_path = layout.runs_dir / "run-other.json"
+    write_run_record(
+        other_run_path,
+        RunRecord(
+            run_id="run-other",
+            job_id="ingest-src-other",
+            job_type="ingest_source",
+            started_at="2026-05-05T00:00:00Z",
+            finished_at="2026-05-05T00:00:01Z",
+            status="succeeded",
+            pipeline_version=__version__,
+            source_ids=["src-other"],
+        ),
+    )
+    page_path = tmp_path / "wiki" / "topics" / "provenance.md"
+    frontmatter = KnowledgePageFrontmatter(
+        kind="topic",
+        title="Provenance",
+        page_id="topic-provenance",
+        status="active",
+        source_refs=[],
+        provenance_links=[ProvenanceLink(source_id=source_id, role="supports")],
+    )
+    page_path.parent.mkdir(parents=True, exist_ok=True)
+    page_path.write_text(
+        f"---\n{yaml.safe_dump(frontmatter.model_dump(mode='json'), sort_keys=False)}"
+        "---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    malformed_page = tmp_path / "wiki" / "topics" / "malformed.md"
+    malformed_page.write_text(f"body mentions {source_id}\n", encoding="utf-8")
+    planning_path = tmp_path / "planning" / "tasks" / "task-ref.md"
+    planning_path.write_text(f"mentions {source_id}\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "forget", source_id, "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert {
+        (item["kind"], item["path"]) for item in payload["skipped"] if item["kind"] == "run_record"
+    } == {("run_record", "state/runs/run-mixed.json")}
+    assert {(item["kind"], item["path"]) for item in payload["residual_references"]} == {
+        ("planning_text", "planning/tasks/task-ref.md"),
+        ("wiki_text", "wiki/topics/malformed.md"),
+        ("wiki_provenance", "wiki/topics/provenance.md"),
+    }
+
+
+def test_cli_source_forget_human_output_reports_next_commands(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("# Brief\n\nHuman output.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source_path)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    capsys.readouterr()
+
+    preview_exit = main(["--root", str(tmp_path), "source", "forget", source_id])
+    preview_output = capsys.readouterr().out
+    apply_exit = main(["--root", str(tmp_path), "source", "forget", source_id, "--apply"])
+    apply_output = capsys.readouterr().out
+
+    assert preview_exit == 0
+    assert "Source forget preview" in preview_output
+    assert f"Next: splendor source forget {source_id} --apply" in preview_output
+    assert apply_exit == 0
+    assert "Source forget applied" in apply_output
+    assert "Next: splendor lint" in apply_output
+    assert "Next: splendor health" in apply_output
+
+
+def test_cli_source_forget_human_output_reports_empty_matching_preview(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "forget", "--matching", "missing/**"])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "Source forget preview" in output
+    assert "No matching sources." in output
+
+
+def test_cli_source_forget_removes_materialized_copy_artifacts(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "external.md"
+    source_path.write_text("# External\n\nCopied.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source_path), "--storage-mode", "copy"])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    manifest_path = tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
+    materialized_path = tmp_path / "raw" / "sources" / source_id / "external.md"
+    assert materialized_path.exists()
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "forget", source_id, "--apply", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert {(item["kind"], item["path"]) for item in payload["actions"]} >= {
+        ("materialized_artifact", f"raw/sources/{source_id}/external.md"),
+        ("source_manifest", f"state/manifests/sources/{source_id}.json"),
+    }
+    assert not materialized_path.exists()
+    assert not materialized_path.parent.exists()
+    assert not manifest_path.exists()
 
 
 def test_cli_workspace_refresh_parser_accepts_safe_refresh_flags() -> None:

--- a/tests/test_source_forget.py
+++ b/tests/test_source_forget.py
@@ -1,0 +1,134 @@
+from pathlib import Path
+
+import pytest
+
+from splendor import __version__
+from splendor.cli import main
+from splendor.commands.source_forget import (
+    SourceForgetAction,
+    _apply_source_forget,
+    forget_sources,
+)
+from splendor.config import load_config
+from splendor.layout import resolve_layout
+from splendor.schemas import RunRecord
+from splendor.state.runtime import write_run_record
+from splendor.state.source_registry import load_source_record, write_source_record
+
+
+def test_source_forget_keeps_run_record_referenced_by_remaining_source(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    forgotten_path = tmp_path / "forgotten.md"
+    forgotten_path.write_text("# Forgotten\n\nHas a run.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(forgotten_path)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    forgotten_manifest = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    forgotten = load_source_record(forgotten_manifest)
+    assert forgotten.last_run_id is not None
+
+    remaining_path = tmp_path / "remaining.md"
+    remaining_path.write_text("# Remaining\n\nKeeps the run ID alive.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(remaining_path)])
+    remaining_manifest = next(
+        path
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if path != forgotten_manifest
+    )
+    remaining = load_source_record(remaining_manifest)
+    write_source_record(
+        remaining_manifest,
+        remaining.model_copy(update={"generated_by_run_ids": [forgotten.last_run_id]}),
+    )
+    run_path = tmp_path / "state" / "runs" / f"{forgotten.last_run_id}.json"
+    capsys.readouterr()
+
+    result = forget_sources(tmp_path, selector=forgotten.source_id, apply=True)
+
+    assert not forgotten_manifest.exists()
+    assert run_path.exists()
+    assert {(action.kind, action.path, action.reason) for action in result.skipped} >= {
+        (
+            "run_record",
+            f"state/runs/{forgotten.last_run_id}.json",
+            "run record is referenced by remaining workspace state",
+        )
+    }
+    assert {
+        (residual.kind, residual.path, residual.ref_id) for residual in result.residual_references
+    } >= {
+        (
+            "source_run_ref",
+            f"state/manifests/sources/{remaining.source_id}.json",
+            forgotten.last_run_id,
+        )
+    }
+
+
+def test_source_forget_apply_preflights_targets_before_mutating(tmp_path: Path) -> None:
+    main(["--root", str(tmp_path), "init"])
+    manifest = tmp_path / "state" / "manifests" / "sources" / "src-manual.json"
+    manifest.write_text("{}\n", encoding="utf-8")
+    directory_target = tmp_path / "derived" / "parsed" / "not-a-file"
+    directory_target.mkdir(parents=True)
+    actions = [
+        SourceForgetAction(
+            kind="source_manifest",
+            path="state/manifests/sources/src-manual.json",
+            source_id="src-manual",
+            status="planned",
+        ),
+        SourceForgetAction(
+            kind="derived_artifact",
+            path="derived/parsed/not-a-file",
+            source_id="src-manual",
+            status="planned",
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="not a removable file"):
+        _apply_source_forget(tmp_path, actions)
+
+    assert manifest.exists()
+    assert directory_target.exists()
+
+
+def test_source_forget_reports_run_id_residuals_from_wiki_and_run_records(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("# Brief\n\nRun references.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source_path)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    manifest = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    source = load_source_record(manifest)
+    assert source.last_run_id is not None
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    topic_path = tmp_path / "wiki" / "topics" / "run-ref.md"
+    topic_path.parent.mkdir(parents=True, exist_ok=True)
+    topic_path.write_text(f"body mentions {source.last_run_id}\n", encoding="utf-8")
+    write_run_record(
+        layout.runs_dir / "run-followup.json",
+        RunRecord(
+            run_id="run-followup",
+            job_id="followup",
+            job_type="maintenance",
+            started_at="2026-05-05T00:00:00Z",
+            finished_at="2026-05-05T00:00:01Z",
+            status="succeeded",
+            pipeline_version=__version__,
+            provenance_links=[{"run_id": source.last_run_id, "role": "supports"}],
+        ),
+    )
+    capsys.readouterr()
+
+    result = forget_sources(tmp_path, selector=source.source_id)
+
+    assert {
+        (residual.kind, residual.path, residual.ref_id) for residual in result.residual_references
+    } >= {
+        ("wiki_text", "wiki/topics/run-ref.md", source.last_run_id),
+        ("run_provenance", "state/runs/run-followup.json", source.last_run_id),
+    }


### PR DESCRIPTION
## Planning notation

- PR sub-slice: M16-P1.2
- Parent slice: M16-P1 source hygiene and registry recovery
- Milestone: 16, v0.3 recovery track
- Issue: Closes #109

## Summary

Adds `splendor source forget` as a preview-first source-registry recovery command for polluted manifests.

## What changed

- Added `splendor source forget [selector] [--matching <workspace-relative-glob>] [--apply] [--json]`.
- Reused strict source selector resolution for single-source cleanup by exact source ID, path/source ref, logical ID, alias, or unambiguous title.
- Added deterministic bulk matching for polluted workspace paths such as `.mypy_cache/**`.
- Kept preview as the default behavior; `--apply` is required before deletion.
- On apply, removes selected manifests plus source-owned generated source-summary pages, queue records, ingest run records, safe derived artifacts, materialized artifacts, and matching wiki index entries.
- Reports residual maintained wiki/planning references and skipped unsafe cleanup instead of rewriting authored state.
- Updated planning state and source lifecycle docs for the M16-P1.2 command contract.

## Self-review follow-up applied

1. Run-record deletion now checks for residual references by run ID before apply. Recommendation: do not delete a source-owned run record if any remaining manifest, wiki page, planning record, or run provenance still points at its run ID; instead move that run cleanup to `skipped` and report deterministic residual references with `ref_id`.
2. Destructive apply now has a preflight pass before unlinking targets. Recommendation: fail before mutation when any planned target is not a removable file, so a bad derived/materialized target cannot leave a partially forgotten source registry.
3. The forget implementation now lives in `src/splendor/commands/source_forget.py` with constrained action/status/residual kinds and focused planner tests. Recommendation: keep `source.py` focused on lifecycle/lookup behavior and test forget safety below the CLI layer, while preserving the existing CLI coverage.

## Validation

- `/Users/shaypalachy/.local/bin/uv run pytest` -> 613 passed
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .` -> passed
- `/Users/shaypalachy/.local/bin/uv run ruff check .` -> passed
- `/Users/shaypalachy/.local/bin/uv run splendor lint` -> passed
- `/Users/shaypalachy/.local/bin/uv run splendor health` -> passed

Note: the ruff check printed a uv interpreter-cache cleanup warning before passing; it did not indicate a repository failure.

## Boundaries

- Does not implement duplicate canonical reconciliation; that remains M16-P1.3 / #110.
- Does not implement health false-positive fixes; that remains M16-P2.1 / #112.
- Does not implement lint live-ref fixes; that remains M16-P2.2 / #113.
- Does not commit the preserved SynthBanshee fixture archive.
