### PR TITLE
M17-P2.1: Expand planning authority lifecycle

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M16-P3.3`
-- Last action taken: `M16-P3.3` was squash-merged into main as commit `5aeb20b`,
-  publishing release artifacts for easier trial installs.
+- Previous completed PR sub-slice: `M17-P1.1`
+- Last action taken: `M17-P1.1` was squash-merged into main as commit `b535465`,
+  creating the public mock client acceptance repository.
 - Current planned slice: `M17 v1 public readiness`
-- Current PR sub-slice: `M17-P1.1`
+- Current PR sub-slice: `M17-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M17 v1 public readiness`
-- Next planned PR sub-slice: `M17-P2.1`
+- Next planned PR sub-slice: `M17-P3.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -342,6 +342,11 @@
   - [x] Seed healthy `main` with a realistic CLI/data project and Splendor workspace
   - [x] Add source-refresh, polluted-registry, and renamed-source acceptance scenarios
   - [x] Document the public acceptance contract in Splendor docs
+- [x] Implement `M17-P2.1`: Expand planning authority lifecycle
+  - [x] Add schema-version-1-compatible lifecycle and PR/issue linkage metadata
+  - [x] Rank current, reviewed, PR-linked, historical, superseded, and archived authority
+  - [x] Include accepted and superseded planning decisions in goal-relevant authority handoff
+  - [x] Update tests, docs, and planning state for issue #116
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,13 @@ historical review, proposal, reference, and generated-summary context, with fres
 current, watch, stale, or historical. Generated `source-summary` pages remain ingestion artifacts
 and are excluded from maintained authority ranking.
 
+`M17-P2.1` expands that authority model for issue #116 without changing schema version `1`.
+Configured authority docs, maintained wiki authority pages, and goal-relevant decision records can
+now expose lifecycle state (`current`, `reviewed`, `pr-linked`, `historical`, `superseded`, or
+`archived`) plus issue/PR and supersession links. `brief --agent-context` and `suggest-next` use
+that lifecycle so current, reviewed, and PR-linked decisions outrank older research, stale plans,
+superseded docs, and archived context while keeping those historical records visible when relevant.
+
 Generated source-summary pages are deterministic ingestion artifacts. For readable in-repo
 markdown/text/code sources, Splendor defaults to concise claim-bearing excerpts and path-first
 display; copied, external, parsed PDF, and OCR-derived sources keep fuller extracts by default
