### PR TITLE
M18-P2.1: Add inferred authority and provisional uncurated-doc context

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M18-P0.1`
-- Last action taken: `M18-P0.1` was squash-merged into main as commit `5192e30`,
-  recording the v0.3 evaluation intake and v0.4 roadmap realignment.
+- Previous completed PR sub-slice: `M18-P1.1`
+- Last action taken: `M18-P1.1` was squash-merged into main as commit `a40e810`,
+  adding git-aware, work-first agent handoff for v0.4 public readiness.
 - Current planned slice: `M18 v0.4 work-first agent handoff`
-- Current PR sub-slice: `M18-P1.1`
+- Current PR sub-slice: `M18-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M18 v0.4 work-first agent handoff`
-- Next planned PR sub-slice: `M18-P2.1`
+- Next planned PR sub-slice: `M18-P3.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -363,12 +363,17 @@
   - [x] Reorganize supporting docs into guides, operations, evaluations, and releases folders
   - [x] Reframe the next implementation path around git-aware, work-first agent handoff
   - [x] Publish a non-draft PR with labels, milestone, issue linkage, and detailed validation
-- [ ] Implement `M18-P1.1`: git-aware, work-first agent handoff
+- [x] Implement `M18-P1.1`: git-aware, work-first agent handoff
   - [x] Add `--since` and `--no-git` handoff options to `brief` and `suggest-next`
   - [x] Add runtime-only local git and best-effort GitHub issue/PR context
   - [x] Rank work context before Splendor maintenance for non-maintenance goals
   - [x] Separate work and maintenance context in agent-facing text and JSON output
   - [x] Cover the SynthBanshee and hocrgen retry bars with deterministic fixtures
+- [ ] Implement `M18-P2.1`: inferred authority fallback and provisional uncurated-doc context
+  - [x] Add runtime-only inferred authority candidates for conventional planning and policy paths
+  - [x] Label provisional uncurated documents distinctly from configured and curated authority
+  - [x] Pair provisional context with exact source curation commands
+  - [x] Cover hocrgen-style planning resume with deterministic regression tests
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -302,12 +302,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M18-P0.1`
+- Previous completed PR sub-slice: `M18-P1.1`
 - Current planned slice: `M18 v0.4 work-first agent handoff`
-- Current PR sub-slice: `M18-P1.1`
+- Current PR sub-slice: `M18-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M18 v0.4 work-first agent handoff`
-- Next planned PR sub-slice: `M18-P2.1`
+- Next planned PR sub-slice: `M18-P3.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -384,10 +384,12 @@ maintenance reports, and query matches for the optional goal. `brief --agent-con
 with the same suggested work before the lower-level metadata lists. Use `--json` on either command
 for machine handoff.
 
-`M18-P1.1` adds runtime-only git-aware handoff context to those same surfaces. For non-maintenance
-goals, open work threads, relevant commits, configured authority, active planning, changed/read-first
-files, and goal matches rank ahead of source freshness, queue, wiki review, synthesis, lint, and
-health maintenance. Maintenance-focused goals can still keep maintenance actions first.
+`M18-P1.1` adds runtime-only git-aware handoff context to those same surfaces. `M18-P2.1` adds
+runtime-only inferred authority fallback and provisional uncurated-document context. For
+non-maintenance goals, open work threads, relevant commits, configured authority, inferred current
+planning/policy context, active planning, changed/read-first files, and goal matches rank ahead of
+source freshness, queue, wiki review, synthesis, lint, and health maintenance. Maintenance-focused
+goals can still keep maintenance actions first.
 
 `M13-P2.5` is implemented: source-summary pages now keep readable in-repo source summaries compact
 and claim-bearing by default, while external, copied, parsed PDF, and OCR-derived sources keep
@@ -584,5 +586,5 @@ agent reached for when resuming real work. The v0.4 path therefore prioritizes g
 work-first handoff before vector search or mutating web review workflows.
 
 `M18-P1.1` implements the first v0.4 handoff step: git-aware work context and structural
-work/maintenance separation. Broader inferred-authority fallback and provisional uncurated-doc
-context remain planned for `M18-P2.1`.
+work/maintenance separation. `M18-P2.1` adds labeled inferred-authority fallback for conventional
+planning and policy paths plus provisional uncurated-doc context with exact curation commands.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -292,7 +292,10 @@ Implemented fields:
   records, queue jobs, manifests, wiki pages, run records, reports, or GitHub state. Human output
   is path-first where possible; `--json` emits ranked action objects with category, priority,
   title, reason, command, path, optional URL, source ID/source ref, planning/page record IDs, and a
-  deterministic `relevance_score` when available.
+  deterministic `relevance_score` when available. Runtime authority entries also expose `origin`,
+  `curation_state`, and `curation_commands`; provisional uncurated authority is repeated under
+  `provisional_context` so agents can use it without confusing it for configured or curated source
+  authority.
 - Suggested actions are derived from local git commits, best-effort read-only GitHub issue/PR
   context through `gh` when available, source freshness, queue operator state, invalid/stale/
   contested/review-needed wiki pages, ingested sources missing maintained synthesis follow-up,

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M18-P0.1`
+- Previous completed PR sub-slice: `M18-P1.1`
 - Current planned slice: `M18 v0.4 work-first agent handoff`
