### PR TITLE
M17-P3.1: Improve semantic ranking for agent handoff

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M17-P1.1`
-- Last action taken: `M17-P1.1` was squash-merged into main as commit `b535465`,
-  creating the public mock client acceptance repository.
+- Previous completed PR sub-slice: `M17-P2.1`
+- Last action taken: `M17-P2.1` was squash-merged into main as commit `ae1a483`,
+  expanding lifecycle-aware planning authority for agent handoff.
 - Current planned slice: `M17 v1 public readiness`
-- Current PR sub-slice: `M17-P2.1`
+- Current PR sub-slice: `M17-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M17 v1 public readiness`
-- Next planned PR sub-slice: `M17-P3.1`
+- Next planned PR sub-slice: `M17-P4.1`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -257,6 +257,13 @@ now expose lifecycle state (`current`, `reviewed`, `pr-linked`, `historical`, `s
 that lifecycle so current, reviewed, and PR-linked decisions outrank older research, stale plans,
 superseded docs, and archived context while keeping those historical records visible when relevant.
 
+`M17-P3.1` improves issue #115 handoff ranking without adding vector search or background
+infrastructure. Briefing and suggestion surfaces use a shared deterministic relevance score across
+authority docs, decisions, active planning records, query matches, synthesis follow-up, and review
+signals. Title/path/scope matches carry more weight than loose body overlap, and category caps keep
+review noise from burying current specs, rollout plans, accepted decisions, and key contradicting
+research.
+
 Generated source-summary pages are deterministic ingestion artifacts. For readable in-repo
 markdown/text/code sources, Splendor defaults to concise claim-bearing excerpts and path-first
 display; copied, external, parsed PDF, and OCR-derived sources keep fuller extracts by default
@@ -288,12 +295,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M17-P1.1`
+- Previous completed PR sub-slice: `M17-P2.1`
 - Current planned slice: `M17 v1 public readiness`
-- Current PR sub-slice: `M17-P2.1`
+- Current PR sub-slice: `M17-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M17 v1 public readiness`
-- Next planned PR sub-slice: `M17-P3.1`
+- Next planned PR sub-slice: `M17-P4.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -440,6 +447,10 @@ external evaluator exercises.
 `M17-P2.1` implements the planning authority lifecycle for issue #116. Authority handoff surfaces
 now carry lifecycle and issue/PR linkage metadata, and accepted planning decisions participate in
 goal-relevant authority ranking while superseded decisions remain historical context.
+
+`M17-P3.1` implements deterministic authority-aware ranking for issue #115. Agent handoff now
+favors task-relevant current specs, rollout plans, accepted decisions, active planning records, and
+focused contradiction/review signals over stale or merely token-similar material.
 
 `M14-P1.5` adds the explicit stale-ingest repair path for issue #93:
 `splendor ingest --changed` detects checksum-drifted curated workspace-backed sources, refreshes

--- a/docs/public_mock_client_acceptance.md
+++ b/docs/public_mock_client_acceptance.md
@@ -47,6 +47,9 @@ Expected result: lint and health pass on `main`, and the agent-context brief ran
 spec, rollout plan, CSV-first decision, and held-entry research above the stale JSONL research note.
 With M17-P2.1 lifecycle-aware handoff, current, reviewed, or PR-linked authority should also rank
 above superseded or archived planning context when those records are present.
+With M17-P3.1 deterministic relevance scoring, `brief --agent-context` and `suggest-next` should
+prefer task-relevant authority, accepted decisions, active planning records, and focused
+contradicting research over stale or token-similar notes without requiring vector search.
 
 ## Source-Refresh Scenario
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -289,11 +289,13 @@ Implemented fields:
 - `splendor suggest-next [goal]` is a read-only handoff view over existing deterministic state. It
   does not create planning records, queue jobs, manifests, wiki pages, run records, or reports.
   Human output is path-first where possible; `--json` emits ranked action objects with category,
-  priority, title, reason, command, path, source ID/source ref, and planning/page record IDs when
-  available.
+  priority, title, reason, command, path, source ID/source ref, planning/page record IDs, and a
+  deterministic `relevance_score` when available.
 - Suggested actions are derived from source freshness, queue operator state, invalid/stale/
   contested/review-needed wiki pages, ingested sources missing maintained synthesis follow-up,
-  active planning records, recent lint/health reports, and optional goal query matches.
+  active planning records, recent lint/health reports, and optional goal query matches. Goal
+  relevance is scored deterministically from weighted title/path/record/scope matches, supporting
+  refs, snippets, and review/authority lifecycle signals before category caps are applied.
 - Text-bearing PDF sources are routed through source-type dispatch during ingest. The source
   manifest keeps the same `source_ref`, `source_ref_kind`, and `storage_mode` contract as
   text-native sources, while extracted text artifacts are recorded in `derived_artifacts`.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M17-P1.1`
+- Previous completed PR sub-slice: `M17-P2.1`
 - Current planned slice: `M17 v1 public readiness`
-- Current PR sub-slice: `M17-P2.1`
+- Current PR sub-slice: `M17-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M17 v1 public readiness`
-- Next planned PR sub-slice: `M17-P3.1`
+- Next planned PR sub-slice: `M17-P4.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1185,6 +1185,14 @@ decisions can now expose lifecycle state for current, reviewed, PR-linked, histo
 and archived authority. Agent handoff surfaces use that lifecycle to rank accepted/current
 decisions above stale plans or older research while retaining superseded and archived documents as
 explicit historical context.
