### PR TITLE
M18-P3.1: Improve handoff reviewability and maintenance discoverability

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M18-P1.1`
-- Last action taken: `M18-P1.1` was squash-merged into main as commit `a40e810`,
-  adding git-aware, work-first agent handoff for v0.4 public readiness.
+- Previous completed PR sub-slice: `M18-P2.1`
+- Last action taken: `M18-P2.1` was squash-merged into main as commit `94db0be`,
+  adding inferred authority fallback and provisional uncurated-doc context.
 - Current planned slice: `M18 v0.4 work-first agent handoff`
-- Current PR sub-slice: `M18-P2.1`
+- Current PR sub-slice: `M18-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M18 v0.4 work-first agent handoff`
-- Next planned PR sub-slice: `M18-P3.1`
+- Next planned slice: `M19 pre-v1 workflow durability after v0.4`
+- Next planned PR sub-slice: `M19-P1.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -369,11 +369,15 @@
   - [x] Rank work context before Splendor maintenance for non-maintenance goals
   - [x] Separate work and maintenance context in agent-facing text and JSON output
   - [x] Cover the SynthBanshee and hocrgen retry bars with deterministic fixtures
-- [ ] Implement `M18-P2.1`: inferred authority fallback and provisional uncurated-doc context
+- [x] Implement `M18-P2.1`: inferred authority fallback and provisional uncurated-doc context
   - [x] Add runtime-only inferred authority candidates for conventional planning and policy paths
   - [x] Label provisional uncurated documents distinctly from configured and curated authority
   - [x] Pair provisional context with exact source curation commands
   - [x] Cover hocrgen-style planning resume with deterministic regression tests
+- [ ] Implement `M18-P3.1`: handoff reviewability and maintenance discoverability polish
+  - [x] Keep default implementation/planning handoff work-first
+  - [x] Expose review-needed wiki, missing synthesis, queue, freshness, and generated-review commands
+  - [x] Clarify task-list and wiki-status behavior for generated maintenance state
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,12 @@ hidden from default active planning handoff, and managed intentionally through t
 and mute workflows. Contested source-summary annotations and query metadata remain available when
 operators ask for contradiction evidence.
 
+Default `splendor task list` shows human-authored planning tasks. Generated contradiction-review
+tasks are available through `splendor task list --generated-review --review-task-state active` or
+`--include-generated-review`, and wiki review-needed pages or missing synthesis follow-up are
+reported through `splendor wiki status` and maintenance-focused handoff. This keeps generated
+maintenance state discoverable without turning it into normal implementation work by default.
+
 Generated source-summary pages are deterministic ingestion artifacts. For readable in-repo
 markdown/text/code sources, Splendor defaults to concise claim-bearing excerpts and path-first
 display; copied, external, parsed PDF, and OCR-derived sources keep fuller extracts by default
@@ -302,12 +308,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M18-P1.1`
+- Previous completed PR sub-slice: `M18-P2.1`
 - Current planned slice: `M18 v0.4 work-first agent handoff`
-- Current PR sub-slice: `M18-P2.1`
+- Current PR sub-slice: `M18-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M18 v0.4 work-first agent handoff`
-- Next planned PR sub-slice: `M18-P3.1`
+- Next planned slice: `M19 pre-v1 workflow durability after v0.4`
+- Next planned PR sub-slice: `M19-P1.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -588,3 +594,6 @@ work-first handoff before vector search or mutating web review workflows.
 `M18-P1.1` implements the first v0.4 handoff step: git-aware work context and structural
 work/maintenance separation. `M18-P2.1` adds labeled inferred-authority fallback for conventional
 planning and policy paths plus provisional uncurated-doc context with exact curation commands.
+`M18-P3.1` keeps normal implementation and planning handoff work-first while adding explicit
+maintenance command guidance for review-needed wiki pages, missing synthesis, source freshness,
+queue drift, and generated contradiction-review tasks.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -295,7 +295,9 @@ Implemented fields:
   deterministic `relevance_score` when available. Runtime authority entries also expose `origin`,
   `curation_state`, and `curation_commands`; provisional uncurated authority is repeated under
   `provisional_context` so agents can use it without confusing it for configured or curated source
