### PR TITLE
M16-P2.1: Fix source validation health false positives

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M16-P1.2`
-- Last action taken: `M16-P1.2` was squash-merged into main as commit `4af6523`,
-  adding the `splendor source forget` recovery command.
-- Current planned slice: `M16-P1 source hygiene and registry recovery`
-- Current PR sub-slice: `M16-P1.3`
+- Previous completed PR sub-slice: `M16-P1.3`
+- Last action taken: `M16-P1.3` was squash-merged into main as commit `752a41c`,
+  adding the `splendor source reconcile` recovery command.
+- Current planned slice: `M16-P2 validation correctness`
+- Current PR sub-slice: `M16-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P2 validation correctness`
-- Next planned PR sub-slice: `M16-P2.1`
+- Next planned PR sub-slice: `M16-P2.2`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ exists. JSON, human stdout, and Markdown reports surface missing active workspac
 `source update-path` / `source freshness` guidance, checksum drift with `source refresh`,
 `ingest --pending`, or `ingest --changed`, and queue repair diagnostics with `queue retry` or
 `repair ingest`. Unknown source provenance refs remain diagnostic-only rather than suggesting
-unsafe broad rewrites.
+unsafe broad rewrites. Run source IDs are validated against the manifest store separately from
+source content freshness, so checksum drift does not become an unknown-source provenance failure.
 
 `splendor pr-summary --since main` is a read-only PR handoff command over local git state. It uses
 the merge base between `HEAD` and the base ref for PR-style diff semantics, then summarizes curated
@@ -263,12 +264,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M16-P1.2`
-- Current planned slice: `M16-P1 source hygiene and registry recovery`
-- Current PR sub-slice: `M16-P1.3`
+- Previous completed PR sub-slice: `M16-P1.3`
+- Current planned slice: `M16-P2 validation correctness`
+- Current PR sub-slice: `M16-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P2 validation correctness`
-- Next planned PR sub-slice: `M16-P2.1`
+- Next planned PR sub-slice: `M16-P2.2`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -490,5 +491,5 @@ rewritten.
 - [x] Repo scan ignores and `.splendorignore` prevent cache/local-agent source pollution.
 - [x] `splendor source forget` provides safe single and bulk source-registry recovery.
 - [x] Duplicate canonical source versions can be reconciled without manual manifest edits.
-- [ ] Health resolves existing manifest source IDs without false unknown-source diagnostics.
+- [x] Health resolves existing manifest source IDs without false unknown-source diagnostics.
 - [ ] Lint validates live source refs after path repair and supersession.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -551,7 +551,9 @@ update-path ... <new-path>` and `splendor source freshness`; checksum drift poin
 `splendor source refresh ...`, `splendor ingest --pending`, or `splendor ingest --changed`;
 failed/dead-letter queue diagnostics and expired leases point to queue retry or ingest repair
 commands. Unknown source provenance references stay diagnostic-only and explicitly avoid a broad
-rewrite command.
+rewrite command. Run `source_ids` and provenance source links are resolved against parsed source
+manifest records separately from source content/storage health, so checksum drift or missing live
+workspace files do not make existing manifest IDs appear unknown.
 
 ## Repo scan
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M16-P1.2`
-- Current planned slice: `M16-P1 source hygiene and registry recovery`
-- Current PR sub-slice: `M16-P1.3`
+- Previous completed PR sub-slice: `M16-P1.3`
+- Current planned slice: `M16-P2 validation correctness`
+- Current PR sub-slice: `M16-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P2 validation correctness`
-- Next planned PR sub-slice: `M16-P2.1`
+- Next planned PR sub-slice: `M16-P2.2`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -997,7 +997,9 @@ to `splendor source update-path ... <new-path>` and `splendor source freshness`;
 points to `splendor source refresh ...`, `splendor ingest --pending`, or `splendor ingest
 --changed`; failed/dead-letter queue shape and expired lease diagnostics point to queue retry or
 ingest repair commands. Unknown source provenance refs remain diagnostic-only and explicitly avoid
