### PR TITLE
M16-P1.3: Reconcile duplicate canonical source versions

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M16-P1.1`
-- Last action taken: `M16-P1.1` was squash-merged into main as commit `ad0d1c4`,
-  hardening repo scan ignores and `.splendorignore`.
+- Previous completed PR sub-slice: `M16-P1.2`
+- Last action taken: `M16-P1.2` was squash-merged into main as commit `4af6523`,
+  adding the `splendor source forget` recovery command.
 - Current planned slice: `M16-P1 source hygiene and registry recovery`
-- Current PR sub-slice: `M16-P1.2`
+- Current PR sub-slice: `M16-P1.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M16-P1 source hygiene and registry recovery`
-- Next planned PR sub-slice: `M16-P1.3`
+- Next planned slice: `M16-P2 validation correctness`
+- Next planned PR sub-slice: `M16-P2.1`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -198,9 +198,10 @@ references for review instead of rewritten.
 `splendor source reconcile <source-id|logical-id|title|path>` is the preview-first repair path for
 duplicate active canonical source versions. It resolves one canonical source-ref group, chooses the
 latest active source version as current unless an exact source ID or `--current` selector is
-provided, and reports the manifest lifecycle edits needed to complete the `supersedes` /
-`superseded_by` graph. Add `--apply` to mark older active versions as superseded by the selected
-current version. Cross-canonical or ambiguous selections are rejected without rewriting manifests.
+provided, and reports the manifest lifecycle edits needed to complete one-way or missing
+`supersedes` / `superseded_by` links around that current version. Add `--apply` to mark older
+active versions as superseded by the selected current version. Cross-canonical selections and
+ambiguous `--current` selectors are rejected without rewriting manifests.
 
 `splendor ingest --changed` is the narrower stale-ingest repair path for checksum-drifted curated
 workspace-backed sources when old ingest queue records are already `done`. It refreshes changed

--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ source-owned generated summaries, queue records, ingest run records, and safe ge
 maintained wiki/planning references and unsafe mixed historical state are reported as residual
 references for review instead of rewritten.
 
+`splendor source reconcile <source-id|logical-id|title|path>` is the preview-first repair path for
+duplicate active canonical source versions. It resolves one canonical source-ref group, chooses the
+latest active source version as current unless an exact source ID or `--current` selector is
+provided, and reports the manifest lifecycle edits needed to complete the `supersedes` /
+`superseded_by` graph. Add `--apply` to mark older active versions as superseded by the selected
+current version. Cross-canonical or ambiguous selections are rejected without rewriting manifests.
+
 `splendor ingest --changed` is the narrower stale-ingest repair path for checksum-drifted curated
 workspace-backed sources when old ingest queue records are already `done`. It refreshes changed
 source versions through the same supersession-aware source lifecycle, ingests only those refreshed
@@ -255,12 +262,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M16-P1.1`
+- Previous completed PR sub-slice: `M16-P1.2`
 - Current planned slice: `M16-P1 source hygiene and registry recovery`
