### PR TITLE
M16-P3.2: Add JSON output for pending ingest drains

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M16-P2.2`
-- Last action taken: `M16-P2.2` was squash-merged into main as commit `1fd85fe`,
-  aligning lint path checks with live source refs.
+- Previous completed PR sub-slice: `M16-P3.1`
+- Last action taken: `M16-P3.1` was squash-merged into main as commit `6a8d374`,
+  loosening workspace maintenance flag coupling.
 - Current planned slice: `M16-P3 workflow polish and trial-install polish`
-- Current PR sub-slice: `M16-P3.1`
+- Current PR sub-slice: `M16-P3.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P3 workflow polish and trial-install polish`
-- Next planned PR sub-slice: `M16-P3.2`
+- Next planned PR sub-slice: `M16-P3.3`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ provided, and reports the manifest lifecycle edits needed to complete one-way or
 active versions as superseded by the selected current version. Cross-canonical selections and
 ambiguous `--current` selectors are rejected without rewriting manifests.
 
+`splendor ingest --pending --json` emits machine-readable pending-drain results with queue totals,
+processed/succeeded/failed/skipped counts, per-item outcomes, and deterministic next actions so
+agents do not need to parse human queue-drain text.
+
 `splendor ingest --changed` is the narrower stale-ingest repair path for checksum-drifted curated
 workspace-backed sources when old ingest queue records are already `done`. It refreshes changed
 source versions through the same supersession-aware source lifecycle, ingests only those refreshed
@@ -261,12 +265,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M16-P2.2`
+- Previous completed PR sub-slice: `M16-P3.1`
 - Current planned slice: `M16-P3 workflow polish and trial-install polish`
-- Current PR sub-slice: `M16-P3.1`
+- Current PR sub-slice: `M16-P3.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P3 workflow polish and trial-install polish`
-- Next planned PR sub-slice: `M16-P3.2`
+- Next planned PR sub-slice: `M16-P3.3`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -495,3 +499,4 @@ rewritten.
 - [x] Health resolves existing manifest source IDs without false unknown-source diagnostics.
 - [x] Lint validates live source refs after path repair and supersession.
 - [x] Workspace maintenance actions can run without unnecessary changed-source coupling.
+- [x] Pending ingest drains provide JSON output for agent handoff.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -260,6 +260,9 @@ Implemented fields:
   reports a clean no-op when no curated workspace-backed source bytes changed. `--json` emits
   initial and final freshness counts, missing-source diagnostics, refreshed source IDs, targeted
   queue outcomes, and summary counts.
