### PR TITLE
M19-P1.1: Generated-state reviewability and compact committed mode

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M18-P2.1`
-- Last action taken: `M18-P2.1` was squash-merged into main as commit `94db0be`,
-  adding inferred authority fallback and provisional uncurated-doc context.
-- Current planned slice: `M18 v0.4 work-first agent handoff`
-- Current PR sub-slice: `M18-P3.1`
+- Previous completed PR sub-slice: `M18-P3.1`
+- Last action taken: `M18-P3.1` was squash-merged into main as commit `f3d75b8`,
+  improving handoff reviewability and maintenance discoverability.
+- Current planned slice: `M19 pre-v1 workflow durability after v0.4`
+- Current PR sub-slice: `M19-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Next planned PR sub-slice: `M19-P1.1`
+- Next planned PR sub-slice: `M19-P2.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -374,10 +374,14 @@
   - [x] Label provisional uncurated documents distinctly from configured and curated authority
   - [x] Pair provisional context with exact source curation commands
   - [x] Cover hocrgen-style planning resume with deterministic regression tests
-- [ ] Implement `M18-P3.1`: handoff reviewability and maintenance discoverability polish
+- [x] Implement `M18-P3.1`: handoff reviewability and maintenance discoverability polish
   - [x] Keep default implementation/planning handoff work-first
   - [x] Expose review-needed wiki, missing synthesis, queue, freshness, and generated-review commands
   - [x] Clarify task-list and wiki-status behavior for generated maintenance state
+- [ ] Implement `M19-P1.1`: generated-state reviewability and compact committed mode
+  - [x] Add compact committed review groups to `splendor pr-summary`
+  - [x] Keep generated runtime churn separate from maintained planning and wiki work
+  - [x] Expose PR-summary review guidance from agent handoff maintenance context
 
 ## Context Pointers
 

--- a/README.md
+++ b/README.md
@@ -308,12 +308,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M18-P2.1`
-- Current planned slice: `M18 v0.4 work-first agent handoff`
-- Current PR sub-slice: `M18-P3.1`
+- Previous completed PR sub-slice: `M18-P3.1`
+- Current planned slice: `M19 pre-v1 workflow durability after v0.4`
+- Current PR sub-slice: `M19-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Next planned PR sub-slice: `M19-P1.1`
+- Next planned PR sub-slice: `M19-P2.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -514,6 +514,12 @@ latest local maintenance report status. The human output is path-first and layou
 `--json` emits the same structure for agent handoff without mutating workspace state or depending
 on GitHub.
 
+`M19-P1.1` adds compact committed review groups to that same PR-summary surface. Human output now
+leads with review-first generated knowledge and maintained wiki changes, usually mechanical
+queue/run/report/query/derived churn, and attention items such as invalid manifests, failed latest
+local reports, or uncategorized paths. JSON exposes the same `compact_review` object for agent
+handoff, including action counts and per-path actions for compact add/change/delete/rename review.
+
 `M14-P3.1` records the internal source-lifecycle re-evaluation gate in
 `docs/evaluations/m14_synthbanshee_reevaluation.md`. The gate covers both the clean current state and a
 controlled changed-source exercise through freshness, full workspace refresh, PR summary, lint, and
@@ -597,3 +603,8 @@ planning and policy paths plus provisional uncurated-doc context with exact cura
 `M18-P3.1` keeps normal implementation and planning handoff work-first while adding explicit
 maintenance command guidance for review-needed wiki pages, missing synthesis, source freshness,
 queue drift, and generated contradiction-review tasks.
+
+`M19-P1.1` starts the pre-v1 durability track by making committed generated-state churn easier to
+review. `splendor pr-summary --since main` now includes compact committed review groups, and
+git-aware `brief --agent-context` / `suggest-next` expose that PR-summary command under Splendor
+maintenance context when a branch has Splendor-specific review groups or attention diagnostics.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -284,7 +284,12 @@ Implemented fields:
   source-summary pages, maintained wiki/topic pages, queue/run/report/derived generated-state
   churn, latest local lint/health report status when available, and reviewer notes. Malformed
   changed source manifests are reported as invalid curated-source changes instead of aborting the