+
+### Agent handoff ranking
+`M17-P3.1` implements issue #115 by adding deterministic authority-aware relevance scoring to
+`brief --agent-context` and `suggest-next`. The ranking remains local-first and schema-version-1
+compatible: no vector store, database, or background semantic service is introduced. Goal terms in
+titles, paths, record IDs, authority scope, and configured `applies_to` metadata are weighted above
+loose body overlap, while lifecycle and freshness keep current, reviewed, and PR-linked authority
+above stale, superseded, archived, or token-similar historical material.
 
 ## Milestone 18 — v2 advanced product track
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1110,7 +1110,10 @@ Current implementation:
 - `splendor suggest-next [goal]` renders the ranked action subset directly. It is read-only and
   deterministic, and ranks source freshness, queue failures or pending work, stale/contested or
   review-needed pages, missing synthesis follow-up, task-relevant authority docs, active planning
-  records, recent maintenance reports, and query matches for the optional goal.
+  records, recent maintenance reports, and query matches for the optional goal. Handoff ranking
+  uses deterministic relevance scoring over weighted title/path/record/scope fields, supporting
+  refs, snippets, and review/authority lifecycle signals so current task authority beats stale or
+  merely token-similar material without introducing vector search.
 - Authority docs come from `briefing.authority_documents` in `splendor.yaml` and optional
   maintained wiki page frontmatter (`authority_role`, `authority_freshness`, and
   `authority_lifecycle`, `authority_scope`, issue/PR refs, and supersession links). Generated

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -94,6 +94,7 @@ _AUTHORITY_ROLE_SCORE = {
     "generated-summary": 5,
 }
 _AUTHORITY_FRESHNESS_SCORE = {"current": 25, "watch": 10, "stale": -10, "historical": -20}