@@ -281,12 +288,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M16-P3.3`
+- Previous completed PR sub-slice: `M17-P1.1`
 - Current planned slice: `M17 v1 public readiness`
-- Current PR sub-slice: `M17-P1.1`
+- Current PR sub-slice: `M17-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M17 v1 public readiness`
-- Next planned PR sub-slice: `M17-P2.1`
+- Next planned PR sub-slice: `M17-P3.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -429,6 +436,10 @@ acceptance workflows in [docs/public_mock_client_acceptance.md](docs/public_mock
 The reviewed external state is pinned by the `m17-p1.1-acceptance-main` and
 `m17-p1.1-source-refresh-scenario` tags, and the mock repository includes merged PR history for
 external evaluator exercises.
+
+`M17-P2.1` implements the planning authority lifecycle for issue #116. Authority handoff surfaces
+now carry lifecycle and issue/PR linkage metadata, and accepted planning decisions participate in
+goal-relevant authority ranking while superseded decisions remain historical context.
 
 `M14-P1.5` adds the explicit stale-ingest repair path for issue #93:
 `splendor ingest --changed` detects checksum-drifted curated workspace-backed sources, refreshes

--- a/docs/public_mock_client_acceptance.md
+++ b/docs/public_mock_client_acceptance.md
@@ -45,6 +45,8 @@ splendor suggest-next "reconciliation contradictions"
 
 Expected result: lint and health pass on `main`, and the agent-context brief ranks the current
 spec, rollout plan, CSV-first decision, and held-entry research above the stale JSONL research note.
+With M17-P2.1 lifecycle-aware handoff, current, reviewed, or PR-linked authority should also rank
+above superseded or archived planning context when those records are present.
 
 ## Source-Refresh Scenario
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -474,17 +474,19 @@ schema-version-1-compatible config, not generated state:
 
 `splendor brief --agent-context [goal]` and `splendor suggest-next [goal]` use this metadata as a
 read-only ranking signal. Omitted lifecycle metadata remains schema-version-1-compatible:
-configured docs default to current unless role/freshness marks them historical or stale, and wiki
-authority lifecycle is derived from page status, review state, freshness, review timestamp, and
-supersession fields. Missing configured files are excluded from the ranked authority list, reported
-as authority warnings in the brief, and surfaced by `splendor lint` as
+configured docs default to current unless role/freshness marks them historical or an explicit
+`superseded_by` replacement exists, and wiki authority lifecycle is derived from review state,
+freshness, review timestamp, and supersession fields. Stale freshness remains separate from
+supersession. Missing configured files are excluded from the ranked authority list, reported as
+authority warnings in the brief, and surfaced by `splendor lint` as
 `missing-authority-document`.
 
 Accepted and superseded decision records can also participate in goal-relevant authority handoff.
 Accepted decisions default to reviewed authority, while superseded decisions default to superseded
 historical context. Optional decision `authority_lifecycle`, `issue_refs`, `pr_refs`,
 `superseded_by`, and existing `supersedes` fields are included in authority JSON output when
-present.
+present. `splendor decision create` can write those optional fields with `--authority-lifecycle`,
+`--issue-ref`, `--pr-ref`, and `--superseded-by`.
 
 Task records now also reserve:
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -395,7 +395,12 @@ Minimal frontmatter contract for wiki pages:
 - `review_state`
 - `authority_role`
 - `authority_freshness`
+- `authority_lifecycle`
 - `authority_scope`
+- `issue_refs`
+- `pr_refs`
+- `supersedes`
+- `superseded_by`
 - `source_refs`
 - `generated_by_run_ids`
 - `last_generated_at`
@@ -416,8 +421,9 @@ Current runtime behavior:
 - `splendor wiki rebuild-index` rewrites `wiki/index.md` from validated wiki page frontmatter and
   does not mutate generated source-summary pages
 - maintained wiki pages may opt into agent authority ranking with `authority_role`,
-  `authority_freshness`, and `authority_scope`; generated `source-summary` pages are ignored by
-  maintained authority ranking even if those fields are present
+  `authority_freshness`, `authority_lifecycle`, `authority_scope`, issue/PR refs, and
+  supersession links; generated `source-summary` pages are ignored by maintained authority ranking
+  even if those fields are present
 - source-summary pages written by `splendor ingest` now use `review_state: machine-generated`
 - those pages persist `last_generated_at`
 - those pages persist structured provenance links back to the source manifest, ingest run, and
@@ -456,14 +462,29 @@ schema-version-1-compatible config, not generated state:
 - `role`: one of `current-authority`, `roadmap`, `historical-review`, `proposal`, `reference`, or
   `generated-summary`
 - `freshness`: one of `current`, `watch`, `stale`, or `historical`
+- `authority_lifecycle`: optional lifecycle state; one of `current`, `reviewed`, `pr-linked`,
+  `historical`, `superseded`, or `archived`
 - `title`: optional display title
 - `purpose`: optional handoff reason
 - `applies_to`: optional task/topic terms used during goal ranking
+- `issue_refs`: optional issue identifiers such as `#116`
+- `pr_refs`: optional PR identifiers such as `#132`
+- `supersedes`: optional authority docs or decision IDs replaced by this entry
+- `superseded_by`: optional authority doc or decision ID that replaced this entry
 
 `splendor brief --agent-context [goal]` and `splendor suggest-next [goal]` use this metadata as a
-read-only ranking signal. Missing configured files are excluded from the ranked authority list,
-reported as authority warnings in the brief, and surfaced by `splendor lint` as
+read-only ranking signal. Omitted lifecycle metadata remains schema-version-1-compatible:
+configured docs default to current unless role/freshness marks them historical or stale, and wiki
+authority lifecycle is derived from page status, review state, freshness, review timestamp, and
+supersession fields. Missing configured files are excluded from the ranked authority list, reported
+as authority warnings in the brief, and surfaced by `splendor lint` as
 `missing-authority-document`.
+
+Accepted and superseded decision records can also participate in goal-relevant authority handoff.
+Accepted decisions default to reviewed authority, while superseded decisions default to superseded
+historical context. Optional decision `authority_lifecycle`, `issue_refs`, `pr_refs`,
+`superseded_by`, and existing `supersedes` fields are included in authority JSON output when
+present.
 
 Task records now also reserve:
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M16-P3.3`
+- Previous completed PR sub-slice: `M17-P1.1`
 - Current planned slice: `M17 v1 public readiness`
-- Current PR sub-slice: `M17-P1.1`
+- Current PR sub-slice: `M17-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M17 v1 public readiness`
-- Next planned PR sub-slice: `M17-P2.1`
+- Next planned PR sub-slice: `M17-P3.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1177,6 +1177,14 @@ renamed-source repair. The reviewed external state is pinned by the
 `m17-p1.1-acceptance-main` and `m17-p1.1-source-refresh-scenario` tags, and the operator-facing
 workflow is documented in
 [public mock client acceptance](public_mock_client_acceptance.md).
+
+### Planning authority lifecycle
+`M17-P2.1` implements issue #116 by expanding authority metadata without changing schema version
+`1`. Configured authority documents, maintained wiki authority pages, and goal-relevant planning
+decisions can now expose lifecycle state for current, reviewed, PR-linked, historical, superseded,
+and archived authority. Agent handoff surfaces use that lifecycle to rank accepted/current
+decisions above stale plans or older research while retaining superseded and archived documents as
+explicit historical context.
 
 ## Milestone 18 — v2 advanced product track
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1113,8 +1113,14 @@ Current implementation:
   records, recent maintenance reports, and query matches for the optional goal.
 - Authority docs come from `briefing.authority_documents` in `splendor.yaml` and optional
   maintained wiki page frontmatter (`authority_role`, `authority_freshness`, and
-  `authority_scope`). Generated source-summary pages are excluded from maintained authority
-  ranking.
+  `authority_lifecycle`, `authority_scope`, issue/PR refs, and supersession links). Generated
+  source-summary pages are excluded from maintained authority ranking.
+- Authority lifecycle values are `current`, `reviewed`, `pr-linked`, `historical`, `superseded`,
+  and `archived`. Briefing and suggest-next rank current, reviewed, and PR-linked authority above
+  stale, historical, superseded, or archived context while still showing relevant historical
+  records. Accepted decision records are included as goal-relevant reviewed authority; superseded
+  decisions are retained below current decisions as historical context. This extends schema version
+  `1` through optional fields only.
 - Briefing is read-only and does not replace `splendor query`; query finds records, while briefing
   packages the surrounding project state needed to resume work.
 
@@ -1416,8 +1422,8 @@ These are not blockers to the spec, but should remain visible:
 7. whether a companion-repo linking model needs a first-class schema element
 8. post-v1 refinements to generated source-summary policy for readable in-repo markdown and code
    files, after the v1 default of concise claim-bearing excerpts has been exercised in real repos
-9. richer authority lifecycle policy for living planning docs after the initial M14-P4.1 metadata
-   and task-oriented brief ranking has been exercised in real repos
+9. richer authority lifecycle policy beyond the M17-P2.1 states, after public mock-client and real
+   evaluator handoffs show which lifecycle distinctions agents actually use
 
 ## 31. Summary Product Statement
 

--- a/docs/v0_2_synthbanshee_evaluation.md
+++ b/docs/v0_2_synthbanshee_evaluation.md
@@ -117,7 +117,8 @@ fixtures. The first public acceptance suite should force three workflows:
    topic refs, and passing `splendor lint` plus `splendor health`.
 2. Agent handoff on a planning question that spans multiple authorities. `brief --agent-context`
    should surface the implementation plan, current decision record, and relevant contradicting
-   research note, with current authority ranked above stale or merely token-similar material.
+   research note, with current, reviewed, or PR-linked authority ranked above stale, superseded,
+   archived, or merely token-similar material.
 3. Recovery from polluted source state. A seeded polluted registry should be recoverable through a
    documented Splendor command, ending with ignored cache/local-agent manifests removed, duplicate
    active source refs reconciled, and no manual deletion under `state/manifests/sources/`.

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -118,7 +118,7 @@ from splendor.schemas import (
     QuestionRecord,
     TaskRecord,
 )
-from splendor.schemas.types import STORAGE_MODES
+from splendor.schemas.types import AUTHORITY_LIFECYCLES, STORAGE_MODES
 from splendor.state.query_snapshot import last_query_path_for, write_query_snapshot
 from splendor.state.source_compat import canonical_source_ref, effective_logical_id
 from splendor.utils.provenance import summarize_provenance_links
