### PR TITLE
M16-P3.1: Loosen workspace maintenance flag coupling

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M16-P2.1`
-- Last action taken: `M16-P2.1` was squash-merged into main as commit `9075401`,
-  fixing source validation health false positives.
-- Current planned slice: `M16-P2 validation correctness`
-- Current PR sub-slice: `M16-P2.2`
+- Previous completed PR sub-slice: `M16-P2.2`
+- Last action taken: `M16-P2.2` was squash-merged into main as commit `1fd85fe`,
+  aligning lint path checks with live source refs.
+- Current planned slice: `M16-P3 workflow polish and trial-install polish`
+- Current PR sub-slice: `M16-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P3 workflow polish and trial-install polish`
-- Next planned PR sub-slice: `M16-P3.1`
+- Next planned PR sub-slice: `M16-P3.2`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Implemented today:
   `splendor source update-path <source-id|logical-id|title|path> <new-path>`
 - `splendor source forget <source-id|logical-id|title|path>` and
   `splendor source forget --matching "glob"` for preview-first registry cleanup
-- `splendor workspace refresh --changed` with optional `--ingest`, `--rebuild-index`,
-  `--prune-superseded`, and `--update-topic-refs`
+- `splendor workspace refresh --changed` with optional `--ingest`, plus standalone or combined
+  `--rebuild-index`, `--prune-superseded`, and `--update-topic-refs`
 - `splendor ingest <source-id>`, `splendor ingest --pending`, and `splendor ingest --changed`
 - `splendor queue inspect [job-id]` and `splendor queue retry <job-id>`
 - `splendor repair ingest <source-id>`
@@ -161,19 +161,16 @@ the same preview for machine handoff, and `--report PATH` writes only an explici
 Relative report paths use the current working directory.
 `splendor workspace refresh --changed` composes that freshness view with the existing
 supersession-aware refresh path for changed curated workspace-backed sources. Add `--ingest` to
-ingest only queue jobs created or reused for the refreshed sources, and add `--rebuild-index` to
-regenerate `wiki/index.md` after that targeted ingest succeeds. JSON output reports both initial
-and final freshness counts, skipped unresolved curated sources, and failed changed-source refreshes.
-Missing, unsupported, or refresh-failed active curated sources are reported as unresolved
-diagnostics while valid changed sources still refresh; the command exits non-zero when those
-unresolved sources remain. Add `--prune-superseded` to delete superseded generated
-`wiki/sources/<source-id>.md` summaries once a current successor summary exists, while keeping
-historical source manifests and run records. Add
-`--update-topic-refs` to rewrite maintained wiki page `source_refs` and generated source-reference
-list bullets from superseded source IDs to the active source version ID. Prune JSON reports skipped
-unsafe candidates with reasons rather than deleting ambiguous state. The command does not discover
-or register uncurated files or mutate maintained synthesis content beyond that explicit source-ref
-migration.
+ingest only queue jobs created or reused for the refreshed sources; unrelated pending ingest jobs
+remain queued. `--rebuild-index`, `--prune-superseded`, and `--update-topic-refs` can run
+standalone or in the same maintenance invocation. A one-pass changed-source cleanup can use
+`workspace refresh --changed --ingest --prune-superseded --update-topic-refs --rebuild-index`;
+pruning still reports skipped candidates when successor source-summary pages do not exist yet, so
+interrupted workflows can rerun `workspace refresh --prune-superseded` after successors are
+ingested. JSON output reports both initial and final freshness counts, skipped unresolved curated
+sources, failed changed-source refreshes, targeted ingest results, index rebuilds, pruning, and
+topic-ref migrations. The command does not discover or register uncurated files or mutate
+maintained synthesis content beyond explicit source-ref migration.
 `splendor source update-path <source-id|logical-id|title|path> <new-path>` is the explicit repair
 path for moved active curated workspace sources. By default it requires the old workspace path to
 be missing; `--force` is available for deliberate reparenting while the old file still exists. It
@@ -264,12 +261,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M16-P2.1`
-- Current planned slice: `M16-P2 validation correctness`
-- Current PR sub-slice: `M16-P2.2`
+- Previous completed PR sub-slice: `M16-P2.2`
+- Current planned slice: `M16-P3 workflow polish and trial-install polish`
+- Current PR sub-slice: `M16-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P3 workflow polish and trial-install polish`
-- Next planned PR sub-slice: `M16-P3.1`
+- Next planned PR sub-slice: `M16-P3.2`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -398,6 +395,10 @@ exists, and `--update-topic-refs` migrates maintained wiki source references to 
 content-addressed source version while schema version `1` continues to validate `source_refs`
 against source manifests. Historical manifests and run records remain valid.
 
