### PR TITLE
M18-P1.1: Add git-aware, work-first agent handoff

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M17-P4.1`
-- Last action taken: `M17-P4.1` was squash-merged into main as commit `ea9cc8d`,
-  and `v0.3.0` was released from commit `592b142` for external evaluation.
+- Previous completed PR sub-slice: `M18-P0.1`
+- Last action taken: `M18-P0.1` was squash-merged into main as commit `5192e30`,
+  recording the v0.3 evaluation intake and v0.4 roadmap realignment.
 - Current planned slice: `M18 v0.4 work-first agent handoff`
-- Current PR sub-slice: `M18-P0.1`
+- Current PR sub-slice: `M18-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M18 v0.4 work-first agent handoff`
-- Next planned PR sub-slice: `M18-P1.1`
+- Next planned PR sub-slice: `M18-P2.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -357,12 +357,18 @@
   - [x] Add intentional list, resolve, and mute workflows
   - [x] Preserve contradiction evidence through contested pages, query metadata, and explicit task listing
   - [x] Update tests, docs, and planning state for issue #117
-- [ ] Implement `M18-P0.1`: v0.3 evaluation intake and v0.4 roadmap realignment
+- [x] Implement `M18-P0.1`: v0.3 evaluation intake and v0.4 roadmap realignment
   - [x] Record SynthBanshee v0.3 evaluation and follow-up feedback
   - [x] Record hocrgen v0.3 evaluation and follow-up feedback
   - [x] Reorganize supporting docs into guides, operations, evaluations, and releases folders
   - [x] Reframe the next implementation path around git-aware, work-first agent handoff
   - [x] Publish a non-draft PR with labels, milestone, issue linkage, and detailed validation
+- [ ] Implement `M18-P1.1`: git-aware, work-first agent handoff
+  - [x] Add `--since` and `--no-git` handoff options to `brief` and `suggest-next`
+  - [x] Add runtime-only local git and best-effort GitHub issue/PR context
+  - [x] Rank work context before Splendor maintenance for non-maintenance goals
+  - [x] Separate work and maintenance context in agent-facing text and JSON output
+  - [x] Cover the SynthBanshee and hocrgen retry bars with deterministic fixtures
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -150,9 +150,10 @@ Implemented today:
   `splendor wiki compile <source-id> --page <page>` for diff-backed proposals and
   `--apply --proposal-hash <hash>` for explicit reviewed synthesis-page updates
 - `splendor wiki rebuild-index`
-- `splendor brief [goal]` and `splendor brief --agent-context [goal]`
+- `splendor brief [goal]` and
+  `splendor brief --agent-context [--since <ref>] [--no-git] [goal]`
 - config-backed authority briefs for maintained planning/docs context through
-  `brief --agent-context` and `suggest-next`
+- `brief --agent-context` and `suggest-next [--since <ref>] [--no-git]`
 - `splendor serve` for a read-only local browse/search/status/planning/runtime UI
 - read-only web `/status`, `/sources/<source-id>`, `/planning`, `/runs`, and `/queue` views
 - `splendor lint` and `splendor health`
@@ -250,6 +251,14 @@ historical review, proposal, reference, and generated-summary context, with fres
 current, watch, stale, or historical. Generated `source-summary` pages remain ingestion artifacts
 and are excluded from maintained authority ranking.
 
