### PR TITLE
M16-P2.2: Align lint path checks with live source refs

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M16-P1.3`
-- Last action taken: `M16-P1.3` was squash-merged into main as commit `752a41c`,
-  adding the `splendor source reconcile` recovery command.
+- Previous completed PR sub-slice: `M16-P2.1`
+- Last action taken: `M16-P2.1` was squash-merged into main as commit `9075401`,
+  fixing source validation health false positives.
 - Current planned slice: `M16-P2 validation correctness`
-- Current PR sub-slice: `M16-P2.1`
+- Current PR sub-slice: `M16-P2.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M16-P2 validation correctness`
-- Next planned PR sub-slice: `M16-P2.2`
+- Next planned slice: `M16-P3 workflow polish and trial-install polish`
+- Next planned PR sub-slice: `M16-P3.1`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -264,12 +264,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M16-P1.3`
+- Previous completed PR sub-slice: `M16-P2.1`
 - Current planned slice: `M16-P2 validation correctness`
-- Current PR sub-slice: `M16-P2.1`
+- Current PR sub-slice: `M16-P2.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M16-P2 validation correctness`
-- Next planned PR sub-slice: `M16-P2.2`
+- Next planned slice: `M16-P3 workflow polish and trial-install polish`
+- Next planned PR sub-slice: `M16-P3.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -492,4 +492,4 @@ rewritten.
 - [x] `splendor source forget` provides safe single and bulk source-registry recovery.
 - [x] Duplicate canonical source versions can be reconciled without manual manifest edits.
 - [x] Health resolves existing manifest source IDs without false unknown-source diagnostics.
-- [ ] Lint validates live source refs after path repair and supersession.
+- [x] Lint validates live source refs after path repair and supersession.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M16-P1.3`
+- Previous completed PR sub-slice: `M16-P2.1`
 - Current planned slice: `M16-P2 validation correctness`