+`M16-P3.1` loosens workspace maintenance flag coupling: index rebuilds, superseded-summary
+pruning, and topic-ref migration can run without pretending source bytes changed, while
+`--changed --ingest` remains a targeted drain of only refreshed-source ingest jobs.
+
 `M14-P1.5` adds the explicit stale-ingest repair path for issue #93:
 `splendor ingest --changed` detects checksum-drifted curated workspace-backed sources, refreshes
 them into current canonical source versions, and ingests only those refreshed queue jobs even when
@@ -493,3 +494,4 @@ rewritten.
 - [x] Duplicate canonical source versions can be reconciled without manual manifest edits.
 - [x] Health resolves existing manifest source IDs without false unknown-source diagnostics.
 - [x] Lint validates live source refs after path repair and supersession.
+- [x] Workspace maintenance actions can run without unnecessary changed-source coupling.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -240,8 +240,14 @@ is the artifact being reviewed.
 
 `source refresh` creates a new canonical content-addressed source version when bytes change.
 Workspace-backed sources keep stable logical IDs, and `workspace refresh --changed` can combine
-changed-source refresh, targeted ingest, index rebuild, superseded generated-summary pruning, and
-maintained-page topic-ref migration through explicit flags.
+changed-source refresh with targeted ingest. `--changed --ingest` drains only queue jobs created or
+reused for refreshed sources, leaving unrelated pending jobs alone. Index rebuilds, superseded
+generated-summary pruning, and maintained-page topic-ref migration can run standalone with
+`workspace refresh --rebuild-index`, `workspace refresh --prune-superseded`, or
+`workspace refresh --update-topic-refs`, or in one pass with
+`workspace refresh --changed --ingest --prune-superseded --update-topic-refs --rebuild-index`.
+If pruning runs before successor source-summary pages exist, rerun
+`workspace refresh --prune-superseded` after the refreshed sources are ingested.
 
 ## 5. Add a planning record
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -237,10 +237,13 @@ Implemented fields:
   records created or reused for successful refreshed sources with `--ingest`. The command exits
   non-zero when unresolved skipped sources, failed source refreshes, or targeted ingest failures
   remain, while preserving successful refresh and ingest work.