@@ -740,6 +740,20 @@ def build_parser() -> argparse.ArgumentParser:
     decision_create_parser.add_argument("--decided-at", help="Decision date")
     decision_create_parser.add_argument(
         "--supersedes", action="append", default=[], help="Superseded decision reference"
+    )
+    decision_create_parser.add_argument(
+        "--superseded-by", help="Decision or authority reference that superseded this decision"
+    )
+    decision_create_parser.add_argument(
+        "--authority-lifecycle",
+        choices=AUTHORITY_LIFECYCLES,
+        help="Authority lifecycle state for agent handoff.",
+    )
+    decision_create_parser.add_argument(
+        "--issue-ref", action="append", default=[], help="Linked GitHub issue reference"
+    )
+    decision_create_parser.add_argument(
+        "--pr-ref", action="append", default=[], help="Linked GitHub pull request reference"
     )
     decision_create_parser.add_argument(
         "--source-ref", action="append", default=[], help="Linked source reference"
@@ -2551,6 +2565,10 @@ def handle_decision_create(args: argparse.Namespace) -> int:
             source_refs=args.source_ref,
             related_tasks=args.related_task,
             related_questions=args.related_question,
+            authority_lifecycle=args.authority_lifecycle,
+            superseded_by=args.superseded_by,
+            issue_refs=args.issue_ref,
+            pr_refs=args.pr_ref,
         )
     except ValueError as exc:
         return _print_error(exc)

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -2158,7 +2158,11 @@ def handle_brief(args: argparse.Namespace) -> int:
     if result.authority_briefs:
         print("Authority docs:")
         for item in result.authority_briefs:
-            print(f"- {item.path} [{item.role}/{item.freshness}] score={item.score}: {item.title}")
+            refs = _authority_link_summary(item)
+            print(
+                f"- {item.path} [{item.role}/{item.freshness}/{item.lifecycle}] "
+                f"score={item.score}: {item.title}{refs}"
+            )
     if result.planning_items:
         print("Active planning:")
         for item in result.planning_items:
@@ -2220,7 +2224,11 @@ def _print_agent_context(result: ProjectBrief) -> None:
     if result.authority_briefs:
         print("Authority docs:")
         for item in result.authority_briefs[:5]:
-            print(f"- {item.path} [{item.role}/{item.freshness}] score={item.score} {item.title}")
+            refs = _authority_link_summary(item)
+            print(
+                f"- {item.path} [{item.role}/{item.freshness}/{item.lifecycle}] "
+                f"score={item.score} {item.title}{refs}"
+            )
     if result.planning_items:
         print("Active planning:")
         for item in result.planning_items:
@@ -2285,6 +2293,19 @@ def handle_suggest_next(args: argparse.Namespace) -> int:
 
 def _suggested_action_target(action) -> str:
     return action.source_ref or action.path or action.record_id or "-"
+
+
+def _authority_link_summary(item) -> str:
+    refs: list[str] = []
+    if item.issue_refs:
+        refs.append("issues=" + ",".join(item.issue_refs))
+    if item.pr_refs:
+        refs.append("prs=" + ",".join(item.pr_refs))
+    if item.superseded_by is not None:
+        refs.append(f"superseded_by={item.superseded_by}")
+    if item.supersedes:
+        refs.append("supersedes=" + ",".join(item.supersedes))
+    return "" if not refs else " " + " ".join(refs)
 
 
 def handle_serve(args: argparse.Namespace) -> int:

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -110,6 +110,14 @@ _AUTHORITY_LIFECYCLE_SCORE = {
     "superseded": -30,
     "archived": -35,
 }
