### PR TITLE
M17-P1.1: Create public mock client acceptance repository

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M16-P3.2`
-- Last action taken: `M16-P3.2` was squash-merged into main as commit `22539e0`,
-  adding JSON output for pending ingest drains.
-- Current planned slice: `M16-P3 workflow polish and trial-install polish`
-- Current PR sub-slice: `M16-P3.3`
+- Previous completed PR sub-slice: `M16-P3.3`
+- Last action taken: `M16-P3.3` was squash-merged into main as commit `5aeb20b`,
+  publishing release artifacts for easier trial installs.
+- Current planned slice: `M17 v1 public readiness`
+- Current PR sub-slice: `M17-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M17 v1 public readiness`
-- Next planned PR sub-slice: `M17-P1.1`
+- Next planned PR sub-slice: `M17-P2.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -333,10 +333,15 @@
 - [x] Implement `M16-P3.2`: JSON output for pending ingest drains
   - [x] Add machine-readable pending-drain output for agent handoff
   - [x] Keep human output deterministic and compatible
-- [ ] Implement `M16-P3.3`: Publish release artifacts for easier trial installs
+- [x] Implement `M16-P3.3`: Publish release artifacts for easier trial installs
   - [x] Add a GitHub Actions release artifact workflow for tagged releases
   - [x] Document GitHub Release wheels as the canonical trial-install path
   - [x] Keep PyPI publishing as a separate maintainer decision
+- [x] Implement `M17-P1.1`: Create public mock client acceptance repository
+  - [x] Create `splendor-dev/mock-client-acceptance` as a public repository
+  - [x] Seed healthy `main` with a realistic CLI/data project and Splendor workspace
+  - [x] Add source-refresh, polluted-registry, and renamed-source acceptance scenarios
+  - [x] Document the public acceptance contract in Splendor docs
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -274,18 +274,19 @@ the source manifest, and kept separate from parsed PDF artifacts.
 - [docs/schema_contracts.md](docs/schema_contracts.md)
 - [docs/ci_and_repo_automation.md](docs/ci_and_repo_automation.md)
 - [docs/release_artifacts.md](docs/release_artifacts.md)
+- [docs/public_mock_client_acceptance.md](docs/public_mock_client_acceptance.md)
 - [docs/v1_release_handoff.md](docs/v1_release_handoff.md)
 - [docs/m14_synthbanshee_reevaluation.md](docs/m14_synthbanshee_reevaluation.md)
 - [docs/v0_2_synthbanshee_evaluation.md](docs/v0_2_synthbanshee_evaluation.md)
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M16-P3.2`
-- Current planned slice: `M16-P3 workflow polish and trial-install polish`
-- Current PR sub-slice: `M16-P3.3`
+- Previous completed PR sub-slice: `M16-P3.3`
+- Current planned slice: `M17 v1 public readiness`
+- Current PR sub-slice: `M17-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M17 v1 public readiness`
-- Next planned PR sub-slice: `M17-P1.1`
+- Next planned PR sub-slice: `M17-P2.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -421,6 +422,10 @@ pruning, and topic-ref migration can run without pretending source bytes changed
 for agents to consume without parsing human text.
 `M16-P3.3` adds GitHub Release artifact publishing for tagged releases and documents the canonical
 wheel-based trial install path for external v0.3 evaluators.