-- Current PR sub-slice: `M16-P1.2`
+- Current PR sub-slice: `M16-P1.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M16-P1 source hygiene and registry recovery`
-- Next planned PR sub-slice: `M16-P1.3`
+- Next planned slice: `M16-P2 validation correctness`
+- Next planned PR sub-slice: `M16-P2.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -481,6 +488,6 @@ rewritten.
 
 - [x] Repo scan ignores and `.splendorignore` prevent cache/local-agent source pollution.
 - [x] `splendor source forget` provides safe single and bulk source-registry recovery.
-- [ ] Duplicate canonical source versions can be reconciled without manual manifest edits.
+- [x] Duplicate canonical source versions can be reconciled without manual manifest edits.
 - [ ] Health resolves existing manifest source IDs without false unknown-source diagnostics.
 - [ ] Lint validates live source refs after path repair and supersession.

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -392,3 +392,6 @@ For source-registry recovery PRs, use `splendor source forget` in preview mode b
 cleanup. Applied recovery changes should be reviewed as intentional source-registry maintenance:
 selected manifests and source-owned generated state may be removed, while residual maintained
 wiki/planning references should remain visible in the command output and PR description.
+Use `splendor source reconcile` in preview mode before applying duplicate canonical source-version
+repairs. Applied reconciliation changes should be limited to source manifest lifecycle links and
+should leave generated pages, maintained wiki pages, queue records, and run records untouched.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -213,10 +213,11 @@ Implemented fields:
 - `splendor source reconcile <source-id|logical-id|title|path>` previews duplicate active source
   version repair for one canonical source-ref group. Without `--current`, an exact source ID keeps
   that source active; otherwise the latest active version by `(added_at, source_id)` is selected.
-  `--current <selector>` must resolve to an active source in the same canonical group. `--apply`
-  writes only affected source manifests, setting `superseded_by` on older active versions and
-  appending those source IDs to the current record's `supersedes` list. Ambiguous, unknown,
-  superseded-current, and cross-canonical selections fail without manifest writes.
+  `--current <selector>` must resolve to exactly one active source in the same canonical group.
+  `--apply` writes only affected source manifests, setting `superseded_by` on older active
+  versions and appending those source IDs plus same-canonical one-way links to the current record's
+  `supersedes` list. Ambiguous, unknown, superseded-current, and cross-canonical selections fail
+  without manifest writes.
 - `splendor source freshness` is a non-mutating preview over curated source manifests. It reports
   path-first freshness state for workspace-backed canonical source refs, including unchanged,
   changed, missing, and unsupported statuses, manifest/current checksums where available, source

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -210,6 +210,13 @@ Implemented fields:
   materialized artifacts under the source-owned raw artifact directory. Maintained wiki/planning
   references, malformed generated pages, mixed run records, and unsafe artifacts are reported as
   residual or skipped references rather than rewritten.
+- `splendor source reconcile <source-id|logical-id|title|path>` previews duplicate active source
+  version repair for one canonical source-ref group. Without `--current`, an exact source ID keeps
+  that source active; otherwise the latest active version by `(added_at, source_id)` is selected.
+  `--current <selector>` must resolve to an active source in the same canonical group. `--apply`
+  writes only affected source manifests, setting `superseded_by` on older active versions and
+  appending those source IDs to the current record's `supersedes` list. Ambiguous, unknown,
+  superseded-current, and cross-canonical selections fail without manifest writes.
 - `splendor source freshness` is a non-mutating preview over curated source manifests. It reports
   path-first freshness state for workspace-backed canonical source refs, including unchanged,
   changed, missing, and unsupported statuses, manifest/current checksums where available, source

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M16-P1.1`
+- Previous completed PR sub-slice: `M16-P1.2`
 - Current planned slice: `M16-P1 source hygiene and registry recovery`
