### PR TITLE
M19-P2.1: Agent-safe preview/apply consistency

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M18-P3.1`
-- Last action taken: `M18-P3.1` was squash-merged into main as commit `f3d75b8`,
-  improving handoff reviewability and maintenance discoverability.
+- Previous completed PR sub-slice: `M19-P1.1`
+- Last action taken: `M19-P1.1` was squash-merged into main as commit `ca73d7b`,
+  adding compact generated-state review groups to `pr-summary`.
 - Current planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Current PR sub-slice: `M19-P1.1`
+- Current PR sub-slice: `M19-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Next planned PR sub-slice: `M19-P2.1`
+- Next planned PR sub-slice: `M19-P3.1`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -308,12 +308,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M18-P3.1`
+- Previous completed PR sub-slice: `M19-P1.1`
 - Current planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Current PR sub-slice: `M19-P1.1`
+- Current PR sub-slice: `M19-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Next planned PR sub-slice: `M19-P2.1`
+- Next planned PR sub-slice: `M19-P3.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -608,3 +608,7 @@ queue drift, and generated contradiction-review tasks.
 review. `splendor pr-summary --since main` now includes compact committed review groups, and
 git-aware `brief --agent-context` / `suggest-next` expose that PR-summary command under Splendor
 maintenance context when a branch has Splendor-specific review groups or attention diagnostics.
+`M19-P2.1` tightens agent-safe preview/apply consistency across mutating CLI surfaces. JSON
+outputs for reviewed compile, source cleanup/reconciliation, source refresh, and workspace refresh
+now expose a deterministic `mutation` object with `mode`, `mutates`, `planned`, and `written`
+fields, while human output labels preview-only invocations and apply/direct write modes clearly.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -278,6 +278,12 @@ Implemented fields:
   append a managed `Compiled Source Evidence` section to the markdown body, and validate the
   resulting `KnowledgePageFrontmatter` before reporting or writing. Generated source-summary pages
   are not valid compile targets.
+- Agent-safe preview/apply outputs use an additive `mutation` object where mutating behavior is
+  already part of the command contract. `mutation.mode` is `preview` or `apply`, `mutation.mutates`
+  is true only when the invocation wrote or removed workspace state, `mutation.planned` lists
+  deterministic planned write/delete records for preview mode, and `mutation.written` lists
+  deterministic write/delete records for apply or direct-write mode. Records include `action`,
+  `path`, `kind`, and `source_id` when source-scoped.
 - `splendor pr-summary --since main` is a read-only PR handoff view over local git diff/status and
   existing report files. It diffs from the merge base between `HEAD` and the base ref, respects
   configured workspace layout directories, and groups curated source manifests, generated

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M18-P3.1`
+- Previous completed PR sub-slice: `M19-P1.1`
 - Current planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Current PR sub-slice: `M19-P1.1`
+- Current PR sub-slice: `M19-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Next planned PR sub-slice: `M19-P2.1`
+- Next planned PR sub-slice: `M19-P3.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1276,6 +1276,13 @@ reports, and uncategorized paths. Git-aware agent handoff surfaces point reviewe
 compact PR summary under Splendor maintenance context only when a branch has Splendor-specific
 review groups or attention diagnostics, without promoting generated maintenance state into default
 planning work.
+
+`M19-P2.1` adds a compact mutation contract to existing preview/apply and direct-write CLI
+surfaces without introducing a transaction framework. Reviewed `wiki compile`, `source forget`,
+`source reconcile`, `source refresh`, and `workspace refresh` JSON outputs expose deterministic
+`mutation.mode`, `mutation.mutates`, `mutation.planned`, and `mutation.written` fields, and human
+output labels preview-only versus apply/direct write modes so agents can tell what is safe to run
+and what changed.
 
 ## Milestone 20 — post-v1 product bets
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -883,7 +883,13 @@ Current implementation:
   preview commands. With `--page <maintained-page>`, it proposes a deterministic source-summary
   evidence update and unified diff for one maintained synthesis page, and `--apply
   --proposal-hash <hash>` explicitly accepts and writes that page after frontmatter and
-  proposal-hash validation.
+  proposal-hash validation. JSON compile output includes a deterministic `mutation` object so
+  agents can distinguish preview-only proposals, apply no-ops, and applied writes without parsing
+  prose.
+- Preview/apply and direct-write CLI surfaces expose consistent mutation signals where natural:
+  `source forget`, `source reconcile`, `source refresh`, and `workspace refresh` JSON include
+  `mutation.mode`, `mutation.mutates`, `mutation.planned`, and `mutation.written`; human output
+  labels preview mode as non-mutating and apply/direct mode as writing workspace state.
 - `splendor wiki rebuild-index` rewrites `wiki/index.md` from validated wiki page frontmatter,
   including maintained synthesis pages and generated source-summary pages, without mutating the
   pages themselves.

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -82,6 +82,7 @@ from splendor.commands.source import (
     resolve_source_query_exact,
     scan_source_freshness,
     source_reconcile_next_commands,
+    source_refresh_written_records,
     update_source_path,
     write_source_freshness_report,
 )
@@ -107,6 +108,7 @@ from splendor.commands.wiki import (
 from splendor.commands.workspace import (
     refresh_workspace,
     render_workspace_refresh_json,
+    workspace_refresh_written_records,
 )
 from splendor.config import load_config
 from splendor.layout import resolve_layout
@@ -1117,6 +1119,7 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
         return 0
 
     if result.changed:
+        print("Mutation mode: apply")
         print(f"Detected changed source content for {canonical_source_ref(result.requested)}")
         print(f"Requested source ID: {result.requested.source_id}")
         if result.refreshed.record.source_id != result.requested.source_id:
@@ -1129,6 +1132,7 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
                 f"{result.requested.source_id} -> {result.refreshed.record.source_id}"
             )
     else:
+        print("Mutation mode: apply")
         print(f"No source content change detected for {canonical_source_ref(result.requested)}")
         print(f"Source ID: {result.requested.source_id}")
     print(f"Source ref: {result.refreshed.source_ref}")
@@ -1145,6 +1149,7 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
     else:
         print(f"Refresh skipped: {result.message}")
         print(f"Next: splendor wiki suggest {result.refreshed.record.source_id}")
+    _print_mutation_written_paths(source_refresh_written_records(root, result))
     return 0
 
 
@@ -1199,6 +1204,9 @@ def handle_source_reconcile(args: argparse.Namespace) -> int:
 
     action = "Applied source reconciliation" if result.applied else "Source reconciliation preview"
     print(action)
