### PR TITLE
M17-P4.1: Reduce contradiction-review task noise

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M17-P2.1`
-- Last action taken: `M17-P2.1` was squash-merged into main as commit `ae1a483`,
-  expanding lifecycle-aware planning authority for agent handoff.
+- Previous completed PR sub-slice: `M17-P3.1`
+- Last action taken: `M17-P3.1` was squash-merged into main as commit `f5df750`,
+  improving deterministic semantic ranking for agent handoff.
 - Current planned slice: `M17 v1 public readiness`
-- Current PR sub-slice: `M17-P3.1`
+- Current PR sub-slice: `M17-P4.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M17 v1 public readiness`
-- Next planned PR sub-slice: `M17-P4.1`
+- Next planned slice: `M18 v2 advanced product track`
+- Next planned PR sub-slice: `M18-P1.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -347,6 +347,16 @@
   - [x] Rank current, reviewed, PR-linked, historical, superseded, and archived authority
   - [x] Include accepted and superseded planning decisions in goal-relevant authority handoff
   - [x] Update tests, docs, and planning state for issue #116
+- [x] Implement `M17-P3.1`: Improve semantic ranking for agent handoff
+  - [x] Add deterministic relevance scoring for authority, planning, query, synthesis, and review signals
+  - [x] Keep the ranking local-first without vector search, databases, or background services
+  - [x] Update tests, docs, and planning state for issue #115
+- [x] Implement `M17-P4.1`: Reduce contradiction-review task noise
+  - [x] Classify generated contradiction-review tasks without changing schema version `1`
+  - [x] Hide generated review tasks from default active planning handoff
+  - [x] Add intentional list, resolve, and mute workflows
+  - [x] Preserve contradiction evidence through contested pages, query metadata, and explicit task listing
+  - [x] Update tests, docs, and planning state for issue #117
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ signals. Title/path/scope matches carry more weight than loose body overlap, and
 review noise from burying current specs, rollout plans, accepted decisions, and key contradicting
 research.
 
+`M17-P4.1` reduces issue #117 contradiction-review task noise without weakening contradiction
+evidence. Ingest-created contradiction-review tasks are classified as generated planning records,
+hidden from default active planning handoff, and managed intentionally through task-list, resolve,
+and mute workflows. Contested source-summary annotations and query metadata remain available when
+operators ask for contradiction evidence.
+
 Generated source-summary pages are deterministic ingestion artifacts. For readable in-repo
 markdown/text/code sources, Splendor defaults to concise claim-bearing excerpts and path-first
 display; copied, external, parsed PDF, and OCR-derived sources keep fuller extracts by default
@@ -295,12 +301,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M17-P2.1`
+- Previous completed PR sub-slice: `M17-P3.1`
 - Current planned slice: `M17 v1 public readiness`
-- Current PR sub-slice: `M17-P3.1`
+- Current PR sub-slice: `M17-P4.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M17 v1 public readiness`
-- Next planned PR sub-slice: `M17-P4.1`
+- Next planned slice: `M18 v2 advanced product track`
+- Next planned PR sub-slice: `M18-P1.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -451,6 +457,11 @@ goal-relevant authority ranking while superseded decisions remain historical con
 `M17-P3.1` implements deterministic authority-aware ranking for issue #115. Agent handoff now
 favors task-relevant current specs, rollout plans, accepted decisions, active planning records, and
 focused contradiction/review signals over stale or merely token-similar material.
+
+`M17-P4.1` implements contradiction-review task noise reduction for issue #117. Generated review
+tasks no longer crowd default active planning handoff, while explicit task commands can list,
+resolve, or mute them and contradiction evidence remains discoverable on contested pages and query
+results.
 
 `M14-P1.5` adds the explicit stale-ingest repair path for issue #93:
 `splendor ingest --changed` detects checksum-drifted curated workspace-backed sources, refreshes

--- a/docs/public_mock_client_acceptance.md
+++ b/docs/public_mock_client_acceptance.md
@@ -50,6 +50,10 @@ above superseded or archived planning context when those records are present.
 With M17-P3.1 deterministic relevance scoring, `brief --agent-context` and `suggest-next` should
 prefer task-relevant authority, accepted decisions, active planning records, and focused
 contradicting research over stale or token-similar notes without requiring vector search.
+With M17-P4.1 contradiction-review task noise reduction, generated contradiction-review tasks
+should not crowd out human-authored planning records in default handoff. Operators should use
+explicit task-list, resolve, and mute workflows when they want to inspect generated review tasks,
+while contested source-summary evidence remains discoverable through query and page metadata.
 
 ## Source-Refresh Scenario
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -492,11 +492,18 @@ present. `splendor decision create` can write those optional fields with `--auth
 
 Task records now also reserve:
 
+- `record_origin`
+- `generated_kind`
+- `review_task_state`
 - `page_refs`
 - `run_refs`
 
-Those fields let contradiction-review tasks carry explicit links back to the affected wiki pages
-and the ingest run that surfaced the conflict.
+`record_origin` defaults to `human`. Ingest-created contradiction-review tasks use
+`record_origin: generated`, `generated_kind: contradiction-review`, and
+`review_task_state: active`. Operators can move those generated review tasks to `resolved` or
+`muted`; resolved tasks also use `status: done`. Those fields let default planning handoff
+prioritize human-authored planning records while preserving explicit links back to the affected
+wiki pages and the ingest run that surfaced the conflict.
 
 ## Query snapshots
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M17-P2.1`
+- Previous completed PR sub-slice: `M17-P3.1`
 - Current planned slice: `M17 v1 public readiness`