+_AUTHORITY_FRESHNESS_ORDER = {"current": 0, "watch": 1, "stale": 2, "historical": 3}
 _AUTHORITY_LIFECYCLE_ORDER = {
     "current": 0,
     "reviewed": 1,
@@ -130,6 +131,7 @@ _PLANNING_STATUSES = {
 class BriefMatch:
     rank: int
     score: int
+    relevance_score: int
     document_class: str
     kind: str
     record_id: str
@@ -147,6 +149,7 @@ class BriefPlanningItem:
     title: str
     status: str
     path: str
+    relevance_score: int = 0
 
 
 @dataclass(frozen=True)
@@ -211,6 +214,7 @@ class SuggestedAction:
     source_id: str | None = None
     source_ref: str | None = None
     record_id: str | None = None
+    relevance_score: int = 0
 
 
 @dataclass(frozen=True)
@@ -330,9 +334,12 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
             query_warning = BriefWarning(area="query", path=None, message=query_summary)
         if query_result is not None:
             query_summary = query_result.summary
-            matches = [_brief_match(match) for match in query_result.matches[:_BRIEF_MATCH_LIMIT]]
+            matches = _rank_brief_matches(
+                [_brief_match(match) for match in query_result.matches],
+                _tokens(normalized_goal),
+            )[:_BRIEF_MATCH_LIMIT]
 
-    planning_items, warnings = _active_planning_items(root, layout)
+    planning_items, warnings = _active_planning_items(root, layout, normalized_goal or None)
     if query_warning is not None:
         warnings.insert(0, query_warning)
     sources = load_sources(layout)
@@ -370,6 +377,7 @@ def _brief_match(match: QueryMatch) -> BriefMatch:
     return BriefMatch(
         rank=match.rank,
         score=match.score,
+        relevance_score=0,
         document_class=match.document_class,
         kind=match.kind,
         record_id=match.record_id,
@@ -381,15 +389,58 @@ def _brief_match(match: QueryMatch) -> BriefMatch:
     )
 
 
+def _rank_brief_matches(matches: list[BriefMatch], goal_tokens: set[str]) -> list[BriefMatch]:
+    ranked: list[tuple[int, BriefMatch]] = []
+    for sequence, match in enumerate(matches):
+        lifecycle_bonus = 0
+        if match.kind == "source-summary":
+            lifecycle_bonus -= 8
+        if match.review_state in {"human-reviewed"}:
+            lifecycle_bonus += 12
+        elif match.review_state in {"contested", "stale"}:
+            lifecycle_bonus += 6
+        elif match.review_state in {"machine-generated", "draft"}:
+            lifecycle_bonus -= 4
+        relevance_score = (
+            _goal_relevance_score(
+                goal_tokens,
+                high_text=" ".join([match.title, match.path, match.record_id]),
+                medium_text=" ".join(
+                    [
+                        match.document_class,
+                        match.kind,
+                        match.review_state or "",
+                        " ".join(match.source_refs),
+                    ]
+                ),
+                low_text=match.snippet,
+            )
+            + lifecycle_bonus
+            + match.score
+        )
+        ranked.append((sequence, replace(match, relevance_score=relevance_score)))
+    ranked.sort(
+        key=lambda item: (
+            -item[1].relevance_score,
+            item[1].rank,
+            item[1].title.lower(),
+            item[1].path,
+            item[0],
+        )
+    )
+    return [replace(match, rank=rank) for rank, (_sequence, match) in enumerate(ranked, start=1)]
+
+
 def _brief_error(exc: Exception) -> str:
     return " ".join(str(exc).splitlines()).strip() or exc.__class__.__name__
 
 
 def _active_planning_items(
-    root: Path, layout
+    root: Path, layout, goal: str | None
 ) -> tuple[list[BriefPlanningItem], list[BriefWarning]]:
     items: list[BriefPlanningItem] = []
     warnings: list[BriefWarning] = []
+    goal_tokens = _tokens(goal or "")
     for kind, statuses in _PLANNING_STATUSES.items():
         model = model_for_planning_kind(kind)
         id_field = record_id_field(kind)
@@ -409,16 +460,39 @@ def _active_planning_items(
             status = record.status
             if status not in statuses:
                 continue
+            payload = record.model_dump(mode="json")
+            record_id = str(getattr(record, id_field))
+            refs: list[str] = []
+            for key, value in payload.items():
+                if key.endswith("_refs") or key in {"supersedes", "superseded_by", "depends_on"}:
+                    refs.extend(_flatten_handoff_values(value))
+            relevance_score = _goal_relevance_score(
+                goal_tokens,
+                high_text=" ".join([record.title, record_id, path.relative_to(root).as_posix()]),
+                medium_text=" ".join([kind, status, *refs]),
+                low_text=parsed.body,
+            )
             items.append(
                 BriefPlanningItem(
                     kind=kind,
-                    record_id=str(getattr(record, id_field)),
+                    record_id=record_id,
                     title=record.title,
                     status=status,
                     path=path.relative_to(root).as_posix(),
+                    relevance_score=relevance_score,
                 )
             )
-    items.sort(key=lambda item: (item.kind, item.status, item.record_id))
+    if goal_tokens:
+        items.sort(
+            key=lambda item: (
+                -item.relevance_score,
+                item.kind,
+                item.status,
+                item.record_id,
+            )
+        )
+    else:
+        items.sort(key=lambda item: (item.kind, item.status, item.record_id))
     return items[:_BRIEF_PLANNING_LIMIT], warnings
 
 
@@ -454,7 +528,11 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
             freshness=doc.freshness,
             lifecycle=lifecycle,
             goal_tokens=goal_tokens,
-            text=" ".join([title, reason, " ".join(doc.applies_to), path.as_posix(), body]),
+            high_text=" ".join([title, path.as_posix(), " ".join(doc.applies_to)]),
+            medium_text=" ".join(
+                [*doc.issue_refs, *doc.pr_refs, *doc.supersedes, doc.superseded_by or ""]
+            ),
+            low_text=" ".join([reason, body]),
         )
         items.append(
             AuthorityBrief(
@@ -492,12 +570,26 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
             freshness=freshness,
             lifecycle=lifecycle,
             goal_tokens=goal_tokens,
-            text=" ".join(
+            high_text=" ".join(
                 [
                     page.frontmatter.title,
                     page.frontmatter.page_id,
                     page.path,
                     " ".join(page.frontmatter.authority_scope),
+                ]
+            ),
+            medium_text=" ".join(
+                [
+                    " ".join(page.frontmatter.tags),
+                    " ".join(page.frontmatter.source_refs),
+                    " ".join(page.frontmatter.issue_refs),
+                    " ".join(page.frontmatter.pr_refs),
+                    " ".join(page.frontmatter.supersedes),
+                    page.frontmatter.superseded_by or "",
+                ]
+            ),
+            low_text=" ".join(
+                [
                     page.body,
                 ]
             ),
@@ -524,8 +616,9 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
         enumerate(items),
         key=lambda item: (
             _AUTHORITY_LIFECYCLE_TIER.get(item[1].lifecycle, 99),
-            _AUTHORITY_LIFECYCLE_ORDER.get(item[1].lifecycle, 99),
+            _AUTHORITY_FRESHNESS_ORDER.get(item[1].freshness, 99),
             _AUTHORITY_ROLE_ORDER.get(item[1].role, 99),
+            _AUTHORITY_LIFECYCLE_ORDER.get(item[1].lifecycle, 99),
             -item[1].score,
             item[0],
             item[1].path,
@@ -538,16 +631,27 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
 
 
 def _authority_score(
-    *, role: str, freshness: str, lifecycle: str, goal_tokens: set[str], text: str
+    *,
+    role: str,
+    freshness: str,
+    lifecycle: str,
+    goal_tokens: set[str],
+    high_text: str = "",
+    medium_text: str = "",
+    low_text: str = "",
+    text: str = "",
 ) -> int:
     score = (
         _AUTHORITY_ROLE_SCORE.get(role, 0)
         + _AUTHORITY_FRESHNESS_SCORE.get(freshness, 0)
         + _AUTHORITY_LIFECYCLE_SCORE.get(lifecycle, 0)
     )
-    if goal_tokens:
-        overlap = goal_tokens & _tokens(text)
-        score += min(len(overlap), 6) * 12
+    score += _goal_relevance_score(
+        goal_tokens,
+        high_text=high_text,
+        medium_text=medium_text,
+        low_text=" ".join([low_text, text]),
+    )
     return score
 
 
@@ -626,7 +730,21 @@ def _decision_authority_briefs(root: Path, layout, goal_tokens: set[str]) -> lis
                     freshness=freshness,
                     lifecycle=lifecycle,
                     goal_tokens=goal_tokens,
-                    text=text,
+                    high_text=" ".join([record.title, record.decision_id, path.name]),
+                    medium_text=" ".join(
+                        [
+                            record.status,
+                            record.decided_at or "",
+                            " ".join(record.source_refs),
+                            " ".join(record.related_tasks),
+                            " ".join(record.related_questions),
+                            " ".join(record.issue_refs),
+                            " ".join(record.pr_refs),
+                            " ".join(record.supersedes),
+                            record.superseded_by or "",
+                        ]
+                    ),
+                    low_text=text,
                 ),
                 reason=reason,
                 issue_refs=record.issue_refs,
@@ -655,7 +773,49 @@ def _title_from_markdown(body: str) -> str | None:
 
 
 def _tokens(text: str) -> set[str]:
-    return set(_TOKEN_PATTERN.findall(text.lower()))
+    tokens: set[str] = set()
+    for token in _TOKEN_PATTERN.findall(text.lower()):
+        tokens.add(token)
+        tokens.update(part for part in re.split(r"[-_]+", token) if len(part) > 1)
+    return tokens
+
+
+def _flatten_handoff_values(value) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    return [str(value)]
+
+
+def _normalize_goal_phrase(text: str) -> str:
+    lowered = text.lower().replace("-", " ").replace("_", " ")
+    return " ".join(_TOKEN_PATTERN.findall(lowered))
+
+
+def _goal_relevance_score(
+    goal_tokens: set[str], *, high_text: str = "", medium_text: str = "", low_text: str = ""
+) -> int:
+    if not goal_tokens:
+        return 0
+    score = 0
+    goal_phrase = _normalize_goal_phrase(" ".join(sorted(goal_tokens)))
+    for text, weight in ((high_text, 18), (medium_text, 10), (low_text, 4)):
+        if not text:
+            continue
+        text_tokens = _tokens(text)
+        overlap = goal_tokens & text_tokens
+        if not overlap:
+            continue
+        score += min(len(overlap), 8) * weight
+        if len(overlap) >= 2:
+            score += len(overlap) * 5
+        if overlap == goal_tokens:
+            score += weight
+        normalized_text = _normalize_goal_phrase(text)
+        if len(goal_tokens) >= 2 and goal_phrase and goal_phrase in normalized_text:
+            score += weight * 3
+    return score
 
 
 def _recent_sources(sources: list[SourceRecord]) -> list[BriefSourceItem]:
@@ -750,8 +910,27 @@ def _next_actions(
 
 def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
     actions: list[SuggestedAction] = []
+    goal_tokens = _tokens(snapshot.goal or "")
 
     def add(priority: str, category: str, title: str, reason: str, command: str | None, **kwargs):
+        relevance_score = kwargs.pop(
+            "relevance_score",
+            _goal_relevance_score(
+                goal_tokens,
+                high_text=" ".join(
+                    [
+                        title,
+                        str(kwargs.get("path") or ""),
+                        str(kwargs.get("record_id") or ""),
+                        str(kwargs.get("source_ref") or ""),
+                    ]
+                ),
+                medium_text=" ".join(
+                    [str(kwargs.get("source_id") or ""), command or "", category, priority]
+                ),
+                low_text=reason,
+            ),
+        )
         actions.append(
             SuggestedAction(
                 rank=0,
@@ -760,6 +939,7 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
                 title=title,
                 reason=reason,
                 command=command,
+                relevance_score=relevance_score,
                 **kwargs,
             )
         )
@@ -831,7 +1011,9 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
                 source_ref=source_ref,
             )
 
-    for page in _review_page_actions(snapshot.wiki_pages, snapshot.invalid_wiki_pages):
+    for page in _review_page_actions(
+        snapshot.wiki_pages, snapshot.invalid_wiki_pages, goal_tokens=goal_tokens
+    ):
         add(**page)
 
     for source_id in _sources_missing_synthesis(snapshot.wiki_pages, snapshot.sources_by_id):
@@ -846,6 +1028,11 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
             path=source_ref,
             source_id=source_id,
             source_ref=source_ref,
+            relevance_score=_goal_relevance_score(
+                goal_tokens,
+                high_text=" ".join([source.title, source_ref, source_id]),
+                medium_text=" ".join([source.review_state, source.status]),
+            ),
         )
 
     for report in snapshot.latest_reports:
@@ -869,6 +1056,7 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
             None,
             path=match.path,
             record_id=match.record_id,
+            relevance_score=match.relevance_score,
         )
 
     for authority in snapshot.authority_briefs[:3]:
@@ -890,6 +1078,7 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
             f"{authority.role}/{authority.freshness}/{authority.lifecycle}: {authority.reason}",
             None,
             path=authority.path,
+            relevance_score=authority.score,
         )
 
     for item in snapshot.planning_items:
@@ -902,6 +1091,7 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
             command,
             path=item.path,
             record_id=item.record_id,
+            relevance_score=item.relevance_score,
         )
 
     for warning in snapshot.warnings:
@@ -933,7 +1123,16 @@ def _first_command(commands: list[str]) -> str | None:
 def _finalize_suggestions(actions: list[SuggestedAction]) -> list[SuggestedAction]:
     by_category: dict[str, int] = {}
     capped: list[tuple[int, SuggestedAction]] = []
-    for sequence, action in enumerate(actions):
+    ordered = sorted(
+        enumerate(actions),
+        key=lambda item: (
+            _SUGGESTION_CATEGORY_ORDER.get(item[1].category, 99),
+            _SUGGESTION_PRIORITY_ORDER.get(item[1].priority, 99),
+            -item[1].relevance_score,
+            item[0],
+        ),
+    )
+    for sequence, action in ordered:
         current_count = by_category.get(action.category, 0)
         category_limit = _SUGGESTION_CATEGORY_LIMITS.get(action.category, 1)
         if current_count >= category_limit:
@@ -945,6 +1144,7 @@ def _finalize_suggestions(actions: list[SuggestedAction]) -> list[SuggestedActio
         key=lambda item: (
             _SUGGESTION_CATEGORY_ORDER.get(item[1].category, 99),
             _SUGGESTION_PRIORITY_ORDER.get(item[1].priority, 99),
+            -item[1].relevance_score,
             item[0],
         )
     )
@@ -955,7 +1155,10 @@ def _finalize_suggestions(actions: list[SuggestedAction]) -> list[SuggestedActio
 
 
 def _review_page_actions(
-    pages: list[WikiPageSnapshot], invalid_pages: list[InvalidWikiPageSnapshot]
+    pages: list[WikiPageSnapshot],
+    invalid_pages: list[InvalidWikiPageSnapshot],
+    *,
+    goal_tokens: set[str],
 ) -> list[dict[str, object]]:
     actions: list[dict[str, object]] = []
     for invalid in invalid_pages:
@@ -967,6 +1170,9 @@ def _review_page_actions(
                 "reason": invalid.error,
                 "command": "splendor lint",
                 "path": invalid.path,
+                "relevance_score": _goal_relevance_score(
+                    goal_tokens, high_text=invalid.path, low_text=invalid.error
+                ),
             }
         )
     for page in pages:
@@ -988,6 +1194,21 @@ def _review_page_actions(
                 "command": None,
                 "path": page.path,
                 "record_id": page.frontmatter.page_id,
+                "relevance_score": _goal_relevance_score(
+                    goal_tokens,
+                    high_text=" ".join(
+                        [page.frontmatter.title, page.frontmatter.page_id, page.path]
+                    ),
+                    medium_text=" ".join(
+                        [
+                            page.frontmatter.kind,
+                            state,
+                            " ".join(page.frontmatter.tags),
+                            " ".join(page.frontmatter.source_refs),
+                        ]
+                    ),
+                    low_text=page.body,
+                ),
             }
         )
     return actions

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -322,6 +322,8 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
     queue = inspect_queue(root)
     freshness = scan_source_freshness(root)
     normalized_goal = goal.strip() if goal is not None else ""