+`M18-P1.1` makes those handoff surfaces git-aware and work-first for normal implementation goals.
+Inside a git worktree they include local branch/head/base context, recent relevant commits,
+best-effort read-only GitHub issue/PR context through `gh` when available, and read-first file
+paths before Splendor maintenance state. Use `--since <ref>` to override the git base and
+`--no-git` to suppress git/GitHub context. JSON output includes separate `work_context`,
+`maintenance_context`, and `git_context` sections while preserving the flattened
+`suggested_actions` list.
+
 `M17-P2.1` expands that authority model for issue #116 without changing schema version `1`.
 Configured authority docs, maintained wiki authority pages, and goal-relevant decision records can
 now expose lifecycle state (`current`, `reviewed`, `pr-linked`, `historical`, `superseded`, or
@@ -293,12 +302,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M17-P4.1`
+- Previous completed PR sub-slice: `M18-P0.1`
 - Current planned slice: `M18 v0.4 work-first agent handoff`
-- Current PR sub-slice: `M18-P0.1`
+- Current PR sub-slice: `M18-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M18 v0.4 work-first agent handoff`
-- Next planned PR sub-slice: `M18-P1.1`
+- Next planned PR sub-slice: `M18-P2.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -374,6 +383,11 @@ stale/contested/review-needed pages, missing synthesis follow-up, active plannin
 maintenance reports, and query matches for the optional goal. `brief --agent-context` now leads
 with the same suggested work before the lower-level metadata lists. Use `--json` on either command
 for machine handoff.
+
+`M18-P1.1` adds runtime-only git-aware handoff context to those same surfaces. For non-maintenance
+goals, open work threads, relevant commits, configured authority, active planning, changed/read-first
+files, and goal matches rank ahead of source freshness, queue, wiki review, synthesis, lint, and
+health maintenance. Maintenance-focused goals can still keep maintenance actions first.
 
 `M13-P2.5` is implemented: source-summary pages now keep readable in-repo source summaries compact
 and claim-bearing by default, while external, copied, parsed PDF, and OCR-derived sources keep
@@ -565,6 +579,10 @@ rewritten.
 The external `v0.3.0` SynthBanshee and hocrgen trials are now captured under
 `docs/evaluations/`. They agree that v0.3 materially fixed source lifecycle safety, registry
 recovery, lint/health trust, release artifacts, queue JSON, and contradiction-review task noise.
-They also agree that `brief --agent-context` and `suggest-next` are not yet the first tool an agent
-reaches for when resuming real work. The v0.4 path therefore prioritizes git-aware, work-first
-handoff before vector search or mutating web review workflows.
+They also showed that `brief --agent-context` and `suggest-next` were not yet the first tool an
+agent reached for when resuming real work. The v0.4 path therefore prioritizes git-aware,
+work-first handoff before vector search or mutating web review workflows.
+
+`M18-P1.1` implements the first v0.4 handoff step: git-aware work context and structural
+work/maintenance separation. Broader inferred-authority fallback and provisional uncurated-doc
+context remain planned for `M18-P2.1`.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -286,16 +286,20 @@ Implemented fields:
   changed source manifests are reported as invalid curated-source changes instead of aborting the
   whole summary. `--json` emits the same structure for agents. The command does not create
   manifests, queue jobs, wiki pages, run records, reports, or GitHub state.
-- `splendor suggest-next [goal]` is a read-only handoff view over existing deterministic state. It
-  does not create planning records, queue jobs, manifests, wiki pages, run records, or reports.
-  Human output is path-first where possible; `--json` emits ranked action objects with category,
-  priority, title, reason, command, path, source ID/source ref, planning/page record IDs, and a
+- `splendor brief --agent-context [--since <ref>] [--no-git] [goal]` and
+  `splendor suggest-next [--since <ref>] [--no-git] [goal]` are read-only handoff views over
+  existing deterministic state plus runtime-only git/GitHub signals. They do not create planning
+  records, queue jobs, manifests, wiki pages, run records, reports, or GitHub state. Human output
+  is path-first where possible; `--json` emits ranked action objects with category, priority,
+  title, reason, command, path, optional URL, source ID/source ref, planning/page record IDs, and a
   deterministic `relevance_score` when available.
-- Suggested actions are derived from source freshness, queue operator state, invalid/stale/
+- Suggested actions are derived from local git commits, best-effort read-only GitHub issue/PR
+  context through `gh` when available, source freshness, queue operator state, invalid/stale/
   contested/review-needed wiki pages, ingested sources missing maintained synthesis follow-up,
-  active planning records, recent lint/health reports, and optional goal query matches. Goal
-  relevance is scored deterministically from weighted title/path/record/scope matches, supporting
-  refs, snippets, and review/authority lifecycle signals before category caps are applied.
+  active planning records, recent lint/health reports, and optional goal query matches. Non-
+  maintenance goals rank work context before Splendor maintenance. Goal relevance is scored
+  deterministically from weighted title/path/record/scope matches, supporting refs, snippets,
+  git/GitHub text, and review/authority lifecycle signals before category caps are applied.
 - Text-bearing PDF sources are routed through source-type dispatch during ingest. The source
   manifest keeps the same `source_ref`, `source_ref_kind`, and `storage_mode` contract as
   text-native sources, while extracted text artifacts are recorded in `derived_artifacts`.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M17-P4.1`
+- Previous completed PR sub-slice: `M18-P0.1`
 - Current planned slice: `M18 v0.4 work-first agent handoff`
-- Current PR sub-slice: `M18-P0.1`
+- Current PR sub-slice: `M18-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M18 v0.4 work-first agent handoff`
-- Next planned PR sub-slice: `M18-P1.1`
+- Next planned PR sub-slice: `M18-P2.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1240,6 +1240,14 @@ The v0.3 evaluation and follow-up inputs live in:
 - Git context is included by default with `--no-git` and `--since <ref>` escape hatches.
 - Source freshness, queue drift, review-needed pages, and missing synthesis are structurally
   separated under a Splendor maintenance section unless the goal is explicitly maintenance-focused.
+
+### Milestone 18 status
+
+`M18-P0.1` is implemented. `M18-P1.1` adds git-aware, work-first handoff without changing schema
+version `1`: `brief --agent-context` and `suggest-next` accept `--since <ref>` and `--no-git`,
+include runtime-only local git plus best-effort read-only GitHub issue/PR context, and split
+agent-facing output into work context before Splendor maintenance. `M18-P2.1` still owns broader
+inferred authority fallback and clearly labeled provisional uncurated-document context.
 
 ## Milestone 19 — pre-v1 workflow durability after v0.4
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -911,11 +911,13 @@ M13-P2 repo-discovery contracts:
   checksums where available, historical source-version status for paths already covered by a current
   manifest, and exact next commands. The default command is non-mutating; `--json` emits
   machine-readable output and `--report PATH` writes only an explicit freshness report.
-- `brief --agent-context` leads with project state, stale/contested/actionable items, and ranked
-  next actions before metadata.
-- `splendor suggest-next [goal]` ranks work from open tasks, stale sources, failed jobs, missing
-  synthesis, contested/review-needed pages, maintenance reports, and goal matches. `--json` emits a
-  machine-readable handoff payload.
+- `brief --agent-context [--since <ref>] [--no-git]` leads with work context, including local git
+  and best-effort GitHub issue/PR signals when available, before structurally separated Splendor
+  maintenance state.
+- `splendor suggest-next [--since <ref>] [--no-git] [goal]` ranks work from open threads, recent
+  commits, read-first files, active planning, authority docs, and goal matches before stale
+  sources, failed jobs, missing synthesis, contested/review-needed pages, and maintenance reports
+  unless the goal is maintenance-focused. `--json` emits a machine-readable handoff payload.
 
 Release-readiness boundary:
 
@@ -1104,17 +1106,20 @@ Current implementation:
 - `splendor brief [goal]` assembles a terminal-friendly and JSON project brief from deterministic
   query matches, wiki status, active planning records, recent sources/runs, latest lint/health
   reports, the last query snapshot, ranked authority docs, and likely next actions.
-- `splendor brief --agent-context [goal]` renders the same deterministic state as a compact
-  coding-agent handoff with relevant matches, source refs, wiki status, active planning records,
-  ranked authority docs, recent sources/runs, maintenance reports, warnings, and ranked suggested
-  actions.
-- `splendor suggest-next [goal]` renders the ranked action subset directly. It is read-only and
-  deterministic, and ranks source freshness, queue failures or pending work, stale/contested or
-  review-needed pages, missing synthesis follow-up, task-relevant authority docs, active planning
-  records, recent maintenance reports, and query matches for the optional goal. Handoff ranking
-  uses deterministic relevance scoring over weighted title/path/record/scope fields, supporting
-  refs, snippets, and review/authority lifecycle signals so current task authority beats stale or
-  merely token-similar material without introducing vector search.
+- `splendor brief --agent-context [--since <ref>] [--no-git] [goal]` renders a compact coding-agent
+  handoff with work context before Splendor maintenance. Inside git worktrees it includes
+  runtime-only local branch/head/base context, recent relevant commits, best-effort read-only
+  GitHub issue/PR context through `gh` when available, read-first file paths, relevant matches,
+  source refs, active planning records, ranked authority docs, recent sources/runs, maintenance
+  reports, warnings, and ranked suggested actions.
+- `splendor suggest-next [--since <ref>] [--no-git] [goal]` renders the ranked action subset
+  directly. It is read-only and deterministic. For non-maintenance goals it ranks open work
+  threads, recent git/PR context, task-relevant authority docs, active planning records, read-first
+  files, and query matches before source freshness, queue failures or pending work,
+  stale/contested/review-needed pages, missing synthesis follow-up, and recent maintenance reports.
+  Maintenance-focused goals can keep maintenance actions first. Handoff ranking uses deterministic
+  relevance scoring over weighted title/path/record/scope fields, supporting refs, snippets,
+  git/GitHub text, and review/authority lifecycle signals without introducing vector search.
 - Generated contradiction-review tasks are classified separately from human-authored planning
   tasks. Default `task list`, `brief --agent-context`, and `suggest-next` keep them out of active
   planning handoff; operators can list, resolve, or mute them explicitly with task subcommands, and
@@ -1149,6 +1154,10 @@ v0.4 direction from external trials:
   `CLAUDE.md`, `README.md`, roadmap-like docs, and planning tests.
 - Important uncurated documentation may be used as provisional context only when clearly labeled
   as uncurated and paired with an exact curation command.
+
+`M18-P1.1` implements the git-aware work-first ranking and work/maintenance separation while
+keeping all new context runtime-only. The inferred-authority and provisional uncurated-doc
+fallbacks remain planned follow-up work for `M18-P2.1`.
 
 ## 18. Search Model
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -2181,7 +2181,8 @@ def handle_brief(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     goal = " ".join(args.goal).strip() or None
     try:
-        result = build_project_brief(root, goal, include_git=not args.no_git, since=args.since)
+        include_git = not args.no_git and (args.agent_context or args.since is not None)
+        result = build_project_brief(root, goal, include_git=include_git, since=args.since)
     except (OSError, ValueError) as exc:
         return _print_error(exc)
 
@@ -2279,9 +2280,10 @@ def _print_agent_context(result: ProjectBrief) -> None:
             f"head={result.git_context.head or '-'} "
             f"base={base} merge_base={merge_base}"
         )
-        if result.git_context.threads:
+        promoted_threads = [thread for thread in result.git_context.threads if thread.promoted]
+        if promoted_threads:
             print("Recent issues and PRs:")
-            for thread in result.git_context.threads[:3]:
+            for thread in promoted_threads[:3]:
                 print(
                     f"- {thread.kind} #{thread.number} [{thread.state}] "
                     f"score={thread.relevance_score}: {thread.title} ({thread.url})"
@@ -2294,6 +2296,25 @@ def _print_agent_context(result: ProjectBrief) -> None:
             print("Files to read first:")
             for path in result.git_context.read_first_paths[:5]:
                 print(f"- {path}")
+    if result.matches:
+        print("Relevant matches:")
+        for match in result.matches:
+            source_refs = ", ".join(match.source_refs) if match.source_refs else "-"
+            print(f"- {match.path} [{match.kind}] score={match.score} sources={source_refs}")
+            if match.snippet:
+                print(f"  {match.snippet}")
+    if result.authority_briefs:
+        print("Authority docs:")
+        for item in result.authority_briefs[:5]:
+            refs = _authority_link_summary(item)
+            print(
+                f"- {item.path} [{item.role}/{item.freshness}/{item.lifecycle}] "
+                f"score={item.score} {item.title}{refs}"
+            )
+    if result.planning_items:
+        print("Active planning:")
+        for item in result.planning_items:
+            print(f"- {item.record_id} [{item.kind}/{item.status}] {item.title}")
     print(
         "Splendor maintenance: "
         f"sources={result.status.source_total} "
@@ -2316,25 +2337,6 @@ def _print_agent_context(result: ProjectBrief) -> None:
         f"queue_pending={result.status.queue_status_counts.get('pending', 0)} "
         f"review_needed={result.status.review_needed_pages}"
     )
-    if result.matches:
-        print("Relevant matches:")
-        for match in result.matches:
-            source_refs = ", ".join(match.source_refs) if match.source_refs else "-"
-            print(f"- {match.path} [{match.kind}] score={match.score} sources={source_refs}")
-            if match.snippet:
-                print(f"  {match.snippet}")
-    if result.authority_briefs:
-        print("Authority docs:")
-        for item in result.authority_briefs[:5]:
-            refs = _authority_link_summary(item)
-            print(
-                f"- {item.path} [{item.role}/{item.freshness}/{item.lifecycle}] "
-                f"score={item.score} {item.title}{refs}"
-            )
-    if result.planning_items:
-        print("Active planning:")
-        for item in result.planning_items:
-            print(f"- {item.record_id} [{item.kind}/{item.status}] {item.title}")
     if result.recent_sources:
         print("Recent sources:")
         for source in result.recent_sources:

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -596,6 +596,15 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit a compact coding-agent handoff over brief state.",
     )
+    brief_parser.add_argument(
+        "--since",
+        help="Base git ref for agent handoff context. Defaults to the mainline merge base.",
+    )
+    brief_parser.add_argument(
+        "--no-git",
+        action="store_true",
+        help="Disable git and GitHub handoff context.",
+    )
     brief_parser.set_defaults(handler=handle_brief)
 
     suggest_next_parser = subparsers.add_parser(
@@ -607,6 +616,15 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         dest="json_output",
         help="Emit machine-readable JSON output.",
+    )
+    suggest_next_parser.add_argument(
+        "--since",
+        help="Base git ref for handoff context. Defaults to the mainline merge base.",
+    )
+    suggest_next_parser.add_argument(
+        "--no-git",
+        action="store_true",
+        help="Disable git and GitHub handoff context.",
     )
     suggest_next_parser.set_defaults(handler=handle_suggest_next)
 
@@ -2163,7 +2181,7 @@ def handle_brief(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     goal = " ".join(args.goal).strip() or None
     try:
-        result = build_project_brief(root, goal)
+        result = build_project_brief(root, goal, include_git=not args.no_git, since=args.since)
     except (OSError, ValueError) as exc:
         return _print_error(exc)
 
@@ -2239,9 +2257,53 @@ def handle_brief(args: argparse.Namespace) -> int:
 def _print_agent_context(result: ProjectBrief) -> None:
     print("Agent context")
     print(f"Goal: {result.goal or '-'}")
-    if result.suggested_actions:
-        print("Suggested next:")
-        for action in result.suggested_actions[:5]:
+    print("Work context:")
+    print("Suggested next:")
+    if result.work_actions:
+        for action in result.work_actions[:5]:
+            subject = _suggested_action_target(action)
+            command = f" command={action.command}" if action.command else ""
+            url = f" url={action.url}" if action.url else ""
+            print(
+                f"- [{action.priority}/{action.category}] {action.title} "
+                f"target={subject}{command}{url}"
+            )
+    else:
+        print("- No work-first actions found.")
+    if result.git_context.enabled and result.git_context.available:
+        base = result.git_context.base_ref or "-"
+        merge_base = result.git_context.merge_base or "-"
+        print(
+            "Git context: "
+            f"branch={result.git_context.branch or '-'} "
+            f"head={result.git_context.head or '-'} "
+            f"base={base} merge_base={merge_base}"
+        )
+        if result.git_context.threads:
+            print("Recent issues and PRs:")
+            for thread in result.git_context.threads[:3]:
+                print(
+                    f"- {thread.kind} #{thread.number} [{thread.state}] "
+                    f"score={thread.relevance_score}: {thread.title} ({thread.url})"
+                )
+        if result.git_context.commits:
+            print("Recent commits:")
+            for commit in result.git_context.commits[:3]:
+                print(f"- {commit.short_sha} score={commit.relevance_score}: {commit.subject}")
+        if result.git_context.read_first_paths:
+            print("Files to read first:")
+            for path in result.git_context.read_first_paths[:5]:
+                print(f"- {path}")
+    print(
+        "Splendor maintenance: "
+        f"sources={result.status.source_total} "
+        f"pages={result.status.page_total} "
+        f"queue_pending={result.status.queue_status_counts.get('pending', 0)} "
+        f"review_needed={result.status.review_needed_pages}"
+    )
+    if result.maintenance_actions:
+        print("Maintenance actions:")
+        for action in result.maintenance_actions[:5]:
             subject = _suggested_action_target(action)
             command = f" command={action.command}" if action.command else ""
             print(
@@ -2292,6 +2354,10 @@ def _print_agent_context(result: ProjectBrief) -> None:
         for warning in result.warnings:
             subject = warning.path or warning.area
             print(f"- {subject}: {warning.message}")
+    if result.git_context.warnings:
+        print("Git warnings:")
+        for warning in result.git_context.warnings:
+            print(f"- {warning}")
     print("Next actions:")
     for action in result.next_actions:
         print(f"- {action}")
@@ -2301,7 +2367,7 @@ def handle_suggest_next(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     goal = " ".join(args.goal).strip() or None
     try:
-        result = build_suggest_next(root, goal)
+        result = build_suggest_next(root, goal, include_git=not args.no_git, since=args.since)
     except (OSError, ValueError) as exc:
         return _print_error(exc)
 
@@ -2311,8 +2377,19 @@ def handle_suggest_next(args: argparse.Namespace) -> int:
 
     print("Suggested next actions")
     print(f"Goal: {result.goal or '-'}")
+    if result.work_actions:
+        print("Work actions:")
+        for action in result.work_actions:
+            target = _suggested_action_target(action)
+            command = f" command={action.command}" if action.command else ""
+            url = f" url={action.url}" if action.url else ""
+            print(
+                f"{action.rank}. [{action.priority}/{action.category}] {action.title} "
+                f"target={target}{command}{url}"
+            )
+            print(f"   Reason: {action.reason}")
     print(
-        "State: "
+        "Splendor maintenance: "
         f"changed_sources={result.freshness.changed} "
         f"missing_sources={result.freshness.missing} "
         f"queue={result.queue.total} "
@@ -2320,7 +2397,7 @@ def handle_suggest_next(args: argparse.Namespace) -> int:
         f"contested={result.status.contested_pages} "
         f"stale={result.status.stale_pages}"
     )
-    for action in result.actions:
+    for action in result.maintenance_actions:
         target = _suggested_action_target(action)
         command = f" command={action.command}" if action.command else ""
         print(

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -49,6 +49,8 @@ _BRIEF_REPORT_COMMANDS = ("lint", "health")
 _SUGGESTION_LIMIT = 8
 _GIT_CONTEXT_LIMIT = 5
 _GIT_FILE_LIMIT = 8
+_GIT_COMMAND_TIMEOUT_SECONDS = 5
+_PROMOTED_THREAD_RELEVANCE_FLOOR = 60
 _SUGGESTION_CATEGORY_LIMITS = {
     "work-thread": 4,
     "git-context": 3,
@@ -296,6 +298,7 @@ class GitThreadBrief:
     state: str
     summary: str
     relevance_score: int
+    promoted: bool
 
 
 @dataclass(frozen=True)
@@ -1034,7 +1037,13 @@ def _build_git_context(
     merge_base = _merge_base_for_context(root, base_ref) if base_ref else None
     if since is not None and merge_base is None:
         warnings.append(f"Git base ref could not be resolved: {since}")
-    commits = _git_commits(root, goal, base_ref=base_ref, merge_base=merge_base)
+    commits = _git_commits(
+        root,
+        goal,
+        base_ref=base_ref,
+        merge_base=merge_base,
+        explicit_since=since is not None,
+    )
     repository = _github_repository(root)
     threads: list[GitThreadBrief] = []
     if repository is not None:
@@ -1090,7 +1099,12 @@ def _merge_base_for_context(root: Path, base_ref: str | None) -> str | None:
 
 
 def _git_commits(
-    root: Path, goal: str | None, *, base_ref: str | None, merge_base: str | None
+    root: Path,
+    goal: str | None,
+    *,
+    base_ref: str | None,
+    merge_base: str | None,
+    explicit_since: bool,
 ) -> list[GitCommitBrief]:
     range_ref = None
     if base_ref is not None and merge_base is not None:
@@ -1100,7 +1114,7 @@ def _git_commits(
         args.append(range_ref)
     args.extend(["--pretty=format:%H%x1f%h%x1f%s%x1f%b%x1e", "--name-only"])
     output = _git_output(root, args, required=False)
-    if not output and range_ref is not None:
+    if not output and range_ref is not None and not explicit_since:
         output = _git_output(
             root,
             [
@@ -1197,7 +1211,19 @@ def _github_threads(
     kinds = ["issue", "pr"]
     for kind, command in zip(kinds, commands, strict=True):
         try:
-            result = subprocess.run(command, cwd=root, check=False, capture_output=True, text=True)
+            result = subprocess.run(
+                command,
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=_GIT_COMMAND_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            warnings.append(
+                f"Timed out after {_GIT_COMMAND_TIMEOUT_SECONDS}s running gh {kind} list."
+            )
+            continue
         except OSError as exc:
             warnings.append(f"Could not run gh {kind} list: {exc}")
             continue
@@ -1234,6 +1260,12 @@ def _github_threads(
             medium_text=body,
         )
         summary = _one_line(body) or title
+        promoted = _promote_git_thread(
+            goal_tokens=goal_tokens,
+            relevance_score=relevance_score,
+            kind=kind,
+            text=" ".join([title, body]),
+        )
         threads.append(
             GitThreadBrief(
                 kind=kind,
@@ -1243,6 +1275,7 @@ def _github_threads(
                 state=state,
                 summary=summary,
                 relevance_score=relevance_score,
+                promoted=promoted,
             )
         )
     if goal_tokens:
@@ -1257,6 +1290,21 @@ def _github_threads(
     else:
         threads.sort(key=lambda item: (item.state != "open", item.kind != "issue", item.number))
     return threads[:_GIT_CONTEXT_LIMIT], warnings
+
+
+def _promote_git_thread(
+    *, goal_tokens: set[str], relevance_score: int, kind: str, text: str
+) -> bool:
+    if not goal_tokens:
+        return True
+    if relevance_score >= _PROMOTED_THREAD_RELEVANCE_FLOOR:
+        return True
+    if kind == "pr":
+        code_tokens = {
+            token for token in goal_tokens if any(character.isdigit() for character in token)
+        }
+        return bool(code_tokens & _tokens(text))
+    return False
 
 
 def _one_line(text: str) -> str:
@@ -1286,6 +1334,8 @@ def _read_first_paths(
                 ),
             )
     for thread in threads:
+        if not thread.promoted:
+            continue
         for path in _repo_paths_in_text(" ".join([thread.title, thread.summary])):
             scored[path] = max(scored.get(path, 0), thread.relevance_score + 20)
     ranked = sorted(scored, key=lambda path: (-scored[path], path))
@@ -1427,6 +1477,8 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
 
     if snapshot.git_context.enabled and snapshot.git_context.available:
         for thread in snapshot.git_context.threads:
+            if not thread.promoted:
+                continue
             priority = "high" if thread.state == "open" else "medium"
             add(
                 priority,

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 import shlex
+import subprocess
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 
@@ -46,7 +47,11 @@ _BRIEF_PLANNING_LIMIT = 8
 _BRIEF_SOURCE_LIMIT = 5
 _BRIEF_REPORT_COMMANDS = ("lint", "health")
 _SUGGESTION_LIMIT = 8
+_GIT_CONTEXT_LIMIT = 5
+_GIT_FILE_LIMIT = 8
 _SUGGESTION_CATEGORY_LIMITS = {
+    "work-thread": 4,
+    "git-context": 3,
     "source-freshness": 3,
     "queue": 3,
     "wiki-validation": 2,
@@ -60,19 +65,47 @@ _SUGGESTION_CATEGORY_LIMITS = {
     "query": 1,
     "orientation": 1,
 }
-_SUGGESTION_CATEGORY_ORDER = {
+_WORK_FIRST_CATEGORY_ORDER = {
+    "work-thread": 0,
+    "git-context": 1,
+    "authority": 2,
+    "planning": 3,
+    "goal-match": 4,
+    "source-freshness": 5,
+    "queue": 6,
+    "wiki-validation": 7,
+    "contradiction-review": 8,
+    "synthesis": 9,
+    "wiki-review": 10,
+    "maintenance": 11,
+    "query": 12,
+    "orientation": 13,
+}
+_MAINTENANCE_FIRST_CATEGORY_ORDER = {
     "source-freshness": 0,
     "queue": 1,
     "wiki-validation": 2,
-    "goal-match": 3,
-    "authority": 4,
-    "planning": 5,
+    "maintenance": 3,
+    "synthesis": 4,
+    "wiki-review": 5,
     "contradiction-review": 6,
-    "synthesis": 7,
-    "wiki-review": 8,
-    "maintenance": 9,
-    "query": 10,
-    "orientation": 11,
+    "work-thread": 7,
+    "git-context": 8,
+    "authority": 9,
+    "planning": 10,
+    "goal-match": 11,
+    "query": 12,
+    "orientation": 13,
+}
+_MAINTENANCE_CATEGORIES = {
+    "source-freshness",
+    "queue",
+    "wiki-validation",
+    "contradiction-review",
+    "synthesis",
+    "wiki-review",
+    "maintenance",
+    "query",
 }
 _SUGGESTION_PRIORITY_ORDER = {"high": 0, "medium": 1, "low": 2}
 _AUTHORITY_LIMIT = 6
@@ -135,6 +168,21 @@ _CONTRADICTION_GOAL_TOKENS = {
     "contradictions",
     "contradicting",
     "contested",
+}
+_MAINTENANCE_GOAL_TOKENS = {
+    "source",
+    "sources",
+    "queue",
+    "ingest",
+    "lint",
+    "health",
+    "refresh",
+    "wiki",
+    "review",
+    "splendor",
+    "maintenance",
+    "synthesis",
+    "freshness",
 }
 
 
@@ -222,10 +270,48 @@ class SuggestedAction:
     reason: str
     command: str | None
     path: str | None = None
+    url: str | None = None
     source_id: str | None = None
     source_ref: str | None = None
     record_id: str | None = None
     relevance_score: int = 0
+
+
+@dataclass(frozen=True)
+class GitCommitBrief:
+    sha: str
+    short_sha: str
+    subject: str
+    body: str
+    paths: list[str]
+    relevance_score: int
+
+
+@dataclass(frozen=True)
+class GitThreadBrief:
+    kind: str
+    number: int
+    title: str
+    url: str
+    state: str
+    summary: str
+    relevance_score: int
+
+
+@dataclass(frozen=True)
+class GitContext:
+    enabled: bool
+    available: bool
+    since: str | None
+    base_ref: str | None
+    merge_base: str | None
+    branch: str | None
+    head: str | None
+    repository: str | None
+    commits: list[GitCommitBrief]
+    threads: list[GitThreadBrief]
+    read_first_paths: list[str]
+    warnings: list[str]
 
 
 @dataclass(frozen=True)
@@ -240,6 +326,9 @@ class SuggestNextResult:
     planning_items: list[BriefPlanningItem]
     latest_reports: list[BriefReportSnapshot]
     warnings: list[BriefWarning]
+    git_context: GitContext
+    work_actions: list[SuggestedAction]
+    maintenance_actions: list[SuggestedAction]
 
 
 @dataclass(frozen=True)
@@ -263,6 +352,8 @@ class BriefStateSnapshot:
     wiki_pages: list[WikiPageSnapshot]
     invalid_wiki_pages: list[InvalidWikiPageSnapshot]
     generated_review_task_count: int
+    git_context: GitContext
+    maintenance_goal: bool
 
 
 @dataclass(frozen=True)
@@ -279,12 +370,18 @@ class ProjectBrief:
     last_query: BriefLastQuery | None
     warnings: list[BriefWarning]
     suggested_actions: list[SuggestedAction]
+    work_actions: list[SuggestedAction]
+    maintenance_actions: list[SuggestedAction]
+    git_context: GitContext
     next_actions: list[str]
 
 
-def build_project_brief(root: Path, goal: str | None) -> ProjectBrief:
-    snapshot = _collect_brief_state(root, goal)
+def build_project_brief(
+    root: Path, goal: str | None, *, include_git: bool = True, since: str | None = None
+) -> ProjectBrief:
+    snapshot = _collect_brief_state(root, goal, include_git=include_git, since=since)
     suggested_actions = _ranked_suggestions(snapshot)
+    work_actions, maintenance_actions = _split_actions(suggested_actions)
     next_actions = _next_actions(
         status=snapshot.status,
         matches=snapshot.matches,
@@ -306,13 +403,19 @@ def build_project_brief(root: Path, goal: str | None) -> ProjectBrief:
         last_query=snapshot.last_query,
         warnings=snapshot.warnings,
         suggested_actions=suggested_actions,
+        work_actions=work_actions,
+        maintenance_actions=maintenance_actions,
+        git_context=snapshot.git_context,
         next_actions=next_actions,
     )
 
 
-def build_suggest_next(root: Path, goal: str | None = None) -> SuggestNextResult:
-    snapshot = _collect_brief_state(root, goal)
+def build_suggest_next(
+    root: Path, goal: str | None = None, *, include_git: bool = True, since: str | None = None
+) -> SuggestNextResult:
+    snapshot = _collect_brief_state(root, goal, include_git=include_git, since=since)
     actions = _ranked_suggestions(snapshot)
+    work_actions, maintenance_actions = _split_actions(actions)
     return SuggestNextResult(
         goal=snapshot.goal,
         actions=actions,
@@ -324,10 +427,15 @@ def build_suggest_next(root: Path, goal: str | None = None) -> SuggestNextResult
         planning_items=snapshot.planning_items,
         latest_reports=snapshot.latest_reports,
         warnings=snapshot.warnings,
+        git_context=snapshot.git_context,
+        work_actions=work_actions,
+        maintenance_actions=maintenance_actions,
     )
 
 
-def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
+def _collect_brief_state(
+    root: Path, goal: str | None, *, include_git: bool, since: str | None
+) -> BriefStateSnapshot:
     config = load_config(root)
     layout = resolve_layout(root, config)
     status = build_wiki_status(root)
@@ -336,6 +444,7 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
     normalized_goal = goal.strip() if goal is not None else ""
     goal_tokens = _tokens(normalized_goal)
     goal_phrase = _normalize_goal_phrase(normalized_goal)
+    maintenance_goal = _is_maintenance_goal(goal_tokens)
     query_summary: str | None = None
     query_warning: BriefWarning | None = None
     matches: list[BriefMatch] = []
@@ -375,6 +484,9 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
     recent_runs = status.recent_runs
     latest_reports = _latest_reports(root, layout)
     last_query = _last_query(layout)
+    git_context = _build_git_context(
+        root, normalized_goal or None, include_git=include_git, since=since
+    )
     return BriefStateSnapshot(
         root=root,
         goal=normalized_goal or None,
@@ -395,6 +507,8 @@ def _collect_brief_state(root: Path, goal: str | None) -> BriefStateSnapshot:
         wiki_pages=wiki_pages,
         invalid_wiki_pages=invalid_wiki_pages,
         generated_review_task_count=generated_review_task_count,
+        git_context=git_context,
+        maintenance_goal=maintenance_goal,
     )
 
 
@@ -831,6 +945,10 @@ def _tokens(text: str) -> set[str]:
     return tokens
 
 
+def _is_maintenance_goal(goal_tokens: set[str]) -> bool:
+    return bool(goal_tokens and goal_tokens <= _MAINTENANCE_GOAL_TOKENS)
+
+
 def _flatten_handoff_values(value) -> list[str]:
     if value is None:
         return []
@@ -871,6 +989,312 @@ def _goal_relevance_score(
         if len(goal_tokens) >= 2 and goal_phrase and goal_phrase in normalized_text:
             score += weight * 3
     return score
+
+
+def _build_git_context(
+    root: Path, goal: str | None, *, include_git: bool, since: str | None
+) -> GitContext:
+    if not include_git:
+        return GitContext(
+            enabled=False,
+            available=False,
+            since=since,
+            base_ref=None,
+            merge_base=None,
+            branch=None,
+            head=None,
+            repository=None,
+            commits=[],
+            threads=[],
+            read_first_paths=[],
+            warnings=[],
+        )
+
+    warnings: list[str] = []
+    inside = _git_output(root, ["rev-parse", "--is-inside-work-tree"], required=False)
+    if inside != "true":
+        return GitContext(
+            enabled=True,
+            available=False,
+            since=since,
+            base_ref=None,
+            merge_base=None,
+            branch=None,
+            head=None,
+            repository=None,
+            commits=[],
+            threads=[],
+            read_first_paths=[],
+            warnings=["Not inside a git worktree."],
+        )
+
+    branch = _git_output(root, ["rev-parse", "--abbrev-ref", "HEAD"], required=False)
+    head = _git_output(root, ["rev-parse", "--short", "HEAD"], required=False)
+    base_ref = since or _default_main_ref(root)
+    merge_base = _merge_base_for_context(root, base_ref) if base_ref else None
+    if since is not None and merge_base is None:
+        warnings.append(f"Git base ref could not be resolved: {since}")
+    commits = _git_commits(root, goal, base_ref=base_ref, merge_base=merge_base)
+    repository = _github_repository(root)
+    threads: list[GitThreadBrief] = []
+    if repository is not None:
+        loaded_threads, thread_warnings = _github_threads(root, repository, goal)
+        threads = loaded_threads
+        warnings.extend(thread_warnings)
+    else:
+        warnings.append("GitHub remote repository could not be inferred from origin.")
+    read_first_paths = _read_first_paths(commits, threads, goal)
+    return GitContext(
+        enabled=True,
+        available=True,
+        since=since,
+        base_ref=base_ref,
+        merge_base=merge_base,
+        branch=branch,
+        head=head,
+        repository=repository,
+        commits=commits,
+        threads=threads,
+        read_first_paths=read_first_paths,
+        warnings=warnings,
+    )
+
+
+def _git_output(root: Path, args: list[str], *, required: bool = True) -> str | None:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        if required:
+            message = result.stderr.strip() or result.stdout.strip() or "git command failed"
+            raise ValueError(message)
+        return None
+    return result.stdout.strip()
+
+
+def _default_main_ref(root: Path) -> str | None:
+    for ref in ("origin/main", "main"):
+        if _git_output(root, ["rev-parse", "--verify", f"{ref}^{{commit}}"], required=False):
+            return ref
+    return None
+
+
+def _merge_base_for_context(root: Path, base_ref: str | None) -> str | None:
+    if base_ref is None:
+        return None
+    return _git_output(root, ["merge-base", base_ref, "HEAD"], required=False)
+
+
+def _git_commits(
+    root: Path, goal: str | None, *, base_ref: str | None, merge_base: str | None
+) -> list[GitCommitBrief]:
+    range_ref = None
+    if base_ref is not None and merge_base is not None:
+        range_ref = f"{merge_base}..HEAD"
+    args = ["log", "--first-parent", f"--max-count={_GIT_CONTEXT_LIMIT * 4}"]
+    if range_ref is not None:
+        args.append(range_ref)
+    args.extend(["--pretty=format:%H%x1f%h%x1f%s%x1f%b%x1e", "--name-only"])
+    output = _git_output(root, args, required=False)
+    if not output and range_ref is not None:
+        output = _git_output(
+            root,
+            [
+                "log",
+                "--first-parent",
+                f"--max-count={_GIT_CONTEXT_LIMIT * 4}",
+                "--pretty=format:%H%x1f%h%x1f%s%x1f%b%x1e",
+                "--name-only",
+            ],
+            required=False,
+        )
+    goal_tokens = _tokens(goal or "")
+    goal_phrase = _normalize_goal_phrase(goal or "")
+    commits: list[GitCommitBrief] = []
+    for entry in (output or "").split("\x1e"):
+        lines = [line for line in entry.splitlines() if line.strip()]
+        if not lines:
+            continue
+        header = lines[0].split("\x1f")
+        if len(header) < 4:
+            continue
+        sha, short_sha, subject, body = header[:4]
+        paths = sorted(dict.fromkeys(line.strip() for line in lines[1:] if line.strip()))
+        relevance_score = _goal_relevance_score(
+            goal_tokens,
+            goal_phrase=goal_phrase,
+            high_text=" ".join([subject, " ".join(paths)]),
+            medium_text=body,
+        )
+        commits.append(
+            GitCommitBrief(
+                sha=sha,
+                short_sha=short_sha,
+                subject=subject.strip(),
+                body=body.strip(),
+                paths=paths,
+                relevance_score=relevance_score,
+            )
+        )
+    if goal_tokens:
+        commits.sort(key=lambda item: (-item.relevance_score, item.short_sha))
+    return commits[:_GIT_CONTEXT_LIMIT]
+
+
+def _github_repository(root: Path) -> str | None:
+    remote = _git_output(root, ["config", "--get", "remote.origin.url"], required=False)
+    if remote is None:
+        return None
+    remote = remote.strip()
+    patterns = (
+        r"github\.com[:/](?P<repo>[^/\s]+/[^/\s]+?)(?:\.git)?$",
+        r"^https://github\.com/(?P<repo>[^/\s]+/[^/\s]+?)(?:\.git)?$",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, remote)
+        if match:
+            return match.group("repo")
+    return None
+
+
+def _github_threads(
+    root: Path, repository: str, goal: str | None
+) -> tuple[list[GitThreadBrief], list[str]]:
+    warnings: list[str] = []
+    raw_threads: list[dict[str, object]] = []
+    commands = [
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repository,
+            "--state",
+            "open",
+            "--limit",
+            "30",
+            "--json",
+            "number,title,url,body,state,labels",
+        ],
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repository,
+            "--state",
+            "all",
+            "--limit",
+            "30",
+            "--json",
+            "number,title,url,body,state,isDraft,mergedAt,labels",
+        ],
+    ]
+    kinds = ["issue", "pr"]
+    for kind, command in zip(kinds, commands, strict=True):
+        try:
+            result = subprocess.run(command, cwd=root, check=False, capture_output=True, text=True)
+        except OSError as exc:
+            warnings.append(f"Could not run gh {kind} list: {exc}")
+            continue
+        if result.returncode != 0:
+            message = result.stderr.strip() or result.stdout.strip() or f"gh {kind} list failed"
+            warnings.append(message)
+            continue
+        try:
+            payload = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError as exc:
+            warnings.append(f"Could not parse gh {kind} output: {exc}")
+            continue
+        if isinstance(payload, list):
+            for item in payload:
+                if isinstance(item, dict):
+                    raw_threads.append({"kind": kind, **item})
+
+    goal_tokens = _tokens(goal or "")
+    goal_phrase = _normalize_goal_phrase(goal or "")
+    threads: list[GitThreadBrief] = []
+    for item in raw_threads:
+        title = str(item.get("title") or "")
+        body = str(item.get("body") or "")
+        url = str(item.get("url") or "")
+        number = item.get("number")
+        if not isinstance(number, int) or not title or not url:
+            continue
+        state = str(item.get("state") or "unknown").lower()
+        kind = str(item.get("kind") or "thread")
+        relevance_score = _goal_relevance_score(
+            goal_tokens,
+            goal_phrase=goal_phrase,
+            high_text=title,
+            medium_text=body,
+        )
+        summary = _one_line(body) or title
+        threads.append(
+            GitThreadBrief(
+                kind=kind,
+                number=number,
+                title=title,
+                url=url,
+                state=state,
+                summary=summary,
+                relevance_score=relevance_score,
+            )
+        )
+    if goal_tokens:
+        threads.sort(
+            key=lambda item: (
+                item.state != "open",
+                -item.relevance_score,
+                item.kind != "issue",
+                item.number,
+            )
+        )
+    else:
+        threads.sort(key=lambda item: (item.state != "open", item.kind != "issue", item.number))
+    return threads[:_GIT_CONTEXT_LIMIT], warnings
+
+
+def _one_line(text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip(" #\t")
+        if stripped:
+            return stripped[:160]
+    return ""
+
+
+def _read_first_paths(
+    commits: list[GitCommitBrief], threads: list[GitThreadBrief], goal: str | None
+) -> list[str]:
+    goal_tokens = _tokens(goal or "")
+    goal_phrase = _normalize_goal_phrase(goal or "")
+    scored: dict[str, int] = {}
+    for commit in commits:
+        for path in commit.paths:
+            scored[path] = max(
+                scored.get(path, 0),
+                commit.relevance_score
+                + _goal_relevance_score(
+                    goal_tokens,
+                    goal_phrase=goal_phrase,
+                    high_text=path,
+                    low_text=commit.subject,
+                ),
+            )
+    for thread in threads:
+        for path in _repo_paths_in_text(" ".join([thread.title, thread.summary])):
+            scored[path] = max(scored.get(path, 0), thread.relevance_score + 20)
+    ranked = sorted(scored, key=lambda path: (-scored[path], path))
+    return ranked[:_GIT_FILE_LIMIT]
+
+
+def _repo_paths_in_text(text: str) -> list[str]:
+    candidates = re.findall(r"(?<![\w/.-])(?:[\w.-]+/)+[\w.-]+(?:\.[A-Za-z0-9]+)?", text)
+    return sorted(dict.fromkeys(candidate.strip("`.,)") for candidate in candidates))
 
 
 def _recent_sources(sources: list[SourceRecord]) -> list[BriefSourceItem]:
@@ -1000,6 +1424,41 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
                 **kwargs,
             )
         )
+
+    if snapshot.git_context.enabled and snapshot.git_context.available:
+        for thread in snapshot.git_context.threads:
+            priority = "high" if thread.state == "open" else "medium"
+            add(
+                priority,
+                "work-thread",
+                f"Review {thread.kind} #{thread.number}: {thread.title}",
+                thread.summary,
+                None,
+                url=thread.url,
+                relevance_score=thread.relevance_score,
+            )
+        for commit in snapshot.git_context.commits:
+            add(
+                "medium",
+                "git-context",
+                f"Review commit {commit.short_sha}: {commit.subject}",
+                "Recent git context relevant to the stated goal.",
+                None,
+                record_id=commit.short_sha,
+                relevance_score=commit.relevance_score,
+            )
+        for path in snapshot.git_context.read_first_paths:
+            add(
+                "medium",
+                "git-context",
+                f"Read changed file {path}",
+                "Recent git or GitHub context points at this file for the work handoff.",
+                None,
+                path=path,
+                relevance_score=_goal_relevance_score(
+                    goal_tokens, goal_phrase=goal_phrase, high_text=path
+                ),
+            )
 
     for item in snapshot.freshness.sources:
         source = item.source
@@ -1187,20 +1646,25 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
             "splendor brief --agent-context",
         )
 
-    return _finalize_suggestions(actions)
+    return _finalize_suggestions(actions, maintenance_goal=snapshot.maintenance_goal)
 
 
 def _first_command(commands: list[str]) -> str | None:
     return commands[0] if commands else None
 
 
-def _finalize_suggestions(actions: list[SuggestedAction]) -> list[SuggestedAction]:
+def _finalize_suggestions(
+    actions: list[SuggestedAction], *, maintenance_goal: bool
+) -> list[SuggestedAction]:
     by_category: dict[str, int] = {}
     capped: list[tuple[int, SuggestedAction]] = []
+    category_order = (
+        _MAINTENANCE_FIRST_CATEGORY_ORDER if maintenance_goal else _WORK_FIRST_CATEGORY_ORDER
+    )
     ordered = sorted(
         enumerate(actions),
         key=lambda item: (
-            _SUGGESTION_CATEGORY_ORDER.get(item[1].category, 99),
+            category_order.get(item[1].category, 99),
             _SUGGESTION_PRIORITY_ORDER.get(item[1].priority, 99),
             -item[1].relevance_score,
             item[0],
@@ -1216,7 +1680,7 @@ def _finalize_suggestions(actions: list[SuggestedAction]) -> list[SuggestedActio
 
     capped.sort(
         key=lambda item: (
-            _SUGGESTION_CATEGORY_ORDER.get(item[1].category, 99),
+            category_order.get(item[1].category, 99),
             _SUGGESTION_PRIORITY_ORDER.get(item[1].priority, 99),
             -item[1].relevance_score,
             item[0],
@@ -1226,6 +1690,16 @@ def _finalize_suggestions(actions: list[SuggestedAction]) -> list[SuggestedActio
         replace(action, rank=rank)
         for rank, (_sequence, action) in enumerate(capped[:_SUGGESTION_LIMIT], start=1)
     ]
+
+
+def _split_actions(
+    actions: list[SuggestedAction],
+) -> tuple[list[SuggestedAction], list[SuggestedAction]]:
+    work_actions = [action for action in actions if action.category not in _MAINTENANCE_CATEGORIES]
+    maintenance_actions = [
+        action for action in actions if action.category in _MAINTENANCE_CATEGORIES
+    ]
+    return work_actions, maintenance_actions
 
 
 def _review_page_actions(
@@ -1321,6 +1795,19 @@ def render_suggest_next_json(result: SuggestNextResult) -> str:
         {
             "goal": result.goal,
             "actions": [asdict(action) for action in result.actions],
+            "work_context": {"actions": [asdict(action) for action in result.work_actions]},
+            "maintenance_context": {
+                "actions": [asdict(action) for action in result.maintenance_actions],
+                "status": {
+                    "changed_sources": result.freshness.changed,
+                    "missing_sources": result.freshness.missing,
+                    "queue": result.queue.total,
+                    "review_needed": result.status.review_needed_pages,
+                    "contested": result.status.contested_pages,
+                    "stale": result.status.stale_pages,
+                },
+            },
+            "git_context": asdict(result.git_context),
             "status": {
                 "source_total": result.status.source_total,
                 "page_total": result.status.page_total,
@@ -1366,7 +1853,12 @@ def render_project_brief_json(brief: ProjectBrief) -> str:
             "latest_reports": [asdict(report) for report in brief.latest_reports],
             "last_query": asdict(brief.last_query) if brief.last_query else None,
             "warnings": [asdict(warning) for warning in brief.warnings],
+            "git_context": asdict(brief.git_context),
             "suggested_actions": [asdict(action) for action in brief.suggested_actions],
+            "work_context": {"actions": [asdict(action) for action in brief.work_actions]},
+            "maintenance_context": {
+                "actions": [asdict(action) for action in brief.maintenance_actions]
+            },
             "next_actions": brief.next_actions,
         },
         indent=2,
@@ -1392,7 +1884,22 @@ def render_agent_context_json(brief: ProjectBrief) -> str:
             "matches": [asdict(match) for match in brief.matches],
             "authority_briefs": [asdict(item) for item in brief.authority_briefs],
             "source_refs": _agent_context_source_refs(brief),
+            "git_context": asdict(brief.git_context),
             "suggested_actions": [asdict(action) for action in brief.suggested_actions],
+            "work_context": {"actions": [asdict(action) for action in brief.work_actions]},
+            "maintenance_context": {
+                "actions": [asdict(action) for action in brief.maintenance_actions],
+                "wiki_status": {
+                    "source_total": brief.status.source_total,
+                    "page_total": brief.status.page_total,
+                    "queue_status_counts": brief.status.queue_status_counts,
+                    "review_needed_pages": brief.status.review_needed_pages,
+                    "machine_generated_pages": brief.status.machine_generated_pages,
+                    "contested_pages": brief.status.contested_pages,
+                    "stale_pages": brief.status.stale_pages,
+                    "sources_missing_synthesis": brief.status.sources_missing_synthesis,
+                },
+            },
             "active_planning": [asdict(item) for item in brief.planning_items],
             "recent_sources": [asdict(source) for source in brief.recent_sources],
             "recent_runs": [asdict(run) for run in brief.recent_runs],

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -186,6 +186,48 @@ _MAINTENANCE_GOAL_TOKENS = {
     "synthesis",
     "freshness",
 }
+_MAINTENANCE_GOAL_FILLER_TOKENS = {
+    "a",
+    "about",
+    "after",
+    "all",
+    "an",
+    "and",
+    "at",
+    "can",
+    "check",
+    "could",
+    "do",
+    "for",
+    "get",
+    "give",
+    "go",
+    "in",
+    "into",
+    "is",
+    "look",
+    "me",
+    "my",
+    "now",
+    "of",
+    "on",
+    "our",
+    "please",
+    "run",
+    "show",
+    "state",
+    "status",
+    "tell",
+    "that",
+    "the",
+    "this",
+    "to",
+    "up",
+    "what",
+    "with",
+    "would",
+    "you",
+}
 
 
 @dataclass(frozen=True)
@@ -949,7 +991,16 @@ def _tokens(text: str) -> set[str]:
 
 
 def _is_maintenance_goal(goal_tokens: set[str]) -> bool:
-    return bool(goal_tokens and goal_tokens <= _MAINTENANCE_GOAL_TOKENS)
+    meaningful_tokens = goal_tokens - _MAINTENANCE_GOAL_FILLER_TOKENS
+    if not meaningful_tokens:
+        return False
+    maintenance_matches = meaningful_tokens & _MAINTENANCE_GOAL_TOKENS
+    if not maintenance_matches:
+        return False
+    non_maintenance_tokens = meaningful_tokens - _MAINTENANCE_GOAL_TOKENS
+    if not non_maintenance_tokens:
+        return True
+    return len(maintenance_matches) >= 2 and len(maintenance_matches) >= len(non_maintenance_tokens)
 
 
 def _flatten_handoff_values(value) -> list[str]:
@@ -1112,7 +1163,7 @@ def _git_commits(
     args = ["log", "--first-parent", f"--max-count={_GIT_CONTEXT_LIMIT * 4}"]
     if range_ref is not None:
         args.append(range_ref)
-    args.extend(["--pretty=format:%H%x1f%h%x1f%s%x1f%b%x1e", "--name-only"])
+    args.append("--pretty=format:%H%x1f%h%x1f%s%x1e")
     output = _git_output(root, args, required=False)
     if not output and range_ref is not None and not explicit_since:
         output = _git_output(
@@ -1121,8 +1172,7 @@ def _git_commits(
                 "log",
                 "--first-parent",
                 f"--max-count={_GIT_CONTEXT_LIMIT * 4}",
-                "--pretty=format:%H%x1f%h%x1f%s%x1f%b%x1e",
-                "--name-only",
+                "--pretty=format:%H%x1f%h%x1f%s%x1e",
             ],
             required=False,
         )
@@ -1130,14 +1180,23 @@ def _git_commits(
     goal_phrase = _normalize_goal_phrase(goal or "")
     commits: list[GitCommitBrief] = []
     for entry in (output or "").split("\x1e"):
-        lines = [line for line in entry.splitlines() if line.strip()]
-        if not lines:
+        stripped_entry = entry.strip()
+        if not stripped_entry:
             continue
-        header = lines[0].split("\x1f")
-        if len(header) < 4:
+        header = stripped_entry.split("\x1f")
+        if len(header) < 3:
             continue
-        sha, short_sha, subject, body = header[:4]
-        paths = sorted(dict.fromkeys(line.strip() for line in lines[1:] if line.strip()))
+        sha, short_sha, subject = header[:3]
+        body = _git_output(root, ["log", "-1", "--pretty=format:%B", sha], required=False) or ""
+        path_output = (
+            _git_output(
+                root, ["show", "--pretty=format:", "--name-only", sha, "--"], required=False
+            )
+            or ""
+        )
+        paths = sorted(
+            dict.fromkeys(line.strip() for line in path_output.splitlines() if line.strip())
+        )
         relevance_score = _goal_relevance_score(
             goal_tokens,
             goal_phrase=goal_phrase,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -814,22 +814,49 @@ def test_cli_query_parser_accepts_filters_and_no_question() -> None:
 def test_cli_brief_parser_accepts_agent_context() -> None:
     parser = build_parser()
 
-    args = parser.parse_args(["brief", "--agent-context", "query", "handoff", "--json"])
+    args = parser.parse_args(
+        ["brief", "--agent-context", "--since", "origin/main", "query", "handoff", "--json"]
+    )
 
     assert args.command == "brief"
     assert args.agent_context is True
+    assert args.since == "origin/main"
+    assert args.no_git is False
     assert args.goal == ["query", "handoff"]
     assert args.json_output is True
+
+
+def test_cli_brief_parser_accepts_no_git() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["brief", "--agent-context", "--no-git", "query", "handoff"])
+
+    assert args.command == "brief"
+    assert args.agent_context is True
+    assert args.no_git is True
+    assert args.goal == ["query", "handoff"]
 
 
 def test_cli_suggest_next_parser_accepts_goal_and_json() -> None:
     parser = build_parser()
 
-    args = parser.parse_args(["suggest-next", "agent", "handoff", "--json"])
+    args = parser.parse_args(["suggest-next", "--since", "main", "agent", "handoff", "--json"])
 
     assert args.command == "suggest-next"
+    assert args.since == "main"
+    assert args.no_git is False
     assert args.goal == ["agent", "handoff"]
     assert args.json_output is True
+
+
+def test_cli_suggest_next_parser_accepts_no_git() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["suggest-next", "--no-git", "agent", "handoff"])
+
+    assert args.command == "suggest-next"
+    assert args.no_git is True
+    assert args.goal == ["agent", "handoff"]
 
 
 def test_cli_repo_scan_parser_accepts_preview_apply_and_report_flags() -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2211,6 +2211,44 @@ def test_agent_context_explicit_since_empty_range_does_not_fallback_to_head(
     assert payload["git_context"]["commits"] == []
 
 
+def test_agent_context_multiline_commit_body_does_not_become_changed_paths(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    context_file = tmp_path / "src" / "context.py"
+    context_file.parent.mkdir()
+    context_file.write_text("VALUE = 'initial'\n", encoding="utf-8")
+    _init_git_repo(tmp_path, repo="example/project")
+    _commit_all(tmp_path, "Initial context")
+    context_file.write_text("VALUE = 'm18 handoff'\n", encoding="utf-8")
+    _git(
+        tmp_path,
+        "add",
+        "src/context.py",
+    )
+    _git(
+        tmp_path,
+        "commit",
+        "-m",
+        "M18 multiline body context",
+        "-m",
+        "Body mentions docs/not-a-changed-path.md\nand tests/not_a_changed_path.py.",
+    )
+    _install_fake_gh(tmp_path, monkeypatch, issues=[], prs=[])
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "brief", "--agent-context", "m18", "handoff", "--json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    paths = payload["git_context"]["commits"][0]["paths"]
+    assert "src/context.py" in paths
+    assert "docs/not-a-changed-path.md" not in paths
+    assert "tests/not_a_changed_path.py." not in paths
+
+
 def test_suggest_next_uses_wiki_authority_metadata_but_skips_source_summaries(
     tmp_path: Path, capsys
 ) -> None:
@@ -2664,7 +2702,18 @@ def test_suggest_next_json_ranks_changed_sources_before_review_work(tmp_path: Pa
     source.write_text("# Handoff\n\nUpdated briefing state.\n", encoding="utf-8")
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "suggest-next", "source", "refresh", "--json"])
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "please",
+            "refresh",
+            "sources",
+            "now",
+            "--json",
+        ]
+    )
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -1,4 +1,6 @@
 import json
+import os
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -12,6 +14,51 @@ from splendor.schemas import KnowledgePageFrontmatter, MaintenanceReport, TaskRe
 from splendor.state.source_registry import load_source_record
 from splendor.utils.planning import render_planning_markdown
 from splendor.utils.wiki import parse_wiki_markdown
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=root, check=True, capture_output=True, text=True)
+
+
+def _init_git_repo(root: Path, *, repo: str = "example/project") -> None:
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test User")
+    _git(root, "remote", "add", "origin", f"git@github.com:{repo}.git")
+
+
+def _commit_all(root: Path, message: str) -> None:
+    _git(root, "add", ".")
+    _git(root, "commit", "-m", message)
+
+
+def _install_fake_gh(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    issues: list[dict[str, object]],
+    prs: list[dict[str, object]],
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    script = bin_dir / "gh"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json\n"
+        "import sys\n"
+        f"issues = {issues!r}\n"
+        f"prs = {prs!r}\n"
+        "if sys.argv[1:3] == ['issue', 'list']:\n"
+        "    print(json.dumps(issues))\n"
+        "elif sys.argv[1:3] == ['pr', 'list']:\n"
+        "    print(json.dumps(prs))\n"
+        "else:\n"
+        "    print('unsupported fake gh call', file=sys.stderr)\n"
+        "    sys.exit(2)\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ.get('PATH', '')}")
 
 
 def write_wiki_page(
@@ -1753,6 +1800,296 @@ def test_brief_agent_context_warns_but_does_not_rank_missing_authority_docs(
     ]
 
 
+def test_agent_context_synthbanshee_retry_bar_is_git_aware_and_work_first(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path="CLAUDE.md",
+            role="current-authority",
+            purpose="ASR sanity policy.",
+            applies_to=["M17 ASR effective prosody"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/m17_phase_a_validation_report.md",
+            role="reference",
+            purpose="M17 ASR validation report.",
+            applies_to=["M17 ASR"],
+        ),
+    ]
+    write_config(tmp_path, config)
+    (tmp_path / "CLAUDE.md").write_text(
+        "# CLAUDE\n\nASR sanity checks gate M17 effective prosody work.\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "m17_phase_a_validation_report.md").write_text(
+        "# M17 Phase A Validation Report\n\nASR WER sanity baseline and effective prosody gap.\n",
+        encoding="utf-8",
+    )
+    renderer = tmp_path / "synthbanshee" / "tts" / "renderer.py"
+    renderer.parent.mkdir(parents=True)
+    renderer.write_text("def _apply_effective_prosody_cap():\n    return 'asr'\n", encoding="utf-8")
+    renderer_test = tmp_path / "tests" / "unit" / "test_effective_prosody_cap.py"
+    renderer_test.parent.mkdir(parents=True, exist_ok=True)
+    renderer_test.write_text(
+        "def test_effective_prosody_cap():\n    assert True\n", encoding="utf-8"
+    )
+    source = tmp_path / "stale.md"
+    source.write_text("# Stale\n\nOriginal maintenance source.\n", encoding="utf-8")
+    add_source(tmp_path, source)
+    source.write_text("# Stale\n\nChanged maintenance source.\n", encoding="utf-8")
+    _init_git_repo(tmp_path, repo="SynthBanshee/SynthBanshee")
+    _commit_all(tmp_path, "Initial SynthBanshee context")
+    renderer.write_text(
+        "def _apply_effective_prosody_cap():\n    return 'm17 asr effective prosody'\n",
+        encoding="utf-8",
+    )
+    _commit_all(tmp_path, "M17 effective-prosody cap addresses ASR sanity policy")
+    _install_fake_gh(
+        tmp_path,
+        monkeypatch,
+        issues=[
+            {
+                "number": 89,
+                "title": "fix(tts): M17 ASR follow-up after effective-prosody cap",
+                "url": "https://github.com/SynthBanshee/SynthBanshee/issues/89",
+                "body": "Next open ASR issue: close WER gap. Read synthbanshee/tts/renderer.py "
+                "and tests/unit/test_effective_prosody_cap.py.",
+                "state": "open",
+                "labels": [],
+            }
+        ],
+        prs=[
+            {
+                "number": 90,
+                "title": "effective-prosody cap addresses Whisper backdoor",
+                "url": "https://github.com/SynthBanshee/SynthBanshee/pull/90",
+                "body": "Merged PR context for ASR sanity and "
+                "docs/m17_phase_a_validation_report.md.",
+                "state": "merged",
+                "isDraft": False,
+                "mergedAt": "2026-05-06T07:14:00Z",
+                "labels": [],
+            }
+        ],
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "pick",
+            "up",
+            "M17",
+            "ASR",
+            "work",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    actions = payload["suggested_actions"]
+    assert actions[0]["category"] == "work-thread"
+    assert actions[0]["url"] == "https://github.com/SynthBanshee/SynthBanshee/issues/89"
+    assert payload["git_context"]["threads"][0]["number"] == 89
+    assert any("effective-prosody cap" in item["title"] for item in actions)
+    read_first = payload["git_context"]["read_first_paths"]
+    assert "synthbanshee/tts/renderer.py" in read_first
+    assert "tests/unit/test_effective_prosody_cap.py" in read_first
+    authority_paths = [item["path"] for item in payload["authority_briefs"]]
+    assert authority_paths[:2] == ["CLAUDE.md", "docs/m17_phase_a_validation_report.md"]
+    maintenance_categories = [
+        action["category"] for action in payload["maintenance_context"]["actions"]
+    ]
+    assert "queue" in maintenance_categories or "source-freshness" in maintenance_categories
+    flattened_categories = [action["category"] for action in actions]
+    assert flattened_categories.index("work-thread") < min(
+        flattened_categories.index(category)
+        for category in flattened_categories
+        if category in {"queue", "source-freshness"}
+    )
+
+    suggest_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "pick",
+            "up",
+            "M17",
+            "ASR",
+            "work",
+            "--json",
+        ]
+    )
+    assert suggest_exit == 0
+    suggest_payload = json.loads(capsys.readouterr().out)
+    suggest_categories = [action["category"] for action in suggest_payload["actions"]]
+    assert suggest_categories[0] == "work-thread"
+    assert suggest_categories.index("work-thread") < min(
+        suggest_categories.index(category)
+        for category in suggest_categories
+        if category in {"queue", "source-freshness"}
+    )
+
+
+def test_agent_context_hocrgen_retry_bar_ranks_current_planning_before_history(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path=".agent-plan.md",
+            role="current-authority",
+            purpose="Current F3b planning state.",
+            applies_to=["hocrgen F3a F3b"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/HeOCR_hocrgen_long_term_roadmap.md",
+            role="roadmap",
+            purpose="Roadmap critical path after F3a.",
+            applies_to=["hocrgen F3b critical path"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/modern_handwritten_acquisition_policy.md",
+            role="current-authority",
+            purpose="Modern handwritten acquisition policy for F3b.",
+            applies_to=["hocrgen F3b"],
+        ),
+        AuthorityDocumentConfig(path="README.md", role="current-authority", applies_to=["hocrgen"]),
+        AuthorityDocumentConfig(
+            path="CONTRIBUTING.md",
+            role="reference",
+            applies_to=["hocrgen planning tests"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/outside_review.md",
+            role="historical-review",
+            freshness="historical",
+            applies_to=["hocrgen F3b"],
+        ),
+    ]
+    write_config(tmp_path, config)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\nCurrent critical path: F3a complete; next implementation step is F3b.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "# hocrgen\n\nF3b adds typed repo-tracked operator intake manifests.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "CONTRIBUTING.md").write_text(
+        "# Contributing\n\nRun planning tests before changing F3 planning docs.\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "HeOCR_hocrgen_long_term_roadmap.md").write_text(
+        "# Roadmap\n\n## Current critical path\n\nF3b follows F3a and precedes F4/F5.\n",
+        encoding="utf-8",
+    )
+    (docs / "modern_handwritten_acquisition_policy.md").write_text(
+        "# Modern Handwritten Acquisition Policy\n\n"
+        "F3b must implement consent, release terms, privacy screening, and intake manifests.\n",
+        encoding="utf-8",
+    )
+    (docs / "outside_review.md").write_text(
+        "# Outside Review\n\nHistorical hocrgen review mentions F3b repeatedly.\n",
+        encoding="utf-8",
+    )
+    planning_test = tmp_path / "tests" / "test_planning_docs.py"
+    planning_test.parent.mkdir(exist_ok=True)
+    planning_test.write_text("def test_f3b_planning_docs():\n    assert True\n", encoding="utf-8")
+    _init_git_repo(tmp_path, repo="HeOCR/hocrgen")
+    _commit_all(tmp_path, "Initial hocrgen planning")
+    planning_test.write_text("def test_f3b_planning_docs():\n    assert 'F3b'\n", encoding="utf-8")
+    _commit_all(tmp_path, "F3a defines rights-clean modern handwritten acquisition policy")
+    _install_fake_gh(
+        tmp_path,
+        monkeypatch,
+        issues=[],
+        prs=[
+            {
+                "number": 63,
+                "title": "F3a: Define rights-clean modern handwritten acquisition policy",
+                "url": "https://github.com/HeOCR/hocrgen/pull/63",
+                "body": "Recent F3a context. Next is F3b with tests/test_planning_docs.py.",
+                "state": "merged",
+                "isDraft": False,
+                "mergedAt": "2026-05-06T07:14:00Z",
+                "labels": [],
+            }
+        ],
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "Resume",
+            "hocrgen",
+            "planning",
+            "after",
+            "F3a",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    authority_paths = [item["path"] for item in payload["authority_briefs"]]
+    assert authority_paths[0] == ".agent-plan.md"
+    current_paths = {
+        "docs/HeOCR_hocrgen_long_term_roadmap.md",
+        "docs/modern_handwritten_acquisition_policy.md",
+        "README.md",
+        "CONTRIBUTING.md",
+    }
+    assert current_paths <= set(authority_paths[:5])
+    assert all(
+        authority_paths.index("docs/outside_review.md") > authority_paths.index(path)
+        for path in current_paths
+    )
+    assert payload["git_context"]["threads"][0]["number"] == 63
+    assert "tests/test_planning_docs.py" in payload["git_context"]["read_first_paths"]
+    work_titles = " ".join(action["title"] for action in payload["work_context"]["actions"])
+    assert "F3a" in work_titles or "F3b" in work_titles
+
+    suggest_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "Resume",
+            "hocrgen",
+            "planning",
+            "after",
+            "F3a",
+            "--json",
+        ]
+    )
+    assert suggest_exit == 0
+    suggest_payload = json.loads(capsys.readouterr().out)
+    suggest_categories = [action["category"] for action in suggest_payload["actions"]]
+    assert suggest_categories[0] in {"work-thread", "git-context", "authority", "planning"}
+    if "goal-match" in suggest_categories:
+        assert suggest_categories.index("authority") < suggest_categories.index("goal-match")
+
+
 def test_suggest_next_uses_wiki_authority_metadata_but_skips_source_summaries(
     tmp_path: Path, capsys
 ) -> None:
@@ -2206,7 +2543,7 @@ def test_suggest_next_json_ranks_changed_sources_before_review_work(tmp_path: Pa
     source.write_text("# Handoff\n\nUpdated briefing state.\n", encoding="utf-8")
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "suggest-next", "handoff", "--json"])
+    exit_code = main(["--root", str(tmp_path), "suggest-next", "source", "refresh", "--json"])
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import yaml
 
 from splendor.cli import main
+from splendor.commands import brief as brief_module
 from splendor.commands.add_source import add_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.wiki import add_topic_page, rebuild_wiki_index
@@ -59,6 +60,26 @@ def _install_fake_gh(
     )
     script.chmod(0o755)
     monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ.get('PATH', '')}")
+
+
+def _install_marker_gh(tmp_path: Path, monkeypatch, *, sleep_seconds: float = 0) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    marker = tmp_path / "gh-called"
+    script = bin_dir / "gh"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import pathlib\n"
+        "import sys\n"
+        "import time\n"
+        f"time.sleep({sleep_seconds!r})\n"
+        f"pathlib.Path({str(marker)!r}).write_text('called', encoding='utf-8')\n"
+        "print('[]')\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ.get('PATH', '')}")
+    return marker
 
 
 def write_wiki_page(
@@ -1862,7 +1883,15 @@ def test_agent_context_synthbanshee_retry_bar_is_git_aware_and_work_first(
                 "and tests/unit/test_effective_prosody_cap.py.",
                 "state": "open",
                 "labels": [],
-            }
+            },
+            {
+                "number": 118,
+                "title": "M20-P1.1 Add advanced semantic search or vector index",
+                "url": "https://github.com/SynthBanshee/SynthBanshee/issues/118",
+                "body": "Deferred vector search can wait until work-first handoff is correct.",
+                "state": "open",
+                "labels": [],
+            },
         ],
         prs=[
             {
@@ -1900,7 +1929,15 @@ def test_agent_context_synthbanshee_retry_bar_is_git_aware_and_work_first(
     actions = payload["suggested_actions"]
     assert actions[0]["category"] == "work-thread"
     assert actions[0]["url"] == "https://github.com/SynthBanshee/SynthBanshee/issues/89"
+    assert all(
+        action.get("url") != "https://github.com/SynthBanshee/SynthBanshee/issues/118"
+        for action in actions
+    )
     assert payload["git_context"]["threads"][0]["number"] == 89
+    irrelevant_threads = [
+        thread for thread in payload["git_context"]["threads"] if thread["number"] == 118
+    ]
+    assert irrelevant_threads and irrelevant_threads[0]["promoted"] is False
     assert any("effective-prosody cap" in item["title"] for item in actions)
     read_first = payload["git_context"]["read_first_paths"]
     assert "synthbanshee/tts/renderer.py" in read_first
@@ -1935,6 +1972,10 @@ def test_agent_context_synthbanshee_retry_bar_is_git_aware_and_work_first(
     suggest_payload = json.loads(capsys.readouterr().out)
     suggest_categories = [action["category"] for action in suggest_payload["actions"]]
     assert suggest_categories[0] == "work-thread"
+    assert all(
+        action.get("url") != "https://github.com/SynthBanshee/SynthBanshee/issues/118"
+        for action in suggest_payload["actions"]
+    )
     assert suggest_categories.index("work-thread") < min(
         suggest_categories.index(category)
         for category in suggest_categories
@@ -2007,6 +2048,22 @@ def test_agent_context_hocrgen_retry_bar_ranks_current_planning_before_history(
     (docs / "outside_review.md").write_text(
         "# Outside Review\n\nHistorical hocrgen review mentions F3b repeatedly.\n",
         encoding="utf-8",
+    )
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "create",
+            "Implement",
+            "F3b",
+            "operator",
+            "intake",
+            "--id",
+            "task-f3b-operator-intake",
+            "--status",
+            "in_progress",
+        ]
     )
     planning_test = tmp_path / "tests" / "test_planning_docs.py"
     planning_test.parent.mkdir(exist_ok=True)
@@ -2088,6 +2145,70 @@ def test_agent_context_hocrgen_retry_bar_ranks_current_planning_before_history(
     assert suggest_categories[0] in {"work-thread", "git-context", "authority", "planning"}
     if "goal-match" in suggest_categories:
         assert suggest_categories.index("authority") < suggest_categories.index("goal-match")
+
+    text_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "Resume",
+            "hocrgen",
+            "planning",
+            "after",
+            "F3a",
+        ]
+    )
+    assert text_exit == 0
+    out = capsys.readouterr().out
+    assert out.index("Authority docs:") < out.index("Splendor maintenance:")
+    assert out.index("Active planning:") < out.index("Splendor maintenance:")
+
+
+def test_brief_plain_text_does_not_call_gh_by_default(tmp_path: Path, capsys, monkeypatch) -> None:
+    initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path, repo="example/project")
+    _commit_all(tmp_path, "Initial context")
+    marker = _install_marker_gh(tmp_path, monkeypatch)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "brief", "agent", "handoff"])
+
+    assert exit_code == 0
+    assert not marker.exists()
+
+
+def test_agent_context_reports_gh_timeout_as_warning(tmp_path: Path, capsys, monkeypatch) -> None:
+    initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path, repo="example/project")
+    _commit_all(tmp_path, "Initial context")
+    _install_marker_gh(tmp_path, monkeypatch, sleep_seconds=1)
+    monkeypatch.setattr(brief_module, "_GIT_COMMAND_TIMEOUT_SECONDS", 0.01)
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "brief", "--agent-context", "agent", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert any("Timed out" in warning for warning in payload["git_context"]["warnings"])
+
+
+def test_agent_context_explicit_since_empty_range_does_not_fallback_to_head(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path, repo="example/project")
+    _commit_all(tmp_path, "Initial context")
+    _install_fake_gh(tmp_path, monkeypatch, issues=[], prs=[])
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "brief", "--agent-context", "--since", "HEAD", "agent", "--json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["git_context"]["commits"] == []
 
 
 def test_suggest_next_uses_wiki_authority_metadata_but_skips_source_summaries(


### PR DESCRIPTION
## Summary

- add `--since` and `--no-git` to `brief` and `suggest-next`
- add runtime-only local git context plus best-effort read-only GitHub issue/PR context for agent handoff
- split agent-facing JSON/text output into work context before Splendor maintenance, while preserving flattened `suggested_actions`
- update M18 planning/docs state for the active `M18-P1.1` slice and add deterministic retry-bar regression coverage

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

Closes #139