+    print(f"Mutation mode: {'apply' if result.applied else 'preview'}")
+    if not result.applied:
+        print("Preview only: no source manifests written.")
     print(f"Canonical source ref: {result.canonical_ref}")
     print(f"Current source ID: {result.current.source_id}")
     print(
@@ -1560,6 +1568,9 @@ def _print_source_lookup_results(results: list[SourceLookupResult]) -> None:
 def _print_source_forget_result(result: SourceForgetResult) -> None:
     mode = "applied" if result.applied else "preview"
     print(f"Source forget {mode}")
+    print(f"Mutation mode: {'apply' if result.applied else 'preview'}")
+    if not result.applied:
+        print("Preview only: no source manifests or generated source-owned state removed.")
     print(
         "Summary: "
         f"candidates={len(result.candidates)} "
@@ -1743,8 +1754,11 @@ def handle_wiki_compile(args: argparse.Namespace) -> int:
         print(f"Status: {result.source_status}")
         print(f"Target page: {result.target_path}")
         print(f"Source summary: {result.source_summary_path}")
+        print(f"Mutation mode: {result.mode}")
         print(f"Compile status: {result.status}")
         print(f"Mutates wiki: {'yes' if result.mutates else 'no'}")
+        if result.mode == "preview":
+            print("Preview only: no wiki pages written.")
         print(f"Target SHA-256: {result.target_sha256}")
         print(f"Source summary SHA-256: {result.source_summary_sha256}")
         print(f"Proposal hash: {result.proposal_hash}")
@@ -1767,7 +1781,9 @@ def handle_wiki_compile(args: argparse.Namespace) -> int:
     print(f"Title: {result.source_title}")
     print(f"Status: {result.source_status}")
     print("Compile contract: review-gated synthesis maintenance")
+    print("Mutation mode: preview")
     print("Mutates wiki: no")
+    print("Preview only: no wiki pages written.")
     for item in result.contract:
         print(f"- {item}")
     if result.suggested_pages:
@@ -1833,6 +1849,7 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
         return 0
 
     print("Workspace refresh")
+    print("Mutation mode: apply")
     print(
         "Initial freshness: "
         f"total={result.initial_freshness.total} "
@@ -1912,6 +1929,7 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
         f"unsupported={result.final_freshness.unsupported} "
         f"historical={result.final_freshness.historical}"
     )
+    _print_mutation_written_paths(workspace_refresh_written_records(root, result))
 
     if result.ingest is not None and result.ingest.failed:
         print("Next: splendor queue inspect")
@@ -1930,6 +1948,15 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
     else:
         print("Next: splendor source freshness")
     return 0
+
+
+def _print_mutation_written_paths(records: list[dict[str, str]]) -> None:
+    if not records:
+        print("Written paths: none")
+        return
+    print("Written paths:")
+    for record in records:
+        print(f"- {record['action']}: {record['kind']} {record['path']}")
 
 
 def handle_pr_summary(args: argparse.Namespace) -> int:

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from splendor import __version__
+from splendor.commands.mutation import mutation_record
 from splendor.config import load_config
 from splendor.ingest_dispatch import IMAGE_SOURCE_TYPES, dispatch_source_content
 from splendor.layout import resolve_layout
@@ -87,6 +88,7 @@ class IngestResult:
     no_op: bool
     canonical_ref: str | None
     content_origin_kind: str | None
+    written_records: list[dict[str, str]]
 
 
 @dataclass(frozen=True)
@@ -95,6 +97,7 @@ class DrainItemResult:
     queue_path: Path
     outcome: str
     message: str
+    written_records: list[dict[str, str]]
 
 
 @dataclass(frozen=True)
@@ -138,12 +141,13 @@ def pending_ingest_next_actions(result: DrainResult) -> list[str]:
     return ["splendor queue inspect"]
 
 
-def _drain_item_payload(root: Path, item: DrainItemResult) -> dict[str, str]:
+def _drain_item_payload(root: Path, item: DrainItemResult) -> dict[str, object]:
     return {
         "source_id": item.source_id,
         "queue_path": _relative_to_root(root, item.queue_path),
         "outcome": item.outcome,
         "message": item.message,
+        "written_records": item.written_records,
     }
 
 
@@ -816,6 +820,84 @@ def _commit_success(
         raise
 
 
+def _ingest_success_written_records(
+    *,
+    root: Path,
+    layout,
+    manifest_path: Path,
+    run_path: Path,
+    queue_path: Path,
+    wiki_payload: WikiUpdatePayload,
+    source_id: str,
+) -> list[dict[str, str]]:
+    records = [
+        mutation_record(
+            action="write",
+            path=_relative_to_root(root, manifest_path),
+            kind="source_manifest",
+            source_id=source_id,
+        ),
+        mutation_record(
+            action="write",
+            path=_relative_to_root(root, run_path),
+            kind="run_record",
+            source_id=source_id,
+        ),
+        mutation_record(
+            action="write",
+            path=_relative_to_root(root, queue_path),
+            kind="queue_record",
+            source_id=source_id,
+        ),
+        mutation_record(
+            action="write",
+            path=_relative_to_root(root, wiki_payload.page_path),
+            kind="source_summary_page",
+            source_id=source_id,
+        ),
+        mutation_record(
+            action="write",
+            path=_relative_to_root(root, layout.index_file),
+            kind="wiki_index",
+        ),
+        mutation_record(
+            action="write",
+            path=_relative_to_root(root, layout.log_file),
+            kind="wiki_log",
+        ),
+    ]
+    records.extend(
+        mutation_record(
+            action="write",
+            path=_relative_to_root(root, path),
+            kind=_extra_write_kind(root, path),
+            source_id=source_id if _extra_write_is_source_scoped(root, path) else None,
+        )
+        for path, _content in wiki_payload.extra_writes
+    )
+    return sorted(records, key=lambda item: (item["kind"], item["path"], item["action"]))
+
+
+def _extra_write_kind(root: Path, path: Path) -> str:
+    relpath = _relative_to_root(root, path)
+    if relpath.startswith("derived/metadata/"):
+        return "metadata_artifact"
+    if relpath.startswith("derived/"):
+        return "derived_artifact"
+    if relpath.startswith("planning/"):
+        return "planning_record"
+    if relpath.startswith("wiki/sources/"):
+        return "source_summary_page"
+    if relpath.startswith("wiki/"):
+        return "wiki_page"
+    return "artifact"
+
+
+def _extra_write_is_source_scoped(root: Path, path: Path) -> bool:
+    relpath = _relative_to_root(root, path)
+    return relpath.startswith(("derived/", "wiki/sources/"))
+
+
 def enqueue_ingest_job(root: Path, source_id: str) -> Path:
     config = load_config(root)
     layout = resolve_layout(root, config)
@@ -930,6 +1012,14 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
             no_op=True,
             canonical_ref=None,
             content_origin_kind=None,
+            written_records=[
+                mutation_record(
+                    action="write",
+                    path=_relative_to_root(root, queue_path),
+                    kind="queue_record",
+                    source_id=source.source_id,
+                )
+            ],
         )
 
     run_id = _make_run_id(source.source_id)
@@ -1196,6 +1286,39 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
                 "last_error": None,
             }
         )