-  whole summary. `--json` emits the same structure for agents. The command does not create
+  whole summary. Human output includes a compact committed review section before detailed path
+  groups. `--json` emits the same structure for agents, including `compact_review` with
+  `review_first`, `usually_mechanical`, and `attention` groups so reviewers can distinguish
+  generated knowledge changes from mechanical queue/run/report/query/derived churn. Compact groups
+  keep `paths` for quick scanning plus `path_actions` and `action_counts` for add/change/delete/
+  rename review without falling back to the detailed groups. The command does not create
   manifests, queue jobs, wiki pages, run records, reports, or GitHub state.
 - `splendor brief --agent-context [--since <ref>] [--no-git] [goal]` and
   `splendor suggest-next [--since <ref>] [--no-git] [goal]` are read-only handoff views over

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M18-P2.1`
-- Current planned slice: `M18 v0.4 work-first agent handoff`
-- Current PR sub-slice: `M18-P3.1`
+- Previous completed PR sub-slice: `M18-P3.1`
+- Current planned slice: `M19 pre-v1 workflow durability after v0.4`
+- Current PR sub-slice: `M19-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Next planned PR sub-slice: `M19-P1.1`
+- Next planned PR sub-slice: `M19-P2.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1265,6 +1265,17 @@ and consistently safe enough for public v1.
 - Orphan queue cleanup and closeable provenance-missing acknowledgements.
 - Reverse curated-source classification in `pr-summary`.
 - Public acceptance coverage for the SynthBanshee and hocrgen v0.4 retry bars.
+
+### Milestone 19 status
+
+`M19-P1.1` starts the pre-v1 durability track by adding compact committed review groups to
+`splendor pr-summary --since main`. The command now separates review-first source lifecycle,
+generated source-summary, and maintained wiki changes from usually mechanical queue, run, report,
+query, and derived churn, with attention groups for invalid manifests, non-passing latest local
+reports, and uncategorized paths. Git-aware agent handoff surfaces point reviewers back to that
+compact PR summary under Splendor maintenance context only when a branch has Splendor-specific
+review groups or attention diagnostics, without promoting generated maintenance state into default
+planning work.
 
 ## Milestone 20 — post-v1 product bets
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -850,8 +850,13 @@ Current implementation:
   existing report files to group curated source lifecycle changes, generated source-summary pages,
   maintained wiki/topic edits, queue/run/report/derived churn, latest local lint/health report
   status, and reviewer notes that separate meaningful generated knowledge from mechanical runtime
-  records. Latest maintenance status is explicitly reported as local report state rather than
-  fresh validation for the current `HEAD`. `--json` emits the same summary for agent handoff.
+  records. The compact committed review section leads with review-first knowledge and maintained
+  wiki changes, separates usually mechanical queue/run/report/query/derived churn, and flags
+  attention items such as invalid manifests, non-passing latest local reports, and uncategorized
+  paths. Compact JSON groups include action counts and per-path actions so reviewers can tell
+  additions, edits, deletions, and renames apart without expanding the detailed path groups. Latest
+  maintenance status is explicitly reported as local report state rather than fresh validation for
+  the current `HEAD`. `--json` emits the same summary for agent handoff.
 - `splendor add-topic "Title"` scaffolds a maintained topic page under `wiki/topics/<slug>.md`
   with valid knowledge-page frontmatter, optional tags/source refs, and deterministic markdown
   templates for default synthesis, research synthesis, and issue tracking.
@@ -1123,6 +1128,11 @@ Current implementation:
   Maintenance-focused goals can keep maintenance actions first. Handoff ranking uses deterministic
   relevance scoring over weighted title/path/record/scope fields, supporting refs, snippets,
   git/GitHub text, and review/authority lifecycle signals without introducing vector search.
+- Git-aware `brief --agent-context` and `suggest-next` include the `splendor pr-summary --since
+  <base>` command under Splendor maintenance context when a branch has Splendor-specific compact
+  review groups or attention diagnostics. This keeps compact committed generated-state review
+  discoverable without promoting it into normal work-first actions or adding noise to plain code
+  branches.
 - Generated contradiction-review tasks are classified separately from human-authored planning
   tasks. Default `task list`, `brief --agent-context`, and `suggest-next` keep them out of active
   planning handoff; operators can list, resolve, or mute them explicitly with task subcommands, and

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -1948,6 +1948,7 @@ def handle_pr_summary(args: argparse.Namespace) -> int:
     if summary.head is not None:
         print(f"Head: {summary.head}")
     print(f"Changed paths: {summary.changed_path_count}")
+    _print_compact_review(summary.compact_review)
     print("Curated sources:")
     if not summary.curated_sources:
         print("- none")
@@ -1987,6 +1988,28 @@ def handle_pr_summary(args: argparse.Namespace) -> int:
     for note in summary.reviewer_notes:
         print(f"- {note}")
     return 0
+
+
+def _print_compact_review(compact_review) -> None:
+    print("Compact committed review:")
+    print(f"- mode: {compact_review.mode}")
+    sections = (
+        ("Review first", compact_review.review_first),
+        ("Usually mechanical", compact_review.usually_mechanical),
+        ("Attention", compact_review.attention),
+    )
+    for label, groups in sections:
+        print(f"{label}:")
+        if not groups:
+            print("- none")
+            continue
+        for group in groups:
+            print(f"- {group.label}: total={group.total} role={group.review_role}")
+            print(f"  Summary: {group.summary}")
+            if group.paths:
+                print(f"  Paths: {', '.join(group.paths[:5])}")
+                if len(group.paths) > 5:
+                    print(f"  Additional paths: {len(group.paths) - 5}")
 
 
 def _print_path_group(label: str, group: PathGroup, *, indent: str = "") -> None:

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -28,6 +28,7 @@ from splendor.utils.planning import (
 )
 
 from .planning import is_generated_contradiction_review_task, model_for_planning_kind
+from .pr_summary import build_pr_summary
 from .query import QueryMatch, QueryValidationError, run_query
 from .queue import QueueInspectResult, inspect_queue
 from .source import SourceFreshnessResult, scan_source_freshness
@@ -1815,6 +1816,19 @@ def _maintenance_guidance(
             "active human tasks."
         )
 
+    if (
+        snapshot.git_context.enabled
+        and snapshot.git_context.available
+        and snapshot.git_context.base_ref is not None
+        and snapshot.git_context.merge_base is not None
+        and _has_pr_summary_reviewable_state(snapshot.root, snapshot.git_context.base_ref)
+    ):
+        add(
+            "pr-summary",
+            f"splendor pr-summary --since {snapshot.git_context.base_ref}",
+            "Review compact committed Splendor state changes before PR handoff.",
+        )
+
     if snapshot.freshness.changed or snapshot.freshness.missing:
         add(
             "source-freshness",
@@ -1851,6 +1865,19 @@ def _maintenance_guidance(
         )
 
     return commands, list(dict.fromkeys(notes))
+
+
+def _has_pr_summary_reviewable_state(root: Path, base_ref: str) -> bool:
+    try:
+        summary = build_pr_summary(root, since=base_ref)
+    except (FileNotFoundError, RuntimeError, ValueError):
+        return False
+    if summary.changed_path_count == 0:
+        return False
+    compact_review = summary.compact_review
+    if compact_review.review_first or compact_review.usually_mechanical:
+        return True
+    return any(group.id != "uncategorized_changed_paths" for group in compact_review.attention)
 
 
 def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:

--- a/src/splendor/commands/pr_summary.py
+++ b/src/splendor/commands/pr_summary.py
@@ -63,6 +63,33 @@ class MaintenanceStatus:
 
 
 @dataclass(frozen=True)
+class CompactReviewPath:
+    action: str
+    path: str
+    old_path: str | None = None
+
+
+@dataclass(frozen=True)
+class CompactReviewGroup:
+    id: str
+    label: str
+    review_role: str
+    total: int
+    paths: list[str]
+    path_actions: list[CompactReviewPath]
+    action_counts: dict[str, int]
+    summary: str
+
+
+@dataclass(frozen=True)
+class CompactReview:
+    mode: str
+    review_first: list[CompactReviewGroup]
+    usually_mechanical: list[CompactReviewGroup]
+    attention: list[CompactReviewGroup]
+
+
+@dataclass(frozen=True)
 class PrSummary:
     since: str
     merge_base: str
@@ -74,6 +101,7 @@ class PrSummary:
     generated_state: dict[str, PathGroup]
     other_paths: PathGroup
     maintenance: dict[str, MaintenanceStatus | None]
+    compact_review: CompactReview
     reviewer_notes: list[str]
 
 
@@ -133,8 +161,15 @@ def build_pr_summary(root: Path, *, since: str) -> PrSummary:
         generated_state=generated_state,
         other_paths=other_paths,
         maintenance=maintenance,
+        compact_review=CompactReview(
+            mode="compact_committed",
+            review_first=[],
+            usually_mechanical=[],
+            attention=[],
+        ),
         reviewer_notes=[],
     )
+    compact_review = _compact_review(summary)
     return PrSummary(
         since=summary.since,
         merge_base=summary.merge_base,
@@ -146,6 +181,7 @@ def build_pr_summary(root: Path, *, since: str) -> PrSummary:
         generated_state=summary.generated_state,
         other_paths=summary.other_paths,
         maintenance=summary.maintenance,
+        compact_review=compact_review,
         reviewer_notes=_reviewer_notes(summary),
     )
 
@@ -389,6 +425,194 @@ def _latest_maintenance_status(
         issue_count=report.issue_count,
         fatal_error=report.fatal_error,
     )
+
+
+def _compact_review(summary: PrSummary) -> CompactReview:
+    review_first: list[CompactReviewGroup] = []
+    usually_mechanical: list[CompactReviewGroup] = []
+    attention: list[CompactReviewGroup] = []
+
+    valid_curated_sources = [
+        source for source in summary.curated_sources if source.action != "invalid"
+    ]
+    if valid_curated_sources:
+        review_first.append(
+            CompactReviewGroup(
+                id="curated_sources",
+                label="Curated source manifests",
+                review_role="source lifecycle authority",
+                total=len(valid_curated_sources),
+                paths=sorted(source.path for source in valid_curated_sources),
+                path_actions=_source_change_actions(valid_curated_sources),
+                action_counts=_action_counts(source.action for source in valid_curated_sources),
+                summary=(
+                    "Review manifest lifecycle and source identity changes before generated "
+                    "wiki or runtime artifacts."
+                ),
+            )
+        )
+    if summary.source_summary_pages.total:
+        review_first.append(
+            _path_group_review(
+                "source_summary_pages",
+                "Generated source-summary pages",
+                "generated knowledge claims",
+                summary.source_summary_pages,
+                "Review extracted claims and provenance; these pages explain meaningful "
+                "generated knowledge changes.",
+            )
+        )
+    if summary.maintained_wiki_pages.total:
+        review_first.append(
+            _path_group_review(
+                "maintained_wiki_pages",
+                "Maintained wiki/topic pages",
+                "authored synthesis",
+                summary.maintained_wiki_pages,
+                "Review as authored maintained knowledge, including source_refs migrations.",
+            )
+        )
+
+    generated_roles = {
+        "queue": ("Generated queue records", "mechanical ingest queue evidence"),
+        "runs": ("Generated run records", "mechanical ingest run evidence"),
+        "queries": ("Generated query snapshots", "mechanical query handoff evidence"),
+        "reports": ("Generated report files", "mechanical maintenance report evidence"),
+        "derived": ("Derived generated artifacts", "mechanical derived artifact evidence"),
+    }
+    for key, group in summary.generated_state.items():
+        if not group.total:
+            continue
+        label, role = generated_roles[key]
+        usually_mechanical.append(
+            _path_group_review(
+                f"generated_{key}",
+                label,
+                role,
+                group,
+                "Usually review as committed evidence unless a failure or diagnostic changes "
+                "the reviewer decision.",
+            )
+        )
+
+    invalid_sources = [
+        source.path for source in summary.curated_sources if source.action == "invalid"
+    ]
+    if invalid_sources:
+        attention.append(
+            CompactReviewGroup(
+                id="invalid_curated_sources",
+                label="Invalid source manifests",
+                review_role="blocking source-manifest diagnostics",
+                total=len(invalid_sources),
+                paths=sorted(invalid_sources),
+                path_actions=[
+                    CompactReviewPath(action="invalid", path=path)
+                    for path in sorted(invalid_sources)
+                ],
+                action_counts={"invalid": len(invalid_sources)},
+                summary="Fix or explain invalid changed source manifests before PR handoff.",
+            )
+        )
+    failed_reports = [
+        status.path
+        for status in summary.maintenance.values()
+        if status is not None and status.status != "passed"
+    ]
+    if failed_reports:
+        attention.append(
+            CompactReviewGroup(
+                id="non_passing_maintenance_reports",
+                label="Non-passing latest maintenance reports",
+                review_role="local validation attention",
+                total=len(failed_reports),
+                paths=sorted(failed_reports),
+                path_actions=[
+                    CompactReviewPath(action="failed", path=path) for path in sorted(failed_reports)
+                ],
+                action_counts={"failed": len(failed_reports)},
+                summary="Inspect latest local lint/health reports before reviewer handoff.",
+            )
+        )
+    if summary.other_paths.total:
+        attention.append(
+            _path_group_review(
+                "uncategorized_changed_paths",
+                "Uncategorized changed paths",
+                "ordinary repository changes",
+                summary.other_paths,
+                "Review as normal code/docs changes outside Splendor generated-state groups.",
+            )
+        )
+
+    return CompactReview(
+        mode="compact_committed",
+        review_first=review_first,
+        usually_mechanical=usually_mechanical,
+        attention=attention,
+    )
+
+
+def _path_group_review(
+    group_id: str, label: str, review_role: str, group: PathGroup, summary: str
+) -> CompactReviewGroup:
+    return CompactReviewGroup(
+        id=group_id,
+        label=label,
+        review_role=review_role,
+        total=group.total,
+        paths=_path_group_paths(group),
+        path_actions=_path_group_actions(group),
+        action_counts=_path_group_action_counts(group),
+        summary=summary,
+    )
+
+
+def _path_group_paths(group: PathGroup) -> list[str]:
+    paths = [*group.added, *group.changed, *group.deleted]
+    paths.extend(f"{item['from']} -> {item['to']}" for item in group.renamed)
+    return sorted(paths)
+
+
+def _path_group_actions(group: PathGroup) -> list[CompactReviewPath]:
+    actions = [
+        *(CompactReviewPath(action="added", path=path) for path in group.added),
+        *(CompactReviewPath(action="changed", path=path) for path in group.changed),
+        *(CompactReviewPath(action="deleted", path=path) for path in group.deleted),
+        *(
+            CompactReviewPath(action="renamed", path=item["to"], old_path=item["from"])
+            for item in group.renamed
+        ),
+    ]
+    return sorted(actions, key=lambda item: (item.path, item.action, item.old_path or ""))
+
+
+def _path_group_action_counts(group: PathGroup) -> dict[str, int]:
+    return {
+        action: count
+        for action, count in {
+            "added": len(group.added),
+            "changed": len(group.changed),
+            "deleted": len(group.deleted),
+            "renamed": len(group.renamed),
+        }.items()
+        if count
+    }
+
+
+def _source_change_actions(sources: list[SourceChange]) -> list[CompactReviewPath]:
+    actions = [
+        CompactReviewPath(action=source.action, path=source.path, old_path=source.old_path)
+        for source in sources
+    ]
+    return sorted(actions, key=lambda item: (item.path, item.action, item.old_path or ""))
+
+
+def _action_counts(actions: Iterable[str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for action in actions:
+        counts[action] = counts.get(action, 0) + 1
+    return dict(sorted(counts.items()))
 
 
 def _reviewer_notes(summary: PrSummary) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2665,6 +2665,12 @@ def test_cli_pr_summary_reports_generated_state_without_mutating(tmp_path: Path,
     source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source)])
     main(["--root", str(tmp_path), "ingest", "--pending"])
+    write_queryable_wiki_page(
+        tmp_path / "wiki" / "topics" / "brief.md",
+        title="Brief synthesis",
+        page_id="topic-brief-synthesis",
+        body="Maintained synthesis changed for review.",
+    )
     main(["--root", str(tmp_path), "lint"])
     main(["--root", str(tmp_path), "health"])
     capsys.readouterr()
@@ -2688,6 +2694,44 @@ def test_cli_pr_summary_reports_generated_state_without_mutating(tmp_path: Path,
         f"state/queue/ingest-{source_manifest['source_id']}.json"
     ]
     assert payload["generated_state"]["runs"]["added"]
+    compact_review = payload["compact_review"]
+    assert compact_review["mode"] == "compact_committed"
+    review_first = {group["id"]: group for group in compact_review["review_first"]}
+    assert set(review_first) == {
+        "curated_sources",
+        "source_summary_pages",
+        "maintained_wiki_pages",
+    }
+    assert review_first["curated_sources"]["review_role"] == "source lifecycle authority"
+    assert review_first["curated_sources"]["action_counts"] == {"added": 1}
+    assert review_first["curated_sources"]["path_actions"] == [
+        {
+            "action": "added",
+            "old_path": None,
+            "path": source_manifest["path"],
+        }
+    ]
+    assert review_first["source_summary_pages"]["paths"] == [
+        f"wiki/sources/{source_manifest['source_id']}.md"
+    ]
+    assert review_first["source_summary_pages"]["action_counts"] == {"added": 1}
+    assert review_first["source_summary_pages"]["path_actions"] == [
+        {
+            "action": "added",
+            "old_path": None,
+            "path": f"wiki/sources/{source_manifest['source_id']}.md",
+        }
+    ]
+    assert "wiki/topics/brief.md" in review_first["maintained_wiki_pages"]["paths"]
+    usually_mechanical = {group["id"]: group for group in compact_review["usually_mechanical"]}
+    assert usually_mechanical["generated_queue"]["paths"] == [
+        f"state/queue/ingest-{source_manifest['source_id']}.json"
+    ]
+    assert usually_mechanical["generated_queue"]["action_counts"] == {"added": 1}
+    assert usually_mechanical["generated_runs"]["total"] == 1
+    assert usually_mechanical["generated_reports"]["total"] == 4
+    attention = {group["id"]: group for group in compact_review["attention"]}
+    assert attention["uncategorized_changed_paths"]["paths"] == ["brief.md"]
     assert payload["maintenance"]["lint"]["status"] == "passed"
     assert payload["maintenance"]["lint"]["scope"] == "latest_local_report"
     assert "not tied to the current HEAD" in payload["maintenance"]["lint"]["warning"]
@@ -2713,6 +2757,10 @@ def test_cli_pr_summary_human_output_is_path_first(tmp_path: Path, capsys) -> No
     out = capsys.readouterr().out
     assert "PR summary since main" in out
     assert "Merge base:" in out
+    assert out.index("Compact committed review:") < out.index("Curated sources:")
+    assert "Review first:" in out
+    assert "- Curated source manifests: total=1 role=source lifecycle authority" in out
+    assert "Usually mechanical:" in out
     assert re.search(r"- state/manifests/sources/src-[a-f0-9]+\.json: added", out)
     assert "Source ref: brief.md" in out
     assert "Generated state:" in out
@@ -2796,6 +2844,56 @@ def test_cli_pr_summary_reports_invalid_source_manifest_without_aborting(
     assert "Invalid JSON" in invalid_source["error"]
     assert invalid_source["path"] == "state/manifests/sources/src-bad.json"
     assert invalid_source["source_id"] == "src-bad"
+    review_first = {group["id"]: group for group in payload["compact_review"]["review_first"]}
+    assert "curated_sources" not in review_first
+    attention = {group["id"]: group for group in payload["compact_review"]["attention"]}
+    assert attention["invalid_curated_sources"]["paths"] == ["state/manifests/sources/src-bad.json"]
+    assert attention["invalid_curated_sources"]["action_counts"] == {"invalid": 1}
+    assert attention["invalid_curated_sources"]["path_actions"] == [
+        {
+            "action": "invalid",
+            "old_path": None,
+            "path": "state/manifests/sources/src-bad.json",
+        }
+    ]
+
+
+def test_cli_pr_summary_attention_flags_failed_reports_and_uncategorized_paths(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    _git_init_main(tmp_path)
+    (tmp_path / "notes.md").write_text("# Notes\n\nOrdinary changed path.\n", encoding="utf-8")
+    report_dir = tmp_path / "reports" / "lint"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = report_dir / "20260506T000000Z.json"
+    report = MaintenanceReport(
+        command="lint",
+        created_at="2026-05-06T00:00:00Z",
+        status="failed",
+        checked_count=1,
+        issue_count=1,
+        issues=[
+            MaintenanceIssue(
+                code="demo-failure",
+                message="Demonstrate failed latest local report attention.",
+            )
+        ],
+    )
+    report_path.write_text(report.model_dump_json(indent=2), encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "pr-summary", "--since", "main", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    attention = {group["id"]: group for group in payload["compact_review"]["attention"]}
+    assert attention["non_passing_maintenance_reports"]["paths"] == [
+        "reports/lint/20260506T000000Z.json"
+    ]
+    assert attention["non_passing_maintenance_reports"]["action_counts"] == {"failed": 1}
+    assert attention["uncategorized_changed_paths"]["action_counts"] == {"added": 1}
+    assert attention["uncategorized_changed_paths"]["paths"] == ["notes.md"]
 
 
 def _git_init_main(root: Path) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -3206,6 +3206,139 @@ def test_implementation_handoff_keeps_maintenance_commands_below_work_context(
     assert "Wiki status:" not in out
 
 
+def test_git_handoff_exposes_pr_summary_as_maintenance_command(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path)
+    _commit_all(tmp_path, "Initial workspace")
+    _git(tmp_path, "switch", "-c", "feature")
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "create",
+            "Implement",
+            "compact",
+            "review",
+            "--id",
+            "task-compact-review",
+            "--status",
+            "in_progress",
+        ]
+    )
+    source = tmp_path / "generated-state.md"
+    source.write_text("# Generated state\n\nNeeds compact review.\n", encoding="utf-8")
+    added_source = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added_source.source_id])
+    _commit_all(tmp_path, "Add compact review planning task")
+    capsys.readouterr()
+
+    brief_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "implement",
+            "compact",
+            "review",
+            "--json",
+        ]
+    )
+    brief_payload = json.loads(capsys.readouterr().out)
+    suggest_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "implement",
+            "compact",
+            "review",
+            "--json",
+        ]
+    )
+    suggest_payload = json.loads(capsys.readouterr().out)
+
+    assert brief_exit == 0
+    assert suggest_exit == 0
+    assert brief_payload["work_context"]["actions"]
+    assert suggest_payload["work_context"]["actions"]
+    assert all(
+        action["category"] != "pr-summary" for action in brief_payload["work_context"]["actions"]
+    )
+    brief_commands = {
+        command["command"] for command in brief_payload["maintenance_context"]["commands"]
+    }
+    suggest_commands = {
+        command["command"] for command in suggest_payload["maintenance_context"]["commands"]
+    }
+    assert "splendor pr-summary --since main" in brief_commands
+    assert "splendor pr-summary --since main" in suggest_commands
+
+
+def test_git_handoff_skips_pr_summary_for_plain_work_changes(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path)
+    _commit_all(tmp_path, "Initial workspace")
+    _git(tmp_path, "switch", "-c", "feature")
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "create",
+            "Implement",
+            "plain",
+            "work",
+            "--id",
+            "task-plain-work",
+            "--status",
+            "in_progress",
+        ]
+    )
+    _commit_all(tmp_path, "Add plain work planning task")
+    capsys.readouterr()
+
+    brief_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "implement",
+            "plain",
+            "work",
+            "--json",
+        ]
+    )
+    brief_payload = json.loads(capsys.readouterr().out)
+    suggest_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "implement",
+            "plain",
+            "work",
+            "--json",
+        ]
+    )
+    suggest_payload = json.loads(capsys.readouterr().out)
+
+    assert brief_exit == 0
+    assert suggest_exit == 0
+    assert brief_payload["work_context"]["actions"]
+    assert suggest_payload["work_context"]["actions"]
+    brief_commands = {
+        command["command"] for command in brief_payload["maintenance_context"]["commands"]
+    }
+    suggest_commands = {
+        command["command"] for command in suggest_payload["maintenance_context"]["commands"]
+    }
+    assert "splendor pr-summary --since main" not in brief_commands
+    assert "splendor pr-summary --since main" not in suggest_commands
+
+
 def test_maintenance_guidance_preserves_dead_letter_repair_command(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
     source = tmp_path / "dead-letter.md"


### PR DESCRIPTION
## Summary

- add compact committed review groups to `splendor pr-summary` text and JSON output
- separate review-first source/knowledge changes from usually mechanical generated queue/run/report/query/derived churn
- add attention groups for invalid manifests, failed latest local reports, and uncategorized paths
- expose `splendor pr-summary --since <base>` from git-aware handoff maintenance context when a branch has reviewable changes
- update synchronized planning state and docs for `M19-P1.1`

Closes #145

## Planning notation

- PR sub-slice: `M19-P1.1`
- Parent milestone: Milestone 19, pre-v1 workflow durability after v0.4
- Plan source: `.agent-plan.md`, README “What Comes Next”, and `docs/splendor_mvp_to_v1_roadmap.md`

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

## Notes

- No persisted schema changes or schema-version bump.
- No databases, background workers, vector search, OCR flow, or mutating web UI.
- Generated contradiction-review tasks remain generated maintenance state and are not promoted into default active planning handoff.