+- `splendor ingest --pending --json` emits the same pending queue drain contract as human output in
+  structured form: queue total, processed/succeeded/failed/skipped summary counts, per-item source
+  IDs, workspace-relative queue paths, outcomes, messages, and deterministic next actions.
 - `splendor wiki compile <source-id|title|path>` remains non-mutating unless a maintained target
   page is selected and `--apply --proposal-hash <hash>` is supplied. Without `--page`, it reports
   the review-gated contract plus ranked maintained-page suggestions and ready-to-run

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M16-P2.2`
+- Previous completed PR sub-slice: `M16-P3.1`
 - Current planned slice: `M16-P3 workflow polish and trial-install polish`
-- Current PR sub-slice: `M16-P3.1`
+- Current PR sub-slice: `M16-P3.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M16-P3 workflow polish and trial-install polish`
-- Next planned PR sub-slice: `M16-P3.2`
+- Next planned PR sub-slice: `M16-P3.3`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -863,7 +863,8 @@ Current implementation:
   adjacent sidecar text files named with `sources.ocr_sidecar_suffix` and writes normalized output
   under `derived/ocr/` plus sidecar checksum metadata under `derived/metadata/`.
 - `splendor ingest --pending` prints the next `wiki suggest` command when exactly one source was
-  ingested, or points back to `wiki status` for batch follow-up.
+  ingested, or points back to `wiki status` for batch follow-up. `--json` emits queue totals,
+  processed/succeeded/failed/skipped counts, per-item outcomes, and deterministic next actions.
 - `splendor wiki status` reports source, page, queue, run, review, contested, stale,
   machine-generated, invalid-page, actionable synthesis-review, and missing
   synthesis-follow-up counts, with optional JSON output.

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -22,7 +22,13 @@ from splendor.commands.file_answer import (
     file_answer_from_last_query,
 )
 from splendor.commands.health import run_health_checks
-from splendor.commands.ingest import drain_pending_ingest_jobs, enqueue_ingest_job, ingest_source
+from splendor.commands.ingest import (
+    drain_pending_ingest_jobs,
+    enqueue_ingest_job,
+    ingest_source,
+    pending_ingest_next_actions,
+    render_pending_ingest_json,
+)
 from splendor.commands.init import initialize_workspace
 from splendor.commands.lint import run_lint_checks
 from splendor.commands.maintenance import execute_maintenance_command, render_report_json
@@ -1242,6 +1248,10 @@ def handle_ingest(args: argparse.Namespace) -> int:
         except (FileNotFoundError, RuntimeError, ValueError) as exc:
             return _print_error(exc)
 
+        if args.json_output:
+            print(render_pending_ingest_json(root, result))
+            return 1 if result.failed else 0
+
         if result.total == 0:
             print("No pending ingest jobs")
             return 0
@@ -1255,13 +1265,9 @@ def handle_ingest(args: argparse.Namespace) -> int:
             f"failed={result.failed} "
             f"skipped={result.skipped}"
         )
-        succeeded_source_ids = [
-            item.source_id for item in result.items if item.outcome == "succeeded"
-        ]
-        if len(succeeded_source_ids) == 1:
-            print(f"Next: splendor wiki suggest {succeeded_source_ids[0]}")
-        elif len(succeeded_source_ids) > 1:
-            print("Next: splendor wiki status")
+        for action in pending_ingest_next_actions(result):
+            if action != "splendor queue inspect":
+                print(f"Next: {action}")
         return 1 if result.failed else 0
 
     try:
@@ -2556,8 +2562,8 @@ def main(argv: list[str] | None = None) -> int:
         mode_count = sum(bool(value) for value in [args.source_id, args.pending, args.changed])
         if mode_count != 1:
             parser.error("ingest requires exactly one of <source_id>, --pending, or --changed")
-        if args.json_output and not args.changed:
-            parser.error("ingest --json is currently supported only with --changed")
+        if args.json_output and not (args.changed or args.pending):
+            parser.error("ingest --json is currently supported only with --pending or --changed")
     return args.handler(args)
 
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -26,7 +26,6 @@ from splendor.commands.ingest import (
     drain_pending_ingest_jobs,
     enqueue_ingest_job,
     ingest_source,
-    pending_ingest_next_actions,
     render_pending_ingest_json,
 )
 from splendor.commands.init import initialize_workspace
@@ -358,7 +357,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--json",
         action="store_true",
         dest="json_output",
-        help="Emit machine-readable JSON output for --changed.",
+        help="Emit machine-readable JSON output for --pending or --changed.",
     )
     ingest_parser.set_defaults(handler=handle_ingest)
 
@@ -1265,9 +1264,13 @@ def handle_ingest(args: argparse.Namespace) -> int:
             f"failed={result.failed} "
             f"skipped={result.skipped}"
         )
-        for action in pending_ingest_next_actions(result):
-            if action != "splendor queue inspect":
-                print(f"Next: {action}")
+        succeeded_source_ids = [
+            item.source_id for item in result.items if item.outcome == "succeeded"
+        ]
+        if len(succeeded_source_ids) == 1:
+            print(f"Next: splendor wiki suggest {succeeded_source_ids[0]}")
+        elif len(succeeded_source_ids) > 1:
+            print("Next: splendor wiki status")
         return 1 if result.failed else 0
 
     try:

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -107,6 +107,46 @@ class DrainResult:
     items: list[DrainItemResult]
 
 
+def render_pending_ingest_json(root: Path, result: DrainResult) -> str:
+    return json.dumps(
+        {
+            "total": result.total,
+            "summary": {
+                "processed": result.processed,
+                "succeeded": result.succeeded,
+                "failed": result.failed,
+                "skipped": result.skipped,
+            },
+            "items": [_drain_item_payload(root, item) for item in result.items],
+            "next_actions": pending_ingest_next_actions(result),
+        },
+        indent=2,
+    )
+
+
+def pending_ingest_next_actions(result: DrainResult) -> list[str]:
+    if result.total == 0:
+        return []
+    if result.failed:
+        return ["splendor queue inspect"]
+
+    succeeded_source_ids = [item.source_id for item in result.items if item.outcome == "succeeded"]
+    if len(succeeded_source_ids) == 1:
+        return [f"splendor wiki suggest {succeeded_source_ids[0]}"]
+    if len(succeeded_source_ids) > 1:
+        return ["splendor wiki status"]
+    return ["splendor queue inspect"]
+
+
+def _drain_item_payload(root: Path, item: DrainItemResult) -> dict[str, str]:
+    return {
+        "source_id": item.source_id,
+        "queue_path": _relative_to_root(root, item.queue_path),
+        "outcome": item.outcome,
+        "message": item.message,
+    }
+
+
 def _make_run_id(source_id: str) -> str:
     stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
     return f"run-{source_id}-{stamp}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3289,7 +3289,7 @@ def test_cli_ingest_requires_exactly_one_target_mode() -> None:
         main(["ingest", "src-123", "--changed"])
 
     with pytest.raises(SystemExit):
-        main(["ingest", "--pending", "--json"])
+        main(["ingest", "src-123", "--json"])
 
 
 def test_cli_ingest_pending_reports_no_jobs(tmp_path: Path, capsys) -> None:
@@ -3300,6 +3300,22 @@ def test_cli_ingest_pending_reports_no_jobs(tmp_path: Path, capsys) -> None:
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "No pending ingest jobs" in captured.out
+
+
+def test_cli_ingest_pending_json_reports_no_jobs(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "total": 0,
+        "summary": {"processed": 0, "succeeded": 0, "failed": 0, "skipped": 0},
+        "items": [],
+        "next_actions": [],
+    }
 
 
 def test_cli_ingest_pending_reports_skipped_items(tmp_path: Path, capsys) -> None:
@@ -3347,6 +3363,51 @@ def test_cli_ingest_pending_prints_summary(tmp_path: Path, capsys) -> None:
     assert "Drain summary: processed=1 succeeded=1 failed=0 skipped=0" in captured.out
 
 
+def test_cli_ingest_pending_json_reports_single_success_next_action(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["total"] == 1
+    assert payload["summary"] == {"processed": 1, "succeeded": 1, "failed": 0, "skipped": 0}
+    assert payload["next_actions"] == [f"splendor wiki suggest {source_id}"]
+    assert payload["items"] == [
+        {
+            "source_id": source_id,
+            "queue_path": f"state/queue/ingest-{source_id}.json",
+            "outcome": "succeeded",
+            "message": payload["items"][0]["message"],
+        }
+    ]
+    assert payload["items"][0]["message"].startswith("run run-")
+
+
+def test_cli_ingest_pending_json_reports_batch_success_next_action(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    first = tmp_path / "first.md"
+    second = tmp_path / "second.md"
+    first.write_text("# First\n\nhello\n", encoding="utf-8")
+    second.write_text("# Second\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(first)])
+    main(["--root", str(tmp_path), "add-source", str(second)])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"] == {"processed": 2, "succeeded": 2, "failed": 0, "skipped": 0}
+    assert payload["next_actions"] == ["splendor wiki status"]
+    assert [item["outcome"] for item in payload["items"]] == ["succeeded", "succeeded"]
+
+
 def test_cli_ingest_pending_continues_after_failure(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
 
@@ -3371,6 +3432,35 @@ def test_cli_ingest_pending_continues_after_failure(tmp_path: Path, capsys) -> N
     assert f"{ok_source_id}: succeeded" in captured.out
     assert f"{bad_source_id}: failed" in captured.out
     assert "Drain summary: processed=2 succeeded=1 failed=1 skipped=0" in captured.out
+
+
+def test_cli_ingest_pending_json_reports_partial_failure(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+
+    ok_source = tmp_path / "brief.md"
+    ok_source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(ok_source)])
+    ok_source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+
+    bad_source = tmp_path / "broken.bin"
+    bad_source.write_bytes(b"\x00\x01\x02")
+    main(["--root", str(tmp_path), "add-source", str(bad_source)])
+    failing_source_id = next(
+        path.stem
+        for path in sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+        if path.stem != ok_source_id
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--json"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"] == {"processed": 2, "succeeded": 1, "failed": 1, "skipped": 0}
+    assert payload["next_actions"] == ["splendor queue inspect"]
+    outcomes = {item["source_id"]: item["outcome"] for item in payload["items"]}
+    assert outcomes[ok_source_id] == "succeeded"
+    assert outcomes[failing_source_id] == "failed"
 
 
 def test_cli_ingest_pending_reports_failed_and_skipped_mix(tmp_path: Path, capsys) -> None:
@@ -3402,6 +3492,56 @@ def test_cli_ingest_pending_reports_failed_and_skipped_mix(tmp_path: Path, capsy
     )
     assert f"{failing_source_id}: failed (Workspace source is missing: missing.md)" in captured.out
     assert "Drain summary: processed=1 succeeded=0 failed=1 skipped=1" in captured.out
+
+
+def test_cli_ingest_pending_json_reports_skipped_queue_states(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    updates = [
+        (
+            "leased.md",
+            {
+                "status": "leased",
+                "lease_owner": "local-cli:123",
+                "lease_expires_at": "2099-01-01T00:00:00+00:00",
+            },
+        ),
+        (
+            "backoff.md",
+            {
+                "status": "failed",
+                "last_error": "broken",
+                "next_attempt_at": "2099-01-01T00:00:00+00:00",
+            },
+        ),
+        ("dead.md", {"status": "dead_letter", "last_error": "broken"}),
+        ("done.md", {"status": "done"}),
+    ]
+    source_ids: dict[str, str] = {}
+    for filename, queue_update in updates:
+        source = tmp_path / filename
+        source.write_text(f"# {filename}\n\nhello\n", encoding="utf-8")
+        main(["--root", str(tmp_path), "add-source", str(source)])
+        source_id = next(
+            path.stem
+            for path in sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+            if path.stem not in source_ids.values()
+        )
+        source_ids[filename] = source_id
+        queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+        write_queue_item(queue_path, load_queue_item(queue_path).model_copy(update=queue_update))
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"] == {"processed": 0, "succeeded": 0, "failed": 0, "skipped": 4}
+    assert payload["next_actions"] == ["splendor queue inspect"]
+    messages = {item["source_id"]: item["message"] for item in payload["items"]}
+    assert "lease active until 2099-01-01T00:00:00+00:00" in messages.values()
+    assert "retry after 2099-01-01T00:00:00+00:00" in messages.values()
+    assert "status=dead_letter" in messages.values()
+    assert "status=done" in messages.values()
 
 
 def test_cli_materialize_source_command(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,6 +148,16 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     assert forget.json_output is True
 
 
+def test_cli_ingest_help_mentions_pending_and_changed_json(capsys) -> None:
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["ingest", "--help"])
+
+    help_text = capsys.readouterr().out
+    assert "Emit machine-readable JSON output for --pending or --changed." in help_text
+
+
 def test_cli_source_reconcile_repairs_duplicate_active_versions(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     source_path = tmp_path / "brief.md"
@@ -3378,15 +3388,12 @@ def test_cli_ingest_pending_json_reports_single_success_next_action(tmp_path: Pa
     assert payload["total"] == 1
     assert payload["summary"] == {"processed": 1, "succeeded": 1, "failed": 0, "skipped": 0}
     assert payload["next_actions"] == [f"splendor wiki suggest {source_id}"]
-    assert payload["items"] == [
-        {
-            "source_id": source_id,
-            "queue_path": f"state/queue/ingest-{source_id}.json",
-            "outcome": "succeeded",
-            "message": payload["items"][0]["message"],
-        }
-    ]
-    assert payload["items"][0]["message"].startswith("run run-")
+    assert len(payload["items"]) == 1
+    item = payload["items"][0]
+    assert item["source_id"] == source_id
+    assert item["queue_path"] == f"state/queue/ingest-{source_id}.json"
+    assert item["outcome"] == "succeeded"
+    assert re.fullmatch(rf"run run-{source_id}-\d{{8}}T\d{{6}}\d{{6}}Z", item["message"])
 
 
 def test_cli_ingest_pending_json_reports_batch_success_next_action(tmp_path: Path, capsys) -> None:
@@ -3432,6 +3439,7 @@ def test_cli_ingest_pending_continues_after_failure(tmp_path: Path, capsys) -> N
     assert f"{ok_source_id}: succeeded" in captured.out
     assert f"{bad_source_id}: failed" in captured.out
     assert "Drain summary: processed=2 succeeded=1 failed=1 skipped=0" in captured.out
+    assert f"Next: splendor wiki suggest {ok_source_id}" in captured.out
 
 
 def test_cli_ingest_pending_json_reports_partial_failure(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

- Add `splendor ingest --pending --json` for machine-readable queue drain results.
- Include queue totals, processed/succeeded/failed/skipped counts, per-item outcomes, workspace-relative queue paths, and deterministic next actions.
- Update M16 planning state and docs for the pending-drain JSON contract.

## Validation

- `uv run pytest tests/test_cli.py -k 'ingest_pending or ingest_requires_exactly_one_target_mode'`
- `uv run pytest tests/test_cli.py tests/test_ingest.py tests/test_wiki_commands.py`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest`
- `uv run splendor lint`
- `uv run splendor pr-summary --since main`

Closes #122