+        extra_writes = [
+            *(
+                [
+                    (
+                        dispatched_content.derived_artifact_path,
+                        dispatched_content.derived_artifact_content,
+                    )
+                ]
+                if dispatched_content.derived_artifact_path is not None
+                and dispatched_content.derived_artifact_content is not None
+                else []
+            ),
+            *(
+                [
+                    (
+                        dispatched_content.metadata_artifact_path,
+                        dispatched_content.metadata_artifact_content,
+                    )
+                ]
+                if dispatched_content.metadata_artifact_path is not None
+                and dispatched_content.metadata_artifact_content is not None
+                else []
+            ),
+            *contradiction_review.page_updates,
+            *[(update.task_path, update.content) for update in contradiction_review.task_updates],
+        ]
+        wiki_payload = WikiUpdatePayload(
+            page_path=page_path,
+            page_content=page_content,
+            index_content=index_content,
+            log_content=log_content,
+            extra_writes=extra_writes,
+        )
         _commit_success(
             layout=layout,
             manifest_path=manifest_path,
@@ -1204,41 +1327,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
             success_run=success_run,
             queue_path=queue_path,
             success_queue=success_queue,
-            wiki_payload=WikiUpdatePayload(
-                page_path=page_path,
-                page_content=page_content,
-                index_content=index_content,
-                log_content=log_content,
-                extra_writes=[
-                    *(
-                        [
-                            (
-                                dispatched_content.derived_artifact_path,
-                                dispatched_content.derived_artifact_content,
-                            )
-                        ]
-                        if dispatched_content.derived_artifact_path is not None
-                        and dispatched_content.derived_artifact_content is not None
-                        else []
-                    ),
-                    *(
-                        [
-                            (
-                                dispatched_content.metadata_artifact_path,
-                                dispatched_content.metadata_artifact_content,
-                            )
-                        ]
-                        if dispatched_content.metadata_artifact_path is not None
-                        and dispatched_content.metadata_artifact_content is not None
-                        else []
-                    ),
-                    *contradiction_review.page_updates,
-                    *[
-                        (update.task_path, update.content)
-                        for update in contradiction_review.task_updates
-                    ],
-                ],
-            ),
+            wiki_payload=wiki_payload,
         )
         return IngestResult(
             source_id=source.source_id,
@@ -1249,6 +1338,15 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
             no_op=False,
             canonical_ref=resolved_source.canonical_ref,
             content_origin_kind=_content_origin_kind(resolved_source.storage_mode),
+            written_records=_ingest_success_written_records(
+                root=root,
+                layout=layout,
+                manifest_path=manifest_path,
+                run_path=run_path,
+                queue_path=queue_path,
+                wiki_payload=wiki_payload,
+                source_id=source.source_id,
+            ),
         )
     except ValueError as exc:
         _mark_attempt_failed(
@@ -1304,6 +1402,7 @@ def drain_pending_ingest_jobs(root: Path) -> DrainResult:
                     queue_path=queue_path,
                     outcome="skipped",
                     message=_skip_message(queue_item, now),
+                    written_records=[],
                 )
             )
             continue
@@ -1319,6 +1418,7 @@ def drain_pending_ingest_jobs(root: Path) -> DrainResult:
                     queue_path=queue_path,
                     outcome="failed",
                     message=str(exc),
+                    written_records=[],
                 )
             )
             continue
@@ -1331,6 +1431,7 @@ def drain_pending_ingest_jobs(root: Path) -> DrainResult:
                     queue_path=queue_path,
                     outcome="skipped",
                     message="already ingested for the current pipeline version",
+                    written_records=result.written_records,
                 )
             )
             continue
@@ -1343,6 +1444,7 @@ def drain_pending_ingest_jobs(root: Path) -> DrainResult:
                 queue_path=queue_path,
                 outcome="succeeded",
                 message=f"run {result.run_id}",
+                written_records=result.written_records,
             )
         )
 
@@ -1380,6 +1482,7 @@ def ingest_source(root: Path, source_id: str) -> IngestResult:
             no_op=True,
             canonical_ref=None,
             content_origin_kind=None,
+            written_records=[],
         )
 
     queue_path = enqueue_ingest_job(root, source_id)

--- a/src/splendor/commands/mutation.py
+++ b/src/splendor/commands/mutation.py
@@ -28,11 +28,26 @@ def mutation_contract(
     planned: Iterable[dict[str, str]] = (),
     written: Iterable[dict[str, str]] = (),
 ) -> dict[str, object]:
-    planned_items = list(planned)
-    written_items = list(written)
+    planned_items = dedupe_mutation_records(planned)
+    written_items = dedupe_mutation_records(written)
     return {
         "mode": mode,
         "mutates": bool(written_items),
         "planned": planned_items,
         "written": written_items,
     }
+
+
+def dedupe_mutation_records(
+    records: Iterable[dict[str, str]],
+) -> list[dict[str, str]]:
+    keyed: dict[tuple[str, str, str, str], dict[str, str]] = {}
+    for record in records:
+        key = (
+            record["kind"],
+            record["path"],
+            record["action"],
+            record.get("source_id", ""),
+        )
+        keyed[key] = record
+    return [keyed[key] for key in sorted(keyed)]

