### PR TITLE
M16-P3.3: Publish release artifacts for easier trial installs

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M16-P3.1`
-- Last action taken: `M16-P3.1` was squash-merged into main as commit `6a8d374`,
-  loosening workspace maintenance flag coupling.
+- Previous completed PR sub-slice: `M16-P3.2`
+- Last action taken: `M16-P3.2` was squash-merged into main as commit `22539e0`,
+  adding JSON output for pending ingest drains.
 - Current planned slice: `M16-P3 workflow polish and trial-install polish`
-- Current PR sub-slice: `M16-P3.2`
+- Current PR sub-slice: `M16-P3.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M16-P3 workflow polish and trial-install polish`
-- Next planned PR sub-slice: `M16-P3.3`
+- Next planned slice: `M17 v1 public readiness`
+- Next planned PR sub-slice: `M17-P1.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -330,6 +330,13 @@
   - [x] Record the sanitized SynthBanshee/Claude Code evaluation findings
   - [x] Synchronize README, roadmap, and planning state for the v0.3 recovery track
   - [x] Publish a non-draft PR with labels, milestone, and detailed validation
+- [x] Implement `M16-P3.2`: JSON output for pending ingest drains
+  - [x] Add machine-readable pending-drain output for agent handoff
+  - [x] Keep human output deterministic and compatible
+- [ ] Implement `M16-P3.3`: Publish release artifacts for easier trial installs
+  - [x] Add a GitHub Actions release artifact workflow for tagged releases
+  - [x] Document GitHub Release wheels as the canonical trial-install path
+  - [x] Keep PyPI publishing as a separate maintainer decision
 
 ## Context Pointers
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -31,15 +31,18 @@ jobs:
         run: |
           python - <<'PY'
           import os
+          import re
           import tomllib
           from pathlib import Path
 
           tag_version = os.environ["RELEASE_TAG"].removeprefix("v")
           project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
           package_version = project["version"]