-- Current PR sub-slice: `M16-P2.1`
+- Current PR sub-slice: `M16-P2.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M16-P2 validation correctness`
-- Next planned PR sub-slice: `M16-P2.2`
+- Next planned slice: `M16-P3 workflow polish and trial-install polish`
+- Next planned PR sub-slice: `M16-P3.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -420,8 +420,9 @@ def _run_reference_integrity_checks(
     for manifest in inventory.source_manifests:
         if manifest.record is None:
             continue
-        checked_count += 1 + len(manifest.record.aliases)
+        checked_count += 2 + len(manifest.record.aliases)
         issues.extend(_source_identity_issues(root, manifest, source_refs_by_identity))
+        issues.extend(_source_live_path_issues(root, manifest))
         checked_count += len(manifest.record.supersedes) + (
             1 if manifest.record.superseded_by is not None else 0
         )
@@ -440,6 +441,7 @@ def _run_reference_integrity_checks(
                 valid_source_ids=valid_source_ids,
                 valid_page_ids=valid_page_ids,
                 check_name="source-provenance",
+                require_existing_paths=False,
             )
         )
 
@@ -520,6 +522,51 @@ def _source_identity_issues(
             )
         )
     return issues
+
+
+def _source_live_path_issues(root: Path, manifest: _SourceInventory) -> list[MaintenanceIssue]:
+    if manifest.record is None:
+        return []
+    source = manifest.record
+    if source.superseded_by is not None or source.source_ref_kind != "workspace_path":
+        return []
+
+    manifest_relpath = workspace_relative_path(root, manifest.manifest_path)
+    live_ref = source.source_ref or source.path
+    if not live_ref:
+        return [
+            MaintenanceIssue(
+                code="missing-source-live-path",
+                message="Workspace source manifest is missing a live source_ref.",
+                path=manifest_relpath,
+                record_id=source.source_id,
+                check_name="source-live-path",
+            )
+        ]
+
+    try:
+        resolved = resolve_workspace_path(root, live_ref, context="Workspace source")
+    except ValueError as exc:
+        return [
+            MaintenanceIssue(
+                code="invalid-source-live-path",
+                message=str(exc),
+                path=manifest_relpath,
+                record_id=source.source_id,
+                check_name="source-live-path",
+            )
+        ]
+    if resolved.is_file():
+        return []
+    return [
+        MaintenanceIssue(
+            code="missing-source-live-path",
+            message=f"Workspace source live path does not exist: {live_ref}",
+            path=manifest_relpath,
+            record_id=source.source_id,
+            check_name="source-live-path",
+        )
+    ]
 
 
 def _source_lifecycle_issues(
@@ -1295,6 +1342,7 @@ def _provenance_link_issues(
     valid_source_ids: set[str],
     valid_page_ids: set[str],
     check_name: str,
+    require_existing_paths: bool = True,
 ) -> list[MaintenanceIssue]:
     issues: list[MaintenanceIssue] = []
     for link in links:
@@ -1332,6 +1380,8 @@ def _provenance_link_issues(
                     check_name=check_name,
                 )
             )
+            continue
+        if not require_existing_paths:
             continue
         if not resolved.exists():
             issues.append(

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -441,7 +441,9 @@ def _run_reference_integrity_checks(
                 valid_source_ids=valid_source_ids,
                 valid_page_ids=valid_page_ids,
                 check_name="source-provenance",
-                require_existing_paths=False,
+                missing_path_is_allowed=lambda link, source=manifest.record: (
+                    _is_historical_source_input_path(source, link)
+                ),
             )
         )
 
@@ -532,8 +534,7 @@ def _source_live_path_issues(root: Path, manifest: _SourceInventory) -> list[Mai
         return []
 
     manifest_relpath = workspace_relative_path(root, manifest.manifest_path)
-    live_ref = source.source_ref or source.path
-    if not live_ref:
+    if not source.source_ref:
         return [
             MaintenanceIssue(
                 code="missing-source-live-path",
@@ -545,7 +546,7 @@ def _source_live_path_issues(root: Path, manifest: _SourceInventory) -> list[Mai
         ]
 
     try:
-        resolved = resolve_workspace_path(root, live_ref, context="Workspace source")
+        resolved = resolve_workspace_path(root, source.source_ref, context="Workspace source")
     except ValueError as exc:
         return [
             MaintenanceIssue(
@@ -561,12 +562,22 @@ def _source_live_path_issues(root: Path, manifest: _SourceInventory) -> list[Mai
     return [
         MaintenanceIssue(
             code="missing-source-live-path",
-            message=f"Workspace source live path does not exist: {live_ref}",
+            message=f"Workspace source live path does not exist: {source.source_ref}",
             path=manifest_relpath,
             record_id=source.source_id,
             check_name="source-live-path",
         )
     ]
+
+
+def _is_historical_source_input_path(source: SourceRecord, link) -> bool:
+    if link.role != "input" or link.path_ref is None:
+        return False
+    if source.source_ref_kind != "workspace_path":
+        return False
+    if source.superseded_by is not None:
+        return True
+    return source.source_ref is not None and link.path_ref != source.source_ref
 
 
 def _source_lifecycle_issues(
@@ -1342,7 +1353,7 @@ def _provenance_link_issues(
     valid_source_ids: set[str],
     valid_page_ids: set[str],
     check_name: str,
-    require_existing_paths: bool = True,
+    missing_path_is_allowed=None,
 ) -> list[MaintenanceIssue]:
     issues: list[MaintenanceIssue] = []
     for link in links:
@@ -1381,9 +1392,9 @@ def _provenance_link_issues(
                 )
             )
             continue
-        if not require_existing_paths:
-            continue
         if not resolved.exists():
+            if missing_path_is_allowed is not None and missing_path_is_allowed(link):
+                continue
             issues.append(
                 MaintenanceIssue(
                     code="missing-provenance-path",

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -9,6 +9,7 @@ from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.lint import run_lint_checks
 from splendor.commands.planning import create_task
+from splendor.commands.source import update_source_path
 from splendor.config import AuthorityDocumentConfig, load_config, write_config
 from splendor.layout import resolve_layout
 from splendor.schemas import (
@@ -280,6 +281,47 @@ def test_run_lint_checks_accepts_ocr_derived_artifact_links(tmp_path: Path) -> N
     result = _run_lint(tmp_path)
 
     assert result.issues == []
+
+
+def test_run_lint_checks_uses_live_source_ref_after_path_update(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    docs = tmp_path / "docs"
+    moved = tmp_path / "moved"
+    docs.mkdir()
+    moved.mkdir()
+    old_source = docs / "brief.md"
+    new_source = moved / "brief.md"
+    old_source.write_text("# Brief\n\nSame bytes.\n", encoding="utf-8")
+    added = add_source(tmp_path, old_source)
+    manifest = load_source_record(added.manifest_path).model_copy(
+        update={"provenance_links": [ProvenanceLink(path_ref="docs/brief.md", role="input")]}
+    )
+    write_source_record(added.manifest_path, manifest)
+    old_source.rename(new_source)
+
+    update_source_path(tmp_path, "docs/brief.md", Path("moved/brief.md"))
+    result = _run_lint(tmp_path)
+
+    source_path_issues = {
+        issue.code
+        for issue in result.issues
+        if issue.code in {"missing-provenance-path", "missing-source-live-path"}
+    }
+    assert source_path_issues == set()
+
+
+def test_run_lint_checks_reports_missing_active_source_ref(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    source.unlink()
+
+    result = _run_lint(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["missing-source-live-path"]
+    assert result.issues[0].message == "Workspace source live path does not exist: brief.md"
+    assert result.issues[0].path == added.manifest_path.relative_to(tmp_path).as_posix()
 
 
 def test_run_lint_checks_validates_source_supersession_refs(tmp_path: Path) -> None:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -324,6 +324,22 @@ def test_run_lint_checks_reports_missing_active_source_ref(tmp_path: Path) -> No
     assert result.issues[0].path == added.manifest_path.relative_to(tmp_path).as_posix()
 
 
+def test_run_lint_checks_requires_source_ref_for_workspace_sources(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello world\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    manifest = load_source_record(added.manifest_path).model_copy(
+        update={"source_ref": None, "path": "brief.md"}
+    )
+    write_source_record(added.manifest_path, manifest)
+
+    result = _run_lint(tmp_path)
+
+    assert [issue.code for issue in result.issues] == ["missing-source-live-path"]
+    assert result.issues[0].message == "Workspace source manifest is missing a live source_ref."
+
+
 def test_run_lint_checks_validates_source_supersession_refs(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "brief.md"
@@ -605,6 +621,7 @@ def test_run_lint_checks_reports_broken_provenance_refs_and_paths(tmp_path: Path
         update={
             "provenance_links": [
                 ProvenanceLink(page_id="missing-page", role="generated-page"),
+                ProvenanceLink(path_ref="wiki/sources/missing.md", role="generated-page"),
                 ProvenanceLink(path_ref="../outside.md", role="input"),
             ]
         }
@@ -633,6 +650,7 @@ def test_run_lint_checks_reports_broken_provenance_refs_and_paths(tmp_path: Path
         or issue.code.startswith("invalid-provenance")
         or issue.code.startswith("source-summary")
     } == {
+        "missing-provenance-path",
         "missing-provenance-page-ref",
         "invalid-provenance-path-ref",
         "source-summary-source-ref-mismatch",


### PR DESCRIPTION
## Summary
- add a source-manifest lint check that validates active workspace-backed live paths from the current `source_ref`/live path fields
- stop treating source-manifest provenance `path_ref` values as required live filesystem paths after intentional `source update-path` repair
- update M16 planning state and the v0.3 recovery readiness checklist for M16-P2.2

## Validation
- `uv run pytest tests/test_lint.py tests/test_cli.py tests/test_health.py tests/test_source_resolver.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run splendor lint`

Closes #113.