--- a/src/splendor/commands/mutation.py
+++ b/src/splendor/commands/mutation.py
@@ -1,0 +1,38 @@
+"""Small helpers for agent-safe CLI mutation contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def mutation_record(
+    *,
+    action: str,
+    path: str,
+    kind: str,
+    source_id: str | None = None,
+) -> dict[str, str]:
+    payload = {
+        "action": action,
+        "path": path,
+        "kind": kind,
+    }
+    if source_id is not None:
+        payload["source_id"] = source_id
+    return payload
+
+
+def mutation_contract(
+    *,
+    mode: str,
+    planned: Iterable[dict[str, str]] = (),
+    written: Iterable[dict[str, str]] = (),
+) -> dict[str, object]:
+    planned_items = list(planned)
+    written_items = list(written)
+    return {
+        "mode": mode,
+        "mutates": bool(written_items),
+        "planned": planned_items,
+        "written": written_items,
+    }

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from splendor.commands.ingest import enqueue_ingest_job, is_ingest_current, run_ingest_job
+from splendor.commands.mutation import mutation_contract, mutation_record
 from splendor.config import load_config
 from splendor.ingest_dispatch import SUPPORTED_SOURCE_TYPES
 from splendor.layout import resolve_layout
@@ -41,6 +42,7 @@ class SourceLookupResult:
 @dataclass(frozen=True)
 class SourceRefreshResult:
     requested: SourceRecord
+    requested_manifest_path: Path
     refreshed: RegisteredSource
     changed: bool
     queued: bool
@@ -330,6 +332,7 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
     if is_ingest_current(root, layout, refreshed.record):
         return SourceRefreshResult(
             requested=requested,
+            requested_manifest_path=requested_match.manifest_path,
             refreshed=refreshed,
             changed=changed,
             queued=False,
@@ -340,6 +343,7 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
     queue_path = enqueue_ingest_job(root, refreshed.record.source_id)
     return SourceRefreshResult(
         requested=requested,
+        requested_manifest_path=requested_match.manifest_path,
         refreshed=refreshed,
         changed=changed,
         queued=True,
@@ -856,6 +860,10 @@ def render_source_refresh_json(root: Path, result: SourceRefreshResult) -> str:
                 else result.queue_path.relative_to(root).as_posix()
             ),
             "message": result.message,
+            "mutation": mutation_contract(
+                mode="apply",
+                written=source_refresh_written_records(root, result),
+            ),
         },
         indent=2,
     )
@@ -886,6 +894,15 @@ def render_source_path_update_json(root: Path, result: SourcePathUpdateResult) -
 
 
 def render_source_reconcile_json(root: Path, result: SourceReconcileResult) -> str:
+    mutation_records = [
+        mutation_record(
+            action="write",
+            path=update.manifest_path.relative_to(root).as_posix(),
+            kind="source_manifest",
+            source_id=update.source.source_id,
+        )
+        for update in result.updates
+    ]
     return json.dumps(
         {
             "applied": result.applied,
@@ -901,6 +918,11 @@ def render_source_reconcile_json(root: Path, result: SourceReconcileResult) -> s
             },
             "updates": [_reconcile_update_payload(root, update) for update in result.updates],
             "next_commands": source_reconcile_next_commands(result),
+            "mutation": mutation_contract(
+                mode="apply" if result.applied else "preview",
+                planned=[] if result.applied else mutation_records,
+                written=mutation_records if result.applied else [],
+            ),
         },
         indent=2,
     )
@@ -914,6 +936,38 @@ def source_reconcile_next_commands(result: SourceReconcileResult) -> list[str]:
         command += " --apply"
         return [command]
     return ["splendor lint", "splendor health"]
+
+
+def source_refresh_written_records(root: Path, result: SourceRefreshResult) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    if result.changed:
+        records.append(
+            mutation_record(
+                action="write",
+                path=result.refreshed.manifest_path.relative_to(root).as_posix(),
+                kind="source_manifest",
+                source_id=result.refreshed.record.source_id,
+            )
+        )
+        if result.refreshed.record.source_id != result.requested.source_id:
+            records.append(
+                mutation_record(
+                    action="write",
+                    path=result.requested_manifest_path.relative_to(root).as_posix(),
+                    kind="source_manifest",
+                    source_id=result.requested.source_id,
+                )
+            )
+    if result.queued and result.queue_path is not None:
+        records.append(
+            mutation_record(
+                action="write",
+                path=result.queue_path.relative_to(root).as_posix(),
+                kind="queue_record",
+                source_id=result.refreshed.record.source_id,
+            )
+        )
+    return sorted(records, key=lambda item: (item["kind"], item["path"], item["action"]))
 
 
 def write_source_freshness_report(

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -941,6 +941,15 @@ def source_reconcile_next_commands(result: SourceReconcileResult) -> list[str]:
 def source_refresh_written_records(root: Path, result: SourceRefreshResult) -> list[dict[str, str]]:
     records: list[dict[str, str]] = []
     if result.changed:
+        if result.refreshed.copied and result.refreshed.stored_path is not None:
+            records.append(
+                mutation_record(
+                    action="write",
+                    path=result.refreshed.stored_path.relative_to(root).as_posix(),
+                    kind="source_artifact",
+                    source_id=result.refreshed.record.source_id,
+                )
+            )
         records.append(
             mutation_record(
                 action="write",

--- a/src/splendor/commands/source_forget.py
+++ b/src/splendor/commands/source_forget.py
@@ -9,6 +9,7 @@ from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Literal
 
+from splendor.commands.mutation import mutation_contract, mutation_record
 from splendor.commands.source import (
     SourceLookupResult,
     list_sources,
@@ -113,6 +114,15 @@ def forget_sources(
 
 
 def render_source_forget_json(root: Path, result: SourceForgetResult) -> str:
+    mutation_records = [
+        mutation_record(
+            action="delete",
+            path=action.path,
+            kind=action.kind,
+            source_id=action.source_id,
+        )
+        for action in result.actions
+    ]
     return json.dumps(
         {
             "applied": result.applied,
@@ -131,6 +141,11 @@ def render_source_forget_json(root: Path, result: SourceForgetResult) -> str:
                 _residual_reference_payload(residual) for residual in result.residual_references
             ],
             "next_commands": forget_next_commands(result),
+            "mutation": mutation_contract(
+                mode="apply" if result.applied else "preview",
+                planned=[] if result.applied else mutation_records,
+                written=mutation_records if result.applied else [],
+            ),
         },
         indent=2,
     )

--- a/src/splendor/commands/source_forget.py
+++ b/src/splendor/commands/source_forget.py
@@ -114,15 +114,7 @@ def forget_sources(
 
 
 def render_source_forget_json(root: Path, result: SourceForgetResult) -> str:
-    mutation_records = [
-        mutation_record(
-            action="delete",
-            path=action.path,
-            kind=action.kind,
-            source_id=action.source_id,
-        )
-        for action in result.actions
-    ]
+    mutation_records = _source_forget_mutation_records(result.actions)
     return json.dumps(
         {
             "applied": result.applied,
@@ -149,6 +141,30 @@ def render_source_forget_json(root: Path, result: SourceForgetResult) -> str:
         },
         indent=2,
     )
+
+
+def _source_forget_mutation_records(
+    actions: list[SourceForgetAction],
+) -> list[dict[str, str]]:
+    records: dict[tuple[str, str, str, str], dict[str, str]] = {}
+    for action in actions:
+        if action.kind == "wiki_index_entry":
+            record = mutation_record(action="write", path=action.path, kind="wiki_index")
+        else:
+            record = mutation_record(
+                action="delete",
+                path=action.path,
+                kind=action.kind,
+                source_id=action.source_id,
+            )
+        key = (
+            record["kind"],
+            record["path"],
+            record["action"],
+            record.get("source_id", ""),
+        )
+        records[key] = record
+    return [records[key] for key in sorted(records)]
 
 
 def forget_next_commands(result: SourceForgetResult) -> list[str]:

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import yaml
 from pydantic import ValidationError
 
+from splendor.commands.mutation import mutation_contract, mutation_record
 from splendor.commands.source import resolve_source_query, resolve_source_query_matches
 from splendor.config import load_config
 from splendor.layout import resolve_layout
@@ -157,6 +158,7 @@ class WikiCompileProposal:
     target_title: str
     target_kind: str
     source_summary_path: str
+    mode: str
     status: str
     mutates: bool
     applied: bool
@@ -847,6 +849,7 @@ def compile_source_into_page(
         target_title=target_page.frontmatter.title,
         target_kind=target_page.frontmatter.kind,
         source_summary_path=summary_page.path,
+        mode="apply" if apply else "preview",
         status=status,
         mutates=apply and changed,
         applied=apply and changed,
@@ -1144,11 +1147,25 @@ def render_wiki_suggest_json(result: WikiSuggestResult) -> str:
 
 
 def render_wiki_compile_contract_json(result: WikiCompileContract) -> str:
-    return json.dumps(asdict(result), indent=2)
+    payload = asdict(result)
+    payload["mutation"] = mutation_contract(mode="preview")
+    return json.dumps(payload, indent=2)
 
 
 def render_wiki_compile_proposal_json(result: WikiCompileProposal) -> str:
-    return json.dumps(asdict(result), indent=2)
+    payload = asdict(result)
+    record = mutation_record(
+        action="write",
+        path=result.target_path,
+        kind="maintained_wiki_page",
+        source_id=result.source_id,
+    )
+    payload["mutation"] = mutation_contract(
+        mode=result.mode,
+        planned=[record] if result.mode == "preview" and result.changed else [],
+        written=[record] if result.mode == "apply" and result.changed else [],
+    )
+    return json.dumps(payload, indent=2)
 
 
 def render_topic_scaffold_json(result: TopicScaffoldResult) -> str:

--- a/src/splendor/commands/workspace.py
+++ b/src/splendor/commands/workspace.py
@@ -522,6 +522,7 @@ def _drain_refreshed_ingest_jobs(root: Path, refreshed: list[SourceRefreshResult
                     queue_path=queue_path,
                     outcome="failed",
                     message=str(exc),
+                    written_records=[],
                 )
             )
             continue
@@ -534,6 +535,7 @@ def _drain_refreshed_ingest_jobs(root: Path, refreshed: list[SourceRefreshResult
                     queue_path=queue_path,
                     outcome="skipped",
                     message="already ingested for the current pipeline version",
+                    written_records=result.written_records,
                 )
             )
             continue
@@ -546,6 +548,7 @@ def _drain_refreshed_ingest_jobs(root: Path, refreshed: list[SourceRefreshResult
                 queue_path=queue_path,
                 outcome="succeeded",
                 message=f"run {result.run_id}",
+                written_records=result.written_records,
             )
         )
 
@@ -618,6 +621,7 @@ def _ingest_payload(root: Path, result: DrainResult) -> dict[str, object]:
                 "queue_path": item.queue_path.relative_to(root).as_posix(),
                 "outcome": item.outcome,
                 "message": item.message,
+                "written_records": item.written_records,
             }
             for item in result.items
         ],
@@ -653,31 +657,10 @@ def workspace_refresh_written_records(
 
 
 def _ingest_written_records(root: Path, result: DrainResult) -> list[dict[str, str]]:
+    del root
     records: list[dict[str, str]] = []
     for item in result.items:
-        if item.outcome != "succeeded" or not item.message.startswith("run "):
+        if item.outcome not in {"succeeded", "skipped"}:
             continue
-        run_id = item.message.removeprefix("run ")
-        records.extend(
-            [
-                mutation_record(
-                    action="write",
-                    path=item.queue_path.relative_to(root).as_posix(),
-                    kind="queue_record",
-                    source_id=item.source_id,
-                ),
-                mutation_record(
-                    action="write",
-                    path=f"state/runs/{run_id}.json",
-                    kind="run_record",
-                    source_id=item.source_id,
-                ),
-                mutation_record(
-                    action="write",
-                    path=f"wiki/sources/{item.source_id}.md",
-                    kind="source_summary_page",
-                    source_id=item.source_id,
-                ),
-            ]
-        )
+        records.extend(item.written_records)
     return records

--- a/src/splendor/commands/workspace.py
+++ b/src/splendor/commands/workspace.py
@@ -7,12 +7,14 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from splendor.commands.ingest import DrainItemResult, DrainResult, run_ingest_job
+from splendor.commands.mutation import mutation_contract, mutation_record
 from splendor.commands.source import (
     SourceFreshnessItem,
     SourceFreshnessResult,
     SourceRefreshResult,
     refresh_source,
     scan_source_freshness,
+    source_refresh_written_records,
 )
 from splendor.commands.wiki import WikiIndexRebuildResult, rebuild_wiki_index
 from splendor.config import load_config
@@ -300,6 +302,10 @@ def render_workspace_refresh_json(root: Path, result: WorkspaceRefreshResult) ->
             "pruning": None if result.pruning is None else asdict(result.pruning),
             "topic_ref_migration": (
                 None if result.topic_ref_migration is None else asdict(result.topic_ref_migration)
+            ),
+            "mutation": mutation_contract(
+                mode="apply",
+                written=workspace_refresh_written_records(root, result),
             ),
         },
         indent=2,
@@ -616,3 +622,62 @@ def _ingest_payload(root: Path, result: DrainResult) -> dict[str, object]:
             for item in result.items
         ],
     }
+
+
+def workspace_refresh_written_records(
+    root: Path, result: WorkspaceRefreshResult
+) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    for refresh in result.refreshed:
+        records.extend(source_refresh_written_records(root, refresh))
+    if result.ingest is not None:
+        records.extend(_ingest_written_records(root, result.ingest))
+    if result.index is not None:
+        records.append(mutation_record(action="write", path=result.index.path, kind="wiki_index"))
+    if result.pruning is not None:
+        records.extend(
+            mutation_record(
+                action="delete",
+                path=item.path,
+                kind="source_summary_page",
+                source_id=item.source_id,
+            )
+            for item in result.pruning.pruned
+        )
+    if result.topic_ref_migration is not None:
+        records.extend(
+            mutation_record(action="write", path=item.path, kind="maintained_wiki_page")
+            for item in result.topic_ref_migration.updated
+        )
+    return sorted(records, key=lambda item: (item["kind"], item["path"], item["action"]))
+
+
+def _ingest_written_records(root: Path, result: DrainResult) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    for item in result.items:
+        if item.outcome != "succeeded" or not item.message.startswith("run "):
+            continue
+        run_id = item.message.removeprefix("run ")
+        records.extend(
+            [
+                mutation_record(
+                    action="write",
+                    path=item.queue_path.relative_to(root).as_posix(),
+                    kind="queue_record",
+                    source_id=item.source_id,
+                ),
+                mutation_record(
+                    action="write",
+                    path=f"state/runs/{run_id}.json",
+                    kind="run_record",
+                    source_id=item.source_id,
+                ),
+                mutation_record(
+                    action="write",
+                    path=f"wiki/sources/{item.source_id}.md",
+                    kind="source_summary_page",
+                    source_id=item.source_id,
+                ),
+            ]
+        )
+    return records

--- a/src/splendor/commands/workspace.py
+++ b/src/splendor/commands/workspace.py
@@ -7,7 +7,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from splendor.commands.ingest import DrainItemResult, DrainResult, run_ingest_job
-from splendor.commands.mutation import mutation_contract, mutation_record
+from splendor.commands.mutation import dedupe_mutation_records, mutation_contract, mutation_record
 from splendor.commands.source import (
     SourceFreshnessItem,
     SourceFreshnessResult,
@@ -639,21 +639,29 @@ def workspace_refresh_written_records(
     if result.index is not None:
         records.append(mutation_record(action="write", path=result.index.path, kind="wiki_index"))
     if result.pruning is not None:
-        records.extend(
-            mutation_record(
-                action="delete",
-                path=item.path,
-                kind="source_summary_page",
-                source_id=item.source_id,
+        for item in result.pruning.pruned:
+            records.extend(
+                [
+                    mutation_record(
+                        action="delete",
+                        path=item.path,
+                        kind="source_summary_page",
+                        source_id=item.source_id,
+                    ),
+                    mutation_record(
+                        action="write",
+                        path=item.manifest_path,
+                        kind="source_manifest",
+                        source_id=item.source_id,
+                    ),
+                ]
             )
-            for item in result.pruning.pruned
-        )
     if result.topic_ref_migration is not None:
         records.extend(
             mutation_record(action="write", path=item.path, kind="maintained_wiki_page")
             for item in result.topic_ref_migration.updated
         )
-    return sorted(records, key=lambda item: (item["kind"], item["path"], item["action"]))
+    return dedupe_mutation_records(records)
 
 
 def _ingest_written_records(root: Path, result: DrainResult) -> list[dict[str, str]]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -186,6 +186,19 @@ def test_cli_source_reconcile_repairs_duplicate_active_versions(tmp_path: Path, 
     assert preview["current_source_id"] == expected_current.source_id
     assert preview["summary"] == {"active_before": 2, "updates": 2}
     assert preview["next_commands"] == ["splendor source reconcile brief.md --apply"]
+    assert preview["mutation"]["mode"] == "preview"
+    assert preview["mutation"]["mutates"] is False
+    assert preview["mutation"]["written"] == []
+    assert {
+        (item["action"], item["kind"], item["source_id"]) for item in preview["mutation"]["planned"]
+    } == {
+        ("write", "source_manifest", expected_current.source_id),
+        *{
+            ("write", "source_manifest", source_id)
+            for source_id in superseded_ids
+            if source_id in {update["source_id"] for update in preview["updates"]}
+        },
+    }
     assert {path.name: path.read_text(encoding="utf-8") for path in manifest_paths} == before_text
 
     ambiguous_current_code = main(
@@ -201,6 +214,7 @@ def test_cli_source_reconcile_repairs_duplicate_active_versions(tmp_path: Path, 
     assert apply_code == 0
     out = capsys.readouterr().out
     assert "Applied source reconciliation" in out
+    assert "Mutation mode: apply" in out
     assert f"Current source ID: {expected_current.source_id}" in out
     assert "Next: splendor lint" in out
     after_records = {
@@ -231,6 +245,10 @@ def test_cli_source_reconcile_explicit_source_id_selects_current(tmp_path: Path,
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["current_source_id"] == original_id
+    assert payload["mutation"]["mode"] == "apply"
+    assert payload["mutation"]["mutates"] is True
+    assert payload["mutation"]["planned"] == []
+    assert {item["kind"] for item in payload["mutation"]["written"]} == {"source_manifest"}
     records = {
         path.stem: load_source_record(path)
         for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
@@ -373,6 +391,14 @@ def test_cli_source_forget_preview_is_non_mutating(tmp_path: Path, capsys) -> No
     assert payload["applied"] is False
     assert payload["summary"]["candidates"] == 1
     assert {action["status"] for action in payload["actions"]} == {"planned"}
+    assert payload["mutation"]["mode"] == "preview"
+    assert payload["mutation"]["mutates"] is False
+    assert payload["mutation"]["written"] == []
+    assert {item["path"] for item in payload["mutation"]["planned"]} >= {
+        f"state/manifests/sources/{source_id}.json",
+        f"wiki/sources/{source_id}.md",
+        f"state/queue/ingest-{source_id}.json",
+    }
     assert manifest_path.exists()
     assert summary_path.exists()
     assert queue_path.exists()
@@ -408,6 +434,14 @@ def test_cli_source_forget_apply_removes_source_owned_state(tmp_path: Path, caps
     payload = json.loads(capsys.readouterr().out)
     assert payload["applied"] is True
     assert {action["status"] for action in payload["actions"]} == {"removed"}
+    assert payload["mutation"]["mode"] == "apply"
+    assert payload["mutation"]["mutates"] is True
+    assert payload["mutation"]["planned"] == []
+    assert {item["path"] for item in payload["mutation"]["written"]} >= {
+        f"state/manifests/sources/{source_id}.json",
+        f"wiki/sources/{source_id}.md",
+        f"state/queue/ingest-{source_id}.json",
+    }
     assert not manifest_path.exists()
     assert not summary_path.exists()
     assert not queue_path.exists()
@@ -727,9 +761,14 @@ def test_cli_source_forget_human_output_reports_next_commands(tmp_path: Path, ca
 
     assert preview_exit == 0
     assert "Source forget preview" in preview_output
+    assert "Mutation mode: preview" in preview_output
+    assert "Preview only: no source manifests or generated source-owned state removed." in (
+        preview_output
+    )
     assert f"Next: splendor source forget {source_id} --apply" in preview_output
     assert apply_exit == 0
     assert "Source forget applied" in apply_output
+    assert "Mutation mode: apply" in apply_output
     assert "Next: splendor lint" in apply_output
     assert "Next: splendor health" in apply_output
 
@@ -1285,12 +1324,15 @@ def test_cli_source_refresh_registers_changed_workspace_source_and_queues_it(
 
     assert exit_code == 0
     out = capsys.readouterr().out
+    assert "Mutation mode: apply" in out
     assert "Detected changed source content for brief.md" in out
     assert f"Requested source ID: {original_id}" in out
     manifests = sorted((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
     assert len(manifests) == 2
     refreshed_id = [path.stem for path in manifests if path.stem != original_id][0]
     assert f"Registered refreshed source ID: {refreshed_id}" in out
+    assert "Written paths:" in out
+    assert f"state/manifests/sources/{refreshed_id}.json" in out
     assert (tmp_path / "state" / "queue" / f"ingest-{refreshed_id}.json").exists()
     records = [load_source_record(path) for path in manifests]
     assert {record.logical_id for record in records} == {"source:brief.md"}
@@ -1357,6 +1399,7 @@ def test_cli_source_refresh_json_reports_queue_handoff(tmp_path: Path, capsys) -
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
+    mutation = payload.pop("mutation")
     refreshed_ids = [
         path.stem
         for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
@@ -1374,6 +1417,32 @@ def test_cli_source_refresh_json_reports_queue_handoff(tmp_path: Path, capsys) -
         "queued": True,
         "queue_path": f"state/queue/ingest-{refreshed_ids[0]}.json",
         "message": "queued ingest",
+    }
+    assert mutation["mode"] == "apply"
+    assert mutation["mutates"] is True
+    assert mutation["planned"] == []
+    assert {
+        (item["action"], item["kind"], item["path"], item["source_id"])
+        for item in mutation["written"]
+    } == {
+        (
+            "write",
+            "queue_record",
+            f"state/queue/ingest-{refreshed_ids[0]}.json",
+            refreshed_ids[0],
+        ),
+        (
+            "write",
+            "source_manifest",
+            f"state/manifests/sources/{original_id}.json",
+            original_id,
+        ),
+        (
+            "write",
+            "source_manifest",
+            f"state/manifests/sources/{refreshed_ids[0]}.json",
+            refreshed_ids[0],
+        ),
     }
 
 
@@ -1550,6 +1619,7 @@ def test_cli_source_refresh_by_path_uses_latest_matching_source_ref(tmp_path: Pa
 
     assert exit_code == 0
     out = capsys.readouterr().out
+    assert "Mutation mode: apply" in out
     assert "ambiguous" not in out
     assert "No source content change detected" in out
 
@@ -2104,6 +2174,12 @@ def test_cli_workspace_refresh_rebuilds_index_standalone(tmp_path: Path, capsys)
     assert payload["ingest"] is None
     assert payload["index"]["path"] == "wiki/index.md"
     assert payload["index"]["page_count"] == 0
+    assert payload["mutation"] == {
+        "mode": "apply",
+        "mutates": True,
+        "planned": [],
+        "written": [{"action": "write", "path": "wiki/index.md", "kind": "wiki_index"}],
+    }
 
 
 def test_cli_workspace_refresh_changed_ingests_and_rebuilds_index(tmp_path: Path, capsys) -> None:
@@ -2136,6 +2212,16 @@ def test_cli_workspace_refresh_changed_ingests_and_rebuilds_index(tmp_path: Path
     assert payload["ingest"]["failed"] == 0
     assert payload["ingest"]["succeeded"] == 1
     assert payload["index"]["path"] == "wiki/index.md"
+    assert payload["mutation"]["mode"] == "apply"
+    assert payload["mutation"]["mutates"] is True
+    assert payload["mutation"]["planned"] == []
+    assert {item["kind"] for item in payload["mutation"]["written"]} >= {
+        "queue_record",
+        "run_record",
+        "source_manifest",
+        "source_summary_page",
+        "wiki_index",
+    }
     refreshed = payload["refreshed"][0]
     assert refreshed["path"] == "brief.md"
     assert refreshed["requested_source_id"] == original_id

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2226,6 +2226,9 @@ def test_cli_workspace_refresh_rebuilds_index_standalone(tmp_path: Path, capsys)
 
 def test_cli_workspace_refresh_changed_ingests_and_rebuilds_index(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    write_config(tmp_path, config)
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source)])
@@ -2353,6 +2356,25 @@ def test_cli_workspace_refresh_prunes_superseded_summaries_standalone(
             "manifest_path": f"state/manifests/sources/{original_id}.json",
         }
     ]
+    assert payload["mutation"] == {
+        "mode": "apply",
+        "mutates": True,
+        "planned": [],
+        "written": [
+            {
+                "action": "write",
+                "path": f"state/manifests/sources/{original_id}.json",
+                "kind": "source_manifest",
+                "source_id": original_id,
+            },
+            {
+                "action": "delete",
+                "path": f"wiki/sources/{original_id}.md",
+                "kind": "source_summary_page",
+                "source_id": original_id,
+            },
+        ],
+    }
     assert not (tmp_path / "wiki" / "sources" / f"{original_id}.md").exists()
     original_manifest = load_source_record(
         tmp_path / "state" / "manifests" / "sources" / f"{original_id}.json"
@@ -2451,6 +2473,20 @@ def test_cli_workspace_refresh_prunes_superseded_summaries_and_updates_topic_ref
             "replacements": {original_id: refreshed_id},
         }
     ]
+    written_records = {
+        (item["action"], item["kind"], item["path"], item.get("source_id"))
+        for item in payload["mutation"]["written"]
+    }
+    assert written_records >= {
+        (
+            "write",
+            "source_manifest",
+            f"state/manifests/sources/{original_id}.json",
+            original_id,
+        ),
+        ("delete", "source_summary_page", f"wiki/sources/{original_id}.md", original_id),
+        ("write", "maintained_wiki_page", "wiki/topics/brief-synthesis.md", None),
+    }
     assert not (tmp_path / "wiki" / "sources" / f"{original_id}.md").exists()
     assert (tmp_path / "wiki" / "sources" / f"{refreshed_id}.md").exists()
     original_manifest = load_source_record(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -399,6 +399,9 @@ def test_cli_source_forget_preview_is_non_mutating(tmp_path: Path, capsys) -> No
         f"wiki/sources/{source_id}.md",
         f"state/queue/ingest-{source_id}.json",
     }
+    assert {
+        (item["action"], item["kind"], item["path"]) for item in payload["mutation"]["planned"]
+    } >= {("write", "wiki_index", "wiki/index.md")}
     assert manifest_path.exists()
     assert summary_path.exists()
     assert queue_path.exists()
@@ -442,6 +445,9 @@ def test_cli_source_forget_apply_removes_source_owned_state(tmp_path: Path, caps
         f"wiki/sources/{source_id}.md",
         f"state/queue/ingest-{source_id}.json",
     }
+    assert {
+        (item["action"], item["kind"], item["path"]) for item in payload["mutation"]["written"]
+    } >= {("write", "wiki_index", "wiki/index.md")}
     assert not manifest_path.exists()
     assert not summary_path.exists()
     assert not queue_path.exists()
@@ -805,6 +811,12 @@ def test_cli_source_forget_removes_materialized_copy_artifacts(tmp_path: Path, c
     assert {(item["kind"], item["path"]) for item in payload["actions"]} >= {
         ("materialized_artifact", f"raw/sources/{source_id}/external.md"),
         ("source_manifest", f"state/manifests/sources/{source_id}.json"),
+    }
+    assert {
+        (item["action"], item["kind"], item["path"]) for item in payload["mutation"]["written"]
+    } >= {
+        ("delete", "materialized_artifact", f"raw/sources/{source_id}/external.md"),
+        ("delete", "source_manifest", f"state/manifests/sources/{source_id}.json"),
     }
     assert not materialized_path.exists()
     assert not materialized_path.parent.exists()
@@ -1384,6 +1396,36 @@ def test_source_refresh_noop_returns_existing_materialized_path(tmp_path: Path, 
         tmp_path / "raw" / "sources" / result.refreshed.record.source_id / "brief.md"
     )
     assert result.refreshed.stored_path.exists()
+
+
+def test_cli_source_refresh_json_reports_materialized_artifact_write(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "--storage-mode", "copy", str(source)])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    refreshed_id = payload["source_id"]
+    assert refreshed_id != original_id
+    assert {
+        (item["action"], item["kind"], item["path"], item["source_id"])
+        for item in payload["mutation"]["written"]
+    } >= {
+        (
+            "write",
+            "source_artifact",
+            f"raw/sources/{refreshed_id}/brief.md",
+            refreshed_id,
+        )
+    }
 
 
 def test_cli_source_refresh_json_reports_queue_handoff(tmp_path: Path, capsys) -> None:
@@ -2215,13 +2257,6 @@ def test_cli_workspace_refresh_changed_ingests_and_rebuilds_index(tmp_path: Path
     assert payload["mutation"]["mode"] == "apply"
     assert payload["mutation"]["mutates"] is True
     assert payload["mutation"]["planned"] == []
-    assert {item["kind"] for item in payload["mutation"]["written"]} >= {
-        "queue_record",
-        "run_record",
-        "source_manifest",
-        "source_summary_page",
-        "wiki_index",
-    }
     refreshed = payload["refreshed"][0]
     assert refreshed["path"] == "brief.md"
     assert refreshed["requested_source_id"] == original_id
@@ -2229,6 +2264,37 @@ def test_cli_workspace_refresh_changed_ingests_and_rebuilds_index(tmp_path: Path
     refreshed_id = refreshed["source_id"]
     assert refreshed_id != original_id
     assert refreshed["supersedes"] == [original_id]
+    written = {
+        (item["action"], item["kind"], item["path"], item.get("source_id"))
+        for item in payload["mutation"]["written"]
+    }
+    run_records = [item for item in payload["mutation"]["written"] if item["kind"] == "run_record"]
+    assert len({item["path"] for item in run_records}) == 1
+    run_path = run_records[0]["path"]
+    assert written == {
+        (
+            "write",
+            "source_manifest",
+            f"state/manifests/sources/{original_id}.json",
+            original_id,
+        ),
+        (
+            "write",
+            "source_manifest",
+            f"state/manifests/sources/{refreshed_id}.json",
+            refreshed_id,
+        ),
+        (
+            "write",
+            "queue_record",
+            f"state/queue/ingest-{refreshed_id}.json",
+            refreshed_id,
+        ),
+        ("write", "run_record", run_path, refreshed_id),
+        ("write", "source_summary_page", f"wiki/sources/{refreshed_id}.md", refreshed_id),
+        ("write", "wiki_index", "wiki/index.md", None),
+        ("write", "wiki_log", "wiki/log.md", None),
+    }
     assert (tmp_path / "wiki" / "sources" / f"{refreshed_id}.md").exists()
     index_text = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
     assert f"sources/{refreshed_id}.md" in index_text

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -735,6 +735,12 @@ def test_wiki_compile_reports_review_gated_contract_without_mutating(
     assert payload["source_id"] == added.source_id
     assert payload["mutates"] is False
     assert payload["status"] == "contract-only"
+    assert payload["mutation"] == {
+        "mode": "preview",
+        "mutates": False,
+        "planned": [],
+        "written": [],
+    }
     assert payload["suggested_pages"] == []
     assert "Run `splendor wiki suggest" in payload["next_steps"][0]
     assert (
@@ -876,8 +882,22 @@ def test_wiki_compile_proposes_maintained_page_update_without_mutating(
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "proposed"
+    assert payload["mode"] == "preview"
     assert payload["mutates"] is False
     assert payload["changed"] is True
+    assert payload["mutation"] == {
+        "mode": "preview",
+        "mutates": False,
+        "planned": [
+            {
+                "action": "write",
+                "path": "wiki/topics/compile-loop.md",
+                "kind": "maintained_wiki_page",
+                "source_id": added.source_id,
+            }
+        ],
+        "written": [],
+    }
     assert payload["target_path"] == "wiki/topics/compile-loop.md"
     assert payload["source_summary_path"] == f"wiki/sources/{added.source_id}.md"
     assert added.source_id in payload["proposed_source_refs"]
@@ -925,6 +945,8 @@ def test_wiki_compile_text_proposal_prints_reviewable_diff_and_hash(tmp_path: Pa
     assert exit_code == 0
     out = capsys.readouterr().out
     assert "Target SHA-256:" in out
+    assert "Mutation mode: preview" in out
+    assert "Preview only: no wiki pages written." in out
     assert "Source summary SHA-256:" in out
     assert "Proposal hash:" in out
     assert "Proposed diff:" in out
@@ -988,7 +1010,21 @@ def test_wiki_compile_apply_updates_only_maintained_target_page(tmp_path: Path, 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "applied"
+    assert payload["mode"] == "apply"
     assert payload["mutates"] is True
+    assert payload["mutation"] == {
+        "mode": "apply",
+        "mutates": True,
+        "planned": [],
+        "written": [
+            {
+                "action": "write",
+                "path": "wiki/topics/compile-loop.md",
+                "kind": "maintained_wiki_page",
+                "source_id": added.source_id,
+            }
+        ],
+    }
     target = parse_wiki_markdown(tmp_path / "wiki" / "topics" / "compile-loop.md")
     assert target.frontmatter.kind == "topic"
     assert target.frontmatter.source_refs == [added.source_id]
@@ -1016,7 +1052,14 @@ def test_wiki_compile_apply_updates_only_maintained_target_page(tmp_path: Path, 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "no-op"
+    assert payload["mode"] == "preview"
     assert payload["mutates"] is False
+    assert payload["mutation"] == {
+        "mode": "preview",
+        "mutates": False,
+        "planned": [],
+        "written": [],
+    }
 
 
 def test_wiki_compile_inserts_additional_sources_inside_managed_section(


### PR DESCRIPTION
## Summary

Closes #147.

This PR implements `M19-P2.1` by adding an agent-safe mutation contract to existing preview/apply and direct-write CLI surfaces without introducing a broader transaction framework.

## Changes

- Adds a small additive `mutation` JSON object with `mode`, `mutates`, `planned`, and `written` fields.
- Applies the contract to reviewed `wiki compile`, `source forget`, `source reconcile`, `source refresh`, and `workspace refresh` outputs.
- Updates human output to label preview-only versus apply/direct write mode and list written paths for direct write maintenance flows.
- Preserves existing proposal-hash guards, generated/maintained separation, and M18/M19 handoff behavior.
- Updates synchronized planning state and docs for `M19-P2.1`.

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest tests/test_cli.py tests/test_wiki_commands.py`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

Note: `splendor lint` passed after uv emitted and removed a local interpreter-cache warning outside the repo.