+    goal_tokens = _tokens(normalized_goal)
+    goal_phrase = _normalize_goal_phrase(normalized_goal)
     query_summary: str | None = None
     query_warning: BriefWarning | None = None
     matches: list[BriefMatch] = []
@@ -336,16 +338,21 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
             query_summary = query_result.summary
             matches = _rank_brief_matches(
                 [_brief_match(match) for match in query_result.matches],
-                _tokens(normalized_goal),
+                goal_tokens,
+                goal_phrase,
             )[:_BRIEF_MATCH_LIMIT]
 
-    planning_items, warnings = _active_planning_items(root, layout, normalized_goal or None)
+    planning_items, warnings = _active_planning_items(
+        root, layout, normalized_goal or None, goal_phrase
+    )
     if query_warning is not None:
         warnings.insert(0, query_warning)
     sources = load_sources(layout)
     sources_by_id = {source.source_id: source for source in sources}
     wiki_pages, invalid_wiki_pages = load_wiki_pages(root, layout)
-    authority_briefs, authority_warnings = _authority_briefs(root, layout, config, wiki_pages, goal)
+    authority_briefs, authority_warnings = _authority_briefs(
+        root, layout, config, wiki_pages, normalized_goal or None
+    )
     warnings.extend(authority_warnings)
     recent_sources = _recent_sources(sources)
     recent_runs = status.recent_runs