-inventing unsafe broad repair commands.
+inventing unsafe broad repair commands. Health resolves run source IDs against parsed source
+manifest records independently from storage/content checks, so source freshness failures remain
+source diagnostics rather than false unknown-source provenance diagnostics.
 
 `M14-P1.9` addresses issue #94 as a focused identity review/disposition, not a redesign. The audit
 finds the #94 expected behavior materially covered for curated workspace-backed sources by the

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1223,7 +1223,9 @@ problem. Maintenance issues may include a `remediation_hint` in JSON, human stdo
 reports. Missing active workspace source paths point to `source update-path` plus `source
 freshness`; checksum drift points to `source refresh`, `ingest --pending`, or `ingest --changed`;
 queue failure diagnostics point to `queue retry` or `repair ingest`. Unknown source provenance
-references remain diagnostic-only until a safe provenance repair design exists.
+references remain diagnostic-only until a safe provenance repair design exists. Health checks run
+source provenance against the manifest store separately from live source content checks, so stale or
+drifted source files do not produce false unknown-source diagnostics for existing manifests.
 
 ### 22.2 LLM-assisted maintenance
 

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -228,8 +228,9 @@ def _load_source_records(
     *,
     root: Path,
     issues: list[MaintenanceIssue],
-) -> tuple[dict[str, tuple[Path, SourceRecord]], set[str], int]:
+) -> tuple[dict[str, tuple[Path, SourceRecord]], set[str], set[str], int]:
     records: dict[str, tuple[Path, SourceRecord]] = {}
+    manifest_source_ids: set[str] = set()
     invalid_ids: set[str] = set()
     checked_count = 0
 