-  authority.
+  authority. Maintenance context also exposes runtime-only command guidance and explanatory notes
+  so review-needed wiki state, missing synthesis, queue drift, source freshness, and generated
+  contradiction-review tasks stay discoverable without becoming default human planning records.
 - Suggested actions are derived from local git commits, best-effort read-only GitHub issue/PR
   context through `gh` when available, source freshness, queue operator state, invalid/stale/
   contested/review-needed wiki pages, ingested sources missing maintained synthesis follow-up,
@@ -512,6 +514,10 @@ Task records now also reserve:
 prioritize human-authored planning records while preserving explicit links back to the affected
 wiki pages and the ingest run that surfaced the conflict.
 
+Review-needed wiki pages and sources missing maintained synthesis are not represented as ordinary
+task records by default. Operators review them through `splendor wiki status`, `splendor wiki
+suggest <source-id>`, and the maintenance context in `brief --agent-context` / `suggest-next`.
+
 ## Query snapshots
 
 The latest saved query snapshot lives at `state/queries/last-query.json`.
@@ -657,8 +663,9 @@ Current runtime behavior:
   in `docs/releases/v1_release_handoff.md` treats schema version `1`, legacy manifest compatibility,
   and deferred source-lifecycle fields as release checklist items rather than implicit assumptions.
 - The v0.4 handoff direction should remain schema-version-1-compatible: git context, inferred
-  authority labels, provisional uncurated-doc context, and maintenance-section ranking are runtime
-  briefing signals unless a later PR explicitly defines persisted fields.
+  authority labels, provisional uncurated-doc context, maintenance-section ranking, and
+  maintenance command guidance are runtime briefing signals unless a later PR explicitly defines
+  persisted fields.
 
 ## Review config
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M18-P1.1`
+- Previous completed PR sub-slice: `M18-P2.1`
 - Current planned slice: `M18 v0.4 work-first agent handoff`
-- Current PR sub-slice: `M18-P2.1`
+- Current PR sub-slice: `M18-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M18 v0.4 work-first agent handoff`
-- Next planned PR sub-slice: `M18-P3.1`
+- Next planned slice: `M19 pre-v1 workflow durability after v0.4`
+- Next planned PR sub-slice: `M19-P1.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1249,6 +1249,9 @@ include runtime-only local git plus best-effort read-only GitHub issue/PR contex
 agent-facing output into work context before Splendor maintenance. `M18-P2.1` adds runtime-only
 inferred authority fallback and clearly labeled provisional uncurated-document context for
 conventional planning, roadmap, policy, README/CONTRIBUTING, and planning-test files.
+`M18-P3.1` polishes the public-readiness handoff by keeping implementation/planning goals
+work-first while exposing review-needed wiki pages, missing synthesis, queue/source maintenance,
+and generated contradiction-review tasks through explicit maintenance commands and notes.
 
 ## Milestone 19 — pre-v1 workflow durability after v0.4
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1112,6 +1112,9 @@ Current implementation:
   GitHub issue/PR context through `gh` when available, read-first file paths, relevant matches,
   source refs, active planning records, ranked authority docs, clearly labeled provisional
   uncurated docs, recent sources/runs, maintenance reports, warnings, and ranked suggested actions.
+  JSON maintenance context also includes deterministic command guidance and notes for review-needed
+  wiki pages, missing synthesis follow-up, source freshness, queue drift, and generated review
+  tasks.
 - `splendor suggest-next [--since <ref>] [--no-git] [goal]` renders the ranked action subset
   directly. It is read-only and deterministic. For non-maintenance goals it ranks open work
   threads, recent git/PR context, task-relevant authority docs, active planning records, read-first
@@ -1124,6 +1127,10 @@ Current implementation:
   tasks. Default `task list`, `brief --agent-context`, and `suggest-next` keep them out of active
   planning handoff; operators can list, resolve, or mute them explicitly with task subcommands, and
   contradiction-focused goals expose an intentional inspection action.