+_AUTHORITY_LIFECYCLE_TIER = {
+    "current": 0,
+    "reviewed": 0,
+    "pr-linked": 0,
+    "historical": 1,
+    "superseded": 2,
+    "archived": 3,
+}
 _PLANNING_STATUSES = {
     "task": {"todo", "in_progress", "blocked"},
     "milestone": {"planned", "active"},
@@ -436,7 +444,10 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
         title = doc.title or _title_from_markdown(body) or path.name
         reason = doc.purpose or f"{doc.role} document for {path.as_posix()}"
         lifecycle = _configured_authority_lifecycle(
-            doc.authority_lifecycle, role=doc.role, freshness=doc.freshness
+            doc.authority_lifecycle,
+            role=doc.role,
+            freshness=doc.freshness,
+            superseded_by=doc.superseded_by,
         )
         score = _authority_score(
             role=doc.role,
@@ -512,9 +523,10 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
     ranked = sorted(
         enumerate(items),
         key=lambda item: (
-            -item[1].score,
+            _AUTHORITY_LIFECYCLE_TIER.get(item[1].lifecycle, 99),
             _AUTHORITY_LIFECYCLE_ORDER.get(item[1].lifecycle, 99),
             _AUTHORITY_ROLE_ORDER.get(item[1].role, 99),
+            -item[1].score,
             item[0],
             item[1].path,
         ),
@@ -539,13 +551,15 @@ def _authority_score(
     return score
 
 
-def _configured_authority_lifecycle(lifecycle: str | None, *, role: str, freshness: str) -> str:
+def _configured_authority_lifecycle(
+    lifecycle: str | None, *, role: str, freshness: str, superseded_by: str | None
+) -> str:
     if lifecycle is not None:
         return lifecycle
+    if superseded_by is not None:
+        return "superseded"
     if freshness == "historical" or role == "historical-review":
         return "historical"
-    if freshness == "stale":
-        return "superseded"
     return "current"
 
 
@@ -553,8 +567,6 @@ def _wiki_authority_lifecycle(frontmatter: KnowledgePageFrontmatter, *, freshnes
     if frontmatter.authority_lifecycle is not None:
         return frontmatter.authority_lifecycle
     if frontmatter.superseded_by is not None:
-        return "superseded"
-    if frontmatter.status == "stale" or freshness == "stale":
         return "superseded"
     if freshness == "historical" or frontmatter.authority_role == "historical-review":
         return "historical"
@@ -866,10 +878,15 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
             and authority.role in {"current-authority", "roadmap", "decision"}
             else "low"
         )
+        title = (
+            f"Review decision {authority.path}"
+            if authority.role == "decision"
+            else f"Read authority doc {authority.path}"
+        )
         add(
             priority,
             "authority",
-            f"Read authority doc {authority.path}",
+            title,
             f"{authority.role}/{authority.freshness}/{authority.lifecycle}: {authority.reason}",
             None,
             path=authority.path,

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import (
+    DecisionRecord,
     KnowledgePageFrontmatter,
     MaintenanceReport,
     QuerySnapshot,
@@ -77,20 +78,38 @@ _TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]{1,}")
 _AUTHORITY_ROLE_ORDER = {
     "current-authority": 0,
     "roadmap": 1,
-    "reference": 2,
-    "proposal": 3,
-    "historical-review": 4,
-    "generated-summary": 5,
+    "decision": 2,
+    "reference": 3,
+    "proposal": 4,
+    "historical-review": 5,
+    "generated-summary": 6,
 }
 _AUTHORITY_ROLE_SCORE = {
     "current-authority": 60,
     "roadmap": 45,
+    "decision": 42,
     "reference": 35,
     "proposal": 25,
     "historical-review": 20,
     "generated-summary": 5,
 }
 _AUTHORITY_FRESHNESS_SCORE = {"current": 25, "watch": 10, "stale": -10, "historical": -20}
+_AUTHORITY_LIFECYCLE_ORDER = {
+    "current": 0,
+    "reviewed": 1,
+    "pr-linked": 2,
+    "historical": 3,
+    "superseded": 4,
+    "archived": 5,
+}
+_AUTHORITY_LIFECYCLE_SCORE = {
+    "current": 35,
+    "reviewed": 30,
+    "pr-linked": 28,
+    "historical": -5,
+    "superseded": -30,
+    "archived": -35,
+}
 _PLANNING_STATUSES = {
     "task": {"todo", "in_progress", "blocked"},
     "milestone": {"planned", "active"},
@@ -129,8 +148,13 @@ class AuthorityBrief:
     title: str
     role: str
     freshness: str
+    lifecycle: str
     score: int
     reason: str
+    issue_refs: list[str]
+    pr_refs: list[str]
+    supersedes: list[str]
+    superseded_by: str | None
 
 
 @dataclass(frozen=True)
@@ -306,7 +330,7 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
     sources = load_sources(layout)
     sources_by_id = {source.source_id: source for source in sources}
     wiki_pages, invalid_wiki_pages = load_wiki_pages(root, layout)
-    authority_briefs, authority_warnings = _authority_briefs(root, config, wiki_pages, goal)
+    authority_briefs, authority_warnings = _authority_briefs(root, layout, config, wiki_pages, goal)
     warnings.extend(authority_warnings)
     recent_sources = _recent_sources(sources)
     recent_runs = status.recent_runs
@@ -390,7 +414,7 @@ def _active_planning_items(
     return items[:_BRIEF_PLANNING_LIMIT], warnings
 
 
-def _authority_briefs(root: Path, config, pages: list[WikiPageSnapshot], goal: str | None):
+def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot], goal: str | None):
     items: list[AuthorityBrief] = []
     warnings: list[BriefWarning] = []
     goal_tokens = _tokens(goal or "")
@@ -411,9 +435,13 @@ def _authority_briefs(root: Path, config, pages: list[WikiPageSnapshot], goal: s
             continue
         title = doc.title or _title_from_markdown(body) or path.name
         reason = doc.purpose or f"{doc.role} document for {path.as_posix()}"
+        lifecycle = _configured_authority_lifecycle(
+            doc.authority_lifecycle, role=doc.role, freshness=doc.freshness
+        )
         score = _authority_score(
             role=doc.role,
             freshness=doc.freshness,
+            lifecycle=lifecycle,
             goal_tokens=goal_tokens,
             text=" ".join([title, reason, " ".join(doc.applies_to), path.as_posix(), body]),
         )
@@ -424,8 +452,13 @@ def _authority_briefs(root: Path, config, pages: list[WikiPageSnapshot], goal: s
                 title=title,
                 role=doc.role,
                 freshness=doc.freshness,
+                lifecycle=lifecycle,
                 score=score,
                 reason=reason,
+                issue_refs=doc.issue_refs,
+                pr_refs=doc.pr_refs,
+                supersedes=doc.supersedes,
+                superseded_by=doc.superseded_by,
             )
         )
 
@@ -437,6 +470,7 @@ def _authority_briefs(root: Path, config, pages: list[WikiPageSnapshot], goal: s
         freshness = page.frontmatter.authority_freshness or _derived_authority_freshness(
             page.frontmatter
         )
+        lifecycle = _wiki_authority_lifecycle(page.frontmatter, freshness=freshness)
         reason = (
             "Maintained wiki page marked for agent briefing"
             if not page.frontmatter.authority_scope
@@ -445,6 +479,7 @@ def _authority_briefs(root: Path, config, pages: list[WikiPageSnapshot], goal: s
         score = _authority_score(
             role=page.frontmatter.authority_role,
             freshness=freshness,
+            lifecycle=lifecycle,
             goal_tokens=goal_tokens,
             text=" ".join(
                 [
@@ -463,15 +498,22 @@ def _authority_briefs(root: Path, config, pages: list[WikiPageSnapshot], goal: s
                 title=page.frontmatter.title,
                 role=page.frontmatter.authority_role,
                 freshness=freshness,
+                lifecycle=lifecycle,
                 score=score,
                 reason=reason,
+                issue_refs=page.frontmatter.issue_refs,
+                pr_refs=page.frontmatter.pr_refs,
+                supersedes=page.frontmatter.supersedes,
+                superseded_by=page.frontmatter.superseded_by,
             )
         )
 
+    items.extend(_decision_authority_briefs(root, layout, goal_tokens))
     ranked = sorted(
         enumerate(items),
         key=lambda item: (
             -item[1].score,
+            _AUTHORITY_LIFECYCLE_ORDER.get(item[1].lifecycle, 99),
             _AUTHORITY_ROLE_ORDER.get(item[1].role, 99),
             item[0],
             item[1].path,
@@ -483,12 +525,105 @@ def _authority_briefs(root: Path, config, pages: list[WikiPageSnapshot], goal: s
     ], warnings
 
 
-def _authority_score(*, role: str, freshness: str, goal_tokens: set[str], text: str) -> int:
-    score = _AUTHORITY_ROLE_SCORE.get(role, 0) + _AUTHORITY_FRESHNESS_SCORE.get(freshness, 0)
+def _authority_score(
+    *, role: str, freshness: str, lifecycle: str, goal_tokens: set[str], text: str
+) -> int:
+    score = (
+        _AUTHORITY_ROLE_SCORE.get(role, 0)
+        + _AUTHORITY_FRESHNESS_SCORE.get(freshness, 0)
+        + _AUTHORITY_LIFECYCLE_SCORE.get(lifecycle, 0)
+    )
     if goal_tokens:
         overlap = goal_tokens & _tokens(text)
         score += min(len(overlap), 6) * 12
     return score
+
+
+def _configured_authority_lifecycle(lifecycle: str | None, *, role: str, freshness: str) -> str:
+    if lifecycle is not None:
+        return lifecycle
+    if freshness == "historical" or role == "historical-review":
+        return "historical"
+    if freshness == "stale":
+        return "superseded"
+    return "current"
+
+
+def _wiki_authority_lifecycle(frontmatter: KnowledgePageFrontmatter, *, freshness: str) -> str:
+    if frontmatter.authority_lifecycle is not None:
+        return frontmatter.authority_lifecycle
+    if frontmatter.superseded_by is not None:
+        return "superseded"
+    if frontmatter.status == "stale" or freshness == "stale":
+        return "superseded"
+    if freshness == "historical" or frontmatter.authority_role == "historical-review":
+        return "historical"
+    if frontmatter.review_state == "human-reviewed" or frontmatter.last_reviewed_at is not None:
+        return "reviewed"
+    return "current"
+
+
+def _decision_authority_briefs(root: Path, layout, goal_tokens: set[str]) -> list[AuthorityBrief]:
+    if not goal_tokens:
+        return []
+    items: list[AuthorityBrief] = []
+    for path in iter_planning_paths(planning_directory(layout, "decision")):
+        try:
+            parsed = parse_planning_document(path, DecisionRecord)
+        except (OSError, ValueError):
+            continue
+        record = parsed.record
+        if record.status not in {"accepted", "superseded"}:
+            continue
+        text = " ".join(
+            [
+                record.title,
+                record.decision_id,
+                record.decided_at or "",
+                " ".join(record.source_refs),
+                " ".join(record.related_tasks),
+                " ".join(record.related_questions),
+                " ".join(record.issue_refs),
+                " ".join(record.pr_refs),
+                parsed.body,
+            ]
+        )
+        if not (goal_tokens & _tokens(text)):
+            continue
+        lifecycle = record.authority_lifecycle or (
+            "superseded" if record.status == "superseded" else "reviewed"
+        )
+        freshness = (
+            "historical" if lifecycle in {"historical", "superseded", "archived"} else "current"
+        )
+        reason = (
+            "Accepted planning decision"
+            if record.status == "accepted"
+            else "Superseded planning decision retained for historical context"
+        )
+        items.append(
+            AuthorityBrief(
+                rank=0,
+                path=path.relative_to(root).as_posix(),
+                title=record.title,
+                role="decision",
+                freshness=freshness,
+                lifecycle=lifecycle,
+                score=_authority_score(
+                    role="decision",
+                    freshness=freshness,
+                    lifecycle=lifecycle,
+                    goal_tokens=goal_tokens,
+                    text=text,
+                ),
+                reason=reason,
+                issue_refs=record.issue_refs,
+                pr_refs=record.pr_refs,
+                supersedes=record.supersedes,
+                superseded_by=record.superseded_by,
+            )
+        )
+    return items
 
 
 def _derived_authority_freshness(frontmatter: KnowledgePageFrontmatter) -> str:
@@ -725,12 +860,17 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
         )
 
     for authority in snapshot.authority_briefs[:3]:
-        priority = "medium" if authority.role in {"current-authority", "roadmap"} else "low"
+        priority = (
+            "medium"
+            if authority.lifecycle in {"current", "reviewed", "pr-linked"}
+            and authority.role in {"current-authority", "roadmap", "decision"}
+            else "low"
+        )
         add(
             priority,
             "authority",
             f"Read authority doc {authority.path}",
-            f"{authority.role}/{authority.freshness}: {authority.reason}",
+            f"{authority.role}/{authority.freshness}/{authority.lifecycle}: {authority.reason}",
             None,
             path=authority.path,
         )

--- a/src/splendor/commands/planning.py
+++ b/src/splendor/commands/planning.py
@@ -149,14 +149,22 @@ def create_decision(
     source_refs: list[str],
     related_tasks: list[str],
     related_questions: list[str],
+    authority_lifecycle: str | None = None,
+    superseded_by: str | None = None,
+    issue_refs: list[str] | None = None,
+    pr_refs: list[str] | None = None,
 ) -> CreatePlanningResult:
     decision_id = record_id or default_record_id("decision", title)
     record = DecisionRecord(
         decision_id=decision_id,
         title=title,
         status=status,
+        authority_lifecycle=authority_lifecycle,
         decided_at=decided_at,
         supersedes=supersedes,
+        superseded_by=superseded_by,
+        issue_refs=issue_refs or [],
+        pr_refs=pr_refs or [],
         source_refs=source_refs,
         related_tasks=related_tasks,
         related_questions=related_questions,

--- a/src/splendor/config.py
+++ b/src/splendor/config.py
@@ -11,7 +11,7 @@ from typing import Annotated, Literal
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from splendor.schemas.types import SourceClass, StorageMode, SummaryMode
+from splendor.schemas.types import AuthorityLifecycle, SourceClass, StorageMode, SummaryMode
 
 CONFIG_FILENAME = "splendor.yaml"
 
@@ -89,9 +89,14 @@ class AuthorityDocumentConfig(BaseModel):
         "generated-summary",
     ] = "reference"
     freshness: Literal["current", "watch", "stale", "historical"] = "current"
+    authority_lifecycle: AuthorityLifecycle | None = None
     title: str | None = None
     purpose: str | None = None
     applies_to: list[str] = Field(default_factory=list)
+    issue_refs: list[str] = Field(default_factory=list)
+    pr_refs: list[str] = Field(default_factory=list)
+    supersedes: list[str] = Field(default_factory=list)
+    superseded_by: str | None = None
 
     @field_validator("path")
     @classmethod

--- a/src/splendor/schemas/__init__.py
+++ b/src/splendor/schemas/__init__.py
@@ -14,6 +14,7 @@ from splendor.schemas.runtime import QueueItemRecord, RunRecord
 from splendor.schemas.source import SourceRecord
 from splendor.schemas.source_pointer import SourcePointerArtifact
 from splendor.schemas.types import (
+    AUTHORITY_LIFECYCLES,
     AuthorityLifecycle,
     PageReviewState,
     ProvenanceRole,
@@ -27,6 +28,7 @@ from splendor.schemas.types import (
 from splendor.schemas.wiki import KnowledgePageFrontmatter
 
 __all__ = [
+    "AUTHORITY_LIFECYCLES",
     "AuthorityLifecycle",
     "ContradictionAnnotation",
     "ContradictionEvidence",

--- a/src/splendor/schemas/__init__.py
+++ b/src/splendor/schemas/__init__.py
@@ -14,6 +14,7 @@ from splendor.schemas.runtime import QueueItemRecord, RunRecord
 from splendor.schemas.source import SourceRecord
 from splendor.schemas.source_pointer import SourcePointerArtifact
 from splendor.schemas.types import (
+    AuthorityLifecycle,
     PageReviewState,
     ProvenanceRole,
     SourceClass,
@@ -26,6 +27,7 @@ from splendor.schemas.types import (
 from splendor.schemas.wiki import KnowledgePageFrontmatter
 
 __all__ = [
+    "AuthorityLifecycle",
     "ContradictionAnnotation",
     "ContradictionEvidence",
     "DecisionRecord",

--- a/src/splendor/schemas/planning.py
+++ b/src/splendor/schemas/planning.py
@@ -7,6 +7,7 @@ from typing import Literal
 from pydantic import Field
 
 from splendor.schemas.common import StrictRecord
+from splendor.schemas.types import AuthorityLifecycle
 
 
 class TaskRecord(StrictRecord):
@@ -45,8 +46,12 @@ class DecisionRecord(StrictRecord):
     decision_id: str
     title: str
     status: Literal["proposed", "accepted", "superseded"] = "proposed"
+    authority_lifecycle: AuthorityLifecycle | None = None
     decided_at: str | None = None
     supersedes: list[str] = Field(default_factory=list)
+    superseded_by: str | None = None
+    issue_refs: list[str] = Field(default_factory=list)
+    pr_refs: list[str] = Field(default_factory=list)
     source_refs: list[str] = Field(default_factory=list)
     related_tasks: list[str] = Field(default_factory=list)
     related_questions: list[str] = Field(default_factory=list)

--- a/src/splendor/schemas/types.py
+++ b/src/splendor/schemas/types.py
@@ -17,6 +17,14 @@ AuthorityLifecycle = Literal[
     "superseded",
     "archived",
 ]
+AUTHORITY_LIFECYCLES = (
+    "current",
+    "reviewed",
+    "pr-linked",
+    "historical",
+    "superseded",
+    "archived",
+)
 PageReviewState = Literal["draft", "machine-generated", "human-reviewed", "contested", "stale"]
 SourceReviewState = Literal[
     "unreviewed",

--- a/src/splendor/schemas/types.py
+++ b/src/splendor/schemas/types.py
@@ -9,6 +9,14 @@ SummaryMode = Literal["none", "excerpt", "full"]
 SourceRefKind = Literal["workspace_path", "external_path", "url", "imported", "stored_artifact"]
 SourceClass = Literal["code", "documentation", "configuration", "other"]
 SourceDiscoveryMode = Literal["manual", "repo_scan"]
+AuthorityLifecycle = Literal[
+    "current",
+    "reviewed",
+    "pr-linked",
+    "historical",
+    "superseded",
+    "archived",
+]
 PageReviewState = Literal["draft", "machine-generated", "human-reviewed", "contested", "stale"]
 SourceReviewState = Literal[
     "unreviewed",

--- a/src/splendor/schemas/wiki.py
+++ b/src/splendor/schemas/wiki.py
@@ -9,7 +9,7 @@ from pydantic import Field
 from splendor.schemas.common import StrictRecord
 from splendor.schemas.contradictions import ContradictionAnnotation
 from splendor.schemas.provenance import ProvenanceLink
-from splendor.schemas.types import PageReviewState
+from splendor.schemas.types import AuthorityLifecycle, PageReviewState
 
 
 class KnowledgePageFrontmatter(StrictRecord):
@@ -30,7 +30,12 @@ class KnowledgePageFrontmatter(StrictRecord):
         | None
     ) = None
     authority_freshness: Literal["current", "watch", "stale", "historical"] | None = None
+    authority_lifecycle: AuthorityLifecycle | None = None
     authority_scope: list[str] = Field(default_factory=list)
+    issue_refs: list[str] = Field(default_factory=list)
+    pr_refs: list[str] = Field(default_factory=list)
+    supersedes: list[str] = Field(default_factory=list)
+    superseded_by: str | None = None
     source_refs: list[str] = Field(default_factory=list)
     generated_by_run_ids: list[str] = Field(default_factory=list)
     last_generated_at: str | None = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4480,6 +4480,16 @@ def test_cli_decision_create_command(tmp_path: Path, capsys) -> None:
             "Use",
             "planning",
             "markdown",
+            "--status",
+            "accepted",
+            "--authority-lifecycle",
+            "pr-linked",
+            "--issue-ref",
+            "#116",
+            "--pr-ref",
+            "#133",
+            "--superseded-by",
+            "decision-old-planning-markdown",
             "--related-task",
             "task-write-cli-docs",
         ]
@@ -4488,6 +4498,11 @@ def test_cli_decision_create_command(tmp_path: Path, capsys) -> None:
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "Created decision decision-use-planning-markdown" in captured.out
+    path = tmp_path / "planning" / "decisions" / "decision-use-planning-markdown.md"
+    assert "authority_lifecycle: pr-linked" in path.read_text(encoding="utf-8")
+    assert "- '#116'" in path.read_text(encoding="utf-8")
+    assert "- '#133'" in path.read_text(encoding="utf-8")
+    assert "superseded_by: decision-old-planning-markdown" in path.read_text(encoding="utf-8")
 
 
 def test_cli_question_create_command(tmp_path: Path, capsys) -> None:

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -87,6 +87,10 @@ def test_create_decision_round_trips_with_schema(tmp_path: Path) -> None:
         status="accepted",
         decided_at="2026-04-17",
         supersedes=["decision-old"],
+        superseded_by=None,
+        authority_lifecycle="pr-linked",
+        issue_refs=["#116"],
+        pr_refs=["#133"],
         source_refs=["src-123"],
         related_tasks=["task-write-cli-docs"],
         related_questions=["question-query"],
@@ -96,6 +100,9 @@ def test_create_decision_round_trips_with_schema(tmp_path: Path) -> None:
     assert record.decision_id == "decision-use-planning-markdown"
     assert record.status == "accepted"
     assert record.decided_at == "2026-04-17"
+    assert record.authority_lifecycle == "pr-linked"
+    assert record.issue_refs == ["#116"]
+    assert record.pr_refs == ["#133"]
     assert record.related_tasks == ["task-write-cli-docs"]
 
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,9 +1,11 @@
 import pytest
 from pydantic import ValidationError
 
+from splendor.config import AuthorityDocumentConfig
 from splendor.schemas import (
     ContradictionAnnotation,
     ContradictionEvidence,
+    DecisionRecord,
     KnowledgePageFrontmatter,
     ProvenanceLink,
     QueueItemRecord,
@@ -245,6 +247,56 @@ def test_source_record_validation_rejects_invalid_source_class() -> None:
             pipeline_version="0.1.0a0",
             source_class="bogus",
         )
+
+
+def test_wiki_authority_lifecycle_fields_are_schema_version_one_compatible() -> None:
+    record = KnowledgePageFrontmatter(
+        kind="topic",
+        title="Lifecycle authority",
+        page_id="topic-lifecycle-authority",
+        authority_role="current-authority",
+        authority_freshness="current",
+        authority_lifecycle="pr-linked",
+        authority_scope=["agent handoff"],
+        issue_refs=["#116"],
+        pr_refs=["#132"],
+        supersedes=["docs/old-plan.md"],
+        superseded_by=None,
+    )
+
+    assert record.schema_version == "1"
+    assert record.authority_lifecycle == "pr-linked"
+    assert record.issue_refs == ["#116"]
+    assert record.pr_refs == ["#132"]
+
+
+def test_decision_record_accepts_authority_lifecycle_metadata() -> None:
+    record = DecisionRecord(
+        decision_id="decision-agent-handoff",
+        title="Use lifecycle authority ranking",
+        status="accepted",
+        authority_lifecycle="reviewed",
+        decided_at="2026-05-06",
+        supersedes=["decision-old-handoff"],
+        superseded_by=None,
+        issue_refs=["#116"],
+        pr_refs=["#132"],
+    )
+
+    assert record.schema_version == "1"
+    assert record.authority_lifecycle == "reviewed"
+    assert record.issue_refs == ["#116"]
+
+
+def test_authority_document_config_defaults_and_rejects_invalid_lifecycle() -> None:
+    record = AuthorityDocumentConfig(path="docs/plan.md")
+
+    assert record.authority_lifecycle is None
+    assert record.issue_refs == []
+    assert record.pr_refs == []
+
+    with pytest.raises(ValidationError):
+        AuthorityDocumentConfig(path="docs/plan.md", authority_lifecycle="stale")
 
 
 def test_source_record_validation_rejects_unknown_fields() -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -6,7 +6,6 @@ import yaml
 from splendor.cli import main
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
-from splendor.commands.planning import create_decision
 from splendor.commands.wiki import add_topic_page, rebuild_wiki_index
 from splendor.config import AuthorityDocumentConfig, load_config, write_config
 from splendor.schemas import KnowledgePageFrontmatter, MaintenanceReport
@@ -1645,6 +1644,81 @@ def test_brief_agent_context_ranks_authority_lifecycle_and_links(tmp_path: Path,
     assert authority[3]["superseded_by"] == "docs/current.md"
 
 
+def test_brief_agent_context_treats_lifecycle_as_precedence_tier(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "current.md").write_text("# Current\n\nStill authoritative.\n", encoding="utf-8")
+    (docs / "archived.md").write_text(
+        "# Archived\n\nalpha beta gamma delta epsilon zeta.\n", encoding="utf-8"
+    )
+    config = load_config(tmp_path)
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path="docs/archived.md",
+            role="current-authority",
+            authority_lifecycle="archived",
+            applies_to=["alpha", "beta", "gamma", "delta", "epsilon", "zeta"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/current.md",
+            role="current-authority",
+            authority_lifecycle="current",
+        ),
+    ]
+    write_config(tmp_path, config)
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "alpha",
+            "beta",
+            "gamma",
+            "delta",
+            "epsilon",
+            "zeta",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [item["path"] for item in payload["authority_briefs"][:2]] == [
+        "docs/current.md",
+        "docs/archived.md",
+    ]
+    assert payload["authority_briefs"][1]["score"] > payload["authority_briefs"][0]["score"]
+
+
+def test_brief_agent_context_keeps_stale_freshness_separate_from_supersession(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / "stale.md").write_text("# Stale\n\nNeeds review.\n", encoding="utf-8")
+    config = load_config(tmp_path)
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path="stale.md",
+            role="current-authority",
+            freshness="stale",
+        )
+    ]
+    write_config(tmp_path, config)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "brief", "--agent-context", "--json"])
+
+    assert exit_code == 0
+    authority = json.loads(capsys.readouterr().out)["authority_briefs"][0]
+    assert authority["freshness"] == "stale"
+    assert authority["lifecycle"] == "current"
+    assert authority["superseded_by"] is None
+
+
 def test_brief_agent_context_warns_but_does_not_rank_missing_authority_docs(
     tmp_path: Path, capsys
 ) -> None:
@@ -1742,35 +1816,51 @@ def test_suggest_next_derives_draft_wiki_authority_freshness_as_watch(
 
 def test_suggest_next_includes_lifecycle_aware_decision_authority(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
-    create_decision(
-        tmp_path,
-        "Prefer lifecycle authority ranking",
-        record_id="decision-current-authority-ranking",
-        status="accepted",
-        decided_at="2026-05-06",
-        supersedes=["decision-old-authority-ranking"],
-        source_refs=[],
-        related_tasks=[],
-        related_questions=[],
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "decision",
+            "create",
+            "Prefer",
+            "lifecycle",
+            "authority",
+            "ranking",
+            "--id",
+            "decision-current-authority-ranking",
+            "--status",
+            "accepted",
+            "--decided-at",
+            "2026-05-06",
+            "--authority-lifecycle",
+            "reviewed",
+            "--supersedes",
+            "decision-old-authority-ranking",
+            "--issue-ref",
+            "#116",
+            "--pr-ref",
+            "#133",
+        ]
     )
-    old = create_decision(
-        tmp_path,
-        "Older authority ranking research",
-        record_id="decision-old-authority-ranking",
-        status="superseded",
-        decided_at="2026-04-30",
-        supersedes=[],
-        source_refs=[],
-        related_tasks=[],
-        related_questions=[],
-    )
-    old_record_path = old.path
-    old_text = old_record_path.read_text(encoding="utf-8")
-    old_record_path.write_text(
-        old_text.replace(
-            "superseded_by: null", "superseded_by: decision-current-authority-ranking"
-        ),
-        encoding="utf-8",
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "decision",
+            "create",
+            "Older",
+            "authority",
+            "ranking",
+            "research",
+            "--id",
+            "decision-old-authority-ranking",
+            "--status",
+            "superseded",
+            "--decided-at",
+            "2026-04-30",
+            "--superseded-by",
+            "decision-current-authority-ranking",
+        ]
     )
     capsys.readouterr()
 
@@ -1784,8 +1874,14 @@ def test_suggest_next_includes_lifecycle_aware_decision_authority(tmp_path: Path
         "planning/decisions/decision-old-authority-ranking.md",
     ]
     assert decisions[0]["lifecycle"] == "reviewed"
+    assert decisions[0]["issue_refs"] == ["#116"]
+    assert decisions[0]["pr_refs"] == ["#133"]
     assert decisions[1]["lifecycle"] == "superseded"
     assert decisions[1]["superseded_by"] == "decision-current-authority-ranking"
+    authority_actions = [
+        action for action in payload["actions"] if action["category"] == "authority"
+    ]
+    assert authority_actions[0]["title"].startswith("Review decision ")
 
 
 def test_suggest_next_json_ranks_changed_sources_before_review_work(tmp_path: Path, capsys) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -6,6 +6,7 @@ import yaml
 from splendor.cli import main
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
+from splendor.commands.planning import create_decision
 from splendor.commands.wiki import add_topic_page, rebuild_wiki_index
 from splendor.config import AuthorityDocumentConfig, load_config, write_config
 from splendor.schemas import KnowledgePageFrontmatter, MaintenanceReport
@@ -24,7 +25,12 @@ def write_wiki_page(
     tags: list[str] | None = None,
     authority_role: str | None = None,
     authority_freshness: str | None = None,
+    authority_lifecycle: str | None = None,
     authority_scope: list[str] | None = None,
+    issue_refs: list[str] | None = None,
+    pr_refs: list[str] | None = None,
+    supersedes: list[str] | None = None,
+    superseded_by: str | None = None,
     body: str = "",
 ) -> None:
     frontmatter = KnowledgePageFrontmatter(
@@ -37,7 +43,12 @@ def write_wiki_page(
         tags=tags or [],
         authority_role=authority_role,
         authority_freshness=authority_freshness,
+        authority_lifecycle=authority_lifecycle,
         authority_scope=authority_scope or [],
+        issue_refs=issue_refs or [],
+        pr_refs=pr_refs or [],
+        supersedes=supersedes or [],
+        superseded_by=superseded_by,
         confidence=0.8,
     )
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -1560,6 +1571,80 @@ def test_brief_agent_context_ranks_configured_authority_docs(tmp_path: Path, cap
     assert authority_actions[0]["path"] == "README.md"
 
 
+def test_brief_agent_context_ranks_authority_lifecycle_and_links(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "current.md").write_text("# Current\n\nCurrent planning authority.\n", encoding="utf-8")
+    (docs / "reviewed.md").write_text(
+        "# Reviewed\n\nReviewed planning authority.\n", encoding="utf-8"
+    )
+    (docs / "pr.md").write_text("# PR Linked\n\nPR-linked planning authority.\n", encoding="utf-8")
+    (docs / "superseded.md").write_text(
+        "# Superseded\n\nSuperseded planning authority.\n", encoding="utf-8"
+    )
+    (docs / "archived.md").write_text(
+        "# Archived\n\nArchived planning authority.\n", encoding="utf-8"
+    )
+    config = load_config(tmp_path)
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path="docs/superseded.md",
+            role="current-authority",
+            authority_lifecycle="superseded",
+            superseded_by="docs/current.md",
+            applies_to=["planning authority"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/archived.md",
+            role="current-authority",
+            authority_lifecycle="archived",
+            applies_to=["planning authority"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/pr.md",
+            role="current-authority",
+            authority_lifecycle="pr-linked",
+            issue_refs=["#116"],
+            pr_refs=["#132"],
+            applies_to=["planning authority"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/reviewed.md",
+            role="current-authority",
+            authority_lifecycle="reviewed",
+            applies_to=["planning authority"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/current.md",
+            role="current-authority",
+            authority_lifecycle="current",
+            applies_to=["planning authority"],
+        ),
+    ]
+    write_config(tmp_path, config)
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "brief", "--agent-context", "planning", "authority", "--json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    authority = payload["authority_briefs"]
+    assert [item["path"] for item in authority[:5]] == [
+        "docs/current.md",
+        "docs/reviewed.md",
+        "docs/pr.md",
+        "docs/superseded.md",
+        "docs/archived.md",
+    ]
+    assert authority[2]["lifecycle"] == "pr-linked"
+    assert authority[2]["issue_refs"] == ["#116"]
+    assert authority[2]["pr_refs"] == ["#132"]
+    assert authority[3]["superseded_by"] == "docs/current.md"
+
+
 def test_brief_agent_context_warns_but_does_not_rank_missing_authority_docs(
     tmp_path: Path, capsys
 ) -> None:
@@ -1652,7 +1737,55 @@ def test_suggest_next_derives_draft_wiki_authority_freshness_as_watch(
     authority_actions = [
         action for action in payload["actions"] if action["category"] == "authority"
     ]
-    assert authority_actions[0]["reason"].startswith("current-authority/watch:")
+    assert authority_actions[0]["reason"].startswith("current-authority/watch/current:")
+
+
+def test_suggest_next_includes_lifecycle_aware_decision_authority(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    create_decision(
+        tmp_path,
+        "Prefer lifecycle authority ranking",
+        record_id="decision-current-authority-ranking",
+        status="accepted",
+        decided_at="2026-05-06",
+        supersedes=["decision-old-authority-ranking"],
+        source_refs=[],
+        related_tasks=[],
+        related_questions=[],
+    )
+    old = create_decision(
+        tmp_path,
+        "Older authority ranking research",
+        record_id="decision-old-authority-ranking",
+        status="superseded",
+        decided_at="2026-04-30",
+        supersedes=[],
+        source_refs=[],
+        related_tasks=[],
+        related_questions=[],
+    )
+    old_record_path = old.path
+    old_text = old_record_path.read_text(encoding="utf-8")
+    old_record_path.write_text(
+        old_text.replace(
+            "superseded_by: null", "superseded_by: decision-current-authority-ranking"
+        ),
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "suggest-next", "authority", "ranking", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    decisions = [item for item in payload["authority_briefs"] if item["role"] == "decision"]
+    assert [item["path"] for item in decisions] == [
+        "planning/decisions/decision-current-authority-ranking.md",
+        "planning/decisions/decision-old-authority-ranking.md",
+    ]
+    assert decisions[0]["lifecycle"] == "reviewed"
+    assert decisions[1]["lifecycle"] == "superseded"
+    assert decisions[1]["superseded_by"] == "decision-current-authority-ranking"
 
 
 def test_suggest_next_json_ranks_changed_sources_before_review_work(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

- Add schema-version-1-compatible authority lifecycle and issue/PR/supersession metadata for configured authority docs, maintained wiki authority pages, and planning decisions.
- Teach `brief --agent-context` and `suggest-next` to rank current, reviewed, and PR-linked authority above stale, historical, superseded, or archived context while keeping relevant historical records visible.
- Update schema docs, product docs, public mock-client acceptance guidance, README, roadmap, and synchronized planning state for M17-P2.1.

## Compatibility

This preserves schema version `1`. Existing authority config, wiki pages, and planning records remain valid because the new lifecycle/link fields are optional and defaulted. Omitted lifecycle metadata is derived from existing role, freshness, page status, review state, and supersession fields.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest`
- `uv run splendor lint`

## Follow-up

M17-P3.1 remains the semantic-ranking polish slice; this PR adds lifecycle-aware authority state and deterministic ranking inputs without broadening into advanced semantic search.

Closes #116