@@ -240,6 +241,7 @@ def _load_source_records(
         source: SourceRecord | None = None
         try:
             source = load_source_record(manifest_path)
+            manifest_source_ids.add(source_id)
             _validate_storage_policy(source)
             if _should_resolve_source_content(source):
                 resolve_source_content(root, source, layout.raw_sources_dir)
@@ -293,8 +295,7 @@ def _load_source_records(
                 )
                 continue
         records[source_id] = (manifest_path, source)
-
-    return records, invalid_ids, checked_count
+    return records, manifest_source_ids, invalid_ids, checked_count
 
 
 def _load_queue_records(
@@ -666,6 +667,7 @@ def _validate_run_record(
     run_path: Path,
     run_record: RunRecord,
     source_records: dict[str, tuple[Path, SourceRecord]],
+    manifest_source_ids: set[str],
     wiki_pages: dict[str, tuple[Path, KnowledgePageFrontmatter]],
     run_records: dict[str, tuple[Path, RunRecord]],
     task_records: dict[str, Path],
@@ -761,9 +763,11 @@ def _validate_run_record(
                 check_name="run-state",
             )
 
+    reported_missing_source_ids: set[str] = set()
     for source_id in run_record.source_ids:
-        if source_id in source_records:
+        if source_id in manifest_source_ids or source_id in reported_missing_source_ids:
             continue
+        reported_missing_source_ids.add(source_id)
         _append_issue(
             issues,
             code="missing-run-source-id",
@@ -817,17 +821,20 @@ def _validate_run_record(
                 check_name="run-provenance",
             )
 
+    reported_missing_source_refs: set[str] = set()
     for link in run_record.provenance_links:
-        if link.source_id is not None and link.source_id not in source_records:
-            _append_issue(
-                issues,
-                code="missing-run-provenance-source-ref",
-                message=f"Run provenance references unknown source: {link.source_id}",
-                path=run_relpath,
-                record_id=canonical_run_id,
-                check_name="run-provenance",
-                remediation_hint=_unknown_provenance_hint(),
-            )
+        if link.source_id is not None and link.source_id not in manifest_source_ids:
+            if link.source_id not in reported_missing_source_refs:
+                reported_missing_source_refs.add(link.source_id)
+                _append_issue(
+                    issues,
+                    code="missing-run-provenance-source-ref",
+                    message=f"Run provenance references unknown source: {link.source_id}",
+                    path=run_relpath,
+                    record_id=canonical_run_id,
+                    check_name="run-provenance",
+                    remediation_hint=_unknown_provenance_hint(),
+                )
         if link.page_id is not None and link.page_id not in wiki_pages:
             if not _is_expected_pruned_source_summary_page_id(
                 link.page_id, run_record, source_records
@@ -1119,14 +1126,17 @@ def run_health_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckRes
         issues=issues,
         check_name="workspace-layout",
     ):
-        source_records, invalid_source_ids, loaded_sources = _load_source_records(
-            layout,
-            root=root,
-            issues=issues,
+        source_records, manifest_source_ids, invalid_source_ids, loaded_sources = (
+            _load_source_records(
+                layout,
+                root=root,
+                issues=issues,
+            )
         )
         checked_count += loaded_sources
     else:
         source_records = {}
+        manifest_source_ids = set()
         invalid_source_ids = set()
         checked_count += 1
 
@@ -1195,6 +1205,7 @@ def run_health_checks(root: Path, layout: ResolvedLayout) -> MaintenanceCheckRes
             run_path=run_path,
             run_record=run_record,
             source_records=source_records,
+            manifest_source_ids=manifest_source_ids,
             wiki_pages=wiki_pages,
             run_records=run_records,
             task_records=task_records,

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -939,7 +939,10 @@ def test_run_health_checks_hints_unknown_source_refs_without_unsafe_repair(
             errors=["source disappeared"],
             pipeline_version=__version__,
             source_ids=["src-missing"],
-            provenance_links=[ProvenanceLink(source_id="src-missing", role="input")],
+            provenance_links=[
+                ProvenanceLink(source_id="src-missing", role="input"),
+                ProvenanceLink(source_id="src-missing", role="input"),
+            ],
         ),
     )
 
@@ -956,6 +959,74 @@ def test_run_health_checks_hints_unknown_source_refs_without_unsafe_repair(
     assert all(
         "source update-path" not in (issue.remediation_hint or "") for issue in result.issues
     )
+
+
+def test_run_health_checks_resolves_run_sources_against_manifest_store_when_source_drifted(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    source.write_text("# Brief\n\nChanged after registration.\n", encoding="utf-8")
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    write_run_record(
+        layout.runs_dir / "run-drifted-source.json",
+        RunRecord(
+            run_id="run-drifted-source",
+            job_id=f"ingest-{added.source_id}",
+            job_type="ingest_source",
+            started_at="2026-04-20T09:00:00+00:00",
+            finished_at="2026-04-20T09:05:00+00:00",
+            status="failed",
+            input_refs=[],
+            errors=["source drifted"],
+            pipeline_version=__version__,
+            source_ids=[added.source_id],
+            provenance_links=[
+                ProvenanceLink(source_id=added.source_id, role="input"),
+                ProvenanceLink(source_id=added.source_id, role="input"),
+            ],
+        ),
+    )
+
+    result = _run_health(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["source-health-check-failed"]
+    assert "checksum mismatch for ingestion" in result.issues[0].message
+
+
+def test_run_health_checks_accepts_repeated_run_source_provenance_when_manifest_exists(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    write_run_record(
+        layout.runs_dir / "run-existing-source.json",
+        RunRecord(
+            run_id="run-existing-source",
+            job_id=f"ingest-{added.source_id}",
+            job_type="ingest_source",
+            started_at="2026-04-20T09:00:00+00:00",
+            finished_at="2026-04-20T09:05:00+00:00",
+            status="failed",
+            input_refs=[],
+            errors=["representative failed run"],
+            pipeline_version=__version__,
+            source_ids=[added.source_id],
+            provenance_links=[
+                ProvenanceLink(source_id=added.source_id, role="input"),
+                ProvenanceLink(source_id=added.source_id, role="input"),
+            ],
+        ),
+    )
+
+    result = _run_health(tmp_path)
+
+    assert result.issues == []
 
 
 def test_run_health_checks_does_not_repeat_generic_hint_for_missing_page_refs(


### PR DESCRIPTION
## Summary
- resolve run `source_ids` and run provenance source links against parsed source manifest records even when source content/storage health fails separately
- deduplicate repeated missing run provenance source diagnostics per run/source ID
- update M16-P2.1 planning/docs state and mark the v0.3 recovery readiness health item complete

Closes #112.

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest`
- `uv run splendor lint`
- `uv run splendor health`
- `shasum -a 256 /Users/shaypalachy/archive/splendor-fixtures/splendor-fixture-2026-05-05.tar.gz` -> `8b2fea5e3cd04c99d52d79398347ff7a38b41a30c410a3a1ab1985fbe63b162c`

## Boundaries
- No schema changes.
- No source registration, source resolver, lint live-path, or repair-command behavior changes.
- The preserved SynthBanshee fixture remains external and is not committed.