+- Default `task list` intentionally reports human-authored task records. Review-needed wiki pages
+  and missing maintained synthesis follow-up are generated maintenance state surfaced by
+  `splendor wiki status`, `splendor wiki suggest <source-id>`, and maintenance-focused handoff
+  notes rather than being converted into ordinary human planning tasks.
 - Authority docs come from `briefing.authority_documents` in `splendor.yaml` and optional
   maintained wiki page frontmatter (`authority_role`, `authority_freshness`, and
   `authority_lifecycle`, `authority_scope`, issue/PR refs, and supersession links). Generated
@@ -1165,7 +1172,9 @@ v0.4 direction from external trials:
 
 `M18-P1.1` implements the git-aware work-first ranking and work/maintenance separation while
 keeping all new context runtime-only. `M18-P2.1` implements inferred-authority and provisional
-uncurated-doc fallbacks as runtime briefing signals without a schema-version bump.
+uncurated-doc fallbacks as runtime briefing signals without a schema-version bump. `M18-P3.1`
+adds runtime maintenance command guidance for review-needed/generated state while preserving the
+work-first default for implementation and planning goals.
 
 ## 18. Search Model
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -1653,6 +1653,7 @@ def handle_wiki_status(args: argparse.Namespace) -> int:
     print(f"Machine-generated pages: {result.machine_generated_pages}")
     print(f"Contested pages: {result.contested_pages}")
     print(f"Stale pages: {result.stale_pages}")
+    print(f"Review-needed pages: {result.review_needed_pages}")
     print(f"Review-needed synthesis pages: {result.review_needed_synthesis_pages}")
     print(f"Sources missing synthesis follow-up: {result.sources_missing_synthesis}")
     print(f"Invalid wiki pages: {result.invalid_pages}")
@@ -1663,6 +1664,16 @@ def handle_wiki_status(args: argparse.Namespace) -> int:
         for run in result.recent_runs:
             finished = run.finished_at or "-"
             print(f"- {run.run_id} {run.status} finished={finished}")
+    if result.review_needed_pages or result.sources_missing_synthesis:
+        print(
+            "Note: review-needed wiki state is maintenance state, not default active human tasks."
+        )
+        print("Next maintenance commands:")
+        if result.review_needed_pages:
+            print("- Review pages reported above before relying on generated synthesis.")
+        if result.sources_missing_synthesis:
+            print("- splendor wiki suggest <source-id>")
+        print('- splendor brief --agent-context "wiki maintenance review"')
     return 0
 
 
@@ -2253,6 +2264,7 @@ def handle_brief(args: argparse.Namespace) -> int:
         print("Latest maintenance:")
         for report in result.latest_reports:
             print(f"- {report.command}: {report.status} issues={report.issue_count}")
+    _print_maintenance_guidance(result)
     if result.last_query is not None:
         print(f"Last query: {result.last_query.query} ({result.last_query.match_count} matches)")
     if result.warnings:
@@ -2352,13 +2364,7 @@ def _print_agent_context(result: ProjectBrief) -> None:
             print(
                 f"- [{action.priority}/{action.category}] {action.title} target={subject}{command}"
             )
-    print(
-        "Wiki status: "
-        f"sources={result.status.source_total} "
-        f"pages={result.status.page_total} "
-        f"queue_pending={result.status.queue_status_counts.get('pending', 0)} "
-        f"review_needed={result.status.review_needed_pages}"
-    )
+    _print_maintenance_guidance(result)
     if result.recent_sources:
         print("Recent sources:")
         for source in result.recent_sources:
@@ -2447,7 +2453,21 @@ def handle_suggest_next(args: argparse.Namespace) -> int:
             f"target={target}{command}"
         )
         print(f"   Reason: {action.reason}")
+    _print_maintenance_guidance(result)
     return 0
+
+
+def _print_maintenance_guidance(result) -> None:
+    if result.maintenance_commands:
+        print("Maintenance commands:")
+        for command in result.maintenance_commands:
+            target = command.source_ref or command.path or command.source_id or "-"
+            print(f"- [{command.category}] {command.command} target={target}")
+            print(f"  Reason: {command.reason}")
+    if result.maintenance_notes:
+        print("Maintenance notes:")
+        for note in result.maintenance_notes:
+            print(f"- {note}")
 
 
 def _suggested_action_target(action) -> str:
@@ -2667,6 +2687,26 @@ def handle_task_list(args: argparse.Namespace) -> int:
         )
     except ValueError as exc:
         return _print_error(exc)
+
+    if not rows:
+        if args.generated_review or args.review_task_state is not None:
+            print("No generated contradiction-review tasks matched.")
+        elif args.include_generated_review:
+            print("No task records matched.")
+        elif args.status is None and args.priority is None and args.milestone_ref is None:
+            print("No active human task records matched.")
+            print(
+                "Generated contradiction-review tasks are hidden by default; use "
+                "`splendor task list --generated-review --review-task-state active` or "
+                "`--include-generated-review` to inspect them."
+            )
+            print(
+                "Wiki review-needed pages and missing synthesis are maintenance state; use "
+                "`splendor wiki status` or maintenance-focused `splendor brief --agent-context`."
+            )
+        else:
+            print("No human task records matched the supplied filters.")
+        return 0
 
     for row in rows:
         if row.record_origin == "generated":

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -357,6 +357,16 @@ class SuggestedAction:
 
 
 @dataclass(frozen=True)
+class MaintenanceCommand:
+    category: str
+    command: str
+    reason: str
+    path: str | None = None
+    source_id: str | None = None
+    source_ref: str | None = None
+
+
+@dataclass(frozen=True)
 class GitCommitBrief:
     sha: str
     short_sha: str
@@ -409,6 +419,8 @@ class SuggestNextResult:
     git_context: GitContext
     work_actions: list[SuggestedAction]
     maintenance_actions: list[SuggestedAction]
+    maintenance_commands: list[MaintenanceCommand]
+    maintenance_notes: list[str]
     provisional_context: list[AuthorityBrief]
 
 
@@ -453,6 +465,8 @@ class ProjectBrief:
     suggested_actions: list[SuggestedAction]
     work_actions: list[SuggestedAction]
     maintenance_actions: list[SuggestedAction]
+    maintenance_commands: list[MaintenanceCommand]
+    maintenance_notes: list[str]
     provisional_context: list[AuthorityBrief]
     git_context: GitContext
     next_actions: list[str]