-- Current PR sub-slice: `M17-P3.1`
+- Current PR sub-slice: `M17-P4.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M17 v1 public readiness`
-- Next planned PR sub-slice: `M17-P4.1`
+- Next planned slice: `M18 v2 advanced product track`
+- Next planned PR sub-slice: `M18-P1.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1193,6 +1193,12 @@ compatible: no vector store, database, or background semantic service is introdu
 titles, paths, record IDs, authority scope, and configured `applies_to` metadata are weighted above
 loose body overlap, while lifecycle and freshness keep current, reviewed, and PR-linked authority
 above stale, superseded, archived, or token-similar historical material.
+
+`M17-P4.1` implements issue #117 by classifying ingest-created contradiction-review tasks as
+generated planning records, excluding them from default active planning handoff, and adding
+intentional task workflows to list, resolve, or mute them. Contradiction evidence remains attached
+to contested source-summary pages and visible through query/review-task metadata when operators ask
+for it.
 
 ## Milestone 18 — v2 advanced product track
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1114,6 +1114,10 @@ Current implementation:
   uses deterministic relevance scoring over weighted title/path/record/scope fields, supporting
   refs, snippets, and review/authority lifecycle signals so current task authority beats stale or
   merely token-similar material without introducing vector search.
+- Generated contradiction-review tasks are classified separately from human-authored planning
+  tasks. Default `task list`, `brief --agent-context`, and `suggest-next` keep them out of active
+  planning handoff; operators can list, resolve, or mute them explicitly with task subcommands, and
+  contradiction-focused goals expose an intentional inspection action.
 - Authority docs come from `briefing.authority_documents` in `splendor.yaml` and optional
   maintained wiki page frontmatter (`authority_role`, `authority_freshness`, and
   `authority_lifecycle`, `authority_scope`, issue/PR refs, and supersession links). Generated

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -40,6 +40,7 @@ from splendor.commands.planning import (
     list_milestones,
     list_tasks,
     update_question_answer,
+    update_task_review_state,
 )
 from splendor.commands.pr_summary import (
     PathGroup,
@@ -686,7 +687,32 @@ def build_parser() -> argparse.ArgumentParser:
         help="Filter by task priority.",
     )
     task_list_parser.add_argument("--milestone-ref", help="Filter by milestone reference")
+    task_list_parser.add_argument(
+        "--generated-review",
+        action="store_true",
+        help="List only generated contradiction-review tasks.",
+    )
+    task_list_parser.add_argument(
+        "--include-generated-review",
+        action="store_true",
+        help="Include generated contradiction-review tasks in the default task list.",
+    )
+    task_list_parser.add_argument(
+        "--review-task-state",
+        choices=("active", "resolved", "muted"),
+        help="Filter generated review tasks by operator review state.",
+    )
     task_list_parser.set_defaults(handler=handle_task_list)
+    task_resolve_parser = task_subparsers.add_parser(
+        "resolve", help="Mark a generated contradiction-review task resolved"
+    )
+    task_resolve_parser.add_argument("task_id", help="Generated contradiction-review task ID")
+    task_resolve_parser.set_defaults(handler=handle_task_resolve)
+    task_mute_parser = task_subparsers.add_parser(
+        "mute", help="Mute a generated contradiction-review task"
+    )
+    task_mute_parser.add_argument("task_id", help="Generated contradiction-review task ID")
+    task_mute_parser.set_defaults(handler=handle_task_mute)
 
     milestone_parser = subparsers.add_parser(
         "milestone", help="Create or inspect milestone records"
@@ -2512,12 +2538,48 @@ def handle_task_list(args: argparse.Namespace) -> int:
             status=args.status,
             priority=args.priority,
             milestone_ref=args.milestone_ref,
+            generated_review=args.generated_review,
+            include_generated_review=args.include_generated_review,
+            review_task_state=args.review_task_state,
         )
     except ValueError as exc:
         return _print_error(exc)
 
     for row in rows:
-        print(f"{row.task_id}  {row.status}  {row.priority}  {row.title}")
+        if row.record_origin == "generated":
+            generated_kind = row.generated_kind or "-"
+            print(
+                f"{row.task_id}  {row.status}  {row.priority}  "
+                f"{row.record_origin}/{generated_kind}/{row.review_task_state}  {row.title}"
+            )
+        else:
+            print(f"{row.task_id}  {row.status}  {row.priority}  {row.title}")
+    return 0
+
+
+def handle_task_resolve(args: argparse.Namespace) -> int:
+    return _handle_task_review_state(args, "resolved")
+
+
+def handle_task_mute(args: argparse.Namespace) -> int:
+    return _handle_task_review_state(args, "muted")
+
+
+def _handle_task_review_state(args: argparse.Namespace, review_task_state: str) -> int:
+    try:
+        result = update_task_review_state(
+            args.root.resolve(),
+            task_id=args.task_id,
+            review_task_state=review_task_state,
+        )
+    except ValueError as exc:
+        return _print_error(exc)
+
+    print(
+        f"Updated task {result.record_id}: "
+        f"status={result.status} review_task_state={result.review_task_state}"
+    )
+    print(f"Path: {result.path}")
     return 0
 
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -700,7 +700,7 @@ def build_parser() -> argparse.ArgumentParser:
     task_list_parser.add_argument(
         "--review-task-state",
         choices=("active", "resolved", "muted"),
-        help="Filter generated review tasks by operator review state.",
+        help="List generated contradiction-review tasks with this operator review state.",
     )
     task_list_parser.set_defaults(handler=handle_task_list)
     task_resolve_parser = task_subparsers.add_parser(

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -16,6 +16,7 @@ from splendor.schemas import (
     MaintenanceReport,
     QuerySnapshot,
     SourceRecord,
+    TaskRecord,
 )
 from splendor.state.query_snapshot import last_query_path_for
 from splendor.state.source_compat import canonical_source_ref
@@ -350,8 +351,13 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
             query_warning = BriefWarning(area="query", path=None, message=query_summary)
         if query_result is not None:
             query_summary = query_result.summary
+            brief_matches = [
+                _brief_match(match)
+                for match in query_result.matches
+                if not _is_generated_review_task_match(root, match)
+            ]
             matches = _rank_brief_matches(
-                [_brief_match(match) for match in query_result.matches],
+                brief_matches,
                 goal_tokens,
                 goal_phrase,
             )[:_BRIEF_MATCH_LIMIT]
@@ -409,6 +415,16 @@ def _brief_match(match: QueryMatch) -> BriefMatch:
         source_refs=match.source_refs,
         snippet=match.snippet,
     )
+
+
+def _is_generated_review_task_match(root: Path, match: QueryMatch) -> bool:
+    if match.document_class != "planning" or match.kind != "task":
+        return False
+    try:
+        parsed = parse_planning_document(root / match.path, TaskRecord)
+    except (OSError, ValueError):
+        return False
+    return is_generated_contradiction_review_task(parsed.record)
 
 
 def _rank_brief_matches(

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -16,7 +16,6 @@ from splendor.schemas import (
     MaintenanceReport,
     QuerySnapshot,
     SourceRecord,
-    TaskRecord,
 )
 from splendor.state.query_snapshot import last_query_path_for
 from splendor.state.source_compat import canonical_source_ref
@@ -352,7 +351,7 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
             brief_matches = [
                 _brief_match(match)
                 for match in query_result.matches
-                if not _is_generated_review_task_match(root, match)
+                if not _is_generated_review_task_match(match)
             ]
             matches = _rank_brief_matches(
                 brief_matches,
@@ -415,14 +414,13 @@ def _brief_match(match: QueryMatch) -> BriefMatch:
     )
 
 
-def _is_generated_review_task_match(root: Path, match: QueryMatch) -> bool:
-    if match.document_class != "planning" or match.kind != "task":
-        return False
-    try:
-        parsed = parse_planning_document(root / match.path, TaskRecord)
-    except (OSError, ValueError):
-        return False
-    return is_generated_contradiction_review_task(parsed.record)
+def _is_generated_review_task_match(match: QueryMatch) -> bool:
+    return (
+        match.document_class == "planning"
+        and match.kind == "task"
+        and match.record_origin == "generated"
+        and match.generated_kind == "contradiction-review"
+    )
 
 
 def _rank_brief_matches(

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -26,7 +26,7 @@ from splendor.utils.planning import (
     record_id_field,
 )
 
-from .planning import model_for_planning_kind
+from .planning import is_generated_contradiction_review_task, model_for_planning_kind
 from .query import QueryMatch, QueryValidationError, run_query
 from .queue import QueueInspectResult, inspect_queue
 from .source import SourceFreshnessResult, scan_source_freshness
@@ -53,6 +53,7 @@ _SUGGESTION_CATEGORY_LIMITS = {
     "goal-match": 3,
     "authority": 3,
     "planning": 2,
+    "contradiction-review": 1,
     "synthesis": 2,
     "wiki-review": 2,
     "maintenance": 2,
@@ -66,11 +67,12 @@ _SUGGESTION_CATEGORY_ORDER = {
     "goal-match": 3,
     "authority": 4,
     "planning": 5,
-    "synthesis": 6,
-    "wiki-review": 7,
-    "maintenance": 8,
-    "query": 9,
-    "orientation": 10,
+    "contradiction-review": 6,
+    "synthesis": 7,
+    "wiki-review": 8,
+    "maintenance": 9,
+    "query": 10,
+    "orientation": 11,
 }
 _SUGGESTION_PRIORITY_ORDER = {"high": 0, "medium": 1, "low": 2}
 _AUTHORITY_LIMIT = 6
@@ -124,6 +126,17 @@ _PLANNING_STATUSES = {
     "milestone": {"planned", "active"},
     "decision": {"proposed"},
     "question": {"open", "deferred"},
+}
+_CONTRADICTION_GOAL_TOKENS = {
+    "contradiction",
+    "contradictions",
+    "contradicting",
+    "contested",
+    "evidence",
+    "review",
+    "reviews",
+    "task",
+    "tasks",
 }
 
 
@@ -251,6 +264,7 @@ class BriefStateSnapshot:
     sources_by_id: dict[str, SourceRecord]
     wiki_pages: list[WikiPageSnapshot]
     invalid_wiki_pages: list[InvalidWikiPageSnapshot]
+    generated_review_task_count: int
 
 
 @dataclass(frozen=True)
@@ -377,6 +391,7 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
         sources_by_id=sources_by_id,
         wiki_pages=wiki_pages,
         invalid_wiki_pages=invalid_wiki_pages,
+        generated_review_task_count=_generated_review_task_count(layout),
     )
 
 
@@ -467,6 +482,8 @@ def _active_planning_items(
                 )
                 continue
             record = parsed.record
+            if kind == "task" and is_generated_contradiction_review_task(record):
+                continue
             status = record.status
             if status not in statuses:
                 continue
@@ -1123,6 +1140,19 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
             relevance_score=item.relevance_score,
         )
 
+    if snapshot.generated_review_task_count and goal_tokens & _CONTRADICTION_GOAL_TOKENS:
+        add(
+            "low",
+            "contradiction-review",
+            "Inspect generated contradiction-review tasks",
+            (
+                f"{snapshot.generated_review_task_count} generated contradiction-review task(s) "
+                "are available for intentional listing, resolution, or muting."
+            ),
+            "splendor task list --generated-review --review-task-state active",
+            relevance_score=1,
+        )
+
     for warning in snapshot.warnings:
         add(
             "low",
@@ -1269,6 +1299,21 @@ def _sources_missing_synthesis(
             continue
         source_ids.append(source_id)
     return sorted(source_ids, key=lambda source_id: canonical_source_ref(sources_by_id[source_id]))
+
+
+def _generated_review_task_count(layout) -> int:
+    count = 0
+    for path in iter_planning_paths(planning_directory(layout, "task")):
+        try:
+            parsed = parse_planning_document(path, model_for_planning_kind("task"))
+        except (OSError, ValueError):
+            continue
+        if (
+            is_generated_contradiction_review_task(parsed.record)
+            and parsed.record.review_task_state == "active"
+        ):
+            count += 1
+    return count
 
 
 def render_suggest_next_json(result: SuggestNextResult) -> str:

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -129,15 +129,13 @@ _PLANNING_STATUSES = {
     "question": {"open", "deferred"},
 }
 _CONTRADICTION_GOAL_TOKENS = {
+    "conflict",
+    "conflicts",
+    "conflicting",
     "contradiction",
     "contradictions",
     "contradicting",
     "contested",
-    "evidence",
-    "review",
-    "reviews",
-    "task",
-    "tasks",
 }
 
 
@@ -362,7 +360,7 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
                 goal_phrase,
             )[:_BRIEF_MATCH_LIMIT]
 
-    planning_items, warnings = _active_planning_items(
+    planning_items, warnings, generated_review_task_count = _active_planning_items(
         root, layout, normalized_goal or None, goal_phrase
     )
     if query_warning is not None:
@@ -397,7 +395,7 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
         sources_by_id=sources_by_id,
         wiki_pages=wiki_pages,
         invalid_wiki_pages=invalid_wiki_pages,
-        generated_review_task_count=_generated_review_task_count(layout),
+        generated_review_task_count=generated_review_task_count,
     )
 
 
@@ -478,9 +476,10 @@ def _brief_error(exc: Exception) -> str:
 
 def _active_planning_items(
     root: Path, layout, goal: str | None, goal_phrase: str
-) -> tuple[list[BriefPlanningItem], list[BriefWarning]]:
+) -> tuple[list[BriefPlanningItem], list[BriefWarning], int]:
     items: list[BriefPlanningItem] = []
     warnings: list[BriefWarning] = []
+    generated_review_task_count = 0
     goal_tokens = _tokens(goal or "")
     for kind, statuses in _PLANNING_STATUSES.items():
         model = model_for_planning_kind(kind)
@@ -499,6 +498,8 @@ def _active_planning_items(
                 continue
             record = parsed.record
             if kind == "task" and is_generated_contradiction_review_task(record):
+                if record.review_task_state == "active":
+                    generated_review_task_count += 1
                 continue
             status = record.status
             if status not in statuses:
@@ -537,7 +538,7 @@ def _active_planning_items(
         )
     else:
         items.sort(key=lambda item: (item.kind, item.status, item.record_id))
-    return items[:_BRIEF_PLANNING_LIMIT], warnings
+    return items[:_BRIEF_PLANNING_LIMIT], warnings, generated_review_task_count
 
 
 def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot], goal: str | None):
@@ -1315,21 +1316,6 @@ def _sources_missing_synthesis(
             continue
         source_ids.append(source_id)
     return sorted(source_ids, key=lambda source_id: canonical_source_ref(sources_by_id[source_id]))
-
-
-def _generated_review_task_count(layout) -> int:
-    count = 0
-    for path in iter_planning_paths(planning_directory(layout, "task")):
-        try:
-            parsed = parse_planning_document(path, model_for_planning_kind("task"))
-        except (OSError, ValueError):
-            continue
-        if (
-            is_generated_contradiction_review_task(parsed.record)
-            and parsed.record.review_task_state == "active"
-        ):
-            count += 1
-    return count
 
 
 def render_suggest_next_json(result: SuggestNextResult) -> str:

--- a/src/splendor/commands/planning.py
+++ b/src/splendor/commands/planning.py
@@ -283,7 +283,7 @@ def update_task_review_state(
     if not is_generated_contradiction_review_task(record):
         raise ValueError(f"Task is not a generated contradiction-review task: {task_id}")
 
-    status = "done" if review_task_state == "resolved" else record.status
+    status = _status_for_review_task_state(record.status, review_task_state)
     updated = record.model_copy(
         update={
             "status": status,
@@ -302,6 +302,14 @@ def update_task_review_state(
         review_task_state=updated.review_task_state,
         title=updated.title,
     )
+
+
+def _status_for_review_task_state(current_status: str, review_task_state: str) -> str:
+    if review_task_state == "resolved":
+        return "done"
+    if current_status == "done":
+        return "todo"
+    return current_status
 
 
 def list_milestones(root: Path, *, status: str | None) -> list[MilestoneListRow]:

--- a/src/splendor/commands/planning.py
+++ b/src/splendor/commands/planning.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import DecisionRecord, MilestoneRecord, QuestionRecord, TaskRecord
+from splendor.schemas.planning import status_for_review_task_state
 from splendor.utils.planning import (
     default_record_id,
     iter_planning_paths,
@@ -283,7 +284,7 @@ def update_task_review_state(
     if not is_generated_contradiction_review_task(record):
         raise ValueError(f"Task is not a generated contradiction-review task: {task_id}")
 
-    status = _status_for_review_task_state(record.status, review_task_state)
+    status = status_for_review_task_state(record.status, review_task_state)
     updated = record.model_copy(
         update={
             "status": status,
@@ -302,14 +303,6 @@ def update_task_review_state(
         review_task_state=updated.review_task_state,
         title=updated.title,
     )
-
-
-def _status_for_review_task_state(current_status: str, review_task_state: str) -> str:
-    if review_task_state == "resolved":
-        return "done"
-    if current_status == "done":
-        return "todo"
-    return current_status
 
 
 def list_milestones(root: Path, *, status: str | None) -> list[MilestoneListRow]:

--- a/src/splendor/commands/planning.py
+++ b/src/splendor/commands/planning.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import posixpath
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -29,6 +30,7 @@ _RECORD_MODELS = {
     "decision": DecisionRecord,
     "question": QuestionRecord,
 }
+_LEGACY_GENERATED_REVIEW_TASK_ID_PATTERN = re.compile(r"^task-review-.+-[a-f0-9]{10}$")
 
 
 @dataclass(frozen=True)
@@ -220,11 +222,12 @@ def list_tasks(
     review_task_state: str | None = None,
 ) -> list[TaskListRow]:
     rows: list[TaskListRow] = []
+    generated_review_only = generated_review or review_task_state is not None
     for record in _load_records(root, "task"):
         is_generated_review = is_generated_contradiction_review_task(record)
-        if generated_review and not is_generated_review:
+        if generated_review_only and not is_generated_review:
             continue
-        if not generated_review and not include_generated_review and is_generated_review:
+        if not generated_review_only and not include_generated_review and is_generated_review:
             continue
         if status is not None and record.status != status:
             continue
@@ -253,8 +256,11 @@ def list_tasks(
 def is_generated_contradiction_review_task(record: TaskRecord) -> bool:
     if record.record_origin == "generated" and record.generated_kind == "contradiction-review":
         return True
-    return record.task_id.startswith("task-review-") and record.title.startswith(
-        "Review contradiction:"
+    has_generated_refs = bool(record.source_refs or record.page_refs or record.run_refs)
+    return (
+        has_generated_refs
+        and record.title.startswith("Review contradiction:")
+        and _LEGACY_GENERATED_REVIEW_TASK_ID_PATTERN.fullmatch(record.task_id) is not None
     )
 
 

--- a/src/splendor/commands/planning.py
+++ b/src/splendor/commands/planning.py
@@ -44,6 +44,9 @@ class TaskListRow:
     task_id: str
     status: str
     priority: str
+    record_origin: str
+    generated_kind: str | None
+    review_task_state: str
     title: str
 
 
@@ -61,6 +64,15 @@ class UpdateQuestionAnswerResult:
     path: Path
     title: str
     content: str
+
+
+@dataclass(frozen=True)
+class UpdateTaskReviewStateResult:
+    record_id: str
+    path: Path
+    status: str
+    review_task_state: str
+    title: str
 
 
 def model_for_planning_kind(kind: str):
@@ -203,24 +215,87 @@ def list_tasks(
     status: str | None,
     priority: str | None,
     milestone_ref: str | None,
+    generated_review: bool = False,
+    include_generated_review: bool = False,
+    review_task_state: str | None = None,
 ) -> list[TaskListRow]:
     rows: list[TaskListRow] = []
     for record in _load_records(root, "task"):
+        is_generated_review = is_generated_contradiction_review_task(record)
+        if generated_review and not is_generated_review:
+            continue
+        if not generated_review and not include_generated_review and is_generated_review:
+            continue
         if status is not None and record.status != status:
             continue
         if priority is not None and record.priority != priority:
             continue
         if milestone_ref is not None and milestone_ref not in record.milestone_refs:
             continue
+        if review_task_state is not None and record.review_task_state != review_task_state:
+            continue
         rows.append(
             TaskListRow(
                 task_id=record.task_id,
                 status=record.status,
                 priority=record.priority,
+                record_origin="generated" if is_generated_review else record.record_origin,
+                generated_kind=(
+                    "contradiction-review" if is_generated_review else record.generated_kind
+                ),
+                review_task_state=record.review_task_state,
                 title=record.title,
             )
         )
     return rows
+
+
+def is_generated_contradiction_review_task(record: TaskRecord) -> bool:
+    if record.record_origin == "generated" and record.generated_kind == "contradiction-review":
+        return True
+    return record.task_id.startswith("task-review-") and record.title.startswith(
+        "Review contradiction:"
+    )
+
+
+def update_task_review_state(
+    root: Path,
+    *,
+    task_id: str,
+    review_task_state: str,
+) -> UpdateTaskReviewStateResult:
+    if review_task_state not in {"active", "resolved", "muted"}:
+        raise ValueError(f"Unsupported review task state: {review_task_state}")
+
+    layout = resolve_layout(root, load_config(root))
+    path = planning_path(layout, "task", task_id)
+    if not path.exists():
+        raise ValueError(f"Unknown task ID: {task_id}")
+
+    parsed = parse_planning_document(path, TaskRecord)
+    record = parsed.record
+    if not is_generated_contradiction_review_task(record):
+        raise ValueError(f"Task is not a generated contradiction-review task: {task_id}")
+
+    status = "done" if review_task_state == "resolved" else record.status
+    updated = record.model_copy(
+        update={
+            "status": status,
+            "record_origin": "generated",
+            "generated_kind": "contradiction-review",
+            "review_task_state": review_task_state,
+            "updated_at": utc_now_iso(),
+        }
+    )
+    content = render_planning_document(updated, body=parsed.body)
+    write_planning_markdown(path, content)
+    return UpdateTaskReviewStateResult(
+        record_id=task_id,
+        path=path,
+        status=updated.status,
+        review_task_state=updated.review_task_state,
+        title=updated.title,
+    )
 
 
 def list_milestones(root: Path, *, status: str | None) -> list[MilestoneListRow]:

--- a/src/splendor/commands/query.py
+++ b/src/splendor/commands/query.py
@@ -78,6 +78,9 @@ class QueryMatch:
     title: str
     path: str
     status: str | None
+    record_origin: str | None
+    generated_kind: str | None
+    review_task_state: str | None
     review_state: str | None
     last_generated_at: str | None
     snippet: str
@@ -109,6 +112,9 @@ class _QueryDocument:
     title: str
     path: str
     status: str | None
+    record_origin: str | None
+    generated_kind: str | None
+    review_task_state: str | None
     review_state: str | None
     last_generated_at: str | None
     source_refs: list[str]
@@ -181,6 +187,9 @@ def run_query(
             title=item.document.title,
             path=item.document.path,
             status=item.document.status,
+            record_origin=item.document.record_origin,
+            generated_kind=item.document.generated_kind,
+            review_task_state=item.document.review_task_state,
             review_state=item.document.review_state,
             last_generated_at=item.document.last_generated_at,
             snippet=item.snippet,
@@ -290,6 +299,9 @@ def _iter_wiki_documents(root: Path, layout: ResolvedLayout) -> list[_QueryDocum
                 title=frontmatter.title,
                 path=path.relative_to(root).as_posix(),
                 status=frontmatter.status,
+                record_origin=None,
+                generated_kind=None,
+                review_task_state=None,
                 review_state=frontmatter.review_state,
                 last_generated_at=frontmatter.last_generated_at,
                 source_refs=list(frontmatter.source_refs),
@@ -324,6 +336,9 @@ def _iter_planning_documents(root: Path, layout: ResolvedLayout) -> list[_QueryD
             payload = record.model_dump(mode="json")
             record_id = str(getattr(record, record_id_field(kind)))
             status = payload.get("status")
+            record_origin = payload.get("record_origin")
+            generated_kind = payload.get("generated_kind")
+            review_task_state = payload.get("review_task_state")
             source_refs = list(payload.get("source_refs", []))
             keyword_values = [kind]
             if isinstance(status, str):
@@ -343,6 +358,11 @@ def _iter_planning_documents(root: Path, layout: ResolvedLayout) -> list[_QueryD
                     title=record.title,
                     path=path.relative_to(root).as_posix(),
                     status=status if isinstance(status, str) else None,
+                    record_origin=record_origin if isinstance(record_origin, str) else None,
+                    generated_kind=generated_kind if isinstance(generated_kind, str) else None,
+                    review_task_state=(
+                        review_task_state if isinstance(review_task_state, str) else None
+                    ),
                     review_state=None,
                     last_generated_at=None,
                     source_refs=source_refs,

--- a/src/splendor/schemas/planning.py
+++ b/src/splendor/schemas/planning.py
@@ -31,6 +31,16 @@ class TaskRecord(StrictRecord):
     run_refs: list[str] = Field(default_factory=list)
 
 
+def status_for_review_task_state(
+    current_status: str, review_task_state: Literal["active", "resolved", "muted"]
+) -> str:
+    if review_task_state == "resolved":
+        return "done"
+    if current_status == "done":
+        return "todo"
+    return current_status
+
+
 class MilestoneRecord(StrictRecord):
     kind: Literal["milestone"] = "milestone"
     milestone_id: str

--- a/src/splendor/schemas/planning.py
+++ b/src/splendor/schemas/planning.py
@@ -16,6 +16,9 @@ class TaskRecord(StrictRecord):
     title: str
     status: Literal["todo", "in_progress", "blocked", "done"] = "todo"
     priority: Literal["low", "medium", "high"] = "medium"
+    record_origin: Literal["human", "generated"] = "human"
+    generated_kind: Literal["contradiction-review"] | None = None
+    review_task_state: Literal["active", "resolved", "muted"] = "active"
     milestone_refs: list[str] = Field(default_factory=list)
     decision_refs: list[str] = Field(default_factory=list)
     question_refs: list[str] = Field(default_factory=list)

--- a/src/splendor/schemas/query.py
+++ b/src/splendor/schemas/query.py
@@ -23,6 +23,9 @@ class QueryMatchSnapshot(StrictRecord):
     title: str
     path: str
     status: str | None = None
+    record_origin: str | None = None
+    generated_kind: str | None = None
+    review_task_state: str | None = None
     review_state: str | None = None
     last_generated_at: str | None = None
     snippet: str

--- a/src/splendor/utils/contradictions.py
+++ b/src/splendor/utils/contradictions.py
@@ -495,9 +495,15 @@ def _upsert_review_task(
     if task_path.exists():
         parsed = parse_planning_document(task_path, TaskRecord)
         assert isinstance(parsed.record, TaskRecord)
+        review_task_state = parsed.record.review_task_state
+        status = "done" if review_task_state == "resolved" else parsed.record.status
         record = parsed.record.model_copy(
             update={
                 "title": title,
+                "status": status,
+                "record_origin": "generated",
+                "generated_kind": "contradiction-review",
+                "review_task_state": review_task_state,
                 "updated_at": timestamp,
                 "source_refs": sorted(
                     {
@@ -522,6 +528,9 @@ def _upsert_review_task(
             title=title,
             status="todo",
             priority=priority,
+            record_origin="generated",
+            generated_kind="contradiction-review",
+            review_task_state="active",
             created_at=timestamp,
             updated_at=timestamp,
             source_refs=list(annotation.related_source_ids),

--- a/src/splendor/utils/contradictions.py
+++ b/src/splendor/utils/contradictions.py
@@ -496,7 +496,7 @@ def _upsert_review_task(
         parsed = parse_planning_document(task_path, TaskRecord)
         assert isinstance(parsed.record, TaskRecord)
         review_task_state = parsed.record.review_task_state
-        status = "done" if review_task_state == "resolved" else parsed.record.status
+        status = _review_task_status_for_state(parsed.record.status, review_task_state)
         record = parsed.record.model_copy(
             update={
                 "title": title,
@@ -571,6 +571,14 @@ def _render_review_task_body(
         f"(`{candidate.frontmatter.page_id}`)\n\n"
         "## Notes\n\n"
     )
+
+
+def _review_task_status_for_state(current_status: str, review_task_state: str) -> str:
+    if review_task_state == "resolved":
+        return "done"
+    if current_status == "done":
+        return "todo"
+    return current_status
 
 
 def _render_provenance_lines(links: list[ProvenanceLink]) -> list[str]:

--- a/src/splendor/utils/contradictions.py
+++ b/src/splendor/utils/contradictions.py
@@ -20,6 +20,7 @@ from splendor.schemas import (
     ProvenanceLink,
     TaskRecord,
 )
+from splendor.schemas.planning import status_for_review_task_state
 from splendor.utils.planning import parse_planning_document, planning_path, render_planning_document
 from splendor.utils.time import utc_now_iso
 from splendor.utils.wiki import parse_wiki_markdown
@@ -496,7 +497,7 @@ def _upsert_review_task(
         parsed = parse_planning_document(task_path, TaskRecord)
         assert isinstance(parsed.record, TaskRecord)
         review_task_state = parsed.record.review_task_state
-        status = _review_task_status_for_state(parsed.record.status, review_task_state)
+        status = status_for_review_task_state(parsed.record.status, review_task_state)
         record = parsed.record.model_copy(
             update={
                 "title": title,
@@ -571,14 +572,6 @@ def _render_review_task_body(
         f"(`{candidate.frontmatter.page_id}`)\n\n"
         "## Notes\n\n"
     )
-
-
-def _review_task_status_for_state(current_status: str, review_task_state: str) -> str:
-    if review_task_state == "resolved":
-        return "done"
-    if current_status == "done":
-        return "todo"
-    return current_status
 
 
 def _render_provenance_lines(links: list[ProvenanceLink]) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4570,6 +4570,33 @@ def test_cli_task_resolve_and_mute_generated_review_tasks(tmp_path: Path, capsys
     assert "task-review-src-c-src-d-1234567890" not in out
 
 
+def test_cli_task_mute_normalizes_resolved_task_status(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    review_task = TaskRecord(
+        task_id="task-review-src-a-src-b-1234567890",
+        title="Review contradiction: A vs B",
+        status="todo",
+        priority="high",
+        record_origin="generated",
+        generated_kind="contradiction-review",
+        review_task_state="active",
+        created_at="2026-05-06T00:00:00Z",
+        updated_at="2026-05-06T00:00:00Z",
+    )
+    task_path = tmp_path / "planning" / "tasks" / f"{review_task.task_id}.md"
+    task_path.write_text(
+        render_planning_markdown(review_task, title=review_task.title),
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    assert main(["--root", str(tmp_path), "task", "resolve", review_task.task_id]) == 0
+    assert main(["--root", str(tmp_path), "task", "mute", review_task.task_id]) == 0
+
+    out = capsys.readouterr().out
+    assert "status=todo review_task_state=muted" in out
+
+
 def test_cli_milestone_create_and_list_commands(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     main(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,10 +24,12 @@ from splendor.schemas import (
     ProvenanceLink,
     QueueItemRecord,
     RunRecord,
+    TaskRecord,
 )
 from splendor.state.query_snapshot import last_query_path_for, load_query_snapshot
 from splendor.state.runtime import load_queue_item, write_queue_item, write_run_record
 from splendor.state.source_registry import load_source_record, write_source_record
+from splendor.utils.planning import render_planning_markdown
 
 
 def latest_report_paths(root: Path, command: str) -> tuple[Path, Path]:
@@ -4440,6 +4442,103 @@ def test_cli_task_list_command_supports_filters(tmp_path: Path, capsys) -> None:
     captured = capsys.readouterr()
     lines = [line for line in captured.out.splitlines() if line.startswith("task-")]
     assert lines == ["task-write-cli-docs  todo  high  Write CLI docs"]
+
+
+def test_cli_task_list_hides_generated_review_tasks_by_default(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    main(["--root", str(tmp_path), "task", "create", "Write", "CLI", "docs"])
+    review_task = TaskRecord(
+        task_id="task-review-src-a-src-b-1234567890",
+        title="Review contradiction: A vs B",
+        status="todo",
+        priority="high",
+        record_origin="generated",
+        generated_kind="contradiction-review",
+        review_task_state="active",
+        created_at="2026-05-06T00:00:00Z",
+        updated_at="2026-05-06T00:00:00Z",
+        source_refs=["src-a", "src-b"],
+        page_refs=["wiki/sources/src-a.md", "wiki/sources/src-b.md"],
+        run_refs=["state/runs/run-1.json"],
+    )
+    task_path = tmp_path / "planning" / "tasks" / f"{review_task.task_id}.md"
+    task_path.write_text(
+        render_planning_markdown(review_task, title=review_task.title),
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "task", "list"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "task-write-cli-docs" in out
+    assert review_task.task_id not in out
+
+    exit_code = main(["--root", str(tmp_path), "task", "list", "--include-generated-review"])
+
+    assert exit_code == 0
+    assert review_task.task_id in capsys.readouterr().out
+
+    exit_code = main(["--root", str(tmp_path), "task", "list", "--generated-review"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert review_task.task_id in out
+    assert "generated/contradiction-review/active" in out
+
+
+def test_cli_task_resolve_and_mute_generated_review_tasks(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    for task_id in [
+        "task-review-src-a-src-b-1234567890",
+        "task-review-src-c-src-d-1234567890",
+    ]:
+        review_task = TaskRecord(
+            task_id=task_id,
+            title=f"Review contradiction: {task_id}",
+            status="todo",
+            priority="high",
+            record_origin="generated",
+            generated_kind="contradiction-review",
+            review_task_state="active",
+            created_at="2026-05-06T00:00:00Z",
+            updated_at="2026-05-06T00:00:00Z",
+        )
+        task_path = tmp_path / "planning" / "tasks" / f"{task_id}.md"
+        task_path.write_text(
+            render_planning_markdown(review_task, title=review_task.title),
+            encoding="utf-8",
+        )
+    capsys.readouterr()
+
+    resolved = main(
+        ["--root", str(tmp_path), "task", "resolve", "task-review-src-a-src-b-1234567890"]
+    )
+    muted = main(["--root", str(tmp_path), "task", "mute", "task-review-src-c-src-d-1234567890"])
+
+    assert resolved == 0
+    assert muted == 0
+    out = capsys.readouterr().out
+    assert "status=done review_task_state=resolved" in out
+    assert "status=todo review_task_state=muted" in out
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "list",
+            "--generated-review",
+            "--review-task-state",
+            "resolved",
+        ]
+    )
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "task-review-src-a-src-b-1234567890" in out
+    assert "task-review-src-c-src-d-1234567890" not in out
 
 
 def test_cli_milestone_create_and_list_commands(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4488,6 +4488,35 @@ def test_cli_task_list_hides_generated_review_tasks_by_default(tmp_path: Path, c
     assert "generated/contradiction-review/active" in out
 
 
+def test_cli_task_review_state_filter_implies_generated_review(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    main(["--root", str(tmp_path), "task", "create", "Write", "CLI", "docs"])
+    review_task = TaskRecord(
+        task_id="task-review-src-a-src-b-1234567890",
+        title="Review contradiction: A vs B",
+        status="todo",
+        priority="high",
+        record_origin="generated",
+        generated_kind="contradiction-review",
+        review_task_state="active",
+        created_at="2026-05-06T00:00:00Z",
+        updated_at="2026-05-06T00:00:00Z",
+    )
+    task_path = tmp_path / "planning" / "tasks" / f"{review_task.task_id}.md"
+    task_path.write_text(
+        render_planning_markdown(review_task, title=review_task.title),
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "task", "list", "--review-task-state", "active"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert review_task.task_id in out
+    assert "task-write-cli-docs" not in out
+
+
 def test_cli_task_resolve_and_mute_generated_review_tasks(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     for task_id in [

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2055,3 +2055,47 @@ def test_ingest_source_preserves_generated_review_task_disposition_on_upsert(
     assert task_record.generated_kind == "contradiction-review"
     assert task_record.review_task_state == review_task_state
     assert task_record.status == expected_status
+
+
+def test_ingest_source_normalizes_muted_review_task_status_on_upsert(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    initialize_workspace(tmp_path)
+
+    class FakeAnalyzer:
+        def detect(self, *, current, candidate):
+            return [
+                contradictions_module.DetectedContradiction(
+                    summary="The pages disagree about the configured storage mode.",
+                    current_excerpt="Storage mode is none.",
+                    candidate_excerpt="Storage mode is copy.",
+                )
+            ]
+
+    monkeypatch.setattr(
+        contradictions_module,
+        "build_contradiction_analyzer",
+        lambda config: FakeAnalyzer(),
+    )
+
+    first_source = tmp_path / "first.md"
+    first_source.write_text("# First\n\nhello world\n", encoding="utf-8")
+    first_added = add_source(tmp_path, first_source, storage_mode="copy")
+    ingest_source(tmp_path, first_added.source_id)
+
+    second_source = tmp_path / "second.md"
+    second_source.write_text("# Second\n\nhello world\n", encoding="utf-8")
+    second_added = add_source(tmp_path, second_source, storage_mode="copy")
+    first_result = ingest_source(tmp_path, second_added.source_id)
+    assert first_result.page_path is not None
+    task_id = parse_frontmatter(first_result.page_path)[0].contradictions[0].review_task_id
+
+    update_task_review_state(tmp_path, task_id=task_id, review_task_state="resolved")
+    update_task_review_state(tmp_path, task_id=task_id, review_task_state="muted")
+    first_result.page_path.unlink()
+    ingest_source(tmp_path, second_added.source_id)
+
+    task_path = tmp_path / "planning" / "tasks" / f"{task_id}.md"
+    task_record = parse_planning_document(task_path, TaskRecord).record
+    assert task_record.review_task_state == "muted"
+    assert task_record.status == "todo"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -17,12 +17,14 @@ from splendor.commands.ingest import (
     run_ingest_job,
 )
 from splendor.commands.init import initialize_workspace
+from splendor.commands.planning import update_task_review_state
 from splendor.config import load_config, write_config
-from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord
+from splendor.schemas import KnowledgePageFrontmatter, QueueItemRecord, RunRecord, TaskRecord
 from splendor.schemas.types import SummaryMode
 from splendor.state.runtime import load_queue_item, load_run_record, write_queue_item
 from splendor.state.source_pointer import load_source_pointer, write_source_pointer
 from splendor.state.source_registry import load_source_record, write_source_record
+from splendor.utils.planning import parse_planning_document
 
 
 def parse_frontmatter(page_path: Path) -> tuple[KnowledgePageFrontmatter, str]:
@@ -1910,6 +1912,10 @@ def test_ingest_source_marks_contradictions_and_creates_review_task(
     task_id = second_page.contradictions[0].review_task_id
     task_path = tmp_path / "planning" / "tasks" / f"{task_id}.md"
     assert task_path.exists()
+    task_record = parse_planning_document(task_path, TaskRecord).record
+    assert task_record.record_origin == "generated"
+    assert task_record.generated_kind == "contradiction-review"
+    assert task_record.review_task_state == "active"
     task_body = task_path.read_text(encoding="utf-8")
     assert "## Contradiction" in task_body
     assert "## Evidence" in task_body
@@ -1997,3 +2003,55 @@ def test_ingest_source_dedupes_existing_contradictions_and_review_tasks(
     assert len(second_page.contradictions) == 1
     assert len(task_paths) == 1
     assert load_run_record(second_result.run_path).task_ids == [task_id]
+
+
+@pytest.mark.parametrize(
+    ("review_task_state", "expected_status"),
+    [("resolved", "done"), ("muted", "todo")],
+)
+def test_ingest_source_preserves_generated_review_task_disposition_on_upsert(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    review_task_state: str,
+    expected_status: str,
+) -> None:
+    initialize_workspace(tmp_path)
+
+    class FakeAnalyzer:
+        def detect(self, *, current, candidate):
+            return [
+                contradictions_module.DetectedContradiction(
+                    summary="The pages disagree about the configured storage mode.",
+                    current_excerpt="Storage mode is none.",
+                    candidate_excerpt="Storage mode is copy.",
+                )
+            ]
+
+    monkeypatch.setattr(
+        contradictions_module,
+        "build_contradiction_analyzer",
+        lambda config: FakeAnalyzer(),
+    )
+
+    first_source = tmp_path / "first.md"
+    first_source.write_text("# First\n\nhello world\n", encoding="utf-8")
+    first_added = add_source(tmp_path, first_source, storage_mode="copy")
+    ingest_source(tmp_path, first_added.source_id)
+
+    second_source = tmp_path / "second.md"
+    second_source.write_text("# Second\n\nhello world\n", encoding="utf-8")
+    second_added = add_source(tmp_path, second_source, storage_mode="copy")
+    first_result = ingest_source(tmp_path, second_added.source_id)
+    assert first_result.page_path is not None
+    task_id = parse_frontmatter(first_result.page_path)[0].contradictions[0].review_task_id
+
+    update_task_review_state(tmp_path, task_id=task_id, review_task_state=review_task_state)
+    first_result.page_path.unlink()
+    ingest_source(tmp_path, second_added.source_id)
+
+    task_path = tmp_path / "planning" / "tasks" / f"{task_id}.md"
+    task_record = parse_planning_document(task_path, TaskRecord).record
+    assert task_record.record_origin == "generated"
+    assert task_record.generated_kind == "contradiction-review"
+    assert task_record.review_task_state == review_task_state
+    assert task_record.status == expected_status

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -203,6 +203,14 @@ def test_list_tasks_treats_legacy_review_task_ids_as_generated(tmp_path: Path) -
         "title: 'Review contradiction: Source A vs Source B'\n"
         "status: todo\n"
         "priority: high\n"
+        "source_refs:\n"
+        "- src-a\n"
+        "- src-b\n"
+        "page_refs:\n"
+        "- wiki/sources/src-a.md\n"
+        "- wiki/sources/src-b.md\n"
+        "run_refs:\n"
+        "- state/runs/run-1.json\n"
         "created_at: '2026-05-06T00:00:00Z'\n"
         "updated_at: '2026-05-06T00:00:00Z'\n"
         "---\n\n"
@@ -231,6 +239,45 @@ def test_list_tasks_treats_legacy_review_task_ids_as_generated(tmp_path: Path) -
             title="Review contradiction: Source A vs Source B",
         )
     ]
+
+
+def test_list_tasks_does_not_hide_human_review_contradiction_tasks(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    create_task(
+        tmp_path,
+        "Review contradiction: Source A vs Source B",
+        record_id="task-review-src-a-src-b-1234567890",
+        status="todo",
+        priority="high",
+        owner=None,
+        milestone_refs=[],
+        decision_refs=[],
+        question_refs=[],
+        depends_on=[],
+        source_refs=[],
+    )
+
+    rows = list_tasks(tmp_path, status=None, priority=None, milestone_ref=None)
+    generated_rows = list_tasks(
+        tmp_path,
+        status=None,
+        priority=None,
+        milestone_ref=None,
+        generated_review=True,
+    )
+
+    assert rows == [
+        TaskListRow(
+            task_id="task-review-src-a-src-b-1234567890",
+            status="todo",
+            priority="high",
+            record_origin="human",
+            generated_kind=None,
+            review_task_state="active",
+            title="Review contradiction: Source A vs Source B",
+        )
+    ]
+    assert generated_rows == []
 
 
 def test_list_milestones_is_sorted_and_filtered(tmp_path: Path) -> None:

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -184,7 +184,51 @@ def test_list_tasks_is_sorted_and_filtered(tmp_path: Path) -> None:
             task_id="task-b",
             status="todo",
             priority="high",
+            record_origin="human",
+            generated_kind=None,
+            review_task_state="active",
             title="Write CLI docs",
+        )
+    ]
+
+
+def test_list_tasks_treats_legacy_review_task_ids_as_generated(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    task_path = tmp_path / "planning" / "tasks" / "task-review-src-a-src-b-1234567890.md"
+    task_path.write_text(
+        "---\n"
+        "schema_version: '1'\n"
+        "kind: task\n"
+        "task_id: task-review-src-a-src-b-1234567890\n"
+        "title: 'Review contradiction: Source A vs Source B'\n"
+        "status: todo\n"
+        "priority: high\n"
+        "created_at: '2026-05-06T00:00:00Z'\n"
+        "updated_at: '2026-05-06T00:00:00Z'\n"
+        "---\n\n"
+        "# Review contradiction: Source A vs Source B\n",
+        encoding="utf-8",
+    )
+
+    default_rows = list_tasks(tmp_path, status=None, priority=None, milestone_ref=None)
+    generated_rows = list_tasks(
+        tmp_path,
+        status=None,
+        priority=None,
+        milestone_ref=None,
+        generated_review=True,
+    )
+
+    assert default_rows == []
+    assert generated_rows == [
+        TaskListRow(
+            task_id="task-review-src-a-src-b-1234567890",
+            status="todo",
+            priority="high",
+            record_origin="generated",
+            generated_kind="contradiction-review",
+            review_task_state="active",
+            title="Review contradiction: Source A vs Source B",
         )
     ]
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -10,8 +10,9 @@ from splendor.commands.init import initialize_workspace
 from splendor.commands.planning import create_question, create_task
 from splendor.commands.query import run_query
 from splendor.config import load_config, write_config
-from splendor.schemas import KnowledgePageFrontmatter
+from splendor.schemas import KnowledgePageFrontmatter, TaskRecord
 from splendor.state.query_snapshot import load_query_snapshot
+from splendor.utils.planning import render_planning_markdown
 
 
 def enable_sidecar_ocr(root: Path) -> None:
@@ -86,6 +87,35 @@ def test_run_query_returns_ranked_matches_from_wiki_and_planning(tmp_path: Path)
     assert wiki_match.provenance_links == []
     assert wiki_match.contradiction_count == 0
     assert wiki_match.review_task_ids == []
+
+
+def test_run_query_carries_planning_task_generation_metadata(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    review_task = TaskRecord(
+        task_id="task-review-src-a-src-b-1234567890",
+        title="Review contradiction: A vs B",
+        status="todo",
+        priority="high",
+        record_origin="generated",
+        generated_kind="contradiction-review",
+        review_task_state="muted",
+        created_at="2026-05-06T00:00:00Z",
+        updated_at="2026-05-06T00:00:00Z",
+        source_refs=["src-a", "src-b"],
+    )
+    task_path = tmp_path / "planning" / "tasks" / f"{review_task.task_id}.md"
+    task_path.write_text(
+        render_planning_markdown(review_task, title=review_task.title),
+        encoding="utf-8",
+    )
+
+    result = run_query(tmp_path, "contradiction")
+
+    assert result.match_count == 1
+    match = result.matches[0]
+    assert match.record_origin == "generated"
+    assert match.generated_kind == "contradiction-review"
+    assert match.review_task_state == "muted"
 
 
 def test_run_query_filters_by_wiki_tag(tmp_path: Path) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2306,7 +2306,7 @@ def test_suggest_next_exposes_generated_review_tasks_for_contradiction_goal(
     )
     capsys.readouterr()
 
-    default_exit = main(["--root", str(tmp_path), "suggest-next", "handoff", "--json"])
+    default_exit = main(["--root", str(tmp_path), "suggest-next", "review", "tasks", "--json"])
     default_payload = json.loads(capsys.readouterr().out)
     focused_exit = main(["--root", str(tmp_path), "suggest-next", "contradiction", "--json"])
     focused_payload = json.loads(capsys.readouterr().out)

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2313,6 +2313,8 @@ def test_suggest_next_exposes_generated_review_tasks_for_contradiction_goal(
 
     assert default_exit == 0
     assert focused_exit == 0
+    assert all("task-review" not in match["path"] for match in focused_payload["matches"])
+    assert all("task-review" not in str(action["path"]) for action in focused_payload["actions"])
     assert all(
         action["category"] != "contradiction-review" for action in default_payload["actions"]
     )

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -8,8 +8,9 @@ from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.wiki import add_topic_page, rebuild_wiki_index
 from splendor.config import AuthorityDocumentConfig, load_config, write_config
-from splendor.schemas import KnowledgePageFrontmatter, MaintenanceReport
+from splendor.schemas import KnowledgePageFrontmatter, MaintenanceReport, TaskRecord
 from splendor.state.source_registry import load_source_record
+from splendor.utils.planning import render_planning_markdown
 from splendor.utils.wiki import parse_wiki_markdown
 
 
@@ -2094,6 +2095,55 @@ def test_agent_context_orders_active_planning_by_goal_relevance(tmp_path: Path, 
     assert planning_actions[0]["record_id"] == "task-agent-handoff-ranking"
 
 
+def test_agent_context_hides_generated_review_tasks_from_active_planning(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "create",
+            "Continue human handoff plan",
+            "--id",
+            "task-human-handoff-plan",
+            "--status",
+            "in_progress",
+        ]
+    )
+    review_task = TaskRecord(
+        task_id="task-review-src-a-src-b-1234567890",
+        title="Review contradiction: noisy generated task",
+        status="todo",
+        priority="high",
+        record_origin="generated",
+        generated_kind="contradiction-review",
+        review_task_state="active",
+        created_at="2026-05-06T00:00:00Z",
+        updated_at="2026-05-06T00:00:00Z",
+    )
+    task_path = tmp_path / "planning" / "tasks" / f"{review_task.task_id}.md"
+    task_path.write_text(
+        render_planning_markdown(review_task, title=review_task.title),
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "brief", "--agent-context", "human", "handoff", "--json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [item["record_id"] for item in payload["active_planning"]] == ["task-human-handoff-plan"]
+    assert all(
+        action["record_id"] != review_task.task_id
+        for action in payload["suggested_actions"]
+        if action["record_id"] is not None
+    )
+
+
 def test_suggest_next_caps_review_noise_after_goal_relevance(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
     for index in range(8):
@@ -2232,6 +2282,48 @@ def test_suggest_next_caps_review_noise_and_preserves_goal_work(tmp_path: Path, 
     assert "goal-match" in categories
     assert "planning" in categories
     assert categories.index("goal-match") < categories.index("wiki-review")
+
+
+def test_suggest_next_exposes_generated_review_tasks_for_contradiction_goal(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    review_task = TaskRecord(
+        task_id="task-review-src-a-src-b-1234567890",
+        title="Review contradiction: A vs B",
+        status="todo",
+        priority="high",
+        record_origin="generated",
+        generated_kind="contradiction-review",
+        review_task_state="active",
+        created_at="2026-05-06T00:00:00Z",
+        updated_at="2026-05-06T00:00:00Z",
+    )
+    task_path = tmp_path / "planning" / "tasks" / f"{review_task.task_id}.md"
+    task_path.write_text(
+        render_planning_markdown(review_task, title=review_task.title),
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    default_exit = main(["--root", str(tmp_path), "suggest-next", "handoff", "--json"])
+    default_payload = json.loads(capsys.readouterr().out)
+    focused_exit = main(["--root", str(tmp_path), "suggest-next", "contradiction", "--json"])
+    focused_payload = json.loads(capsys.readouterr().out)
+
+    assert default_exit == 0
+    assert focused_exit == 0
+    assert all(
+        action["category"] != "contradiction-review" for action in default_payload["actions"]
+    )
+    contradiction_actions = [
+        action
+        for action in focused_payload["actions"]
+        if action["category"] == "contradiction-review"
+    ]
+    assert contradiction_actions[0]["command"] == (
+        "splendor task list --generated-review --review-task-state active"
+    )
 
 
 def test_brief_skips_invalid_query_matches_without_failing(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

- Classifies ingest-created contradiction-review tasks as generated planning records while keeping schema version `1` compatible.
- Hides generated contradiction-review tasks from default `task list`, `brief --agent-context`, and `suggest-next` active-planning handoff.
- Adds intentional operator workflows to list, resolve, or mute generated contradiction-review tasks while preserving contested-page and query evidence.
- Tightens generated-task detection so human-authored lookalike tasks remain visible, filters generated review tasks out of query-derived handoff matches, and makes `--review-task-state` imply generated-review-only listing.
- Updates synchronized M17 planning state and public-readiness docs for M17-P4.1.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest` (653 passed)
- `uv run splendor lint`

Closes #117