-- Current PR sub-slice: `M18-P1.1`
+- Current PR sub-slice: `M18-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M18 v0.4 work-first agent handoff`
-- Next planned PR sub-slice: `M18-P2.1`
+- Next planned PR sub-slice: `M18-P3.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1246,8 +1246,9 @@ The v0.3 evaluation and follow-up inputs live in:
 `M18-P0.1` is implemented. `M18-P1.1` adds git-aware, work-first handoff without changing schema
 version `1`: `brief --agent-context` and `suggest-next` accept `--since <ref>` and `--no-git`,
 include runtime-only local git plus best-effort read-only GitHub issue/PR context, and split
-agent-facing output into work context before Splendor maintenance. `M18-P2.1` still owns broader
-inferred authority fallback and clearly labeled provisional uncurated-document context.
+agent-facing output into work context before Splendor maintenance. `M18-P2.1` adds runtime-only
+inferred authority fallback and clearly labeled provisional uncurated-document context for
+conventional planning, roadmap, policy, README/CONTRIBUTING, and planning-test files.
 
 ## Milestone 19 — pre-v1 workflow durability after v0.4
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1110,8 +1110,8 @@ Current implementation:
   handoff with work context before Splendor maintenance. Inside git worktrees it includes
   runtime-only local branch/head/base context, recent relevant commits, best-effort read-only
   GitHub issue/PR context through `gh` when available, read-first file paths, relevant matches,
-  source refs, active planning records, ranked authority docs, recent sources/runs, maintenance
-  reports, warnings, and ranked suggested actions.
+  source refs, active planning records, ranked authority docs, clearly labeled provisional
+  uncurated docs, recent sources/runs, maintenance reports, warnings, and ranked suggested actions.
 - `splendor suggest-next [--since <ref>] [--no-git] [goal]` renders the ranked action subset
   directly. It is read-only and deterministic. For non-maintenance goals it ranks open work
   threads, recent git/PR context, task-relevant authority docs, active planning records, read-first
@@ -1128,6 +1128,14 @@ Current implementation:
   maintained wiki page frontmatter (`authority_role`, `authority_freshness`, and
   `authority_lifecycle`, `authority_scope`, issue/PR refs, and supersession links). Generated
   source-summary pages are excluded from maintained authority ranking.
+- When configured or maintained authority is incomplete, handoff can infer runtime-only authority
+  from conventional paths such as `.agent-plan.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`,
+  `CONTRIBUTING.md`, roadmap/plan/policy/guideline docs under `docs/`, and planning-doc tests.
+  These entries carry `origin: inferred-authority`. If the file is not an active curated source,
+  it carries `curation_state: provisional-uncurated`, appears in `provisional_context`, and includes
+  exact `splendor add-source <path>` and `splendor ingest <path>` commands. Provisional context can
+  rank above historical outside reviews for planning-resume goals but does not masquerade as
+  configured or reviewed source authority.
 - Authority lifecycle values are `current`, `reviewed`, `pr-linked`, `historical`, `superseded`,
   and `archived`. Briefing and suggest-next rank current, reviewed, and PR-linked authority above
   stale, historical, superseded, or archived context while still showing relevant historical
@@ -1156,8 +1164,8 @@ v0.4 direction from external trials:
   as uncurated and paired with an exact curation command.
 
 `M18-P1.1` implements the git-aware work-first ranking and work/maintenance separation while
-keeping all new context runtime-only. The inferred-authority and provisional uncurated-doc
-fallbacks remain planned follow-up work for `M18-P2.1`.
+keeping all new context runtime-only. `M18-P2.1` implements inferred-authority and provisional
+uncurated-doc fallbacks as runtime briefing signals without a schema-version bump.
 
 ## 18. Search Model
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -2214,14 +2214,25 @@ def handle_brief(args: argparse.Namespace) -> int:
         print("Relevant records:")
         for match in result.matches:
             print(f"- {match.path} [{match.kind}] score={match.score}: {match.title}")
-    if result.authority_briefs:
+    curated_authority = _curated_authority_briefs(result.authority_briefs)
+    if curated_authority:
         print("Authority docs:")
-        for item in result.authority_briefs:
+        for item in curated_authority:
             refs = _authority_link_summary(item)
             print(
-                f"- {item.path} [{item.role}/{item.freshness}/{item.lifecycle}] "
+                f"- {item.path} [{item.role}/{item.freshness}/{item.lifecycle}/{item.origin}] "
                 f"score={item.score}: {item.title}{refs}"
             )
+    if result.provisional_context:
+        print("Provisional uncurated docs:")
+        for item in result.provisional_context:
+            commands = "; ".join(item.curation_commands)
+            print(
+                f"- {item.path} [{item.role}/{item.freshness}/{item.lifecycle}/"
+                f"{item.origin}/{item.curation_state}] score={item.score}: {item.title}"
+            )
+            if commands:
+                print(f"  Curate: {commands}")
     if result.planning_items:
         print("Active planning:")
         for item in result.planning_items:
@@ -2303,14 +2314,25 @@ def _print_agent_context(result: ProjectBrief) -> None:
             print(f"- {match.path} [{match.kind}] score={match.score} sources={source_refs}")
             if match.snippet:
                 print(f"  {match.snippet}")
-    if result.authority_briefs:
+    curated_authority = _curated_authority_briefs(result.authority_briefs)
+    if curated_authority:
         print("Authority docs:")
-        for item in result.authority_briefs[:5]:
+        for item in curated_authority[:5]:
             refs = _authority_link_summary(item)
             print(
-                f"- {item.path} [{item.role}/{item.freshness}/{item.lifecycle}] "
+                f"- {item.path} [{item.role}/{item.freshness}/{item.lifecycle}/{item.origin}] "
                 f"score={item.score} {item.title}{refs}"
             )
+    if result.provisional_context:
+        print("Provisional uncurated docs:")
+        for item in result.provisional_context[:5]:
+            commands = "; ".join(item.curation_commands)
+            print(
+                f"- {item.path} [{item.role}/{item.freshness}/{item.lifecycle}/"
+                f"{item.origin}/{item.curation_state}] score={item.score} {item.title}"
+            )
+            if commands:
+                print(f"  Curate: {commands}")
     if result.planning_items:
         print("Active planning:")
         for item in result.planning_items:
@@ -2390,6 +2412,24 @@ def handle_suggest_next(args: argparse.Namespace) -> int:
                 f"target={target}{command}{url}"
             )
             print(f"   Reason: {action.reason}")
+    curated_authority = _curated_authority_briefs(result.authority_briefs)
+    if curated_authority:
+        print("Authority docs:")
+        for item in curated_authority[:5]:
+            print(
+                f"- {item.path} [{item.role}/{item.freshness}/{item.lifecycle}/{item.origin}] "
+                f"score={item.score} {item.title}"
+            )
+    if result.provisional_context:
+        print("Provisional uncurated docs:")
+        for item in result.provisional_context[:5]:
+            commands = "; ".join(item.curation_commands)
+            print(
+                f"- {item.path} [{item.role}/{item.freshness}/{item.lifecycle}/"
+                f"{item.origin}/{item.curation_state}] score={item.score} {item.title}"
+            )
+            if commands:
+                print(f"  Curate: {commands}")
     print(
         "Splendor maintenance: "
         f"changed_sources={result.freshness.changed} "
@@ -2425,6 +2465,10 @@ def _authority_link_summary(item) -> str:
     if item.supersedes:
         refs.append("supersedes=" + ",".join(item.supersedes))
     return "" if not refs else " " + " ".join(refs)
+
+
+def _curated_authority_briefs(items) -> list:
+    return [item for item in items if item.curation_state != "provisional-uncurated"]
 
 
 def handle_serve(args: argparse.Namespace) -> int:

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -117,6 +117,12 @@ _AUTHORITY_SOURCE_SCORE = {
     "planning-decision": 14,
     "inferred-authority": 0,
 }
+_AUTHORITY_ORIGIN_ORDER = {
+    "configured-authority": 0,
+    "wiki-authority": 0,
+    "planning-decision": 0,
+    "inferred-authority": 1,
+}
 _TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]{1,}")
 _AUTHORITY_ROLE_ORDER = {
     "current-authority": 0,
@@ -233,6 +239,26 @@ _MAINTENANCE_GOAL_FILLER_TOKENS = {
     "with",
     "would",
     "you",
+}
+_INFERRED_CONTEXT_FILLER_TOKENS = _MAINTENANCE_GOAL_FILLER_TOKENS | {
+    "agent",
+    "critical",
+    "current",
+    "doc",
+    "docs",
+    "file",
+    "implementation",
+    "next",
+    "path",
+    "plan",
+    "planning",
+    "project",
+    "read",
+    "repo",
+    "roadmap",
+    "step",
+    "test",
+    "tests",
 }
 
 
@@ -851,6 +877,7 @@ def _authority_briefs(
         key=lambda item: (
             _AUTHORITY_LIFECYCLE_TIER.get(item[1].lifecycle, 99),
             _AUTHORITY_FRESHNESS_ORDER.get(item[1].freshness, 99),
+            _AUTHORITY_ORIGIN_ORDER.get(item[1].origin, 99),
             -item[1].score,
             _AUTHORITY_ROLE_ORDER.get(item[1].role, 99),
             _AUTHORITY_LIFECYCLE_ORDER.get(item[1].lifecycle, 99),
@@ -1012,6 +1039,7 @@ def _inferred_authority_briefs(
     configured_paths = {doc.path for doc in config.briefing.authority_documents}
     existing_paths = {item.path for item in existing_items}
     excluded_paths = configured_paths | existing_paths
+    fallback_context_tokens = _inferred_root_context_tokens(root)
     candidates: list[AuthorityBrief] = []
     for path in _inferred_authority_candidate_paths(root):
         if path.as_posix() in excluded_paths:
@@ -1027,6 +1055,15 @@ def _inferred_authority_briefs(
         freshness = "current"
         lifecycle = "current"
         reason = _inferred_authority_reason(path)
+        gating_tokens = goal_tokens | fallback_context_tokens
+        relevance_score = _goal_relevance_score(
+            gating_tokens,
+            goal_phrase=goal_phrase,
+            high_text=" ".join([title, path_text]),
+            low_text=body,
+        )
+        if _inferred_authority_requires_goal_match(path) and relevance_score <= 0:
+            continue
         curated_source = _curated_source_for_path(sources, path_text)
         if curated_source is None:
             curation_state = "provisional-uncurated"
@@ -1091,6 +1128,30 @@ def _inferred_authority_candidate_paths(root: Path) -> list[Path]:
         for path in sorted(tests_dir.rglob("test_planning*.py")):
             candidates.append(path.relative_to(root))
     return sorted(dict.fromkeys(candidates), key=lambda item: item.as_posix())
+
+
+def _inferred_root_context_tokens(root: Path) -> set[str]:
+    tokens: set[str] = set()
+    for name in (".agent-plan.md", "README.md", "CONTRIBUTING.md"):
+        path = root / name
+        if not path.is_file():
+            continue
+        try:
+            body = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        tokens.update(_tokens(body) - _INFERRED_CONTEXT_FILLER_TOKENS)
+    return tokens
+
+
+def _inferred_authority_requires_goal_match(path: Path) -> bool:
+    return path.as_posix() not in {
+        ".agent-plan.md",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "README.md",
+        "CONTRIBUTING.md",
+    }
 
 
 def _is_inferred_docs_authority_path(path: Path) -> bool:

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -110,7 +110,13 @@ _MAINTENANCE_CATEGORIES = {
     "query",
 }
 _SUGGESTION_PRIORITY_ORDER = {"high": 0, "medium": 1, "low": 2}
-_AUTHORITY_LIMIT = 6
+_AUTHORITY_LIMIT = 8
+_AUTHORITY_SOURCE_SCORE = {
+    "configured-authority": 18,
+    "wiki-authority": 16,
+    "planning-decision": 14,
+    "inferred-authority": 0,
+}
 _TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]{1,}")
 _AUTHORITY_ROLE_ORDER = {
     "current-authority": 0,
@@ -265,6 +271,9 @@ class AuthorityBrief:
     lifecycle: str
     score: int
     reason: str
+    origin: str
+    curation_state: str
+    curation_commands: list[str]
     issue_refs: list[str]
     pr_refs: list[str]
     supersedes: list[str]
@@ -374,6 +383,7 @@ class SuggestNextResult:
     git_context: GitContext
     work_actions: list[SuggestedAction]
     maintenance_actions: list[SuggestedAction]
+    provisional_context: list[AuthorityBrief]
 
 
 @dataclass(frozen=True)
@@ -417,6 +427,7 @@ class ProjectBrief:
     suggested_actions: list[SuggestedAction]
     work_actions: list[SuggestedAction]
     maintenance_actions: list[SuggestedAction]
+    provisional_context: list[AuthorityBrief]
     git_context: GitContext
     next_actions: list[str]
 
@@ -450,6 +461,7 @@ def build_project_brief(
         suggested_actions=suggested_actions,
         work_actions=work_actions,
         maintenance_actions=maintenance_actions,
+        provisional_context=_provisional_authority_briefs(snapshot.authority_briefs),
         git_context=snapshot.git_context,
         next_actions=next_actions,
     )
@@ -475,6 +487,7 @@ def build_suggest_next(
         git_context=snapshot.git_context,
         work_actions=work_actions,
         maintenance_actions=maintenance_actions,
+        provisional_context=_provisional_authority_briefs(snapshot.authority_briefs),
     )
 
 
@@ -522,7 +535,7 @@ def _collect_brief_state(
     sources_by_id = {source.source_id: source for source in sources}
     wiki_pages, invalid_wiki_pages = load_wiki_pages(root, layout)
     authority_briefs, authority_warnings = _authority_briefs(
-        root, layout, config, wiki_pages, normalized_goal or None
+        root, layout, config, wiki_pages, sources, normalized_goal or None
     )
     warnings.extend(authority_warnings)
     recent_sources = _recent_sources(sources)
@@ -698,7 +711,14 @@ def _active_planning_items(
     return items[:_BRIEF_PLANNING_LIMIT], warnings, generated_review_task_count
 
 
-def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot], goal: str | None):
+def _authority_briefs(
+    root: Path,
+    layout,
+    config,
+    pages: list[WikiPageSnapshot],
+    sources: list[SourceRecord],
+    goal: str | None,
+):
     items: list[AuthorityBrief] = []
     warnings: list[BriefWarning] = []
     goal_tokens = _tokens(goal or "")
@@ -730,6 +750,7 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
             role=doc.role,
             freshness=doc.freshness,
             lifecycle=lifecycle,
+            origin="configured-authority",
             goal_tokens=goal_tokens,
             goal_phrase=goal_phrase,
             high_text=" ".join([title, path.as_posix(), " ".join(doc.applies_to)]),
@@ -748,6 +769,9 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
                 lifecycle=lifecycle,
                 score=score,
                 reason=reason,
+                origin="configured-authority",
+                curation_state="configured",
+                curation_commands=[],
                 issue_refs=doc.issue_refs,
                 pr_refs=doc.pr_refs,
                 supersedes=doc.supersedes,
@@ -773,6 +797,7 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
             role=page.frontmatter.authority_role,
             freshness=freshness,
             lifecycle=lifecycle,
+            origin="wiki-authority",
             goal_tokens=goal_tokens,
             goal_phrase=goal_phrase,
             high_text=" ".join(
@@ -809,6 +834,9 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
                 lifecycle=lifecycle,
                 score=score,
                 reason=reason,
+                origin="wiki-authority",
+                curation_state="curated",
+                curation_commands=[],
                 issue_refs=page.frontmatter.issue_refs,
                 pr_refs=page.frontmatter.pr_refs,
                 supersedes=page.frontmatter.supersedes,
@@ -817,6 +845,7 @@ def _authority_briefs(root: Path, layout, config, pages: list[WikiPageSnapshot],
         )
 
     items.extend(_decision_authority_briefs(root, layout, goal_tokens, goal_phrase))
+    items.extend(_inferred_authority_briefs(root, config, sources, goal_tokens, goal_phrase, items))
     ranked = sorted(
         enumerate(items),
         key=lambda item: (
@@ -840,6 +869,7 @@ def _authority_score(
     role: str,
     freshness: str,
     lifecycle: str,
+    origin: str,
     goal_tokens: set[str],
     goal_phrase: str = "",
     high_text: str = "",
@@ -851,6 +881,7 @@ def _authority_score(
         _AUTHORITY_ROLE_SCORE.get(role, 0)
         + _AUTHORITY_FRESHNESS_SCORE.get(freshness, 0)
         + _AUTHORITY_LIFECYCLE_SCORE.get(lifecycle, 0)
+        + _AUTHORITY_SOURCE_SCORE.get(origin, 0)
     )
     score += _goal_relevance_score(
         goal_tokens,
@@ -938,6 +969,7 @@ def _decision_authority_briefs(
                     role="decision",
                     freshness=freshness,
                     lifecycle=lifecycle,
+                    origin="planning-decision",
                     goal_tokens=goal_tokens,
                     goal_phrase=goal_phrase,
                     high_text=" ".join([record.title, record.decision_id, path.name]),
@@ -957,6 +989,9 @@ def _decision_authority_briefs(
                     low_text=text,
                 ),
                 reason=reason,
+                origin="planning-decision",
+                curation_state="planning-record",
+                curation_commands=[],
                 issue_refs=record.issue_refs,
                 pr_refs=record.pr_refs,
                 supersedes=record.supersedes,
@@ -964,6 +999,172 @@ def _decision_authority_briefs(
             )
         )
     return items
+
+
+def _inferred_authority_briefs(
+    root: Path,
+    config,
+    sources: list[SourceRecord],
+    goal_tokens: set[str],
+    goal_phrase: str,
+    existing_items: list[AuthorityBrief],
+) -> list[AuthorityBrief]:
+    configured_paths = {doc.path for doc in config.briefing.authority_documents}
+    existing_paths = {item.path for item in existing_items}
+    excluded_paths = configured_paths | existing_paths
+    candidates: list[AuthorityBrief] = []
+    for path in _inferred_authority_candidate_paths(root):
+        if path.as_posix() in excluded_paths:
+            continue
+        absolute = root / path
+        try:
+            body = absolute.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        path_text = path.as_posix()
+        title = _title_from_markdown(body) or _inferred_authority_title(path)
+        role = _inferred_authority_role(path)
+        freshness = "current"
+        lifecycle = "current"
+        reason = _inferred_authority_reason(path)
+        curated_source = _curated_source_for_path(sources, path_text)
+        if curated_source is None:
+            curation_state = "provisional-uncurated"
+            curation_commands = [
+                f"splendor add-source {shlex.quote(path_text)}",
+                f"splendor ingest {shlex.quote(path_text)}",
+            ]
+            reason = (
+                f"{reason} Detected by filename/path heuristic; provisional until curated as a "
+                "source."
+            )
+        else:
+            curation_state = "curated"
+            curation_commands = []
+            reason = f"{reason} Detected by filename/path heuristic over a curated source."
+        candidates.append(
+            AuthorityBrief(
+                rank=0,
+                path=path_text,
+                title=title,
+                role=role,
+                freshness=freshness,
+                lifecycle=lifecycle,
+                score=_authority_score(
+                    role=role,
+                    freshness=freshness,
+                    lifecycle=lifecycle,
+                    origin="inferred-authority",
+                    goal_tokens=goal_tokens,
+                    goal_phrase=goal_phrase,
+                    high_text=" ".join([title, path_text]),
+                    medium_text=reason,
+                    low_text=body,
+                ),
+                reason=reason,
+                origin="inferred-authority",
+                curation_state=curation_state,
+                curation_commands=curation_commands,
+                issue_refs=[],
+                pr_refs=[],
+                supersedes=[],
+                superseded_by=None,
+            )
+        )
+    return candidates
+
+
+def _inferred_authority_candidate_paths(root: Path) -> list[Path]:
+    candidates: list[Path] = []
+    for name in (".agent-plan.md", "AGENTS.md", "CLAUDE.md", "README.md", "CONTRIBUTING.md"):
+        path = root / name
+        if path.is_file():
+            candidates.append(Path(name))
+    docs_dir = root / "docs"
+    if docs_dir.is_dir():
+        for path in sorted(docs_dir.rglob("*.md")):
+            relative = path.relative_to(root)
+            if _is_inferred_docs_authority_path(relative):
+                candidates.append(relative)
+    tests_dir = root / "tests"
+    if tests_dir.is_dir():
+        for path in sorted(tests_dir.rglob("test_planning*.py")):
+            candidates.append(path.relative_to(root))
+    return sorted(dict.fromkeys(candidates), key=lambda item: item.as_posix())
+
+
+def _is_inferred_docs_authority_path(path: Path) -> bool:
+    name = path.name.lower()
+    return any(
+        marker in name
+        for marker in (
+            "roadmap",
+            "plan",
+            "planning",
+            "policy",
+            "policies",
+            "guideline",
+            "guidelines",
+        )
+    )
+
+
+def _inferred_authority_role(path: Path) -> str:
+    path_text = path.as_posix().lower()
+    name = path.name.lower()
+    if path_text == ".agent-plan.md" or "roadmap" in name or "plan" in name:
+        return "roadmap"
+    if path_text in {"agents.md", "claude.md", "readme.md"} or "policy" in name:
+        return "current-authority"
+    return "reference"
+
+
+def _inferred_authority_reason(path: Path) -> str:
+    path_text = path.as_posix()
+    name = path.name.lower()
+    if path_text == ".agent-plan.md":
+        return "Inferred current planning state from the conventional agent-plan file."
+    if path_text in {"AGENTS.md", "CLAUDE.md"}:
+        return "Inferred agent policy authority from a conventional repo-root policy file."
+    if path_text == "README.md":
+        return "Inferred project orientation authority from the repo README."
+    if path_text == "CONTRIBUTING.md":
+        return "Inferred contributor workflow context from the repo contributing guide."
+    if "roadmap" in name or "plan" in name:
+        return "Inferred roadmap or planning authority from a conventional docs path."
+    if "policy" in name or "guideline" in name:
+        return "Inferred policy context from a conventional docs path."
+    return "Inferred planning regression context from a conventional tests path."
+
+
+def _inferred_authority_title(path: Path) -> str:
+    if path.as_posix() == ".agent-plan.md":
+        return "Agent Plan"
+    return path.stem.replace("_", " ").replace("-", " ").title()
+
+
+def _curated_source_for_path(sources: list[SourceRecord], path: str) -> SourceRecord | None:
+    for source in sources:
+        if source.superseded_by is not None:
+            continue
+        identities = {
+            source.path,
+            canonical_source_ref(source),
+            source.original_path or "",
+            source.source_ref or "",
+            *source.aliases,
+        }
+        if path in identities:
+            return source
+    return None
+
+
+def _provisional_authority_briefs(items: list[AuthorityBrief]) -> list[AuthorityBrief]:
+    return [item for item in items if item.curation_state == "provisional-uncurated"]
+
+
+def _curated_authority_briefs(items: list[AuthorityBrief]) -> list[AuthorityBrief]:
+    return [item for item in items if item.curation_state != "provisional-uncurated"]
 
 
 def _derived_authority_freshness(frontmatter: KnowledgePageFrontmatter) -> str:
@@ -1700,13 +1901,24 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
         title = (
             f"Review decision {authority.path}"
             if authority.role == "decision"
+            else f"Read provisional doc {authority.path}"
+            if authority.curation_state == "provisional-uncurated"
             else f"Read authority doc {authority.path}"
+        )
+        command_note = (
+            " Curate with: " + "; ".join(authority.curation_commands)
+            if authority.curation_commands
+            else ""
         )
         add(
             priority,
             "authority",
             title,
-            f"{authority.role}/{authority.freshness}/{authority.lifecycle}: {authority.reason}",
+            (
+                f"{authority.role}/{authority.freshness}/{authority.lifecycle}/"
+                f"{authority.origin}/{authority.curation_state}: {authority.reason}"
+                f"{command_note}"
+            ),
             None,
             path=authority.path,
             relevance_score=authority.score,
@@ -1942,6 +2154,9 @@ def render_suggest_next_json(result: SuggestNextResult) -> str:
             },
             "matches": [asdict(match) for match in result.matches],
             "authority_briefs": [asdict(brief) for brief in result.authority_briefs],
+            "provisional_context": {
+                "authority": [asdict(brief) for brief in result.provisional_context]
+            },
             "planning_items": [asdict(item) for item in result.planning_items],
             "latest_reports": [asdict(report) for report in result.latest_reports],
             "warnings": [asdict(warning) for warning in result.warnings],
@@ -1958,6 +2173,9 @@ def render_project_brief_json(brief: ProjectBrief) -> str:
             "status": asdict(brief.status),
             "matches": [asdict(match) for match in brief.matches],
             "authority_briefs": [asdict(item) for item in brief.authority_briefs],
+            "provisional_context": {
+                "authority": [asdict(item) for item in brief.provisional_context]
+            },
             "planning_items": [asdict(item) for item in brief.planning_items],
             "recent_sources": [asdict(source) for source in brief.recent_sources],
             "recent_runs": [asdict(run) for run in brief.recent_runs],
@@ -1994,6 +2212,9 @@ def render_agent_context_json(brief: ProjectBrief) -> str:
             },
             "matches": [asdict(match) for match in brief.matches],
             "authority_briefs": [asdict(item) for item in brief.authority_briefs],
+            "provisional_context": {
+                "authority": [asdict(item) for item in brief.provisional_context]
+            },
             "source_refs": _agent_context_source_refs(brief),
             "git_context": asdict(brief.git_context),
             "suggested_actions": [asdict(action) for action in brief.suggested_actions],

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2165,6 +2165,150 @@ def test_agent_context_hocrgen_retry_bar_ranks_current_planning_before_history(
     assert out.index("Active planning:") < out.index("Splendor maintenance:")
 
 
+def test_agent_context_hocrgen_retry_bar_uses_provisional_uncurated_authority(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path="docs/outside_review.md",
+            role="historical-review",
+            freshness="historical",
+            applies_to=["hocrgen F3b"],
+        )
+    ]
+    write_config(tmp_path, config)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\nCurrent critical path: F3a complete; next implementation step is F3b.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "# hocrgen\n\nF3b adds typed repo-tracked operator intake manifests.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "CONTRIBUTING.md").write_text(
+        "# Contributing\n\nRun planning tests before changing F3b planning docs.\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "HeOCR_hocrgen_long_term_roadmap.md").write_text(
+        "# Roadmap\n\n## Current critical path\n\nF3b follows F3a and precedes F4/F5.\n",
+        encoding="utf-8",
+    )
+    (docs / "modern_handwritten_acquisition_policy.md").write_text(
+        "# Modern Handwritten Acquisition Policy\n\n"
+        "F3b requires consent, release terms, privacy screening, and typed intake manifests.\n",
+        encoding="utf-8",
+    )
+    (docs / "outside_review.md").write_text(
+        "# Outside Review\n\nHistorical hocrgen review mentions F3b repeatedly.\n",
+        encoding="utf-8",
+    )
+    planning_test = tmp_path / "tests" / "test_planning_docs.py"
+    planning_test.parent.mkdir(exist_ok=True)
+    planning_test.write_text("def test_f3b_planning_docs():\n    assert 'F3b'\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "--no-git",
+            "Resume",
+            "hocrgen",
+            "planning",
+            "after",
+            "F3a",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    authority_paths = [item["path"] for item in payload["authority_briefs"]]
+    expected_provisional = {
+        ".agent-plan.md",
+        "docs/HeOCR_hocrgen_long_term_roadmap.md",
+        "docs/modern_handwritten_acquisition_policy.md",
+        "README.md",
+        "CONTRIBUTING.md",
+        "tests/test_planning_docs.py",
+    }
+    assert expected_provisional <= set(authority_paths)
+    assert all(
+        authority_paths.index(path) < authority_paths.index("docs/outside_review.md")
+        for path in expected_provisional
+    )
+    provisional = payload["provisional_context"]["authority"]
+    provisional_by_path = {item["path"]: item for item in provisional}
+    assert expected_provisional <= set(provisional_by_path)
+    agent_plan = provisional_by_path[".agent-plan.md"]
+    assert agent_plan["origin"] == "inferred-authority"
+    assert agent_plan["curation_state"] == "provisional-uncurated"
+    assert agent_plan["curation_commands"] == [
+        "splendor add-source .agent-plan.md",
+        "splendor ingest .agent-plan.md",
+    ]
+    assert (
+        payload["authority_briefs"][authority_paths.index("docs/outside_review.md")][
+            "curation_state"
+        ]
+        == "configured"
+    )
+    authority_actions = [
+        action for action in payload["suggested_actions"] if action["category"] == "authority"
+    ]
+    assert authority_actions[0]["path"] in expected_provisional
+    assert "provisional-uncurated" in authority_actions[0]["reason"]
+
+    suggest_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "--no-git",
+            "Resume",
+            "hocrgen",
+            "planning",
+            "after",
+            "F3a",
+            "--json",
+        ]
+    )
+    assert suggest_exit == 0
+    suggest_payload = json.loads(capsys.readouterr().out)
+    suggest_paths = [item["path"] for item in suggest_payload["authority_briefs"]]
+    assert suggest_paths.index(".agent-plan.md") < suggest_paths.index("docs/outside_review.md")
+    assert ".agent-plan.md" in {
+        item["path"] for item in suggest_payload["provisional_context"]["authority"]
+    }
+
+    text_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "--no-git",
+            "Resume",
+            "hocrgen",
+            "planning",
+            "after",
+            "F3a",
+        ]
+    )
+    assert text_exit == 0
+    out = capsys.readouterr().out
+    assert "Provisional uncurated docs:" in out
+    assert "Curate: splendor add-source .agent-plan.md; splendor ingest .agent-plan.md" in out
+    assert out.index("Provisional uncurated docs:") < out.index("Splendor maintenance:")
+
+
 def test_brief_plain_text_does_not_call_gh_by_default(tmp_path: Path, capsys, monkeypatch) -> None:
     initialize_workspace(tmp_path)
     _init_git_repo(tmp_path, repo="example/project")
@@ -2308,7 +2452,9 @@ def test_suggest_next_derives_draft_wiki_authority_freshness_as_watch(
     authority_actions = [
         action for action in payload["actions"] if action["category"] == "authority"
     ]
-    assert authority_actions[0]["reason"].startswith("current-authority/watch/current:")
+    assert authority_actions[0]["reason"].startswith(
+        "current-authority/watch/current/wiki-authority/curated:"
+    )
 
 
 def test_suggest_next_includes_lifecycle_aware_decision_authority(tmp_path: Path, capsys) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2309,6 +2309,72 @@ def test_agent_context_hocrgen_retry_bar_uses_provisional_uncurated_authority(
     assert out.index("Provisional uncurated docs:") < out.index("Splendor maintenance:")
 
 
+def test_agent_context_inferred_authority_stays_goal_relevant_and_below_configured(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path="docs/current_reference.md",
+            role="reference",
+            freshness="current",
+            applies_to=["hocrgen F3b"],
+        )
+    ]
+    write_config(tmp_path, config)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\nCurrent critical path: F3a complete; next implementation step is F3b.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "# hocrgen\n\nF3b adds typed repo-tracked operator intake manifests.\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "current_reference.md").write_text(
+        "# Current Reference\n\nConfigured hocrgen F3b reference.\n",
+        encoding="utf-8",
+    )
+    (docs / "some_other_plan.md").write_text(
+        "# Billing Migration Plan\n\nUnrelated rollout plan for billing imports.\n",
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "--no-git",
+            "Resume",
+            "hocrgen",
+            "planning",
+            "after",
+            "F3a",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    authority_paths = [item["path"] for item in payload["authority_briefs"]]
+    assert authority_paths.index("docs/current_reference.md") < authority_paths.index(
+        ".agent-plan.md"
+    )
+    assert "docs/some_other_plan.md" not in authority_paths
+    assert "docs/some_other_plan.md" not in {
+        item["path"] for item in payload["provisional_context"]["authority"]
+    }
+    configured = payload["authority_briefs"][authority_paths.index("docs/current_reference.md")]
+    assert configured["origin"] == "configured-authority"
+    assert configured["curation_state"] == "configured"
+
+
 def test_brief_plain_text_does_not_call_gh_by_default(tmp_path: Path, capsys, monkeypatch) -> None:
     initialize_workspace(tmp_path)
     _init_git_repo(tmp_path, repo="example/project")


### PR DESCRIPTION
## Summary

- Add runtime-only inferred authority fallback for conventional planning, policy, README/CONTRIBUTING, roadmap, and planning-test paths.
- Label uncurated inferred docs as provisional context with exact curation commands instead of presenting them as configured or curated authority.
- Keep work-first handoff behavior while ensuring current inferred planning authority outranks historical outside-review context for planning-resume goals.
- Update M18 planning state and schema/product docs for the new runtime JSON/text fields.

Closes #140

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

Note: `splendor lint` emitted a transient uv interpreter-cache warning, then completed successfully with `Lint check passed`.