@@ -464,6 +478,7 @@ def build_project_brief(
     snapshot = _collect_brief_state(root, goal, include_git=include_git, since=since)
     suggested_actions = _ranked_suggestions(snapshot)
     work_actions, maintenance_actions = _split_actions(suggested_actions)
+    maintenance_commands, maintenance_notes = _maintenance_guidance(snapshot, maintenance_actions)
     next_actions = _next_actions(
         status=snapshot.status,
         matches=snapshot.matches,
@@ -487,6 +502,8 @@ def build_project_brief(
         suggested_actions=suggested_actions,
         work_actions=work_actions,
         maintenance_actions=maintenance_actions,
+        maintenance_commands=maintenance_commands,
+        maintenance_notes=maintenance_notes,
         provisional_context=_provisional_authority_briefs(snapshot.authority_briefs),
         git_context=snapshot.git_context,
         next_actions=next_actions,
@@ -499,6 +516,7 @@ def build_suggest_next(
     snapshot = _collect_brief_state(root, goal, include_git=include_git, since=since)
     actions = _ranked_suggestions(snapshot)
     work_actions, maintenance_actions = _split_actions(actions)
+    maintenance_commands, maintenance_notes = _maintenance_guidance(snapshot, maintenance_actions)
     return SuggestNextResult(
         goal=snapshot.goal,
         actions=actions,
@@ -513,6 +531,8 @@ def build_suggest_next(
         git_context=snapshot.git_context,
         work_actions=work_actions,
         maintenance_actions=maintenance_actions,
+        maintenance_commands=maintenance_commands,
+        maintenance_notes=maintenance_notes,
         provisional_context=_provisional_authority_briefs(snapshot.authority_briefs),
     )
 
@@ -1758,6 +1778,81 @@ def _next_actions(
     return actions
 
 
+def _maintenance_guidance(
+    snapshot: BriefStateSnapshot, maintenance_actions: list[SuggestedAction]
+) -> tuple[list[MaintenanceCommand], list[str]]:
+    commands: list[MaintenanceCommand] = []
+    notes: list[str] = []
+
+    def add(
+        category: str,
+        command: str,
+        reason: str,
+        *,
+        path: str | None = None,
+        source_id: str | None = None,
+        source_ref: str | None = None,
+    ) -> None:
+        candidate = MaintenanceCommand(
+            category=category,
+            command=command,
+            reason=reason,
+            path=path,
+            source_id=source_id,
+            source_ref=source_ref,
+        )
+        if all(existing.command != command for existing in commands):
+            commands.append(candidate)
+
+    if snapshot.status.review_needed_pages or snapshot.status.sources_missing_synthesis:
+        add(
+            "wiki-status",
+            "splendor wiki status",
+            "Review generated wiki maintenance counts before turning them into human work.",
+        )
+        notes.append(
+            "Wiki review-needed pages and missing synthesis are maintenance state, not default "
+            "active human tasks."
+        )
+
+    if snapshot.freshness.changed or snapshot.freshness.missing:
+        add(
+            "source-freshness",
+            "splendor source freshness",
+            "Inspect the full changed or missing curated source set.",
+        )
+    if any(
+        item.operator_state
+        in {"pending", "failed_due", "expired_leased", "dead_letter", "failed_backoff"}
+        for item in snapshot.queue.items
+    ):
+        add(
+            "queue",
+            "splendor queue inspect",
+            "Inspect generated ingest queue records and operator states.",
+        )
+
+    for action in maintenance_actions:
+        if action.command is None:
+            continue
+        add(
+            action.category,
+            action.command,
+            action.reason,
+            path=action.path,
+            source_id=action.source_id,
+            source_ref=action.source_ref,
+        )
+
+    if snapshot.generated_review_task_count:
+        notes.append(
+            "Default task list hides generated contradiction-review tasks; use "
+            "`--generated-review` or `--include-generated-review` when reviewing them."
+        )
+
+    return commands, list(dict.fromkeys(notes))
+
+
 def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
     actions: list[SuggestedAction] = []
     goal_tokens = _tokens(snapshot.goal or "")
@@ -1998,7 +2093,9 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
             relevance_score=item.relevance_score,
         )
 
-    if snapshot.generated_review_task_count and goal_tokens & _CONTRADICTION_GOAL_TOKENS:
+    if snapshot.generated_review_task_count and (
+        snapshot.maintenance_goal or goal_tokens & _CONTRADICTION_GOAL_TOKENS
+    ):
         add(
             "low",
             "contradiction-review",
@@ -2127,7 +2224,7 @@ def _review_page_actions(
                     f"Page `{page.frontmatter.title}` is {state}; verify current source-backed "
                     "synthesis before relying on it."
                 ),
-                "command": None,
+                "command": "splendor wiki status",
                 "path": page.path,
                 "record_id": page.frontmatter.page_id,
                 "relevance_score": _goal_relevance_score(
@@ -2182,6 +2279,8 @@ def render_suggest_next_json(result: SuggestNextResult) -> str:
             "work_context": {"actions": [asdict(action) for action in result.work_actions]},
             "maintenance_context": {
                 "actions": [asdict(action) for action in result.maintenance_actions],
+                "commands": [asdict(command) for command in result.maintenance_commands],
+                "notes": result.maintenance_notes,
                 "status": {
                     "changed_sources": result.freshness.changed,
                     "missing_sources": result.freshness.missing,
@@ -2247,7 +2346,9 @@ def render_project_brief_json(brief: ProjectBrief) -> str:
             "suggested_actions": [asdict(action) for action in brief.suggested_actions],
             "work_context": {"actions": [asdict(action) for action in brief.work_actions]},
             "maintenance_context": {
-                "actions": [asdict(action) for action in brief.maintenance_actions]
+                "actions": [asdict(action) for action in brief.maintenance_actions],
+                "commands": [asdict(command) for command in brief.maintenance_commands],
+                "notes": brief.maintenance_notes,
             },
             "next_actions": brief.next_actions,
         },
@@ -2282,6 +2383,8 @@ def render_agent_context_json(brief: ProjectBrief) -> str:
             "work_context": {"actions": [asdict(action) for action in brief.work_actions]},
             "maintenance_context": {
                 "actions": [asdict(action) for action in brief.maintenance_actions],
+                "commands": [asdict(command) for command in brief.maintenance_commands],
+                "notes": brief.maintenance_notes,
                 "wiki_status": {
                     "source_total": brief.status.source_total,
                     "page_total": brief.status.page_total,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4471,6 +4471,34 @@ def test_cli_task_list_command_supports_filters(tmp_path: Path, capsys) -> None:
     assert lines == ["task-write-cli-docs  todo  high  Write CLI docs"]
 
 
+def test_cli_task_list_empty_default_explains_generated_maintenance_state(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "task", "list"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "No active human task records matched." in out
+    assert "splendor task list --generated-review --review-task-state active" in out
+    assert "splendor wiki status" in out
+
+
+def test_cli_task_list_empty_filtered_output_stays_filter_specific(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "task", "list", "--status", "blocked"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "No human task records matched the supplied filters." in out
+    assert "generated-review" not in out
+    assert "wiki status" not in out
+
+
 def test_cli_task_list_hides_generated_review_tasks_by_default(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     main(["--root", str(tmp_path), "task", "create", "Write", "CLI", "docs"])

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -8,10 +8,12 @@ import yaml
 from splendor.cli import main
 from splendor.commands import brief as brief_module
 from splendor.commands.add_source import add_source
+from splendor.commands.ingest import enqueue_ingest_job
 from splendor.commands.init import initialize_workspace
 from splendor.commands.wiki import add_topic_page, rebuild_wiki_index
 from splendor.config import AuthorityDocumentConfig, load_config, write_config
 from splendor.schemas import KnowledgePageFrontmatter, MaintenanceReport, TaskRecord
+from splendor.state.runtime import load_queue_item, write_queue_item
 from splendor.state.source_registry import load_source_record
 from splendor.utils.planning import render_planning_markdown
 from splendor.utils.wiki import parse_wiki_markdown
@@ -399,7 +401,11 @@ def test_wiki_status_text_output_reports_stable_counts(tmp_path: Path, capsys) -
     assert "Wiki status" in out
     assert "Sources: total=1 registered=0 ingested=1 failed=0" in out
     assert "Machine-generated pages: 1" in out
+    assert "Review-needed pages: 1" in out
     assert "Review-needed synthesis pages: 0" in out
+    assert "Sources missing synthesis follow-up: 1" in out
+    assert "review-needed wiki state is maintenance state" in out
+    assert "splendor wiki suggest <source-id>" in out
 
 
 def test_wiki_status_uninitialized_workspace_reports_empty_state(tmp_path: Path, capsys) -> None:
@@ -1574,7 +1580,7 @@ def test_brief_agent_context_text_output_is_compact(tmp_path: Path, capsys) -> N
     out = capsys.readouterr().out
     assert "Agent context" in out
     assert "Suggested next:" in out
-    assert "Wiki status:" in out
+    assert "Splendor maintenance:" in out
     assert "Next actions:" in out
 
 
@@ -3045,6 +3051,190 @@ def test_suggest_next_exposes_generated_review_tasks_for_contradiction_goal(
     assert contradiction_actions[0]["command"] == (
         "splendor task list --generated-review --review-task-state active"
     )
+
+
+def test_maintenance_focused_handoff_exposes_review_and_generated_state_commands(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    reviewed_source = tmp_path / "reviewed.md"
+    reviewed_source.write_text("# Reviewed\n\nInitial maintenance source.\n", encoding="utf-8")
+    added_reviewed = add_source(tmp_path, reviewed_source)
+    main(["--root", str(tmp_path), "ingest", added_reviewed.source_id])
+    reviewed_source.write_text("# Reviewed\n\nChanged maintenance source.\n", encoding="utf-8")
+    queued_source = tmp_path / "queued.md"
+    queued_source.write_text("# Queued\n\nPending ingest source.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "queued.md"])
+    review_task = TaskRecord(
+        task_id="task-review-src-a-src-b-1234567890",
+        title="Review contradiction: A vs B",
+        status="todo",
+        priority="high",
+        record_origin="generated",
+        generated_kind="contradiction-review",
+        review_task_state="active",
+        created_at="2026-05-06T00:00:00Z",
+        updated_at="2026-05-06T00:00:00Z",
+    )
+    task_path = tmp_path / "planning" / "tasks" / f"{review_task.task_id}.md"
+    task_path.write_text(
+        render_planning_markdown(review_task, title=review_task.title),
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    suggest_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "wiki",
+            "maintenance",
+            "review",
+            "--json",
+        ]
+    )
+    suggest_payload = json.loads(capsys.readouterr().out)
+    brief_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "--no-git",
+            "wiki",
+            "maintenance",
+            "review",
+            "--json",
+        ]
+    )
+    brief_payload = json.loads(capsys.readouterr().out)
+
+    assert suggest_exit == 0
+    assert brief_exit == 0
+    suggest_commands = {
+        command["command"] for command in suggest_payload["maintenance_context"]["commands"]
+    }
+    brief_commands = {
+        command["command"] for command in brief_payload["maintenance_context"]["commands"]
+    }
+    expected_commands = {
+        "splendor wiki status",
+        f"splendor wiki suggest {added_reviewed.source_id}",
+        "splendor source freshness",
+        "splendor source refresh reviewed.md",
+        "splendor queue inspect",
+        "splendor ingest --pending",
+        "splendor task list --generated-review --review-task-state active",
+    }
+    assert expected_commands <= suggest_commands
+    assert expected_commands <= brief_commands
+    assert "contradiction-review" in {
+        action["category"] for action in suggest_payload["maintenance_context"]["actions"]
+    }
+    assert any(
+        "not default active human tasks" in note
+        for note in brief_payload["maintenance_context"]["notes"]
+    )
+    assert brief_payload["active_planning"] == []
+
+
+def test_implementation_handoff_keeps_maintenance_commands_below_work_context(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "create",
+            "Implement",
+            "handoff",
+            "polish",
+            "--id",
+            "task-handoff-polish",
+            "--status",
+            "in_progress",
+        ]
+    )
+    source = tmp_path / "review-needed.md"
+    source.write_text("# Review needed\n\nGenerated maintenance state.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    capsys.readouterr()
+
+    json_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "--no-git",
+            "implement",
+            "handoff",
+            "polish",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    text_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "--no-git",
+            "implement",
+            "handoff",
+            "polish",
+        ]
+    )
+    out = capsys.readouterr().out
+
+    assert json_exit == 0
+    assert text_exit == 0
+    assert payload["work_context"]["actions"]
+    assert payload["maintenance_context"]["actions"]
+    assert payload["maintenance_context"]["commands"]
+    assert all(
+        action["category"] not in {"synthesis", "wiki-review", "source-freshness", "queue"}
+        for action in payload["work_context"]["actions"]
+    )
+    assert out.index("Work context:") < out.index("Splendor maintenance:")
+    assert out.index("Splendor maintenance:") < out.index("Maintenance commands:")
+    assert "Wiki status:" not in out
+
+
+def test_maintenance_guidance_preserves_dead_letter_repair_command(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "dead-letter.md"
+    source.write_text("# Dead letter\n\nNeeds repair.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_record = load_queue_item(queue_path).model_copy(
+        update={"status": "dead_letter", "last_error": "broken ingest"}
+    )
+    write_queue_item(queue_path, queue_record)
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "wiki",
+            "maintenance",
+            "review",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    commands = {command["command"] for command in payload["maintenance_context"]["commands"]}
+    assert "splendor queue inspect" in commands
+    assert f"splendor repair ingest {added.source_id}" in commands
 
 
 def test_brief_skips_invalid_query_matches_without_failing(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

- add runtime-only maintenance command guidance and notes to `brief --agent-context` and `suggest-next` JSON/text handoff surfaces
- keep default implementation/planning handoff work-first while making review-needed wiki pages, missing synthesis, source freshness, queue drift, and generated contradiction-review tasks discoverable
- clarify `task list` and `wiki status` behavior so generated maintenance state is not confused with active human tasks
- update synchronized planning state for `M18-P3.1`

Closes #141

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

## Notes

- No persisted schema changes or schema-version bump.
- Handoff changes remain deterministic, local-first, and read-only.