@@ -389,7 +396,9 @@ def _brief_match(match: QueryMatch) -> BriefMatch:
     )
 
 
-def _rank_brief_matches(matches: list[BriefMatch], goal_tokens: set[str]) -> list[BriefMatch]:
+def _rank_brief_matches(
+    matches: list[BriefMatch], goal_tokens: set[str], goal_phrase: str
+) -> list[BriefMatch]:
     ranked: list[tuple[int, BriefMatch]] = []
     for sequence, match in enumerate(matches):
         lifecycle_bonus = 0
@@ -404,6 +413,7 @@ def _rank_brief_matches(matches: list[BriefMatch], goal_tokens: set[str]) -> lis
         relevance_score = (
             _goal_relevance_score(
                 goal_tokens,
+                goal_phrase=goal_phrase,
                 high_text=" ".join([match.title, match.path, match.record_id]),
                 medium_text=" ".join(
                     [
@@ -436,7 +446,7 @@ def _brief_error(exc: Exception) -> str:
 
 
 def _active_planning_items(
-    root: Path, layout, goal: str | None
+    root: Path, layout, goal: str | None, goal_phrase: str
 ) -> tuple[list[BriefPlanningItem], list[BriefWarning]]:
     items: list[BriefPlanningItem] = []
     warnings: list[BriefWarning] = []
@@ -468,6 +478,7 @@ def _active_planning_items(
                     refs.extend(_flatten_handoff_values(value))
             relevance_score = _goal_relevance_score(
                 goal_tokens,
+                goal_phrase=goal_phrase,
                 high_text=" ".join([record.title, record_id, path.relative_to(root).as_posix()]),
                 medium_text=" ".join([kind, status, *refs]),
                 low_text=parsed.body,
@@ -500,6 +511,7 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
     items: list[AuthorityBrief] = []
     warnings: list[BriefWarning] = []
     goal_tokens = _tokens(goal or "")
+    goal_phrase = _normalize_goal_phrase(goal or "")
 
     for doc in config.briefing.authority_documents:
         path = Path(doc.path)
@@ -528,6 +540,7 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
             freshness=doc.freshness,
             lifecycle=lifecycle,
             goal_tokens=goal_tokens,
+            goal_phrase=goal_phrase,
             high_text=" ".join([title, path.as_posix(), " ".join(doc.applies_to)]),
             medium_text=" ".join(
                 [*doc.issue_refs, *doc.pr_refs, *doc.supersedes, doc.superseded_by or ""]
@@ -570,6 +583,7 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
             freshness=freshness,
             lifecycle=lifecycle,
             goal_tokens=goal_tokens,
+            goal_phrase=goal_phrase,
             high_text=" ".join(
                 [
                     page.frontmatter.title,
@@ -611,15 +625,15 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
             )
         )
 
-    items.extend(_decision_authority_briefs(root, layout, goal_tokens))
+    items.extend(_decision_authority_briefs(root, layout, goal_tokens, goal_phrase))
     ranked = sorted(
         enumerate(items),
         key=lambda item: (
             _AUTHORITY_LIFECYCLE_TIER.get(item[1].lifecycle, 99),
             _AUTHORITY_FRESHNESS_ORDER.get(item[1].freshness, 99),
+            -item[1].score,
             _AUTHORITY_ROLE_ORDER.get(item[1].role, 99),
             _AUTHORITY_LIFECYCLE_ORDER.get(item[1].lifecycle, 99),
-            -item[1].score,
             item[0],
             item[1].path,
         ),
@@ -636,6 +650,7 @@ def _authority_score(
     freshness: str,
     lifecycle: str,
     goal_tokens: set[str],
+    goal_phrase: str = "",
     high_text: str = "",
     medium_text: str = "",
     low_text: str = "",
@@ -648,6 +663,7 @@ def _authority_score(
     )
     score += _goal_relevance_score(
         goal_tokens,
+        goal_phrase=goal_phrase,
         high_text=high_text,
         medium_text=medium_text,
         low_text=" ".join([low_text, text]),
@@ -679,7 +695,9 @@ def _wiki_authority_lifecycle(frontmatter: KnowledgePageFrontmatter, *, freshnes
     return "current"
 
 
-def _decision_authority_briefs(root: Path, layout, goal_tokens: set[str]) -> list[AuthorityBrief]:
+def _decision_authority_briefs(
+    root: Path, layout, goal_tokens: set[str], goal_phrase: str
+) -> list[AuthorityBrief]:
     if not goal_tokens:
         return []
     items: list[AuthorityBrief] = []
@@ -730,6 +748,7 @@ def _decision_authority_briefs(root: Path, layout, goal_tokens: set[str]) -> lis
                     freshness=freshness,
                     lifecycle=lifecycle,
                     goal_tokens=goal_tokens,
+                    goal_phrase=goal_phrase,
                     high_text=" ".join([record.title, record.decision_id, path.name]),
                     medium_text=" ".join(
                         [
@@ -794,12 +813,16 @@ def _normalize_goal_phrase(text: str) -> str:
 
 
 def _goal_relevance_score(
-    goal_tokens: set[str], *, high_text: str = "", medium_text: str = "", low_text: str = ""
+    goal_tokens: set[str],
+    *,
+    goal_phrase: str = "",
+    high_text: str = "",
+    medium_text: str = "",
+    low_text: str = "",
 ) -> int:
     if not goal_tokens:
         return 0
     score = 0
-    goal_phrase = _normalize_goal_phrase(" ".join(sorted(goal_tokens)))
     for text, weight in ((high_text, 18), (medium_text, 10), (low_text, 4)):
         if not text:
             continue
@@ -911,12 +934,14 @@ def _next_actions(
 def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
     actions: list[SuggestedAction] = []
     goal_tokens = _tokens(snapshot.goal or "")
+    goal_phrase = _normalize_goal_phrase(snapshot.goal or "")
 
     def add(priority: str, category: str, title: str, reason: str, command: str | None, **kwargs):
         relevance_score = kwargs.pop(
             "relevance_score",
             _goal_relevance_score(
                 goal_tokens,
+                goal_phrase=goal_phrase,
                 high_text=" ".join(
                     [
                         title,
@@ -1012,7 +1037,10 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
             )
 
     for page in _review_page_actions(
-        snapshot.wiki_pages, snapshot.invalid_wiki_pages, goal_tokens=goal_tokens
+        snapshot.wiki_pages,
+        snapshot.invalid_wiki_pages,
+        goal_tokens=goal_tokens,
+        goal_phrase=goal_phrase,
     ):
         add(**page)
 
@@ -1030,6 +1058,7 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
             source_ref=source_ref,
             relevance_score=_goal_relevance_score(
                 goal_tokens,
+                goal_phrase=goal_phrase,
                 high_text=" ".join([source.title, source_ref, source_id]),
                 medium_text=" ".join([source.review_state, source.status]),
             ),
@@ -1159,6 +1188,7 @@ def _review_page_actions(
     invalid_pages: list[InvalidWikiPageSnapshot],
     *,
     goal_tokens: set[str],
+    goal_phrase: str,
 ) -> list[dict[str, object]]:
     actions: list[dict[str, object]] = []
     for invalid in invalid_pages:
@@ -1171,7 +1201,10 @@ def _review_page_actions(
                 "command": "splendor lint",
                 "path": invalid.path,
                 "relevance_score": _goal_relevance_score(
-                    goal_tokens, high_text=invalid.path, low_text=invalid.error
+                    goal_tokens,
+                    goal_phrase=goal_phrase,
+                    high_text=invalid.path,
+                    low_text=invalid.error,
                 ),
             }
         )
@@ -1196,6 +1229,7 @@ def _review_page_actions(
                 "record_id": page.frontmatter.page_id,
                 "relevance_score": _goal_relevance_score(
                     goal_tokens,
+                    goal_phrase=goal_phrase,
                     high_text=" ".join(
                         [page.frontmatter.title, page.frontmatter.page_id, page.path]
                     ),

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -1884,6 +1884,212 @@ def test_suggest_next_includes_lifecycle_aware_decision_authority(tmp_path: Path
     assert authority_actions[0]["title"].startswith("Review decision ")
 
 
+def test_agent_context_ranks_mock_client_authority_above_stale_token_matches(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "current-spec.md").write_text(
+        "# Balance Reconciliation Spec\n\nCurrent balance reconciliation rollout authority.\n",
+        encoding="utf-8",
+    )
+    (docs / "rollout-plan.md").write_text(
+        "# Reconciliation Rollout Plan\n\nPR-linked rollout plan for balance reconciliation.\n",
+        encoding="utf-8",
+    )
+    (docs / "stale-jsonl-note.md").write_text(
+        "# JSONL Reconciliation Note\n\n"
+        "balance reconciliation rollout balance reconciliation rollout jsonl jsonl jsonl\n",
+        encoding="utf-8",
+    )
+    config = load_config(tmp_path)
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path="docs/stale-jsonl-note.md",
+            role="current-authority",
+            freshness="stale",
+            purpose="Older JSONL research note retained for comparison.",
+            applies_to=["balance reconciliation rollout"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/rollout-plan.md",
+            role="roadmap",
+            freshness="current",
+            authority_lifecycle="pr-linked",
+            purpose="Current rollout plan.",
+            applies_to=["balance reconciliation rollout"],
+            pr_refs=["#133"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/current-spec.md",
+            role="current-authority",
+            freshness="current",
+            purpose="Current reviewed spec.",
+            applies_to=["balance reconciliation rollout"],
+        ),
+    ]
+    write_config(tmp_path, config)
+    write_wiki_page(
+        tmp_path / "wiki" / "sources" / "held-entry-research.md",
+        kind="source-summary",
+        title="Held-entry reconciliation research",
+        page_id="source-held-entry-research",
+        review_state="contested",
+        body="Held-entry research contradicts parts of the balance reconciliation rollout.",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "held-entry-research.md",
+        kind="topic",
+        title="Held-entry research authority",
+        page_id="topic-held-entry-research",
+        review_state="human-reviewed",
+        authority_role="reference",
+        authority_freshness="current",
+        authority_lifecycle="reviewed",
+        authority_scope=["balance reconciliation rollout", "held-entry research"],
+        body="Reviewed held-entry research for reconciliation contradictions.",
+    )
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "decision",
+            "create",
+            "Use",
+            "CSV-first",
+            "balance",
+            "reconciliation",
+            "--id",
+            "decision-csv-first-reconciliation",
+            "--status",
+            "accepted",
+            "--authority-lifecycle",
+            "reviewed",
+            "--issue-ref",
+            "#115",
+        ]
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "balance",
+            "reconciliation",
+            "rollout",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    authority_paths = [item["path"] for item in payload["authority_briefs"]]
+    assert authority_paths[:4] == [
+        "docs/current-spec.md",
+        "docs/rollout-plan.md",
+        "planning/decisions/decision-csv-first-reconciliation.md",
+        "wiki/topics/held-entry-research.md",
+    ]
+    assert authority_paths.index("docs/stale-jsonl-note.md") > authority_paths.index(
+        "wiki/topics/held-entry-research.md"
+    )
+    assert any(
+        match["path"] == "wiki/sources/held-entry-research.md" for match in payload["matches"]
+    )
+    assert payload["suggested_actions"][0]["category"] in {"goal-match", "authority"}
+
+
+def test_agent_context_orders_active_planning_by_goal_relevance(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "create",
+            "Clean up unrelated import scripts",
+            "--id",
+            "task-import-cleanup",
+            "--status",
+            "in_progress",
+        ]
+    )
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "create",
+            "Improve agent handoff ranking",
+            "--id",
+            "task-agent-handoff-ranking",
+            "--status",
+            "in_progress",
+        ]
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "brief", "--agent-context", "agent", "handoff", "--json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["active_planning"][0]["record_id"] == "task-agent-handoff-ranking"
+    planning_actions = [
+        action for action in payload["suggested_actions"] if action["category"] == "planning"
+    ]
+    assert planning_actions[0]["record_id"] == "task-agent-handoff-ranking"
+
+
+def test_suggest_next_caps_review_noise_after_goal_relevance(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    for index in range(8):
+        write_wiki_page(
+            tmp_path / "wiki" / "topics" / f"generated-noise-{index}.md",
+            kind="topic",
+            title=f"Generated noise {index}",
+            page_id=f"topic-generated-noise-{index}",
+            review_state="machine-generated",
+            body="Generated review noise without handoff context.",
+        )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "agent-handoff-contested.md",
+        kind="topic",
+        title="Agent handoff contested ranking",
+        page_id="topic-agent-handoff-contested-ranking",
+        review_state="contested",
+        body="Agent handoff ranking needs review because stale notes conflict.",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "agent-handoff-authority.md",
+        kind="topic",
+        title="Agent handoff authority",
+        page_id="topic-agent-handoff-authority",
+        review_state="human-reviewed",
+        authority_role="current-authority",
+        authority_freshness="current",
+        authority_lifecycle="reviewed",
+        authority_scope=["agent handoff ranking"],
+        body="Current reviewed handoff ranking authority.",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "suggest-next", "agent", "handoff", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    categories = [action["category"] for action in payload["actions"]]
+    assert categories.index("authority") < categories.index("wiki-review")
+    wiki_review = [action for action in payload["actions"] if action["category"] == "wiki-review"]
+    assert wiki_review[0]["path"] == "wiki/topics/agent-handoff-contested.md"
+    assert len(wiki_review) == 2
+
+
 def test_suggest_next_json_ranks_changed_sources_before_review_work(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "handoff.md"

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -1898,6 +1898,10 @@ def test_agent_context_ranks_mock_client_authority_above_stale_token_matches(
         "# Reconciliation Rollout Plan\n\nPR-linked rollout plan for balance reconciliation.\n",
         encoding="utf-8",
     )
+    (docs / "generic-authority.md").write_text(
+        "# Current Project Authority\n\nGeneral current authority for public readiness.\n",
+        encoding="utf-8",
+    )
     (docs / "stale-jsonl-note.md").write_text(
         "# JSONL Reconciliation Note\n\n"
         "balance reconciliation rollout balance reconciliation rollout jsonl jsonl jsonl\n",
@@ -1910,7 +1914,12 @@ def test_agent_context_ranks_mock_client_authority_above_stale_token_matches(
             role="current-authority",
             freshness="stale",
             purpose="Older JSONL research note retained for comparison.",
-            applies_to=["balance reconciliation rollout"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/generic-authority.md",
+            role="current-authority",
+            freshness="current",
+            purpose="Generic current authority that should not outrank task-specific context.",
         ),
         AuthorityDocumentConfig(
             path="docs/rollout-plan.md",
@@ -1988,19 +1997,58 @@ def test_agent_context_ranks_mock_client_authority_above_stale_token_matches(
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
     authority_paths = [item["path"] for item in payload["authority_briefs"]]
-    assert authority_paths[:4] == [
+    assert authority_paths[:2] == [
         "docs/current-spec.md",
         "docs/rollout-plan.md",
-        "planning/decisions/decision-csv-first-reconciliation.md",
-        "wiki/topics/held-entry-research.md",
     ]
-    assert authority_paths.index("docs/stale-jsonl-note.md") > authority_paths.index(
-        "wiki/topics/held-entry-research.md"
+    stale_index = authority_paths.index("docs/stale-jsonl-note.md")
+    generic_index = authority_paths.index("docs/generic-authority.md")
+    decision_index = authority_paths.index(
+        "planning/decisions/decision-csv-first-reconciliation.md"
     )
+    research_index = authority_paths.index("wiki/topics/held-entry-research.md")
+    assert decision_index < stale_index
+    assert research_index < stale_index
+    assert decision_index < generic_index
+    assert research_index < generic_index
     assert any(
         match["path"] == "wiki/sources/held-entry-research.md" for match in payload["matches"]
     )
     assert payload["suggested_actions"][0]["category"] in {"goal-match", "authority"}
+
+
+def test_agent_context_preserves_goal_phrase_order_for_authority_ranking(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "ordered.md").write_text(
+        "# Held Entry Research\n\nUse held entry research for reconciliation.",
+        encoding="utf-8",
+    )
+    (docs / "permuted.md").write_text(
+        "# Entry Held Research\n\nUse entry held research for reconciliation.",
+        encoding="utf-8",
+    )
+    config = load_config(tmp_path)
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(path="docs/permuted.md", role="reference", freshness="current"),
+        AuthorityDocumentConfig(path="docs/ordered.md", role="reference", freshness="current"),
+    ]
+    write_config(tmp_path, config)
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "brief", "--agent-context", "held", "entry", "research", "--json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [item["path"] for item in payload["authority_briefs"][:2]] == [
+        "docs/ordered.md",
+        "docs/permuted.md",
+    ]
 
 
 def test_agent_context_orders_active_planning_by_goal_relevance(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

- Add deterministic goal relevance scoring for agent handoff matches, authority briefs, active planning records, review signals, and suggested actions.
- Keep M17-P2.1 lifecycle precedence while adding freshness and weighted field matching so current specs, rollout plans, accepted decisions, and focused contradiction/review signals beat stale or token-similar material.
- Update M17 planning state and public-readiness docs for the M17-P3.1 handoff-ranking contract.

## Validation

- `uv run pytest tests/test_wiki_commands.py tests/test_schemas.py tests/test_config.py`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`

## Issue linkage

Closes #115.

Issue #116 was already completed by PR #133, which was squash-merged into `main` as `ae1a483`.