-- `splendor workspace refresh --changed --ingest --rebuild-index` rebuilds `wiki/index.md` only
-  after the targeted refreshed-source ingest succeeds. JSON output reports both initial and final
-  freshness counts plus skipped-source and failed-refresh diagnostics. `--prune-superseded` deletes
-  superseded generated source-summary pages after a current successor summary exists, removes the pruned
+- `splendor workspace refresh --rebuild-index` rebuilds `wiki/index.md` as standalone maintenance
+  or after any requested changed-source refresh, targeted ingest, pruning, or topic-ref migration.
+  `--changed --ingest` drains only refreshed-source queue records, not unrelated pending ingest
+  jobs. JSON output reports both initial and final freshness counts plus skipped-source,
+  failed-refresh, targeted-ingest, index, pruning, and topic-ref migration diagnostics.
+  `--prune-superseded` deletes superseded generated source-summary pages after a current successor
+  summary exists, removes the pruned
   generated-page link from the superseded source manifest, and preserves historical source
   manifests and run records. Health treats run page refs for those exact pruned superseded
   workspace summaries as valid historical provenance without exempting unrelated broken run refs.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M16-P2.1`
-- Current planned slice: `M16-P2 validation correctness`
-- Current PR sub-slice: `M16-P2.2`
+- Previous completed PR sub-slice: `M16-P2.2`
+- Current planned slice: `M16-P3 workflow polish and trial-install polish`
+- Current PR sub-slice: `M16-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P3 workflow polish and trial-install polish`
-- Next planned PR sub-slice: `M16-P3.1`
+- Next planned PR sub-slice: `M16-P3.2`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -822,12 +822,15 @@ Current implementation:
 - `splendor workspace refresh --changed` safely refreshes only changed curated workspace-backed
   sources by composing `source freshness` with the supersession-aware `source refresh` path. It
   reports missing or unsupported active curated workspace sources as skipped unresolved diagnostics,
-  records per-source refresh failures without aborting the whole command, can ingest only refreshed
-  sources' queue jobs with `--ingest`, and can rebuild `wiki/index.md` after successful targeted
-  ingest with `--rebuild-index`. Valid changed sources still refresh and ingest even when unrelated
-  curated sources are unresolved; the command exits non-zero while skipped sources, failed refreshes,
-  or targeted ingest failures remain. JSON output reports both initial and final freshness counts
-  plus skipped-source and failed-refresh diagnostics.
+  records per-source refresh failures without aborting the whole command, and can ingest only
+  refreshed sources' queue jobs with `--ingest`. Valid changed sources still refresh and ingest
+  even when unrelated curated sources are unresolved; the command exits non-zero while skipped
+  sources, failed refreshes, or targeted ingest failures remain. JSON output reports both initial
+  and final freshness counts plus skipped-source and failed-refresh diagnostics.
+  `--rebuild-index`, `--prune-superseded`, and `--update-topic-refs` can run standalone or in the
+  same invocation as changed-source refresh. A one-pass cleanup can run
+  `workspace refresh --changed --ingest --prune-superseded --update-topic-refs --rebuild-index`,
+  while pruning can be rerun after refreshed successor summaries are ingested.
   `--prune-superseded` deletes old generated source-summary pages only after a current successor
   summary exists, removes stale generated-page links from the superseded source manifest, and keeps
   historical source manifests and run records valid. Unsafe prune candidates are reported with

--- a/docs/v0_2_synthbanshee_evaluation.md
+++ b/docs/v0_2_synthbanshee_evaluation.md
@@ -91,8 +91,10 @@ v0.3 items land:
 4. Lint reads the live source model correctly after source refresh and path repair.
 5. Health resolves source IDs against the manifest store without false unknown-source errors.
 
-Lower-priority v0.3 polish includes standalone workspace maintenance actions, JSON output for
-pending ingest drains, and easier release artifacts for trial installs.
+M16-P3 polish covers standalone workspace maintenance actions, JSON output for pending ingest
+drains, and easier release artifacts for trial installs. M16-P3.1 specifically removes the need to
+pair idempotent index rebuilds, superseded-summary pruning, and topic-ref migration with
+changed-source refresh.
 
 ## Public Mock Client Acceptance Workflows
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -1764,7 +1764,7 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
         f"unsupported={result.initial_freshness.unsupported} "
         f"historical={result.initial_freshness.historical}"
     )
-    if not result.refreshed:
+    if args.changed and not result.refreshed:
         print("No changed curated workspace-backed sources were refreshed.")
     if result.skipped_sources:
         print("Skipped unresolved curated workspace sources:")
@@ -1842,8 +1842,11 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
         print("Workspace refresh completed with unresolved curated sources.")
         print("Next: splendor source freshness")
         return 1
-    if result.index is None and result.ingest is None and result.refreshed:
-        print("Next: splendor ingest --pending")
+    if result.ingest is None and result.refreshed:
+        if result.index is not None:
+            print("Next: splendor ingest --pending, then splendor wiki rebuild-index")
+        else:
+            print("Next: splendor ingest --pending")
     elif result.index is None and result.ingest is not None and result.ingest.succeeded:
         print("Next: splendor wiki rebuild-index")
     else:

--- a/src/splendor/commands/workspace.py
+++ b/src/splendor/commands/workspace.py
@@ -93,32 +93,28 @@ def refresh_workspace(
     prune_superseded: bool = False,
     update_topic_refs: bool = False,
 ) -> WorkspaceRefreshResult:
-    if not changed:
-        msg = "workspace refresh requires --changed in this release"
+    if ingest and not changed:
+        msg = "workspace refresh --ingest requires --changed"
         raise ValueError(msg)
-    if rebuild_index and not ingest:
-        msg = "workspace refresh --rebuild-index requires --ingest"
+    if not any([changed, rebuild_index, prune_superseded, update_topic_refs]):
+        msg = (
+            "workspace refresh requires at least one maintenance action: "
+            "--changed, --rebuild-index, --prune-superseded, or --update-topic-refs"
+        )
         raise ValueError(msg)
 
     initial_freshness = scan_source_freshness(root)
     skipped_sources = _unresolved_active_workspace_sources(initial_freshness)
-    changed_items = [item for item in initial_freshness.sources if item.status == "changed"]
+    changed_items = (
+        [item for item in initial_freshness.sources if item.status == "changed"] if changed else []
+    )
     refreshed, failed_sources = _refresh_changed_items(root, changed_items)
 
     ingest_result = _drain_refreshed_ingest_jobs(root, refreshed) if ingest else None
-    index_result = None
-    if rebuild_index and (ingest_result is None or ingest_result.failed == 0):
-        index_result = rebuild_wiki_index(root)
     topic_ref_migration_result = migrate_superseded_topic_refs(root) if update_topic_refs else None
     pruning_result = prune_superseded_source_summaries(root) if prune_superseded else None
-    if rebuild_index and (
-        (pruning_result is not None and pruning_result.pruned)
-        or (
-            topic_ref_migration_result is not None
-            and topic_ref_migration_result.updated
-            and index_result is None
-        )
-    ):
+    index_result = None
+    if rebuild_index and (ingest_result is None or ingest_result.failed == 0):
         index_result = rebuild_wiki_index(root)
     final_freshness = scan_source_freshness(root)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2031,26 +2031,40 @@ def test_cli_source_freshness_relative_report_uses_current_working_directory(
     assert not (root / "reports" / "source-freshness.json").exists()
 
 
-def test_cli_workspace_refresh_requires_explicit_changed_flag(tmp_path: Path, capsys) -> None:
+def test_cli_workspace_refresh_requires_maintenance_action(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     capsys.readouterr()
 
     exit_code = main(["--root", str(tmp_path), "workspace", "refresh"])
 
     assert exit_code == 1
-    assert "Error: workspace refresh requires --changed in this release" in capsys.readouterr().out
+    assert "Error: workspace refresh requires at least one maintenance action" in (
+        capsys.readouterr().out
+    )
 
 
-def test_cli_workspace_refresh_rebuild_index_requires_ingest(tmp_path: Path, capsys) -> None:
+def test_cli_workspace_refresh_ingest_requires_changed(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     capsys.readouterr()
 
-    exit_code = main(
-        ["--root", str(tmp_path), "workspace", "refresh", "--changed", "--rebuild-index"]
-    )
+    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--ingest"])
 
     assert exit_code == 1
-    assert "Error: workspace refresh --rebuild-index requires --ingest" in capsys.readouterr().out
+    assert "Error: workspace refresh --ingest requires --changed" in capsys.readouterr().out
+
+
+def test_cli_workspace_refresh_rebuilds_index_standalone(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--rebuild-index", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["refreshed"] == []
+    assert payload["ingest"] is None
+    assert payload["index"]["path"] == "wiki/index.md"
+    assert payload["index"]["page_count"] == 0
 
 
 def test_cli_workspace_refresh_changed_ingests_and_rebuilds_index(tmp_path: Path, capsys) -> None:
@@ -2096,6 +2110,85 @@ def test_cli_workspace_refresh_changed_ingests_and_rebuilds_index(tmp_path: Path
 
     assert main(["--root", str(tmp_path), "lint"]) == 0
     assert main(["--root", str(tmp_path), "health"]) == 0
+
+
+def test_cli_workspace_refresh_prunes_superseded_summaries_standalone(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    write_config(tmp_path, config)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "workspace",
+            "refresh",
+            "--changed",
+            "--ingest",
+            "--rebuild-index",
+        ]
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "workspace",
+            "refresh",
+            "--prune-superseded",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    refreshed_id = payload["pruning"]["pruned"][0]["superseded_by"]
+    assert payload["refreshed"] == []
+    assert payload["ingest"] is None
+    assert payload["pruning"]["pruned"] == [
+        {
+            "path": f"wiki/sources/{original_id}.md",
+            "source_id": original_id,
+            "superseded_by": refreshed_id,
+            "manifest_path": f"state/manifests/sources/{original_id}.json",
+        }
+    ]
+    assert not (tmp_path / "wiki" / "sources" / f"{original_id}.md").exists()
+    original_manifest = load_source_record(
+        tmp_path / "state" / "manifests" / "sources" / f"{original_id}.json"
+    )
+    assert f"wiki/sources/{original_id}.md" not in original_manifest.linked_pages
+
+
+def test_cli_workspace_refresh_changed_rebuilds_index_without_ingest(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    main(["--root", str(tmp_path), "ingest", "--pending"])
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "workspace", "refresh", "--changed", "--rebuild-index"]
+    )
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Rebuilt index: " in out
+    assert "Next: splendor ingest --pending, then splendor wiki rebuild-index" in out
+    assert list((tmp_path / "state" / "queue").glob("ingest-*.json"))
 
 
 def test_cli_workspace_refresh_prunes_superseded_summaries_and_updates_topic_refs(
@@ -2221,7 +2314,6 @@ def test_cli_workspace_refresh_reports_skipped_superseded_prune_candidates(
             str(tmp_path),
             "workspace",
             "refresh",
-            "--changed",
             "--prune-superseded",
             "--json",
         ]


### PR DESCRIPTION
## Summary

Implements `M16-P3.1` under the Milestone 16 workflow-polish track.

- Loosens `splendor workspace refresh` so index rebuilds, superseded-summary pruning, and topic-ref migration can run as standalone maintenance actions without `--changed`.
- Keeps `--ingest` intentionally coupled to `--changed`, so `workspace refresh --changed --ingest` drains only queue jobs created or reused for refreshed sources.
- Updates human/JSON workflow docs, CLI coverage, and planning state for the M16-P3.1 handoff.

## Validation

- `uv run pytest tests/test_cli.py`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run pytest`

Closes #121.