-          package_namespace = {}
-          exec(Path("src/splendor/__init__.py").read_text(encoding="utf-8"), package_namespace)
-          runtime_version = package_namespace["__version__"]
+          init_text = Path("src/splendor/__init__.py").read_text(encoding="utf-8")
+          version_match = re.search(r'^__version__ = "([^"]+)"$', init_text, flags=re.MULTILINE)
+          if version_match is None:
+              raise SystemExit("Could not find __version__ assignment in src/splendor/__init__.py")
+          runtime_version = version_match.group(1)
 
           if package_version != tag_version or runtime_version != tag_version:
               raise SystemExit(
@@ -56,10 +59,17 @@ jobs:
         run: |
           python -m venv .release-smoke
           . .release-smoke/bin/activate
-          wheel="dist/splendor-${RELEASE_TAG#v}-py3-none-any.whl"
-          test -f "$wheel"
-          uv pip install "$wheel"
+          wheels=(dist/splendor-${RELEASE_TAG#v}-*.whl)
+          if [ "${#wheels[@]}" -ne 1 ] || [ ! -f "${wheels[0]}" ]; then
+            printf 'Expected exactly one wheel for %s, found: %s\n' "$RELEASE_TAG" "${wheels[*]}"
+            exit 1
+          fi
+          uv pip install "${wheels[0]}"
           splendor --version
+          splendor --help
+          rm -rf /tmp/splendor-release-smoke
+          splendor --root /tmp/splendor-release-smoke init
+          splendor --root /tmp/splendor-release-smoke lint
       - name: Upload build artifacts to workflow run
         uses: actions/upload-artifact@v4
         with:
@@ -71,6 +81,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release create "$RELEASE_TAG" --title "Splendor $RELEASE_TAG" --notes "Release artifacts for $RELEASE_TAG."
+            printf 'GitHub Release %s does not exist. Create release notes before publishing artifacts.\n' "$RELEASE_TAG"
+            exit 1
           fi
           gh release upload "$RELEASE_TAG" dist/* --clobber

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,76 @@
+name: Release artifacts
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to build and publish, for example v0.3.0"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v5
+      - name: Verify tag matches package version
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          tag_version = os.environ["RELEASE_TAG"].removeprefix("v")
+          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
+          package_version = project["version"]
+          package_namespace = {}
+          exec(Path("src/splendor/__init__.py").read_text(encoding="utf-8"), package_namespace)
+          runtime_version = package_namespace["__version__"]
+
+          if package_version != tag_version or runtime_version != tag_version:
+              raise SystemExit(
+                  "Tag "
+                  f"{os.environ['RELEASE_TAG']} does not match package versions: "
+                  f"pyproject.toml={package_version}, src/splendor/__init__.py={runtime_version}"
+              )
+          PY
+      - name: Build wheel and source distribution
+        run: |
+          rm -rf dist
+          uv build
+      - name: Smoke install built wheel
+        run: |
+          python -m venv .release-smoke
+          . .release-smoke/bin/activate
+          wheel="dist/splendor-${RELEASE_TAG#v}-py3-none-any.whl"
+          test -f "$wheel"
+          uv pip install "$wheel"
+          splendor --version
+      - name: Upload build artifacts to workflow run
+        uses: actions/upload-artifact@v4
+        with:
+          name: splendor-dist-${{ env.RELEASE_TAG }}
+          path: dist/*
+          if-no-files-found: error
+      - name: Publish artifacts on GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" --title "Splendor $RELEASE_TAG" --notes "Release artifacts for $RELEASE_TAG."
+          fi
+          gh release upload "$RELEASE_TAG" dist/* --clobber

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ uv pip install dist/splendor-*.whl
 splendor --help
 ```
 
+### Trial release install
+
+For external trial installs, use the wheel attached to the matching GitHub Release:
+
+```bash
+uv tool install https://github.com/splendor-dev/splendor/releases/download/v0.3.0/splendor-0.3.0-py3-none-any.whl
+splendor --help
+```
+
+Replace `v0.3.0` and `0.3.0` with the exact release tag under evaluation. Maintainer publishing
+details live in [docs/release_artifacts.md](docs/release_artifacts.md).
+
 ## 5 Minute Quickstart
 
 This is the primary MVP flow: one repository that contains both your project files and the
@@ -259,18 +271,19 @@ the source manifest, and kept separate from parsed PDF artifacts.
 - [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md)
 - [docs/schema_contracts.md](docs/schema_contracts.md)
 - [docs/ci_and_repo_automation.md](docs/ci_and_repo_automation.md)
+- [docs/release_artifacts.md](docs/release_artifacts.md)
 - [docs/v1_release_handoff.md](docs/v1_release_handoff.md)
 - [docs/m14_synthbanshee_reevaluation.md](docs/m14_synthbanshee_reevaluation.md)
 - [docs/v0_2_synthbanshee_evaluation.md](docs/v0_2_synthbanshee_evaluation.md)
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M16-P3.1`
+- Previous completed PR sub-slice: `M16-P3.2`
 - Current planned slice: `M16-P3 workflow polish and trial-install polish`
-- Current PR sub-slice: `M16-P3.2`
+- Current PR sub-slice: `M16-P3.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M16-P3 workflow polish and trial-install polish`
-- Next planned PR sub-slice: `M16-P3.3`
+- Next planned slice: `M17 v1 public readiness`
+- Next planned PR sub-slice: `M17-P1.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -402,6 +415,10 @@ against source manifests. Historical manifests and run records remain valid.
 `M16-P3.1` loosens workspace maintenance flag coupling: index rebuilds, superseded-summary
 pruning, and topic-ref migration can run without pretending source bytes changed, while
 `--changed --ingest` remains a targeted drain of only refreshed-source ingest jobs.
+`M16-P3.2` adds JSON output for `splendor ingest --pending`, making pending-drain results easier
+for agents to consume without parsing human text.
+`M16-P3.3` adds GitHub Release artifact publishing for tagged releases and documents the canonical
+wheel-based trial install path for external v0.3 evaluators.
 
 `M14-P1.5` adds the explicit stale-ingest repair path for issue #93:
 `splendor ingest --changed` detects checksum-drifted curated workspace-backed sources, refreshes
@@ -500,3 +517,5 @@ rewritten.
 - [x] Lint validates live source refs after path repair and supersession.
 - [x] Workspace maintenance actions can run without unnecessary changed-source coupling.
 - [x] Pending ingest drains provide JSON output for agent handoff.
+- [x] GitHub Release wheels and source distributions are documented as the canonical trial-install
+  artifact path.

--- a/README.md
+++ b/README.md
@@ -44,12 +44,14 @@ splendor --help
 For external trial installs, use the wheel attached to the matching GitHub Release:
 
 ```bash
-uv tool install https://github.com/splendor-dev/splendor/releases/download/v0.3.0/splendor-0.3.0-py3-none-any.whl
+TAG="v..."
+VERSION="${TAG#v}"
+uv tool install "https://github.com/splendor-dev/splendor/releases/download/${TAG}/splendor-${VERSION}-py3-none-any.whl"
 splendor --help
 ```
 
-Replace `v0.3.0` and `0.3.0` with the exact release tag under evaluation. Maintainer publishing
-details live in [docs/release_artifacts.md](docs/release_artifacts.md).
+Set `TAG` to the exact published release under evaluation. Maintainer publishing details and the
+release-page fallback live in [docs/release_artifacts.md](docs/release_artifacts.md).
 
 ## 5 Minute Quickstart
 

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -116,6 +116,34 @@ Review expectations:
 - distinguish reviewer-significant generated artifacts from mechanical timestamp-only churn
 - manually dispatch or rerun normal CI if repository policy requires checks on the generated PR
 
+## `Release artifacts`
+
+File: `.github/workflows/release-artifacts.yml`
+
+Runs on:
+
+- `v*` tag pushes
+- manual dispatch for an existing tag
+
+What it does:
+
+- checks out the selected tag
+- installs Python 3.12 and `uv`
+- verifies that the tag version matches `pyproject.toml` and `src/splendor/__init__.py`
+- runs `uv build`
+- smoke-installs the built wheel and runs `splendor --version`
+- uploads `dist/*` as a GitHub Actions artifact
+- creates or reuses the matching GitHub Release and uploads the wheel and source distribution
+
+Permissions:
+
+- `contents: write`
+
+Secrets and external dependencies:
+
+- no secret is required
+- release upload uses the repository `GITHUB_TOKEN` through the GitHub CLI
+
 ## `planning-validator`
 
 File: `.github/workflows/planning-validator.yml`
@@ -305,6 +333,8 @@ Required secrets:
   artifacts.
 - `Splendor generated-change PR` proposes deterministic repo-refresh output as a reviewable PR
   without making GitHub part of the core runtime.
+- `Release artifacts` publishes tag-built wheels and source distributions on GitHub Releases for
+  lower-friction trial installs.
 - `Claude Code Review` provides automated AI code review after CI `lint` and `test` pass, plus
   interactive follow-up.
 - `pr-agent-context` turns CI, review, and failing-check state into a maintained PR handoff comment.
@@ -324,7 +354,9 @@ package their output, but they do not replace the operator-reviewed local valida
 For the current `v0.2.0` evaluation-release prep, `docs/v1_release_handoff.md` remains the
 historical v1-style checklist that connects local validation, GitHub PR metadata, issue state, and
 known non-blockers, while `docs/v0_2_0_release_notes.md` names the immediate tag target and
-post-release SynthBanshee/Claude Code evaluation step. GitHub automation remains supporting
+post-release SynthBanshee/Claude Code evaluation step. `docs/release_artifacts.md` names GitHub
+Release wheels as the canonical trial-install channel for v0.3 evaluators. GitHub automation
+remains supporting
 infrastructure around the local CLI, not a substitute for the explicit validation commands named in
 that handoff.
 

--- a/docs/ci_and_repo_automation.md
+++ b/docs/ci_and_repo_automation.md
@@ -131,9 +131,11 @@ What it does:
 - installs Python 3.12 and `uv`
 - verifies that the tag version matches `pyproject.toml` and `src/splendor/__init__.py`
 - runs `uv build`
-- smoke-installs the built wheel and runs `splendor --version`
+- smoke-installs the built wheel and exercises the installed CLI with `splendor --version`,
+  `splendor --help`, `splendor init`, and `splendor lint`
 - uploads `dist/*` as a GitHub Actions artifact
-- creates or reuses the matching GitHub Release and uploads the wheel and source distribution
+- requires the matching GitHub Release to already exist with release notes
+- uploads the wheel and source distribution to that release
 
 Permissions:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -29,6 +29,17 @@ uv pip install dist/splendor-*.whl
 splendor --help
 ```
 
+### Trial release install
+
+For external trial installs, prefer the wheel attached to the matching GitHub Release:
+
+```bash
+uv tool install https://github.com/splendor-dev/splendor/releases/download/v0.3.0/splendor-0.3.0-py3-none-any.whl
+splendor --help
+```
+
+Replace `v0.3.0` and `0.3.0` with the exact release tag under evaluation.
+
 The examples below use `uv run splendor ... --root ...` from a contributor checkout. If you
 installed Splendor into an environment instead, replace `uv run splendor` with `splendor`. If that
 environment lives inside the target repository, you can also drop `--root`.
@@ -218,9 +229,9 @@ Refresh does not override active ingest leases or dead-letter protections; use `
 `repair ingest` for those recovery cases.
 
 For release verification, use `docs/v1_release_handoff.md` together with
-`docs/v0_2_0_release_notes.md`. The handoff keeps the quickstart focused on normal operator
-workflow while the release notes name the immediate `v0.2.0` evaluation tag target, validation
-commands, issue state, and post-release SynthBanshee/Claude Code evaluation step.
+`docs/v0_2_0_release_notes.md` and `docs/release_artifacts.md`. The handoff keeps the quickstart
+focused on normal operator workflow while the release notes name the immediate `v0.2.0`
+evaluation tag target and the release artifact guide names the wheel-based trial-install path.
 
 For a read-only browser view over the same status and source-detail contracts:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -34,11 +34,13 @@ splendor --help
 For external trial installs, prefer the wheel attached to the matching GitHub Release:
 
 ```bash
-uv tool install https://github.com/splendor-dev/splendor/releases/download/v0.3.0/splendor-0.3.0-py3-none-any.whl
+TAG="v..."
+VERSION="${TAG#v}"
+uv tool install "https://github.com/splendor-dev/splendor/releases/download/${TAG}/splendor-${VERSION}-py3-none-any.whl"
 splendor --help
 ```
 
-Replace `v0.3.0` and `0.3.0` with the exact release tag under evaluation.
+Set `TAG` to the exact published release under evaluation.
 
 The examples below use `uv run splendor ... --root ...` from a contributor checkout. If you
 installed Splendor into an environment instead, replace `uv run splendor` with `splendor`. If that

--- a/docs/release_artifacts.md
+++ b/docs/release_artifacts.md
@@ -1,0 +1,41 @@
+# Release Artifacts
+
+This document defines the supported release artifact path for trial installs. It keeps release
+publishing separate from Splendor runtime behavior.
+
+## Canonical Trial Install
+
+For external v0.3 trial users, prefer the wheel attached to the matching GitHub Release:
+
+```bash
+uv tool install https://github.com/splendor-dev/splendor/releases/download/v0.3.0/splendor-0.3.0-py3-none-any.whl
+splendor --help
+```
+
+If the evaluator wants Splendor inside a project-specific virtual environment instead:
+
+```bash
+uv venv .venv
+. .venv/bin/activate
+uv pip install https://github.com/splendor-dev/splendor/releases/download/v0.3.0/splendor-0.3.0-py3-none-any.whl
+splendor --help
+```
+
+Replace `v0.3.0` and `0.3.0` with the exact release tag being evaluated.
+
+## Maintainer Publishing Flow
+
+`.github/workflows/release-artifacts.yml` publishes release artifacts when a `v*` tag is pushed.
+Maintainers can also run it manually for an existing tag through `workflow_dispatch`.
+
+The workflow:
+
+- checks out the tag
+- verifies that the tag version matches `pyproject.toml` and `src/splendor/__init__.py`
+- runs `uv build`
+- smoke-installs the built wheel and runs `splendor --version`
+- uploads `dist/*` as a workflow artifact
+- creates or reuses the matching GitHub Release and uploads the wheel and source distribution
+
+This makes GitHub Releases the canonical trial-install channel while leaving PyPI publishing as a
+separate maintainer decision.

--- a/docs/release_artifacts.md
+++ b/docs/release_artifacts.md
@@ -5,23 +5,36 @@ publishing separate from Splendor runtime behavior.
 
 ## Canonical Trial Install
 
-For external v0.3 trial users, prefer the wheel attached to the matching GitHub Release:
+For external v0.3 trial users, prefer the wheel attached to the matching GitHub Release. Start from
+the release page so the evaluator sees the release notes, validation status, and known limitations
+before installing:
+
+```text
+https://github.com/splendor-dev/splendor/releases/tag/<release-tag>
+```
+
+Then install the wheel asset for that release:
 
 ```bash
-uv tool install https://github.com/splendor-dev/splendor/releases/download/v0.3.0/splendor-0.3.0-py3-none-any.whl
+TAG="v..."
+VERSION="${TAG#v}"
+uv tool install "https://github.com/splendor-dev/splendor/releases/download/${TAG}/splendor-${VERSION}-py3-none-any.whl"
 splendor --help
 ```
 
 If the evaluator wants Splendor inside a project-specific virtual environment instead:
 
 ```bash
+TAG="v..."
+VERSION="${TAG#v}"
 uv venv .venv
 . .venv/bin/activate
-uv pip install https://github.com/splendor-dev/splendor/releases/download/v0.3.0/splendor-0.3.0-py3-none-any.whl
+uv pip install "https://github.com/splendor-dev/splendor/releases/download/${TAG}/splendor-${VERSION}-py3-none-any.whl"
 splendor --help
 ```
 
-Replace `v0.3.0` and `0.3.0` with the exact release tag being evaluated.
+Set `TAG` to the exact published release under evaluation. If the wheel asset name differs, copy
+the wheel URL from the GitHub Release page instead of guessing the filename.
 
 ## Maintainer Publishing Flow
 
@@ -33,9 +46,11 @@ The workflow:
 - checks out the tag
 - verifies that the tag version matches `pyproject.toml` and `src/splendor/__init__.py`
 - runs `uv build`
-- smoke-installs the built wheel and runs `splendor --version`
+- smoke-installs the built wheel, runs `splendor --version`, `splendor --help`, `splendor init`,
+  and `splendor lint` in an isolated workspace
 - uploads `dist/*` as a workflow artifact
-- creates or reuses the matching GitHub Release and uploads the wheel and source distribution
+- requires the matching GitHub Release to already exist with release notes
+- uploads the wheel and source distribution to that release
 
 This makes GitHub Releases the canonical trial-install channel while leaving PyPI publishing as a
 separate maintainer decision.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M16-P3.1`
+- Previous completed PR sub-slice: `M16-P3.2`
 - Current planned slice: `M16-P3 workflow polish and trial-install polish`
-- Current PR sub-slice: `M16-P3.2`
+- Current PR sub-slice: `M16-P3.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M16-P3 workflow polish and trial-install polish`
-- Next planned PR sub-slice: `M16-P3.3`
+- Next planned slice: `M17 v1 public readiness`
+- Next planned PR sub-slice: `M17-P1.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1130,6 +1130,12 @@ is preserved outside the repository at
 - `M16-P3.1` Loosen workspace maintenance flag coupling (#121).
 - `M16-P3.2` Add JSON output for pending ingest drains (#122).
 - `M16-P3.3` Publish release artifacts for easier trial installs (#120).
+
+`M16-P3.3` adds a GitHub Actions release-artifact workflow for `v*` tags, supports manual
+backfill for existing tags, verifies the tag matches package metadata, builds wheel/sdist outputs,
+smoke-installs the wheel, and uploads `dist/*` to the matching GitHub Release. The canonical
+external trial-install path is the GitHub Release wheel documented in `docs/release_artifacts.md`.
+PyPI publishing remains a separate maintainer decision outside the v0.3 recovery loop.
 
 ### Minimum v0.3 retry bar
 - Repo scan honors `.gitignore`, `.splendorignore`, and safe built-in ignore rules across

--- a/docs/v0_2_synthbanshee_evaluation.md
+++ b/docs/v0_2_synthbanshee_evaluation.md
@@ -95,6 +95,8 @@ M16-P3 polish covers standalone workspace maintenance actions, JSON output for p
 drains, and easier release artifacts for trial installs. M16-P3.1 specifically removes the need to
 pair idempotent index rebuilds, superseded-summary pruning, and topic-ref migration with
 changed-source refresh.
+M16-P3.3 makes GitHub Release wheels and source distributions the documented trial-install
+artifact path for v0.3 evaluators, while keeping PyPI publishing as a separate maintainer decision.
 
 ## Public Mock Client Acceptance Workflows
 

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -45,6 +45,8 @@ Before publishing release notes, verify that:
 - `docs/quickstart.md` demonstrates the current safe source workflow
 - `docs/ci_and_repo_automation.md` and `docs/github_automation_architecture.md` still describe
   GitHub automation as optional around the local CLI
+- `docs/release_artifacts.md` names the GitHub Release wheel as the canonical trial-install path
+  for external v0.3 evaluators
 
 ## GitHub Handoff
 
@@ -139,3 +141,6 @@ git push origin v0.2.0
 
 The build and wheel smoke test must pass before the tag is pushed. If either fails, fix the release
 prep on a PR branch instead of publishing and then repairing a bad tag.
+After the tag is pushed, the release-artifacts workflow should attach the built wheel and source
+distribution to the matching GitHub Release. For manual backfill of an existing tag, run the
+`Release artifacts` workflow with the exact tag name.

--- a/docs/v1_release_handoff.md
+++ b/docs/v1_release_handoff.md
@@ -141,6 +141,7 @@ git push origin v0.2.0
 
 The build and wheel smoke test must pass before the tag is pushed. If either fails, fix the release
 prep on a PR branch instead of publishing and then repairing a bad tag.
-After the tag is pushed, the release-artifacts workflow should attach the built wheel and source
-distribution to the matching GitHub Release. For manual backfill of an existing tag, run the
-`Release artifacts` workflow with the exact tag name.
+Before the tag is pushed, prepare the matching GitHub Release with real release notes. After the
+tag is pushed, the release-artifacts workflow should attach the built wheel and source distribution
+to that release. For manual backfill of an existing tag, run the `Release artifacts` workflow with
+the exact tag name after confirming the release page already exists.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -69,7 +69,17 @@ def test_release_artifacts_workflow_contract() -> None:
     assert "actions/checkout@v4" in uses
     assert "actions/upload-artifact@v4" in uses
     assert any("rm -rf dist" in run and "uv build" in run for run in runs if run)
+    assert not any("exec(" in run for run in runs if run)
     assert any(
-        'wheel="dist/splendor-${RELEASE_TAG#v}-py3-none-any.whl"' in run for run in runs if run
+        "wheels=(dist/splendor-${RELEASE_TAG#v}-*.whl)" in run
+        and "splendor --root /tmp/splendor-release-smoke init" in run
+        and "splendor --root /tmp/splendor-release-smoke lint" in run
+        for run in runs
+        if run
+    )
+    assert any(
+        "GitHub Release %s does not exist. Create release notes before publishing artifacts." in run
+        for run in runs
+        if run
     )
     assert any('gh release upload "$RELEASE_TAG" dist/* --clobber' in run for run in runs if run)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -45,3 +45,31 @@ def test_generated_change_pr_workflow_contract() -> None:
         "state/manifests/sources/**",
         "raw/sources/**",
     ]
+
+
+def test_release_artifacts_workflow_contract() -> None:
+    workflow = _load_workflow(".github/workflows/release-artifacts.yml")
+
+    assert workflow["name"] == "Release artifacts"
+    triggers = _workflow_triggers(workflow)
+    assert set(triggers) == {"push", "workflow_dispatch"}
+    assert triggers["push"]["tags"] == ["v*"]
+    assert triggers["workflow_dispatch"]["inputs"]["tag"]["required"] is True
+    assert workflow["permissions"] == {"contents": "write"}
+
+    job = workflow["jobs"]["build-and-upload"]
+    assert job["env"]["RELEASE_TAG"] == (
+        "${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+    )
+
+    steps = job["steps"]
+    runs = [step.get("run") for step in steps]
+    uses = [step.get("uses") for step in steps]
+
+    assert "actions/checkout@v4" in uses
+    assert "actions/upload-artifact@v4" in uses
+    assert any("rm -rf dist" in run and "uv build" in run for run in runs if run)
+    assert any(
+        'wheel="dist/splendor-${RELEASE_TAG#v}-py3-none-any.whl"' in run for run in runs if run
+    )
+    assert any('gh release upload "$RELEASE_TAG" dist/* --clobber' in run for run in runs if run)


### PR DESCRIPTION
## Summary

- Add a `Release artifacts` GitHub Actions workflow that builds tag-matched wheels and source distributions for `v*` releases.
- Require a real GitHub Release page with release notes before uploading artifacts, instead of creating placeholder public releases.
- Verify tag/package version alignment without executing repository Python source in the write-token release job.
- Smoke-install the exact tag-matched wheel and exercise the installed CLI with `splendor --version`, `splendor --help`, `splendor init`, and `splendor lint` before publishing artifacts.
- Upload `dist/*` both as workflow artifacts and to the matching GitHub Release, with manual backfill support for existing tags.
- Document the GitHub Release wheel as the canonical external v0.3 trial-install path while using editable `TAG` commands and a release-page fallback instead of a hardcoded future artifact URL.
- Advance M16 planning state from `M16-P3.2` to `M16-P3.3` and point the next planned PR at `M17-P1.1`.

## Review response

- Finding 1: release upload now fails when the matching GitHub Release is missing, so maintainers must publish real release notes first.
- Finding 2: version validation now parses `src/splendor/__init__.py` with a regex instead of executing it.
- Finding 3: the wheel smoke test now runs real installed CLI commands against an isolated workspace.
- Finding 4: docs now start from the release page and use `TAG`/`VERSION` variables, with guidance to copy the asset URL if the wheel filename differs.

## Validation

- `uv run pytest tests/test_workflows.py`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run splendor health`
- `env -u OPENAI_API_KEY uv run pytest`
- `rm -rf dist && uv build`
- Local installed-wheel smoke: install `dist/splendor-0.2.0-py3-none-any.whl` in a fresh virtual environment, then run `splendor --version`, `splendor --help`, `splendor --root /tmp/splendor-release-smoke init`, and `splendor --root /tmp/splendor-release-smoke lint`

Closes #120