+`M17-P1.1` creates the public
+[`splendor-dev/mock-client-acceptance`](https://github.com/splendor-dev/mock-client-acceptance)
+repository and documents its baseline, source-refresh, polluted-registry, and renamed-source
+acceptance workflows in [docs/public_mock_client_acceptance.md](docs/public_mock_client_acceptance.md).
 
 `M14-P1.5` adds the explicit stale-ingest repair path for issue #93:
 `splendor ingest --changed` detects checksum-drifted curated workspace-backed sources, refreshes

--- a/README.md
+++ b/README.md
@@ -426,6 +426,9 @@ wheel-based trial install path for external v0.3 evaluators.
 [`splendor-dev/mock-client-acceptance`](https://github.com/splendor-dev/mock-client-acceptance)
 repository and documents its baseline, source-refresh, polluted-registry, and renamed-source
 acceptance workflows in [docs/public_mock_client_acceptance.md](docs/public_mock_client_acceptance.md).
+The reviewed external state is pinned by the `m17-p1.1-acceptance-main` and
+`m17-p1.1-source-refresh-scenario` tags, and the mock repository includes merged PR history for
+external evaluator exercises.
 
 `M14-P1.5` adds the explicit stale-ingest repair path for issue #93:
 `splendor ingest --changed` detects checksum-drifted curated workspace-backed sources, refreshes

--- a/docs/public_mock_client_acceptance.md
+++ b/docs/public_mock_client_acceptance.md
@@ -1,0 +1,63 @@
+# Public Mock Client Acceptance Repository
+
+Splendor's public mock client acceptance target is
+[`splendor-dev/mock-client-acceptance`](https://github.com/splendor-dev/mock-client-acceptance).
+It exists so external evaluators can exercise realistic Splendor workflows without private client
+material.
+
+## Repository Contract
+
+- Healthy `main` is safe for first-time evaluators.
+- The default branch contains a small CLI/data project, human-authored authority docs, contradictory
+  research notes, Splendor-generated workspace state, and recovery fixtures.
+- Intentionally broken source state is isolated under `acceptance-fixtures/` or on scenario
+  branches.
+- `.splendorignore` excludes fixtures and runtime scratch paths from healthy-root discovery.
+
+## Baseline Evaluation
+
+Clone the public repository and run:
+
+```bash
+splendor lint
+splendor health
+splendor brief --agent-context "balance reconciliation rollout"
+splendor suggest-next "reconciliation contradictions"
+```
+
+Expected result: lint and health pass on `main`, and the agent-context brief ranks the current
+spec, rollout plan, CSV-first decision, and held-entry research above the stale JSONL research note.
+
+## Source-Refresh Scenario
+
+Use branch `scenario/source-refresh-lifecycle`:
+
+```bash
+git switch scenario/source-refresh-lifecycle
+splendor source freshness
+splendor workspace refresh --changed --ingest --prune-superseded --update-topic-refs --rebuild-index
+splendor lint
+splendor health
+```
+
+Expected result: Splendor detects changed curated sources, registers successor source versions,
+ingests the refreshed sources, migrates maintained topic refs, and finishes with passing lint and
+health.
+
+## Polluted-Registry Scenario
+
+Copy `acceptance-fixtures/polluted-registry/` from the public repository to a temporary working
+directory and follow that fixture's README.
+
+The fixture intentionally includes source manifests for ignored cache/local-agent paths and
+duplicate active versions for `docs/specs/reconciliation.md`. The recovery path uses
+`splendor source forget` and `splendor source reconcile` without manual deletion under
+`state/manifests/sources/`.
+
+## Renamed-Source Scenario
+
+Copy `acceptance-fixtures/renamed-source/` from the public repository to a temporary working
+directory and follow that fixture's README.
+
+The fixture models active source path repair with `splendor source update-path` while retaining the
+old path as historical provenance for existing run records.

--- a/docs/public_mock_client_acceptance.md
+++ b/docs/public_mock_client_acceptance.md
@@ -5,6 +5,13 @@ Splendor's public mock client acceptance target is
 It exists so external evaluators can exercise realistic Splendor workflows without private client
 material.
 
+The reviewed M17-P1.1 acceptance state is pinned to immutable refs:
+
+- Healthy baseline tag: `m17-p1.1-acceptance-main`
+  (`fa733da2a344cb55605a364f403aba9e290bbd62`)
+- Source-refresh scenario tag: `m17-p1.1-source-refresh-scenario`
+  (`ee4768ae12650e17f227bafa2a813e47af8ae77c`)
+
 ## Repository Contract
 
 - Healthy `main` is safe for first-time evaluators.
@@ -13,10 +20,21 @@ material.
 - Intentionally broken source state is isolated under `acceptance-fixtures/` or on scenario
   branches.
 - `.splendorignore` excludes fixtures and runtime scratch paths from healthy-root discovery.
+- M17-P1.1 validation should use the pinned tags above, not floating branch names.
+- The repository includes real merged PR history for evaluator review:
+  [#1](https://github.com/splendor-dev/mock-client-acceptance/pull/1),
+  [#2](https://github.com/splendor-dev/mock-client-acceptance/pull/2), and
+  [#3](https://github.com/splendor-dev/mock-client-acceptance/pull/3).
 
 ## Baseline Evaluation
 
-Clone the public repository and run:
+Clone the pinned public repository baseline and run:
+
+```bash
+git clone --branch m17-p1.1-acceptance-main \
+  https://github.com/splendor-dev/mock-client-acceptance.git
+cd mock-client-acceptance
+```
 
 ```bash
 splendor lint
@@ -30,10 +48,11 @@ spec, rollout plan, CSV-first decision, and held-entry research above the stale 
 
 ## Source-Refresh Scenario
 
-Use branch `scenario/source-refresh-lifecycle`:
+Use the pinned source-refresh scenario tag:
 
 ```bash
-git switch scenario/source-refresh-lifecycle
+git fetch --tags
+git switch --detach m17-p1.1-source-refresh-scenario
 splendor source freshness
 splendor workspace refresh --changed --ingest --prune-superseded --update-topic-refs --rebuild-index
 splendor lint
@@ -52,7 +71,8 @@ directory and follow that fixture's README.
 The fixture intentionally includes source manifests for ignored cache/local-agent paths and
 duplicate active versions for `docs/specs/reconciliation.md`. The recovery path uses
 `splendor source forget` and `splendor source reconcile` without manual deletion under
-`state/manifests/sources/`.
+`state/manifests/sources/`. The ignored fixture files are force-committed in the pinned baseline so
+fresh clones include `.mypy_cache/cache.py` and `.codex/session.log`.
 
 ## Renamed-Source Scenario
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -1171,9 +1171,11 @@ handoff.
 [`splendor-dev/mock-client-acceptance`](https://github.com/splendor-dev/mock-client-acceptance) as
 the public mock client acceptance repository. It models a realistic small CLI/data project with
 human-authored specs, implementation plans, decision records, contradictory research notes, a
-non-trivial commit history, a healthy Splendor workspace on `main`, a source-refresh scenario
-branch, and isolated recovery fixtures for polluted registries and renamed-source repair. The
-operator-facing workflow is documented in
+non-trivial commit and merged PR history, a healthy Splendor workspace on `main`, a pinned
+source-refresh scenario tag, and isolated recovery fixtures for polluted registries and
+renamed-source repair. The reviewed external state is pinned by the
+`m17-p1.1-acceptance-main` and `m17-p1.1-source-refresh-scenario` tags, and the operator-facing
+workflow is documented in
 [public mock client acceptance](public_mock_client_acceptance.md).
 
 ## Milestone 18 — v2 advanced product track

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M16-P3.2`
-- Current planned slice: `M16-P3 workflow polish and trial-install polish`
-- Current PR sub-slice: `M16-P3.3`
+- Previous completed PR sub-slice: `M16-P3.3`
+- Current planned slice: `M17 v1 public readiness`
+- Current PR sub-slice: `M17-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M17 v1 public readiness`
-- Next planned PR sub-slice: `M17-P1.1`
+- Next planned PR sub-slice: `M17-P2.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1167,12 +1167,14 @@ handoff.
 - `M17-P4.1` Reduce contradiction-review task noise (#117).
 
 ### Public mock client guidance
-The public mock client should model a realistic small CLI/data project with human-authored specs,
-implementation plans, decision records, research notes that contain real contradictions, a
-non-trivial PR history, populated ignored cache directories in local scenarios, and dedicated
-failure branches or fixtures for polluted manifests, dangling active sources, and renamed-file
-repairs. Healthy `main` should be useful for first-run evaluation; intentionally broken states
-belong in scenario branches or fixtures.
+`M17-P1.1` creates
+[`splendor-dev/mock-client-acceptance`](https://github.com/splendor-dev/mock-client-acceptance) as
+the public mock client acceptance repository. It models a realistic small CLI/data project with
+human-authored specs, implementation plans, decision records, contradictory research notes, a
+non-trivial commit history, a healthy Splendor workspace on `main`, a source-refresh scenario
+branch, and isolated recovery fixtures for polluted registries and renamed-source repair. The
+operator-facing workflow is documented in
+[public mock client acceptance](public_mock_client_acceptance.md).
 
 ## Milestone 18 — v2 advanced product track
 


### PR DESCRIPTION
## Summary

- Created the public acceptance target at https://github.com/splendor-dev/mock-client-acceptance.
- Seeded the mock client repo with a realistic small CLI/data project, Splendor workspace state, contradictory authority docs, recovery fixtures, and a source-refresh scenario.
- Addressed review gaps by pinning the reviewed external state with tags, adding real merged mock-repo PR history, and force-committing the polluted fixture scratch/cache files.
- Documented the public acceptance workflow in `docs/public_mock_client_acceptance.md` and advanced the planning markers to M17-P1.1.

## External acceptance refs

- Healthy baseline tag: `m17-p1.1-acceptance-main` at `fa733da2a344cb55605a364f403aba9e290bbd62`
- Source-refresh scenario tag: `m17-p1.1-source-refresh-scenario` at `ee4768ae12650e17f227bafa2a813e47af8ae77c`
- Mock repo merged PR history:
  - https://github.com/splendor-dev/mock-client-acceptance/pull/1
  - https://github.com/splendor-dev/mock-client-acceptance/pull/2
  - https://github.com/splendor-dev/mock-client-acceptance/pull/3

## Validation

Splendor repo:
- `uv run splendor lint`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest` (633 passed)

Public mock client repo:
- Fresh clone of `m17-p1.1-acceptance-main`: fixture files exist, `splendor lint`, `splendor health`, and `brief --agent-context "balance reconciliation rollout"` pass/show expected authority ranking.
- Fresh clone of `m17-p1.1-source-refresh-scenario`: `splendor workspace refresh --changed --ingest --prune-superseded --update-topic-refs --rebuild-index`, `splendor lint`, and `splendor health` pass.
- Fresh copy of `acceptance-fixtures/polluted-registry` from the pinned baseline: `splendor source forget` plus `splendor source reconcile` recovery ends with passing lint and health.

Closes #114.