-- Current PR sub-slice: `M16-P1.2`
+- Current PR sub-slice: `M16-P1.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M16-P1 source hygiene and registry recovery`
-- Next planned PR sub-slice: `M16-P1.3`
+- Next planned slice: `M16-P2 validation correctness`
+- Next planned PR sub-slice: `M16-P2.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -816,8 +816,9 @@ Current implementation:
   duplicate active versions of the same canonical source ref. The command previews by default,
   selects the latest active version unless an exact source ID or `--current` selector names the
   desired active version, and requires `--apply` before writing the bidirectional
-  `supersedes`/`superseded_by` manifest updates. It rejects ambiguous selectors and
-  cross-canonical reconciliation attempts instead of guessing.
+  `supersedes`/`superseded_by` manifest updates. It also repairs same-canonical one-way lifecycle
+  links around the selected current version so interrupted reconciliation can be rerun. It rejects
+  ambiguous selectors and cross-canonical reconciliation attempts instead of guessing.
 - `splendor workspace refresh --changed` safely refreshes only changed curated workspace-backed
   sources by composing `source freshness` with the supersession-aware `source refresh` path. It
   reports missing or unsupported active curated workspace sources as skipped unresolved diagnostics,

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -812,6 +812,12 @@ Current implementation:
   derived artifacts, and source-owned materialized artifacts. Maintained wiki/planning references,
   malformed generated pages, mixed historical records, and unsafe artifact paths are reported for
   operator review rather than rewritten.
+- `splendor source reconcile <source-id|logical-id|title|path>` is the CLI-first repair path for
+  duplicate active versions of the same canonical source ref. The command previews by default,
+  selects the latest active version unless an exact source ID or `--current` selector names the
+  desired active version, and requires `--apply` before writing the bidirectional
+  `supersedes`/`superseded_by` manifest updates. It rejects ambiguous selectors and
+  cross-canonical reconciliation attempts instead of guessing.
 - `splendor workspace refresh --changed` safely refreshes only changed curated workspace-backed
   sources by composing `source freshness` with the supersession-aware `source refresh` path. It
   reports missing or unsupported active curated workspace sources as skipped unresolved diagnostics,

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -65,14 +65,17 @@ from splendor.commands.source import (
     ingest_changed_sources,
     list_sources,
     lookup_sources,
+    reconcile_sources,
     refresh_source,
     render_source_freshness_json,
     render_source_lookup_json,
     render_source_path_update_json,
+    render_source_reconcile_json,
     render_source_refresh_json,
     render_stale_ingest_json,
     resolve_source_query_exact,
     scan_source_freshness,
+    source_reconcile_next_commands,
     update_source_path,
     write_source_freshness_report,
 )
@@ -263,6 +266,29 @@ def build_parser() -> argparse.ArgumentParser:
         help="Allow updating a source path even when the current path still exists.",
     )
     source_update_path_parser.set_defaults(handler=handle_source_update_path)
+    source_reconcile_parser = source_subparsers.add_parser(
+        "reconcile", help="Preview or repair duplicate active source versions"
+    )
+    source_reconcile_parser.add_argument(
+        "selector",
+        help="Source ID, logical ID, title, path, or source ref for one canonical source group",
+    )
+    source_reconcile_parser.add_argument(
+        "--current",
+        help="Source ID, logical ID, title, path, or source ref to keep active.",
+    )
+    source_reconcile_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the planned source lifecycle reconciliation.",
+    )
+    source_reconcile_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    source_reconcile_parser.set_defaults(handler=handle_source_reconcile)
     source_forget_parser = source_subparsers.add_parser(
         "forget", help="Preview or apply source registry cleanup"
     )
@@ -1090,6 +1116,49 @@ def handle_source_update_path(args: argparse.Namespace) -> int:
     for command in result.next_commands:
         print(f"Next: {command}")
     return 0 if result.status == "repaired" else 1
+
+
+def handle_source_reconcile(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = reconcile_sources(
+            root,
+            args.selector,
+            current_selector=args.current,
+            apply=args.apply,
+        )
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_source_reconcile_json(root, result))
+        return 0
+
+    action = "Applied source reconciliation" if result.applied else "Source reconciliation preview"
+    print(action)
+    print(f"Canonical source ref: {result.canonical_ref}")
+    print(f"Current source ID: {result.current.source_id}")
+    print(
+        f"Active versions before: {', '.join(source.source_id for source in result.active_before)}"
+    )
+    if not result.updates:
+        print("No reconciliation changes needed.")
+    else:
+        print("Planned updates:" if not result.applied else "Applied updates:")
+        for update in result.updates:
+            print(f"- {update.source.source_id}: {update.manifest_path}")
+            if update.before_superseded_by != update.after_superseded_by:
+                print(
+                    "  superseded_by: "
+                    f"{update.before_superseded_by or '-'} -> {update.after_superseded_by or '-'}"
+                )
+            if update.before_supersedes != update.after_supersedes:
+                before = ", ".join(update.before_supersedes) or "-"
+                after = ", ".join(update.after_supersedes) or "-"
+                print(f"  supersedes: {before} -> {after}")
+    for command in source_reconcile_next_commands(result):
+        print(f"Next: {command}")
+    return 0
 
 
 def handle_source_forget(args: argparse.Namespace) -> int:

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -477,17 +477,11 @@ def reconcile_sources(
         msg = f"Current source version is already superseded: {current.source_id}"
         raise ValueError(msg)
 
-    superseded_ids = [
-        result.source.source_id
-        for result in sorted(active_group, key=_latest_source_sort_key)
-        if result.source.source_id != current.source_id
-    ]
+    superseded_ids = _reconcile_superseded_ids(group, current)
     updates: list[SourceReconcileUpdate] = []
-    for result in sorted(active_group, key=lambda item: item.source.source_id):
+    for result in sorted(group, key=lambda item: item.source.source_id):
         source = result.source
-        if source.source_id == current.source_id:
-            continue
-        if source.superseded_by == current.source_id:
+        if source.source_id not in superseded_ids or source.superseded_by == current.source_id:
             continue
         updates.append(
             SourceReconcileUpdate(
@@ -513,16 +507,22 @@ def reconcile_sources(
             )
         )
 
-    if apply:
-        for update in updates:
-            updated = SourceRecord.model_validate(
+    validated_updates = [
+        (
+            update.manifest_path,
+            SourceRecord.model_validate(
                 update.source.model_dump(mode="json")
                 | {
                     "supersedes": update.after_supersedes,
                     "superseded_by": update.after_superseded_by,
                 }
-            )
-            write_source_record(update.manifest_path, updated)
+            ),
+        )
+        for update in updates
+    ]
+    if apply:
+        for manifest_path, updated in validated_updates:
+            write_source_record(manifest_path, updated)
 
     return SourceReconcileResult(
         applied=apply,
@@ -712,7 +712,7 @@ def _current_reconcile_match(
     if current_selector is None:
         msg = "--current requires a source selector"
         raise ValueError(msg)
-    current_match = resolve_source_query_exact(root, current_selector)
+    current_match = _resolve_reconcile_current_exact(root, current_selector)
     if canonical_source_ref(current_match.source) != canonical_ref:
         msg = (
             "Current source version must share the selected canonical source ref: "
@@ -720,6 +720,64 @@ def _current_reconcile_match(
         )
         raise ValueError(msg)
     return current_match
+
+
+def _resolve_reconcile_current_exact(root: Path, selector: str) -> SourceLookupResult:
+    matches = list_sources(root)
+    exact_id_matches = [match for match in matches if match.source.source_id == selector]
+    if exact_id_matches:
+        return exact_id_matches[0]
+
+    exact_identity_matches = [
+        match
+        for match in matches
+        if canonical_source_ref(match.source) == selector
+        or (match.source.original_path is not None and match.source.original_path == selector)
+        or effective_logical_id(match.source) == selector
+        or selector in effective_aliases(match.source)
+    ]
+    if exact_identity_matches:
+        return _single_reconcile_current_match(selector, exact_identity_matches)
+
+    exact_title_matches = [
+        match for match in matches if match.source.title.casefold() == selector.casefold()
+    ]
+    if exact_title_matches:
+        return _single_reconcile_current_match(selector, exact_title_matches)
+
+    label = "source ID" if selector.startswith("src-") else "source"
+    msg = f"Unknown {label}: {selector}"
+    raise FileNotFoundError(msg)
+
+
+def _single_reconcile_current_match(
+    selector: str, matches: list[SourceLookupResult]
+) -> SourceLookupResult:
+    if len(matches) == 1:
+        return matches[0]
+    ids = ", ".join(match.source.source_id for match in matches[:5])
+    suffix = "" if len(matches) <= 5 else ", ..."
+    msg = f"Current source selector is ambiguous for {selector!r}: {ids}{suffix}"
+    raise ValueError(msg)
+
+
+def _reconcile_superseded_ids(group: list[SourceLookupResult], current: SourceRecord) -> list[str]:
+    current_supersedes = set(current.supersedes)
+    target_ids = {
+        result.source.source_id
+        for result in group
+        if result.source.source_id != current.source_id
+        and (
+            result.source.superseded_by is None
+            or result.source.superseded_by == current.source_id
+            or result.source.source_id in current_supersedes
+        )
+    }
+    return [
+        result.source.source_id
+        for result in sorted(group, key=_latest_source_sort_key)
+        if result.source.source_id in target_ids
+    ]
 
 
 def _latest_source_sort_key(result: SourceLookupResult) -> tuple[str, str]:

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -64,6 +64,28 @@ class SourcePathUpdateResult:
 
 
 @dataclass(frozen=True)
+class SourceReconcileUpdate:
+    source: SourceRecord
+    manifest_path: Path
+    before_supersedes: list[str]
+    after_supersedes: list[str]
+    before_superseded_by: str | None
+    after_superseded_by: str | None
+
+
+@dataclass(frozen=True)
+class SourceReconcileResult:
+    applied: bool
+    selector: str
+    current_selector: str | None
+    canonical_ref: str
+    current: SourceRecord
+    current_manifest_path: Path
+    active_before: list[SourceRecord]
+    updates: list[SourceReconcileUpdate]
+
+
+@dataclass(frozen=True)
 class SourceFreshnessItem:
     source: SourceRecord
     manifest_path: Path
@@ -431,6 +453,91 @@ def update_source_path(
     )
 
 
+def reconcile_sources(
+    root: Path,
+    selector: str,
+    *,
+    current_selector: str | None = None,
+    apply: bool = False,
+) -> SourceReconcileResult:
+    group = _reconcile_group(root, selector)
+    canonical_ref = canonical_source_ref(group[0].source)
+    active_group = [result for result in group if result.source.superseded_by is None]
+    if not active_group:
+        msg = f"No active source versions found for canonical source ref: {canonical_ref}"
+        raise ValueError(msg)
+
+    current_match = (
+        _current_reconcile_match(root, current_selector, canonical_ref)
+        if current_selector is not None
+        else _default_reconcile_current(selector, group, active_group)
+    )
+    current = current_match.source
+    if current.superseded_by is not None:
+        msg = f"Current source version is already superseded: {current.source_id}"
+        raise ValueError(msg)
+
+    superseded_ids = [
+        result.source.source_id
+        for result in sorted(active_group, key=_latest_source_sort_key)
+        if result.source.source_id != current.source_id
+    ]
+    updates: list[SourceReconcileUpdate] = []
+    for result in sorted(active_group, key=lambda item: item.source.source_id):
+        source = result.source
+        if source.source_id == current.source_id:
+            continue
+        if source.superseded_by == current.source_id:
+            continue
+        updates.append(
+            SourceReconcileUpdate(
+                source=source,
+                manifest_path=result.manifest_path,
+                before_supersedes=list(source.supersedes),
+                after_supersedes=list(source.supersedes),
+                before_superseded_by=source.superseded_by,
+                after_superseded_by=current.source_id,
+            )
+        )
+
+    current_supersedes = _dedupe_aliases([*current.supersedes, *superseded_ids])
+    if current_supersedes != current.supersedes:
+        updates.append(
+            SourceReconcileUpdate(
+                source=current,
+                manifest_path=current_match.manifest_path,
+                before_supersedes=list(current.supersedes),
+                after_supersedes=current_supersedes,
+                before_superseded_by=current.superseded_by,
+                after_superseded_by=None,
+            )
+        )
+
+    if apply:
+        for update in updates:
+            updated = SourceRecord.model_validate(
+                update.source.model_dump(mode="json")
+                | {
+                    "supersedes": update.after_supersedes,
+                    "superseded_by": update.after_superseded_by,
+                }
+            )
+            write_source_record(update.manifest_path, updated)
+
+    return SourceReconcileResult(
+        applied=apply,
+        selector=selector,
+        current_selector=current_selector,
+        canonical_ref=canonical_ref,
+        current=current,
+        current_manifest_path=current_match.manifest_path,
+        active_before=[
+            result.source for result in sorted(active_group, key=_latest_source_sort_key)
+        ],
+        updates=updates,
+    )
+
+
 def ingest_changed_sources(root: Path) -> StaleIngestResult:
     initial_freshness = scan_source_freshness(root)
     missing_items = [item for item in initial_freshness.sources if item.status == "missing"]
@@ -571,6 +678,50 @@ def _select_refresh_candidate(
     raise ValueError(msg)
 
 
+def _reconcile_group(root: Path, selector: str) -> list[SourceLookupResult]:
+    matches = resolve_source_query_matches(root, selector)
+    refs = {canonical_source_ref(match.source) for match in matches}
+    if len(refs) != 1:
+        ids = ", ".join(match.source.source_id for match in matches[:5])
+        suffix = "" if len(matches) <= 5 else ", ..."
+        msg = f"Source reconcile selector is ambiguous for {selector!r}: {ids}{suffix}"
+        raise ValueError(msg)
+    canonical_ref = next(iter(refs))
+    group = [
+        result
+        for result in list_sources(root)
+        if canonical_source_ref(result.source) == canonical_ref
+    ]
+    return sorted(group, key=_latest_source_sort_key)
+
+
+def _default_reconcile_current(
+    selector: str,
+    group: list[SourceLookupResult],
+    active_group: list[SourceLookupResult],
+) -> SourceLookupResult:
+    exact_id_matches = [result for result in group if result.source.source_id == selector]
+    if exact_id_matches:
+        return exact_id_matches[0]
+    return max(active_group, key=_latest_source_sort_key)
+
+
+def _current_reconcile_match(
+    root: Path, current_selector: str | None, canonical_ref: str
+) -> SourceLookupResult:
+    if current_selector is None:
+        msg = "--current requires a source selector"
+        raise ValueError(msg)
+    current_match = resolve_source_query_exact(root, current_selector)
+    if canonical_source_ref(current_match.source) != canonical_ref:
+        msg = (
+            "Current source version must share the selected canonical source ref: "
+            f"expected {canonical_ref}, got {canonical_source_ref(current_match.source)}"
+        )
+        raise ValueError(msg)
+    return current_match
+
+
 def _latest_source_sort_key(result: SourceLookupResult) -> tuple[str, str]:
     return (result.source.added_at, result.source.source_id)
 
@@ -674,6 +825,37 @@ def render_source_path_update_json(root: Path, result: SourcePathUpdateResult) -
         },
         indent=2,
     )
+
+
+def render_source_reconcile_json(root: Path, result: SourceReconcileResult) -> str:
+    return json.dumps(
+        {
+            "applied": result.applied,
+            "selector": result.selector,
+            "current_selector": result.current_selector,
+            "canonical_ref": result.canonical_ref,
+            "current_source_id": result.current.source_id,
+            "current_manifest_path": result.current_manifest_path.relative_to(root).as_posix(),
+            "active_before": [source.source_id for source in result.active_before],
+            "summary": {
+                "active_before": len(result.active_before),
+                "updates": len(result.updates),
+            },
+            "updates": [_reconcile_update_payload(root, update) for update in result.updates],
+            "next_commands": source_reconcile_next_commands(result),
+        },
+        indent=2,
+    )
+
+
+def source_reconcile_next_commands(result: SourceReconcileResult) -> list[str]:
+    if not result.applied and result.updates:
+        command = f"splendor source reconcile {shlex.quote(result.selector)}"
+        if result.current_selector is not None:
+            command += f" --current {shlex.quote(result.current_selector)}"
+        command += " --apply"
+        return [command]
+    return ["splendor lint", "splendor health"]
 
 
 def write_source_freshness_report(
@@ -1028,4 +1210,19 @@ def _source_payload(root: Path, result: SourceLookupResult) -> dict[str, object]
         "manifest_path": result.manifest_path.relative_to(root).as_posix(),
         "queue_job_id": ingest_job_id(source.source_id),
         "linked_pages": source.linked_pages,
+    }
+
+
+def _reconcile_update_payload(root: Path, update: SourceReconcileUpdate) -> dict[str, object]:
+    return {
+        "source_id": update.source.source_id,
+        "manifest_path": update.manifest_path.relative_to(root).as_posix(),
+        "before": {
+            "supersedes": update.before_supersedes,
+            "superseded_by": update.before_superseded_by,
+        },
+        "after": {
+            "supersedes": update.after_supersedes,
+            "superseded_by": update.after_superseded_by,
+        },
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ import splendor.commands.workspace as workspace_module
 from splendor import __version__
 from splendor.cli import build_parser, main
 from splendor.commands.ingest import enqueue_ingest_job
+from splendor.commands.lint import run_lint_checks
 from splendor.commands.source import ingest_changed_sources, refresh_source
 from splendor.config import load_config, write_config
 from splendor.layout import resolve_layout
@@ -36,6 +37,11 @@ def latest_report_paths(root: Path, command: str) -> tuple[Path, Path]:
     assert json_reports, f"expected JSON reports in {report_dir}"
     assert markdown_reports, f"expected Markdown reports in {report_dir}"
     return json_reports[-1], markdown_reports[-1]
+
+
+def lint_issue_codes(root: Path) -> list[str]:
+    layout = resolve_layout(root, load_config(root))
+    return [issue.code for issue in run_lint_checks(root, layout).issues]
 
 
 def test_cli_init_command(tmp_path: Path, capsys) -> None:
@@ -106,6 +112,9 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     update_path = parser.parse_args(
         ["source", "update-path", "docs/old.md", "docs/new.md", "--force", "--json"]
     )
+    reconcile = parser.parse_args(
+        ["source", "reconcile", "docs/brief.md", "--current", "src-a", "--apply", "--json"]
+    )
     freshness = parser.parse_args(
         ["source", "freshness", "--report", "reports/freshness.json", "--json"]
     )
@@ -125,6 +134,11 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     assert update_path.new_path == Path("docs/new.md")
     assert update_path.force is True
     assert update_path.json_output is True
+    assert reconcile.source_command == "reconcile"
+    assert reconcile.selector == "docs/brief.md"
+    assert reconcile.current == "src-a"
+    assert reconcile.apply is True
+    assert reconcile.json_output is True
     assert freshness.source_command == "freshness"
     assert freshness.report == Path("reports/freshness.json")
     assert freshness.json_output is True
@@ -132,6 +146,142 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     assert forget.matching == ".mypy_cache/**"
     assert forget.apply is True
     assert forget.json_output is True
+
+
+def test_cli_source_reconcile_repairs_duplicate_active_versions(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "brief.md"])
+    source_path.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "brief.md"])
+    manifest_paths = sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    before_text = {path.name: path.read_text(encoding="utf-8") for path in manifest_paths}
+    records = [load_source_record(path) for path in manifest_paths]
+    expected_current = max(records, key=lambda record: (record.added_at, record.source_id))
+    superseded_ids = sorted(
+        record.source_id for record in records if record.source_id != expected_current.source_id
+    )
+    assert "multiple-active-source-versions" in lint_issue_codes(tmp_path)
+    capsys.readouterr()
+
+    preview_code = main(["--root", str(tmp_path), "source", "reconcile", "brief.md", "--json"])
+
+    assert preview_code == 0
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["applied"] is False
+    assert preview["canonical_ref"] == "brief.md"
+    assert preview["current_source_id"] == expected_current.source_id
+    assert preview["summary"] == {"active_before": 2, "updates": 2}
+    assert preview["next_commands"] == ["splendor source reconcile brief.md --apply"]
+    assert {path.name: path.read_text(encoding="utf-8") for path in manifest_paths} == before_text
+
+    apply_code = main(["--root", str(tmp_path), "source", "reconcile", "brief.md", "--apply"])
+
+    assert apply_code == 0
+    out = capsys.readouterr().out
+    assert "Applied source reconciliation" in out
+    assert f"Current source ID: {expected_current.source_id}" in out
+    assert "Next: splendor lint" in out
+    after_records = {
+        path.stem: load_source_record(path)
+        for path in sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    }
+    assert after_records[expected_current.source_id].supersedes == superseded_ids
+    assert after_records[expected_current.source_id].superseded_by is None
+    for source_id in superseded_ids:
+        assert after_records[source_id].superseded_by == expected_current.source_id
+    assert lint_issue_codes(tmp_path) == []
+
+
+def test_cli_source_reconcile_explicit_source_id_selects_current(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "brief.md"])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    source_path.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "brief.md"])
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "source", "reconcile", original_id, "--apply", "--json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["current_source_id"] == original_id
+    records = {
+        path.stem: load_source_record(path)
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+    }
+    assert records[original_id].superseded_by is None
+    assert records[original_id].supersedes
+    assert all(
+        record.superseded_by == original_id
+        for source_id, record in records.items()
+        if source_id != original_id
+    )
+    superseded_id = next(source_id for source_id in records if source_id != original_id)
+
+    rejected_code = main(["--root", str(tmp_path), "source", "reconcile", superseded_id])
+
+    assert rejected_code == 1
+    assert "Current source version is already superseded" in capsys.readouterr().out
+
+
+def test_cli_source_reconcile_rejects_ambiguous_or_cross_canonical_current(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    first = tmp_path / "a" / "brief.md"
+    second = tmp_path / "b" / "brief.md"
+    first.write_text("# First\n", encoding="utf-8")
+    second.write_text("# Second\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "a/brief.md"])
+    main(["--root", str(tmp_path), "add-source", "b/brief.md"])
+    ids_by_ref = {
+        load_source_record(path).source_ref: path.stem
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+    }
+    capsys.readouterr()
+
+    ambiguous_code = main(["--root", str(tmp_path), "source", "reconcile", "brief"])
+
+    assert ambiguous_code == 1
+    assert "ambiguous" in capsys.readouterr().out
+
+    cross_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "source",
+            "reconcile",
+            ids_by_ref["a/brief.md"],
+            "--current",
+            ids_by_ref["b/brief.md"],
+        ]
+    )
+
+    assert cross_code == 1
+    assert "must share the selected canonical source ref" in capsys.readouterr().out
+
+
+def test_cli_source_reconcile_noops_for_single_active_source(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "brief.md"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "reconcile", "brief.md", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"] == {"active_before": 1, "updates": 0}
+    assert payload["next_commands"] == ["splendor lint", "splendor health"]
 
 
 def test_cli_source_forget_preview_is_non_mutating(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -176,6 +176,14 @@ def test_cli_source_reconcile_repairs_duplicate_active_versions(tmp_path: Path, 
     assert preview["next_commands"] == ["splendor source reconcile brief.md --apply"]
     assert {path.name: path.read_text(encoding="utf-8") for path in manifest_paths} == before_text
 
+    ambiguous_current_code = main(
+        ["--root", str(tmp_path), "source", "reconcile", "brief.md", "--current", "brief.md"]
+    )
+
+    assert ambiguous_current_code == 1
+    assert "Current source selector is ambiguous" in capsys.readouterr().out
+    assert {path.name: path.read_text(encoding="utf-8") for path in manifest_paths} == before_text
+
     apply_code = main(["--root", str(tmp_path), "source", "reconcile", "brief.md", "--apply"])
 
     assert apply_code == 0
@@ -228,6 +236,54 @@ def test_cli_source_reconcile_explicit_source_id_selects_current(tmp_path: Path,
 
     assert rejected_code == 1
     assert "Current source version is already superseded" in capsys.readouterr().out
+
+
+def test_cli_source_reconcile_repairs_partial_same_canonical_graph(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source_path = tmp_path / "brief.md"
+    source_path.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "brief.md"])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    source_path.write_text("# Brief\n\nRepo scan duplicate.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "brief.md"])
+    source_path.write_text("# Brief\n\nRefreshed repo scan duplicate.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "brief.md"])
+
+    records = {
+        path.stem: load_source_record(path)
+        for path in sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    }
+    current_id = max(
+        records.values(), key=lambda record: (record.added_at, record.source_id)
+    ).source_id
+    middle_id = next(
+        source_id for source_id in records if source_id not in {original_id, current_id}
+    )
+    middle_path = tmp_path / "state" / "manifests" / "sources" / f"{middle_id}.json"
+    current_path = tmp_path / "state" / "manifests" / "sources" / f"{current_id}.json"
+    write_source_record(
+        middle_path,
+        records[middle_id].model_copy(update={"superseded_by": current_id}),
+    )
+    write_source_record(
+        current_path,
+        records[current_id].model_copy(update={"supersedes": [middle_id]}),
+    )
+    assert "multiple-active-source-versions" in lint_issue_codes(tmp_path)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "reconcile", "brief.md", "--apply"])
+
+    assert exit_code == 0
+    after_records = {
+        path.stem: load_source_record(path)
+        for path in sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    }
+    assert after_records[original_id].superseded_by == current_id
+    assert after_records[middle_id].superseded_by == current_id
+    assert after_records[current_id].superseded_by is None
+    assert set(after_records[current_id].supersedes) == {original_id, middle_id}
+    assert lint_issue_codes(tmp_path) == []
 
 
 def test_cli_source_reconcile_rejects_ambiguous_or_cross_canonical_current(


### PR DESCRIPTION
## Summary
- add `splendor source reconcile` as a preview-first repair command for duplicate active canonical source versions
- complete bidirectional `supersedes` / `superseded_by` manifest links with deterministic current-version selection and `--current` override support
- document the M16-P1.3 recovery workflow and advance the synchronized planning state

Closes #110.

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest`
- `uv run splendor lint`

## Notes
- `repo scan --apply` behavior is intentionally unchanged in this focused repair slice.
