### PR TITLE
M19-P3.1: Registry and queue cleanup closure paths

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M19-P1.1`
-- Last action taken: `M19-P1.1` was squash-merged into main as commit `ca73d7b`,
-  adding compact generated-state review groups to `pr-summary`.
+- Previous completed PR sub-slice: `M19-P2.1`
+- Last action taken: `M19-P2.1` was squash-merged into main as commit `da6375d`,
+  adding agent-safe mutation contracts across preview/apply CLI surfaces.
 - Current planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Current PR sub-slice: `M19-P2.1`
+- Current PR sub-slice: `M19-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Next planned PR sub-slice: `M19-P3.1`
+- Next planned slice: `M20 post-v1 product bets`
+- Next planned PR sub-slice: `M20-P1.1`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ Implemented today:
 - `splendor workspace refresh --changed` with optional `--ingest`, plus standalone or combined
   `--rebuild-index`, `--prune-superseded`, and `--update-topic-refs`
 - `splendor ingest <source-id>`, `splendor ingest --pending`, and `splendor ingest --changed`
-- `splendor queue inspect [job-id]` and `splendor queue retry <job-id>`
+- `splendor queue inspect [job-id]`, `splendor queue retry <job-id>`, and
+  `splendor queue clean --orphaned|--superseded|--completed`
 - `splendor repair ingest <source-id>`
 - `splendor materialize-source <source-id>`
 - `splendor query "<question>"`, `splendor query --tag <tag>`,
@@ -207,6 +208,13 @@ source-owned generated summaries, queue records, ingest run records, and safe ge
 maintained wiki/planning references and unsafe mixed historical state are reported as residual
 references for review instead of rewritten.
 
+`splendor queue clean --orphaned|--superseded|--completed` is the preview-first closure path for
+stale ingest queue records after registry maintenance. It reports planned queue JSON deletions by
+default and requires `--apply` before deleting anything. Orphan cleanup covers queue payloads whose
+source manifests are gone, superseded cleanup covers historical source versions, and completed
+cleanup covers `done` ingest jobs. Active leases, invalid payloads, unsupported job types, and
+source/job mismatches are skipped with explicit reasons.
+
 `splendor source reconcile <source-id|logical-id|title|path>` is the preview-first repair path for
 duplicate active canonical source versions. It resolves one canonical source-ref group, chooses the
 latest active source version as current unless an exact source ID or `--current` selector is
@@ -231,7 +239,8 @@ outcomes, and the summary.
 exists. JSON, human stdout, and Markdown reports surface missing active workspace source paths with
 `source update-path` / `source freshness` guidance, checksum drift with `source refresh`,
 `ingest --pending`, or `ingest --changed`, and queue repair diagnostics with `queue retry` or
-`repair ingest`. Unknown source provenance refs remain diagnostic-only rather than suggesting
+`repair ingest`. Stale queue closure diagnostics point to `queue clean` when queue records are
+orphaned, superseded, or completed. Unknown source provenance refs remain diagnostic-only rather than suggesting
 unsafe broad rewrites. Run source IDs are validated against the manifest store separately from
 source content freshness, so checksum drift does not become an unknown-source provenance failure.
 
@@ -308,12 +317,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M19-P1.1`
+- Previous completed PR sub-slice: `M19-P2.1`
 - Current planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Current PR sub-slice: `M19-P2.1`
+- Current PR sub-slice: `M19-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Next planned PR sub-slice: `M19-P3.1`
+- Next planned slice: `M20 post-v1 product bets`
+- Next planned PR sub-slice: `M20-P1.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -612,3 +621,5 @@ maintenance context when a branch has Splendor-specific review groups or attenti
 outputs for reviewed compile, source cleanup/reconciliation, source refresh, and workspace refresh
 now expose a deterministic `mutation` object with `mode`, `mutates`, `planned`, and `written`
 fields, while human output labels preview-only invocations and apply/direct write modes clearly.
+`M19-P3.1` adds preview/apply queue cleanup closure paths for orphaned, superseded, and completed
+ingest queue records, with additive cleanup state in queue inspection and maintenance handoff.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -175,7 +175,10 @@ This creates:
 Generated source-summary pages are reviewer-significant when they help explain a curated source,
 its provenance, or synthesis follow-up. Queue and run records are deterministic operational state;
 review them for broken references or surprising failures, but do not treat every timestamp-only
-record as hand-authored knowledge. Explicit reports under `reports/` should be committed only when
+record as hand-authored knowledge. Use `splendor queue clean --orphaned`,
+`splendor queue clean --superseded`, or `splendor queue clean --completed` to preview stale queue
+closure, then add `--apply` after reviewing the planned queue JSON deletions. Explicit reports
+under `reports/` should be committed only when
 they support the reviewed workspace update; failed or exploratory local reports can stay local.
 Readable in-repo markdown/text/code summaries default to concise excerpts, while external, copied,
 parsed PDF, and OCR-derived sources keep fuller extracts because the generated artifact may be the

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -217,7 +217,8 @@ Implemented fields:
   `--superseded` for queue records whose payload source has `superseded_by`, and `--completed` for
   `done` queue records. JSON output includes `mutation.mode`, `mutation.mutates`,
   `mutation.planned`, and `mutation.written`; skipped records report invalid payloads, unsupported
-  job types, active leases, and source/job mismatches without deleting them.
+  job types, active leases, queue filename/job ID mismatches, and source/job mismatches without
+  deleting them.
 - `splendor source reconcile <source-id|logical-id|title|path>` previews duplicate active source
   version repair for one canonical source-ref group. Without `--current`, an exact source ID keeps
   that source active; otherwise the latest active version by `(added_at, source_id)` is selected.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -210,6 +210,14 @@ Implemented fields:
   materialized artifacts under the source-owned raw artifact directory. Maintained wiki/planning
   references, malformed generated pages, mixed run records, and unsafe artifacts are reported as
   residual or skipped references rather than rewritten.
+- `splendor queue clean --orphaned|--superseded|--completed` provides preview-first closure for
+  stale ingest queue records. The command requires at least one selector, previews by default, and
+  requires `--apply` before deleting queue JSON. It selects only valid source-owned `ingest_source`
+  records that are not actively leased: `--orphaned` for missing source-manifest payloads,
+  `--superseded` for queue records whose payload source has `superseded_by`, and `--completed` for
+  `done` queue records. JSON output includes `mutation.mode`, `mutation.mutates`,
+  `mutation.planned`, and `mutation.written`; skipped records report invalid payloads, unsupported
+  job types, active leases, and source/job mismatches without deleting them.
 - `splendor source reconcile <source-id|logical-id|title|path>` previews duplicate active source
   version repair for one canonical source-ref group. Without `--current`, an exact source ID keeps
   that source active; otherwise the latest active version by `(added_at, source_id)` is selected.
@@ -572,7 +580,9 @@ Current persisted locations:
 Queue status values are `pending`, `leased`, `done`, `failed`, and `dead_letter`. Failed records may
 carry `next_attempt_at` to defer the next automatic `splendor ingest --pending` retry. Dead-letter
 records preserve `last_error` and require an explicit `splendor queue retry <job-id>` or
-`splendor repair ingest <source-id>` action.
+`splendor repair ingest <source-id>` action. Queue inspection also reports additive
+`cleanup_state` values so orphaned, superseded, completed, active-leased, invalid-payload, and
+non-candidate records can be distinguished without parsing payload paths by hand.
 
 Run records now reserve explicit provenance fields beside the original generic refs so later
 pipeline steps can answer questions like "which page did this run generate?" without parsing

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -581,8 +581,9 @@ Queue status values are `pending`, `leased`, `done`, `failed`, and `dead_letter`
 carry `next_attempt_at` to defer the next automatic `splendor ingest --pending` retry. Dead-letter
 records preserve `last_error` and require an explicit `splendor queue retry <job-id>` or
 `splendor repair ingest <source-id>` action. Queue inspection also reports additive
-`cleanup_state` values so orphaned, superseded, completed, active-leased, invalid-payload, and
-non-candidate records can be distinguished without parsing payload paths by hand.
+`cleanup_state` values so `orphaned`, `superseded`, `completed`, `active_leased`,
+`invalid_payload`, and `not_cleanup_candidate` records can be distinguished without parsing
+payload paths by hand.
 
 Run records now reserve explicit provenance fields beside the original generic refs so later
 pipeline steps can answer questions like "which page did this run generate?" without parsing

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M19-P1.1`
+- Previous completed PR sub-slice: `M19-P2.1`
 - Current planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Current PR sub-slice: `M19-P2.1`
+- Current PR sub-slice: `M19-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Next planned PR sub-slice: `M19-P3.1`
+- Next planned slice: `M20 post-v1 product bets`
+- Next planned PR sub-slice: `M20-P1.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1283,6 +1283,12 @@ surfaces without introducing a transaction framework. Reviewed `wiki compile`, `
 `mutation.mode`, `mutation.mutates`, `mutation.planned`, and `mutation.written` fields, and human
 output labels preview-only versus apply/direct write modes so agents can tell what is safe to run
 and what changed.
+
+`M19-P3.1` closes registry and queue cleanup gaps by adding preview/apply `splendor queue clean`
+paths for orphaned queue payloads, superseded source-version queues, and completed ingest jobs.
+Queue inspection now exposes additive cleanup state, and agent handoff keeps these closure commands
+discoverable under maintenance context without promoting generated queue cleanup above work-first
+handoff.
 
 ## Milestone 20 — post-v1 product bets
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -812,6 +812,13 @@ Current implementation:
   derived artifacts, and source-owned materialized artifacts. Maintained wiki/planning references,
   malformed generated pages, mixed historical records, and unsafe artifact paths are reported for
   operator review rather than rewritten.
+- `splendor queue clean --orphaned|--superseded|--completed` is the CLI-first closure path for
+  stale ingest queue records that no longer represent work. The command previews by default,
+  requires `--apply` before deleting queue JSON, and emits the same additive `mutation` object as
+  other preview/apply surfaces. It deletes only valid source-owned ingest queue records that are
+  not actively leased. Missing source-manifest payloads are orphaned, queues for superseded source
+  versions are superseded, and `done` queues are completed. Invalid payload refs, unsupported job
+  types, active leases, and source/job mismatches are skipped with explicit reasons.
 - `splendor source reconcile <source-id|logical-id|title|path>` is the CLI-first repair path for
   duplicate active versions of the same canonical source ref. The command previews by default,
   selects the latest active version unless an exact source ID or `--current` selector names the
@@ -887,9 +894,10 @@ Current implementation:
   agents can distinguish preview-only proposals, apply no-ops, and applied writes without parsing
   prose.
 - Preview/apply and direct-write CLI surfaces expose consistent mutation signals where natural:
-  `source forget`, `source reconcile`, `source refresh`, and `workspace refresh` JSON include
-  `mutation.mode`, `mutation.mutates`, `mutation.planned`, and `mutation.written`; human output
-  labels preview mode as non-mutating and apply/direct mode as writing workspace state.
+  `source forget`, `source reconcile`, `source refresh`, `workspace refresh`, and `queue clean`
+  JSON include `mutation.mode`, `mutation.mutates`, `mutation.planned`, and `mutation.written`;
+  human output labels preview mode as non-mutating and apply/direct mode as writing workspace
+  state.
 - `splendor wiki rebuild-index` rewrites `wiki/index.md` from validated wiki page frontmatter,
   including maintained synthesis pages and generated source-summary pages, without mutating the
   pages themselves.
@@ -1357,6 +1365,7 @@ splendor lint
 splendor health
 splendor queue inspect [job-id]
 splendor queue retry job-id
+splendor queue clean --orphaned|--superseded|--completed
 splendor repair ingest source-id
 splendor task create
 splendor milestone create

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -50,8 +50,10 @@ from splendor.commands.pr_summary import (
 from splendor.commands.query import run_query
 from splendor.commands.queue import (
     QueueItemSnapshot,
+    clean_queue,
     inspect_queue,
     inspect_queue_job,
+    render_queue_clean_json,
     render_queue_inspect_json,
     render_queue_item_json,
     render_queue_retry_json,
@@ -377,6 +379,36 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     queue_inspect_parser.set_defaults(handler=handle_queue_inspect)
+    queue_clean_parser = queue_subparsers.add_parser(
+        "clean", help="Preview or apply stale ingest queue cleanup"
+    )
+    queue_clean_parser.add_argument(
+        "--orphaned",
+        action="store_true",
+        help="Select ingest queue records whose source manifest payload is missing.",
+    )
+    queue_clean_parser.add_argument(
+        "--superseded",
+        action="store_true",
+        help="Select ingest queue records for superseded source versions.",
+    )
+    queue_clean_parser.add_argument(
+        "--completed",
+        action="store_true",
+        help="Select completed ingest queue records.",
+    )
+    queue_clean_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Delete selected queue records. Without this flag, queue clean only previews.",
+    )
+    queue_clean_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON output.",
+    )
+    queue_clean_parser.set_defaults(handler=handle_queue_clean)
     queue_retry_parser = queue_subparsers.add_parser(
         "retry", help="Reset a failed queue job for another ingest attempt"
     )
@@ -1462,10 +1494,16 @@ def handle_queue_inspect(args: argparse.Namespace) -> int:
     for item in result.items:
         print(
             f"- {item.job_id} [{item.status}/{item.operator_state}] type={item.job_type} "
-            f"attempts={item.attempt_count}/{item.max_attempts} payload={item.payload_ref}"
+            f"attempts={item.attempt_count}/{item.max_attempts} "
+            f"cleanup={item.cleanup_state} payload={item.payload_ref}"
         )
     operator_states = {item.operator_state for item in result.items}
-    if operator_states.intersection({"pending", "failed_due", "expired_leased"}):
+    cleanup_states = {item.cleanup_state for item in result.items}
+    if "orphaned" in cleanup_states:
+        print("Next: splendor queue clean --orphaned --apply")
+    elif "superseded" in cleanup_states:
+        print("Next: splendor queue clean --superseded --apply")
+    elif operator_states.intersection({"pending", "failed_due", "expired_leased"}):
         print("Next: splendor ingest --pending")
     elif "dead_letter" in operator_states:
         print("Next: splendor queue retry <job-id> or splendor repair ingest <source-id>")
@@ -1473,6 +1511,53 @@ def handle_queue_inspect(args: argparse.Namespace) -> int:
         print("Next: wait for retry backoff or run splendor queue retry <job-id>")
     elif result.status_counts.get("failed", 0):
         print("Next: splendor queue retry <job-id>")
+    return 0
+
+
+def handle_queue_clean(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    try:
+        result = clean_queue(
+            root,
+            orphaned=args.orphaned,
+            superseded=args.superseded,
+            completed=args.completed,
+            apply=args.apply,
+        )
+    except ValueError as exc:
+        return _print_error(exc)
+
+    if args.json_output:
+        print(render_queue_clean_json(root, result))
+        return 0
+
+    print("Applied queue cleanup" if result.applied else "Queue cleanup preview")
+    print(f"Mutation mode: {'apply' if result.applied else 'preview'}")
+    if not result.applied:
+        print("Preview only: no queue records deleted.")
+    print(f"Selectors: {', '.join(result.selectors)}")
+    if result.actions:
+        print("Deleted queue records:" if result.applied else "Planned queue deletions:")
+        for action in result.actions:
+            print(
+                f"- {action.path} [{action.cleanup_state}] "
+                f"job_id={action.job_id} source_id={action.source_id or '-'}"
+            )
+    else:
+        print("Planned queue deletions: none")
+    if result.skipped:
+        print("Skipped queue records:")
+        for action in result.skipped:
+            print(
+                f"- {action.path} [{action.cleanup_state}] "
+                f"job_id={action.job_id} source_id={action.source_id or '-'} "
+                f"reason={action.reason or '-'}"
+            )
+    if not result.applied and result.actions:
+        selector_flags = " ".join(f"--{selector}" for selector in result.selectors)
+        print(f"Next: splendor queue clean {selector_flags} --apply")
+    else:
+        print("Next: splendor queue inspect")
     return 0
 
 
@@ -1531,12 +1616,17 @@ def _print_queue_item_detail(item: QueueItemSnapshot) -> None:
     print(f"Payload: {item.payload_ref}")
     print(f"Source ID: {item.source_id or '-'}")
     print(f"Operator state: {item.operator_state}")
+    print(f"Cleanup state: {item.cleanup_state}")
     print(f"Lease owner: {item.lease_owner or '-'}")
     print(f"Lease expires: {item.lease_expires_at or '-'}")
     print(f"Next attempt: {item.next_attempt_at or '-'}")
     print(f"Last error: {item.last_error or '-'}")
     print(f"Record: {item.record_path}")
-    if item.status == "dead_letter":
+    if item.cleanup_state == "orphaned":
+        print("Next: splendor queue clean --orphaned --apply")
+    elif item.cleanup_state == "superseded":
+        print("Next: splendor queue clean --superseded --apply")
+    elif item.status == "dead_letter":
         print(
             f"Next: splendor queue retry {item.job_id} or splendor repair ingest {item.source_id}"
         )

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -1511,6 +1511,8 @@ def handle_queue_inspect(args: argparse.Namespace) -> int:
         print("Next: splendor queue clean --orphaned --apply")
     elif "superseded" in cleanup_states:
         print("Next: splendor queue clean --superseded --apply")
+    elif "completed" in cleanup_states:
+        print("Next: splendor queue clean --completed --apply")
     return 0
 
 
@@ -1627,6 +1629,8 @@ def _print_queue_item_detail(item: QueueItemSnapshot) -> None:
         print("Next: splendor queue clean --orphaned --apply")
     elif item.cleanup_state == "superseded":
         print("Next: splendor queue clean --superseded --apply")
+    elif item.cleanup_state == "completed":
+        print("Next: splendor queue clean --completed --apply")
     elif item.status == "dead_letter":
         print(
             f"Next: splendor queue retry {item.job_id} or splendor repair ingest {item.source_id}"

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -1499,11 +1499,7 @@ def handle_queue_inspect(args: argparse.Namespace) -> int:
         )
     operator_states = {item.operator_state for item in result.items}
     cleanup_states = {item.cleanup_state for item in result.items}
-    if "orphaned" in cleanup_states:
-        print("Next: splendor queue clean --orphaned --apply")
-    elif "superseded" in cleanup_states:
-        print("Next: splendor queue clean --superseded --apply")
-    elif operator_states.intersection({"pending", "failed_due", "expired_leased"}):
+    if operator_states.intersection({"pending", "failed_due", "expired_leased"}):
         print("Next: splendor ingest --pending")
     elif "dead_letter" in operator_states:
         print("Next: splendor queue retry <job-id> or splendor repair ingest <source-id>")
@@ -1511,6 +1507,10 @@ def handle_queue_inspect(args: argparse.Namespace) -> int:
         print("Next: wait for retry backoff or run splendor queue retry <job-id>")
     elif result.status_counts.get("failed", 0):
         print("Next: splendor queue retry <job-id>")
+    elif "orphaned" in cleanup_states:
+        print("Next: splendor queue clean --orphaned --apply")
+    elif "superseded" in cleanup_states:
+        print("Next: splendor queue clean --superseded --apply")
     return 0
 
 
@@ -1536,9 +1536,10 @@ def handle_queue_clean(args: argparse.Namespace) -> int:
     if not result.applied:
         print("Preview only: no queue records deleted.")
     print(f"Selectors: {', '.join(result.selectors)}")
-    if result.actions:
+    output_actions = result.written if result.applied else result.actions
+    if output_actions:
         print("Deleted queue records:" if result.applied else "Planned queue deletions:")
-        for action in result.actions:
+        for action in output_actions:
             print(
                 f"- {action.path} [{action.cleanup_state}] "
                 f"job_id={action.job_id} source_id={action.source_id or '-'}"

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -1835,6 +1835,19 @@ def _maintenance_guidance(
             "splendor source freshness",
             "Inspect the full changed or missing curated source set.",
         )
+    queue_cleanup_states = {item.cleanup_state for item in snapshot.queue.items}
+    if "orphaned" in queue_cleanup_states:
+        add(
+            "queue",
+            "splendor queue clean --orphaned",
+            "Preview stale ingest queue records whose source manifests are gone.",
+        )
+    if "superseded" in queue_cleanup_states:
+        add(
+            "queue",
+            "splendor queue clean --superseded",
+            "Preview stale ingest queue records for superseded source versions.",
+        )
     if any(
         item.operator_state
         in {"pending", "failed_due", "expired_leased", "dead_letter", "failed_backoff"}
@@ -1983,7 +1996,29 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
     for item in snapshot.queue.items:
         source = snapshot.sources_by_id.get(item.source_id or "")
         source_ref = canonical_source_ref(source) if source is not None else None
-        if item.operator_state in {"pending", "failed_due", "expired_leased"}:
+        if item.cleanup_state == "orphaned":
+            add(
+                "medium",
+                "queue",
+                f"Close orphaned queue job {item.job_id}",
+                "The ingest queue payload source manifest no longer exists.",
+                "splendor queue clean --orphaned",
+                path=item.record_path.as_posix(),
+                source_id=item.source_id,
+                source_ref=source_ref,
+            )
+        elif item.cleanup_state == "superseded":
+            add(
+                "medium",
+                "queue",
+                f"Close superseded queue job {item.job_id}",
+                "The ingest queue record belongs to a superseded source version.",
+                "splendor queue clean --superseded",
+                path=item.record_path.as_posix(),
+                source_id=item.source_id,
+                source_ref=source_ref,
+            )
+        elif item.operator_state in {"pending", "failed_due", "expired_leased"}:
             add(
                 "high",
                 "queue",

--- a/src/splendor/commands/queue.py
+++ b/src/splendor/commands/queue.py
@@ -9,9 +9,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from splendor.commands.ingest import enqueue_ingest_job, is_ingest_current, run_ingest_job
+from splendor.commands.mutation import mutation_contract, mutation_record
 from splendor.config import load_config
 from splendor.layout import resolve_layout
-from splendor.schemas import QueueItemRecord
+from splendor.schemas import QueueItemRecord, SourceRecord
+from splendor.state.paths import resolve_workspace_path
 from splendor.state.runtime import (
     ingest_job_id,
     load_queue_item,
@@ -39,6 +41,7 @@ class QueueItemSnapshot:
     last_error: str | None
     source_id: str | None
     operator_state: str
+    cleanup_state: str
     record_path: Path
 
 
@@ -52,6 +55,24 @@ class QueueInspectResult:
 @dataclass(frozen=True)
 class QueueRetryResult:
     item: QueueItemSnapshot
+
+
+@dataclass(frozen=True)
+class QueueCleanAction:
+    job_id: str
+    path: Path
+    source_id: str | None
+    cleanup_state: str
+    status: str
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class QueueCleanResult:
+    applied: bool
+    selectors: list[str]
+    actions: list[QueueCleanAction]
+    skipped: list[QueueCleanAction]
 
 
 @dataclass(frozen=True)
@@ -99,6 +120,56 @@ def retry_queue_job(root: Path, job_id: str) -> QueueRetryResult:
     reset = _reset_failed_ingest_queue_item(queue_item)
     write_queue_item(queue_path, reset)
     return QueueRetryResult(item=_snapshot_queue_item(root, queue_path, reset))
+
+
+def clean_queue(
+    root: Path,
+    *,
+    orphaned: bool = False,
+    superseded: bool = False,
+    completed: bool = False,
+    apply: bool = False,
+) -> QueueCleanResult:
+    selectors = [
+        label
+        for label, enabled in [
+            ("orphaned", orphaned),
+            ("superseded", superseded),
+            ("completed", completed),
+        ]
+        if enabled
+    ]
+    if not selectors:
+        msg = "queue clean requires at least one cleanup selector"
+        raise ValueError(msg)
+
+    layout = resolve_layout(root, load_config(root))
+    actions: list[QueueCleanAction] = []
+    skipped: list[QueueCleanAction] = []
+    for queue_path in sorted(layout.queue_dir.glob("*.json")):
+        planned, skip = _queue_clean_action(
+            root,
+            queue_path,
+            selectors=set(selectors),
+        )
+        if skip is not None:
+            skipped.append(skip)
+        if planned is None:
+            continue
+        actions.append(planned)
+
+    if apply:
+        for action in actions:
+            target = root / action.path
+            if target.exists() or target.is_symlink():
+                target.unlink()
+
+    return QueueCleanResult(
+        applied=apply,
+        selectors=selectors,
+        actions=actions,
+        skipped=skipped,
+    )
 
 
 def repair_ingest_source(root: Path, source_id: str) -> RepairIngestResult:
@@ -178,6 +249,28 @@ def render_queue_retry_json(result: QueueRetryResult) -> str:
     return json.dumps({"item": _snapshot_payload(result.item)}, indent=2)
 
 
+def render_queue_clean_json(root: Path, result: QueueCleanResult) -> str:
+    mutation_records = _queue_clean_mutation_records(root, result.actions)
+    return json.dumps(
+        {
+            "applied": result.applied,
+            "selectors": result.selectors,
+            "summary": {
+                "planned": len(result.actions),
+                "skipped": len(result.skipped),
+            },
+            "actions": [_queue_clean_action_payload(action) for action in result.actions],
+            "skipped": [_queue_clean_action_payload(action) for action in result.skipped],
+            "mutation": mutation_contract(
+                mode="apply" if result.applied else "preview",
+                planned=[] if result.applied else mutation_records,
+                written=mutation_records if result.applied else [],
+            ),
+        },
+        indent=2,
+    )
+
+
 def render_repair_ingest_json(root: Path, result: RepairIngestResult) -> str:
     return json.dumps(
         {
@@ -235,6 +328,7 @@ def _next_attempt_budget(queue_item: QueueItemRecord) -> int:
 def _snapshot_queue_item(
     root: Path, queue_path: Path, queue_item: QueueItemRecord
 ) -> QueueItemSnapshot:
+    operator_state = _operator_state(queue_item)
     return QueueItemSnapshot(
         job_id=queue_item.job_id,
         job_type=queue_item.job_type,
@@ -249,7 +343,8 @@ def _snapshot_queue_item(
         next_attempt_at=queue_item.next_attempt_at,
         last_error=queue_item.last_error,
         source_id=source_id_from_ingest_job_id(queue_item.job_id),
-        operator_state=_operator_state(queue_item),
+        operator_state=operator_state,
+        cleanup_state=_queue_cleanup_state(root, queue_item, operator_state=operator_state),
         record_path=queue_path.relative_to(root),
     )
 
@@ -270,6 +365,7 @@ def _snapshot_payload(item: QueueItemSnapshot) -> dict[str, object]:
         "last_error": item.last_error,
         "source_id": item.source_id,
         "operator_state": item.operator_state,
+        "cleanup_state": item.cleanup_state,
         "record_path": item.record_path.as_posix(),
     }
 
@@ -297,3 +393,187 @@ def _operator_state(queue_item: QueueItemRecord) -> str:
             return "failed_due"
         return "failed_backoff"
     return queue_item.status
+
+
+def _queue_clean_action(
+    root: Path, queue_path: Path, *, selectors: set[str]
+) -> tuple[QueueCleanAction | None, QueueCleanAction | None]:
+    queue_ref = queue_path.relative_to(root)
+    job_id = queue_path.stem
+    source_id = source_id_from_ingest_job_id(job_id)
+    try:
+        queue_item = load_queue_item(queue_path)
+    except ValueError as exc:
+        return None, QueueCleanAction(
+            job_id=job_id,
+            path=queue_ref,
+            source_id=source_id,
+            cleanup_state="invalid_record",
+            status="skipped",
+            reason=f"queue record is invalid: {exc}",
+        )
+
+    source_id = source_id_from_ingest_job_id(queue_item.job_id)
+    skip = _queue_clean_skip(root, queue_item, source_id=source_id, queue_ref=queue_ref)
+    if skip is not None:
+        return None, skip
+
+    cleanup_state = _queue_cleanup_state(
+        root, queue_item, operator_state=_operator_state(queue_item)
+    )
+    if cleanup_state not in selectors:
+        return None, None
+
+    return QueueCleanAction(
+        job_id=queue_item.job_id,
+        path=queue_ref,
+        source_id=source_id,
+        cleanup_state=cleanup_state,
+        status="planned",
+    ), None
+
+
+def _queue_clean_skip(
+    root: Path, queue_item: QueueItemRecord, *, source_id: str | None, queue_ref: Path
+) -> QueueCleanAction | None:
+    if queue_item.job_type != "ingest_source":
+        return QueueCleanAction(
+            job_id=queue_item.job_id,
+            path=queue_ref,
+            source_id=source_id,
+            cleanup_state="unsupported_job_type",
+            status="skipped",
+            reason=f"unsupported queue job type: {queue_item.job_type}",
+        )
+    if source_id is None:
+        return QueueCleanAction(
+            job_id=queue_item.job_id,
+            path=queue_ref,
+            source_id=None,
+            cleanup_state="unsupported_job_id",
+            status="skipped",
+            reason="queue job is not a source-owned ingest job",
+        )
+    if _operator_state(queue_item) == "active_leased":
+        return QueueCleanAction(
+            job_id=queue_item.job_id,
+            path=queue_ref,
+            source_id=source_id,
+            cleanup_state="active_leased",
+            status="skipped",
+            reason="queue record has an active lease",
+        )
+    manifest_path, source, reason = _queue_payload_source(root, queue_item, source_id=source_id)
+    if source is not None and source.source_id != source_id:
+        return QueueCleanAction(
+            job_id=queue_item.job_id,
+            path=queue_ref,
+            source_id=source_id,
+            cleanup_state="source_mismatch",
+            status="skipped",
+            reason=(
+                f"queue payload resolves to source_id={source.source_id!r}, "
+                f"but job_id expects {source_id!r}"
+            ),
+        )
+    if reason is not None and not reason.startswith("missing source manifest:"):
+        return QueueCleanAction(
+            job_id=queue_item.job_id,
+            path=queue_ref,
+            source_id=source_id,
+            cleanup_state="invalid_payload",
+            status="skipped",
+            reason=reason,
+        )
+    if manifest_path is not None and source is None and reason is None:
+        return QueueCleanAction(
+            job_id=queue_item.job_id,
+            path=queue_ref,
+            source_id=source_id,
+            cleanup_state="invalid_payload",
+            status="skipped",
+            reason="queue payload source manifest is invalid",
+        )
+    return None
+
+
+def _queue_cleanup_state(
+    root: Path, queue_item: QueueItemRecord, *, operator_state: str | None = None
+) -> str:
+    source_id = source_id_from_ingest_job_id(queue_item.job_id)
+    operator_state = operator_state or _operator_state(queue_item)
+    if queue_item.job_type != "ingest_source" or source_id is None:
+        return "not_cleanup_candidate"
+    if operator_state == "active_leased":
+        return "active_leased"
+    _manifest_path, source, reason = _queue_payload_source(root, queue_item, source_id=source_id)
+    if reason is not None:
+        if reason.startswith("missing source manifest:"):
+            return "orphaned"
+        return "invalid_payload"
+    if source is None:
+        return "invalid_payload"
+    if source.source_id != source_id:
+        return "source_mismatch"
+    if source.superseded_by is not None:
+        return "superseded"
+    if queue_item.status == "done":
+        return "completed"
+    return "not_cleanup_candidate"
+
+
+def _queue_payload_source(
+    root: Path, queue_item: QueueItemRecord, *, source_id: str
+) -> tuple[Path | None, SourceRecord | None, str | None]:
+    try:
+        manifest_path = resolve_workspace_path(
+            root,
+            queue_item.payload_ref,
+            context="Queue payload",
+        )
+    except ValueError as exc:
+        return None, None, str(exc)
+    if not manifest_path.exists():
+        return manifest_path, None, f"missing source manifest: {queue_item.payload_ref}"
+    expected_manifest_path = manifest_path_for(root, source_id)
+    try:
+        source = load_source_record(manifest_path)
+    except ValueError as exc:
+        return manifest_path, None, str(exc)
+    if manifest_path.resolve() != expected_manifest_path.resolve():
+        return (
+            manifest_path,
+            source,
+            (
+                f"queue payload points to {queue_item.payload_ref!r}, but the canonical "
+                "manifest path for this source is "
+                f"{expected_manifest_path.relative_to(root).as_posix()!r}"
+            ),
+        )
+    return manifest_path, source, None
+
+
+def _queue_clean_mutation_records(
+    root: Path, actions: list[QueueCleanAction]
+) -> list[dict[str, str]]:
+    del root
+    return [
+        mutation_record(
+            action="delete",
+            path=action.path.as_posix(),
+            kind="queue_record",
+            source_id=action.source_id,
+        )
+        for action in sorted(actions, key=lambda item: item.path.as_posix())
+    ]
+
+
+def _queue_clean_action_payload(action: QueueCleanAction) -> dict[str, object]:
+    return {
+        "job_id": action.job_id,
+        "path": action.path.as_posix(),
+        "source_id": action.source_id,
+        "cleanup_state": action.cleanup_state,
+        "status": action.status,
+        "reason": action.reason,
+    }

--- a/src/splendor/commands/queue.py
+++ b/src/splendor/commands/queue.py
@@ -72,6 +72,7 @@ class QueueCleanResult:
     applied: bool
     selectors: list[str]
     actions: list[QueueCleanAction]
+    written: list[QueueCleanAction]
     skipped: list[QueueCleanAction]
 
 
@@ -146,6 +147,7 @@ def clean_queue(
     layout = resolve_layout(root, load_config(root))
     actions: list[QueueCleanAction] = []
     skipped: list[QueueCleanAction] = []
+    written: list[QueueCleanAction] = []
     for queue_path in sorted(layout.queue_dir.glob("*.json")):
         planned, skip = _queue_clean_action(
             root,
@@ -158,16 +160,30 @@ def clean_queue(
             continue
         actions.append(planned)
 
-    if apply:
+    if apply and actions:
+        _preflight_queue_clean_targets(root, actions)
         for action in actions:
             target = root / action.path
-            if target.exists() or target.is_symlink():
+            if target.is_file() or target.is_symlink():
                 target.unlink()
+                written.append(action)
+            else:
+                skipped.append(
+                    QueueCleanAction(
+                        job_id=action.job_id,
+                        path=action.path,
+                        source_id=action.source_id,
+                        cleanup_state=action.cleanup_state,
+                        status="skipped",
+                        reason="queue record disappeared before apply",
+                    )
+                )
 
     return QueueCleanResult(
         applied=apply,
         selectors=selectors,
         actions=actions,
+        written=written,
         skipped=skipped,
     )
 
@@ -251,20 +267,23 @@ def render_queue_retry_json(result: QueueRetryResult) -> str:
 
 def render_queue_clean_json(root: Path, result: QueueCleanResult) -> str:
     mutation_records = _queue_clean_mutation_records(root, result.actions)
+    written_records = _queue_clean_mutation_records(root, result.written)
     return json.dumps(
         {
             "applied": result.applied,
             "selectors": result.selectors,
             "summary": {
                 "planned": len(result.actions),
+                "written": len(result.written),
                 "skipped": len(result.skipped),
             },
             "actions": [_queue_clean_action_payload(action) for action in result.actions],
+            "written": [_queue_clean_action_payload(action) for action in result.written],
             "skipped": [_queue_clean_action_payload(action) for action in result.skipped],
             "mutation": mutation_contract(
                 mode="apply" if result.applied else "preview",
                 planned=[] if result.applied else mutation_records,
-                written=mutation_records if result.applied else [],
+                written=written_records if result.applied else [],
             ),
         },
         indent=2,
@@ -403,7 +422,7 @@ def _queue_clean_action(
     source_id = source_id_from_ingest_job_id(job_id)
     try:
         queue_item = load_queue_item(queue_path)
-    except ValueError as exc:
+    except (OSError, ValueError) as exc:
         return None, QueueCleanAction(
             job_id=job_id,
             path=queue_ref,
@@ -418,10 +437,15 @@ def _queue_clean_action(
     if skip is not None:
         return None, skip
 
-    cleanup_state = _queue_cleanup_state(
+    cleanup_states = _queue_cleanup_states(
         root, queue_item, operator_state=_operator_state(queue_item)
     )
-    if cleanup_state not in selectors:
+    selected_states = [state for state in _QUEUE_CLEANUP_SELECTOR_ORDER if state in selectors]
+    cleanup_state = next(
+        (state for state in selected_states if state in cleanup_states),
+        None,
+    )
+    if cleanup_state is None:
         return None, None
 
     return QueueCleanAction(
@@ -500,26 +524,49 @@ def _queue_clean_skip(
 def _queue_cleanup_state(
     root: Path, queue_item: QueueItemRecord, *, operator_state: str | None = None
 ) -> str:
+    states = _queue_cleanup_states(root, queue_item, operator_state=operator_state)
+    for state in ["orphaned", "superseded", "completed"]:
+        if state in states:
+            return state
+    for state in ["active_leased", "invalid_payload", "source_mismatch"]:
+        if state in states:
+            return state
+    return "not_cleanup_candidate"
+
+
+_QUEUE_CLEANUP_SELECTOR_ORDER = ["orphaned", "superseded", "completed"]
+
+
+def _queue_cleanup_states(
+    root: Path, queue_item: QueueItemRecord, *, operator_state: str | None = None
+) -> set[str]:
     source_id = source_id_from_ingest_job_id(queue_item.job_id)
     operator_state = operator_state or _operator_state(queue_item)
     if queue_item.job_type != "ingest_source" or source_id is None:
-        return "not_cleanup_candidate"
+        return {"not_cleanup_candidate"}
     if operator_state == "active_leased":
-        return "active_leased"
+        return {"active_leased"}
     _manifest_path, source, reason = _queue_payload_source(root, queue_item, source_id=source_id)
+    states: set[str] = set()
+    if queue_item.status == "done":
+        states.add("completed")
     if reason is not None:
         if reason.startswith("missing source manifest:"):
-            return "orphaned"
-        return "invalid_payload"
+            states.add("orphaned")
+            return states
+        states.add("invalid_payload")
+        return states
     if source is None:
-        return "invalid_payload"
+        states.add("invalid_payload")
+        return states
     if source.source_id != source_id:
-        return "source_mismatch"
+        states.add("source_mismatch")
+        return states
     if source.superseded_by is not None:
-        return "superseded"
-    if queue_item.status == "done":
-        return "completed"
-    return "not_cleanup_candidate"
+        states.add("superseded")
+    if states:
+        return states
+    return {"not_cleanup_candidate"}
 
 
 def _queue_payload_source(
@@ -566,6 +613,14 @@ def _queue_clean_mutation_records(
         )
         for action in sorted(actions, key=lambda item: item.path.as_posix())
     ]
+
+
+def _preflight_queue_clean_targets(root: Path, actions: list[QueueCleanAction]) -> None:
+    for action in actions:
+        target = root / action.path
+        if target.is_dir() and not target.is_symlink():
+            msg = f"Queue cleanup target is not a removable file: {action.path.as_posix()}"
+            raise ValueError(msg)
 
 
 def _queue_clean_action_payload(action: QueueCleanAction) -> dict[str, object]:

--- a/src/splendor/commands/queue.py
+++ b/src/splendor/commands/queue.py
@@ -432,6 +432,18 @@ def _queue_clean_action(
             reason=f"queue record is invalid: {exc}",
         )
 
+    if queue_item.job_id != job_id:
+        return None, QueueCleanAction(
+            job_id=queue_item.job_id,
+            path=queue_ref,
+            source_id=source_id_from_ingest_job_id(queue_item.job_id),
+            cleanup_state="job_id_mismatch",
+            status="skipped",
+            reason=(
+                f"queue record job_id {queue_item.job_id!r} does not match filename {job_id!r}"
+            ),
+        )
+
     source_id = source_id_from_ingest_job_id(queue_item.job_id)
     skip = _queue_clean_skip(root, queue_item, source_id=source_id, queue_ref=queue_ref)
     if skip is not None:

--- a/tests/test_queue_commands.py
+++ b/tests/test_queue_commands.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import splendor.commands.queue as queue_module
 from splendor.cli import main
 from splendor.commands.add_source import add_source
 from splendor.commands.ingest import enqueue_ingest_job
@@ -259,6 +260,42 @@ def test_queue_clean_selects_superseded_and_completed_records(tmp_path: Path) ->
     }
 
 
+def test_queue_clean_completed_selector_matches_done_orphaned_and_superseded_records(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    orphan_path = tmp_path / "orphan.md"
+    superseded_path = tmp_path / "superseded.md"
+    orphan_path.write_text("# Orphan\n\nOriginal.\n", encoding="utf-8")
+    superseded_path.write_text("# Superseded\n\nOriginal.\n", encoding="utf-8")
+    orphan = add_source(tmp_path, orphan_path)
+    superseded = add_source(tmp_path, superseded_path)
+    orphan_queue_path = enqueue_ingest_job(tmp_path, orphan.source_id)
+    superseded_queue_path = enqueue_ingest_job(tmp_path, superseded.source_id)
+    orphan.manifest_path.unlink()
+    superseded_path.write_text("# Superseded\n\nUpdated.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "source", "refresh", superseded.source_id])
+    for queue_path in [orphan_queue_path, superseded_queue_path]:
+        write_queue_item(
+            queue_path,
+            load_queue_item(queue_path).model_copy(update={"status": "done"}),
+        )
+
+    result = clean_queue(tmp_path, completed=True)
+
+    assert {
+        (action.source_id, action.cleanup_state, action.path.as_posix())
+        for action in result.actions
+    } == {
+        (orphan.source_id, "completed", orphan_queue_path.relative_to(tmp_path).as_posix()),
+        (
+            superseded.source_id,
+            "completed",
+            superseded_queue_path.relative_to(tmp_path).as_posix(),
+        ),
+    }
+
+
 def test_queue_clean_skips_active_leases_invalid_payloads_and_unsupported_jobs(
     tmp_path: Path,
 ) -> None:
@@ -367,11 +404,43 @@ def test_cli_queue_clean_json_reports_preview_and_apply_mutation_contract(
     assert exit_code == 0
     applied = json.loads(capsys.readouterr().out)
     assert applied["applied"] is True
+    assert applied["summary"]["written"] == 1
+    assert applied["written"][0]["path"] == f"state/queue/ingest-{source_id}.json"
     assert applied["mutation"]["mode"] == "apply"
     assert applied["mutation"]["mutates"] is True
     assert applied["mutation"]["planned"] == []
     assert applied["mutation"]["written"][0]["path"] == f"state/queue/ingest-{source_id}.json"
     assert not queue_path.exists()
+
+
+def test_queue_clean_apply_reports_only_actual_deleted_records_when_target_disappears(
+    tmp_path: Path, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    added.manifest_path.unlink()
+    original_preflight = queue_module._preflight_queue_clean_targets
+
+    def disappear_after_preflight(root: Path, actions) -> None:
+        original_preflight(root, actions)
+        queue_path.unlink()
+
+    monkeypatch.setattr(
+        queue_module,
+        "_preflight_queue_clean_targets",
+        disappear_after_preflight,
+    )
+
+    result = clean_queue(tmp_path, orphaned=True, apply=True)
+
+    assert result.actions
+    assert result.written == []
+    assert [(action.status, action.reason) for action in result.skipped] == [
+        ("skipped", "queue record disappeared before apply")
+    ]
 
 
 def test_cli_queue_clean_human_output_reports_preview_and_next_action(
@@ -394,6 +463,31 @@ def test_cli_queue_clean_human_output_reports_preview_and_next_action(
     assert "Preview only: no queue records deleted." in out
     assert f"- state/queue/ingest-{source_id}.json [orphaned]" in out
     assert "Next: splendor queue clean --orphaned --apply" in out
+
+
+def test_cli_queue_inspect_prioritizes_runnable_work_over_cleanup(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    pending_source = tmp_path / "pending.md"
+    orphan_source = tmp_path / "orphan.md"
+    pending_source.write_text("# Pending\n\nNeeds ingest.\n", encoding="utf-8")
+    orphan_source.write_text("# Orphan\n\nManifest will disappear.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(pending_source)])
+    main(["--root", str(tmp_path), "add-source", str(orphan_source)])
+    orphan_id = next(
+        load_source_record(path).source_id
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+        if load_source_record(path).source_ref == "orphan.md"
+    )
+    (tmp_path / "state" / "manifests" / "sources" / f"{orphan_id}.json").unlink()
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "queue", "inspect"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "cleanup=orphaned" in out
+    assert "Next: splendor ingest --pending" in out
+    assert "Next: splendor queue clean --orphaned --apply" not in out
 
 
 def test_cli_queue_retry_resets_failed_job(tmp_path: Path, capsys) -> None:

--- a/tests/test_queue_commands.py
+++ b/tests/test_queue_commands.py
@@ -8,7 +8,7 @@ from splendor.cli import main
 from splendor.commands.add_source import add_source
 from splendor.commands.ingest import enqueue_ingest_job
 from splendor.commands.init import initialize_workspace
-from splendor.commands.queue import inspect_queue, inspect_queue_job, retry_queue_job
+from splendor.commands.queue import clean_queue, inspect_queue, inspect_queue_job, retry_queue_job
 from splendor.schemas import QueueItemRecord
 from splendor.state.runtime import load_queue_item, write_queue_item
 from splendor.state.source_registry import load_source_record
@@ -179,6 +179,7 @@ def test_cli_queue_inspect_human_and_json_output(tmp_path: Path, capsys) -> None
     assert payload["status_counts"] == {"pending": 1}
     assert payload["items"][0]["job_id"] == f"ingest-{source_id}"
     assert payload["items"][0]["operator_state"] == "pending"
+    assert payload["items"][0]["cleanup_state"] == "not_cleanup_candidate"
     assert payload["items"][0]["next_attempt_at"] is None
 
 
@@ -204,6 +205,195 @@ def test_cli_queue_inspect_single_job_outputs_detail_and_json(tmp_path: Path, ca
     payload = json.loads(capsys.readouterr().out)
     assert payload["job_id"] == job_id
     assert payload["record_path"] == f"state/queue/{job_id}.json"
+    assert payload["cleanup_state"] == "not_cleanup_candidate"
+
+
+def test_queue_clean_previews_and_applies_orphaned_queue_records(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    added.manifest_path.unlink()
+
+    preview = clean_queue(tmp_path, orphaned=True)
+
+    assert preview.applied is False
+    assert [(action.cleanup_state, action.path.as_posix()) for action in preview.actions] == [
+        ("orphaned", f"state/queue/ingest-{added.source_id}.json")
+    ]
+    assert queue_path.exists()
+
+    applied = clean_queue(tmp_path, orphaned=True, apply=True)
+
+    assert applied.applied is True
+    assert not queue_path.exists()
+
+
+def test_queue_clean_selects_superseded_and_completed_records(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    old_path = tmp_path / "old.md"
+    done_path = tmp_path / "done.md"
+    old_path.write_text("# Old\n\nOriginal.\n", encoding="utf-8")
+    done_path.write_text("# Done\n\nDone.\n", encoding="utf-8")
+    old = add_source(tmp_path, old_path)
+    done = add_source(tmp_path, done_path)
+    old_queue_path = enqueue_ingest_job(tmp_path, old.source_id)
+    done_queue_path = enqueue_ingest_job(tmp_path, done.source_id)
+    old_path.write_text("# Old\n\nUpdated.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "source", "refresh", old.source_id])
+    write_queue_item(
+        done_queue_path,
+        load_queue_item(done_queue_path).model_copy(update={"status": "done"}),
+    )
+
+    result = clean_queue(tmp_path, superseded=True, completed=True)
+
+    action_states = {
+        (action.source_id, action.cleanup_state, action.path.as_posix())
+        for action in result.actions
+    }
+    assert action_states == {
+        (old.source_id, "superseded", old_queue_path.relative_to(tmp_path).as_posix()),
+        (done.source_id, "completed", done_queue_path.relative_to(tmp_path).as_posix()),
+    }
+
+
+def test_queue_clean_skips_active_leases_invalid_payloads_and_unsupported_jobs(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    active_source = tmp_path / "active.md"
+    invalid_source = tmp_path / "invalid.md"
+    mismatch_source = tmp_path / "mismatch.md"
+    payload_source = tmp_path / "payload.md"
+    active_source.write_text("# Active\n\nhello\n", encoding="utf-8")
+    invalid_source.write_text("# Invalid\n\nhello\n", encoding="utf-8")
+    mismatch_source.write_text("# Mismatch\n\nhello\n", encoding="utf-8")
+    payload_source.write_text("# Payload\n\nhello\n", encoding="utf-8")
+    active = add_source(tmp_path, active_source)
+    invalid = add_source(tmp_path, invalid_source)
+    mismatch = add_source(tmp_path, mismatch_source)
+    payload = add_source(tmp_path, payload_source)
+    active_queue_path = enqueue_ingest_job(tmp_path, active.source_id)
+    invalid_queue_path = enqueue_ingest_job(tmp_path, invalid.source_id)
+    mismatch_queue_path = enqueue_ingest_job(tmp_path, mismatch.source_id)
+    active.manifest_path.unlink()
+    invalid.manifest_path.unlink()
+    write_queue_item(
+        active_queue_path,
+        load_queue_item(active_queue_path).model_copy(
+            update={
+                "status": "leased",
+                "lease_owner": "local-cli:123",
+                "lease_expires_at": (datetime.now(UTC) + timedelta(minutes=5)).isoformat(),
+            }
+        ),
+    )
+    write_queue_item(
+        invalid_queue_path,
+        load_queue_item(invalid_queue_path).model_copy(update={"payload_ref": "/tmp/outside.json"}),
+    )
+    write_queue_item(
+        mismatch_queue_path,
+        load_queue_item(mismatch_queue_path).model_copy(
+            update={
+                "job_id": f"ingest-{mismatch.source_id}",
+                "payload_ref": payload.manifest_path.relative_to(tmp_path).as_posix(),
+            }
+        ),
+    )
+    unsupported_path = tmp_path / "state" / "queue" / "refresh-page.json"
+    write_queue_item(
+        unsupported_path,
+        QueueItemRecord(
+            job_id="refresh-page",
+            job_type="refresh_page",
+            status="done",
+            created_at="2026-04-10T12:00:00+00:00",
+            updated_at="2026-04-10T12:00:00+00:00",
+            payload_ref="wiki/index.md",
+        ),
+    )
+
+    result = clean_queue(tmp_path, orphaned=True, completed=True)
+
+    assert result.actions == []
+    skipped = {action.cleanup_state for action in result.skipped}
+    assert skipped >= {
+        "active_leased",
+        "invalid_payload",
+        "source_mismatch",
+        "unsupported_job_type",
+    }
+
+
+def test_cli_queue_clean_json_reports_preview_and_apply_mutation_contract(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    manifest_path = tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    manifest_path.unlink()
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "queue", "clean", "--orphaned", "--json"])
+
+    assert exit_code == 0
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["applied"] is False
+    assert preview["actions"][0]["cleanup_state"] == "orphaned"
+    assert preview["mutation"] == {
+        "mode": "preview",
+        "mutates": False,
+        "planned": [
+            {
+                "action": "delete",
+                "path": f"state/queue/ingest-{source_id}.json",
+                "kind": "queue_record",
+                "source_id": source_id,
+            }
+        ],
+        "written": [],
+    }
+    assert queue_path.exists()
+
+    exit_code = main(["--root", str(tmp_path), "queue", "clean", "--orphaned", "--apply", "--json"])
+
+    assert exit_code == 0
+    applied = json.loads(capsys.readouterr().out)
+    assert applied["applied"] is True
+    assert applied["mutation"]["mode"] == "apply"
+    assert applied["mutation"]["mutates"] is True
+    assert applied["mutation"]["planned"] == []
+    assert applied["mutation"]["written"][0]["path"] == f"state/queue/ingest-{source_id}.json"
+    assert not queue_path.exists()
+
+
+def test_cli_queue_clean_human_output_reports_preview_and_next_action(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    (tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json").unlink()
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "queue", "clean", "--orphaned"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Queue cleanup preview" in out
+    assert "Mutation mode: preview" in out
+    assert "Preview only: no queue records deleted." in out
+    assert f"- state/queue/ingest-{source_id}.json [orphaned]" in out
+    assert "Next: splendor queue clean --orphaned --apply" in out
 
 
 def test_cli_queue_retry_resets_failed_job(tmp_path: Path, capsys) -> None:

--- a/tests/test_queue_commands.py
+++ b/tests/test_queue_commands.py
@@ -365,6 +365,27 @@ def test_queue_clean_skips_active_leases_invalid_payloads_and_unsupported_jobs(
     }
 
 
+def test_queue_clean_skips_record_when_filename_and_job_id_disagree(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    queue_item = load_queue_item(queue_path)
+    mismatch_path = tmp_path / "state" / "queue" / "ingest-corrupt-filename.json"
+    queue_path.unlink()
+    added.manifest_path.unlink()
+    write_queue_item(mismatch_path, queue_item)
+
+    result = clean_queue(tmp_path, orphaned=True)
+
+    assert result.actions == []
+    assert [(action.cleanup_state, action.path.as_posix()) for action in result.skipped] == [
+        ("job_id_mismatch", "state/queue/ingest-corrupt-filename.json")
+    ]
+    assert "does not match filename" in (result.skipped[0].reason or "")
+
+
 def test_cli_queue_clean_json_reports_preview_and_apply_mutation_contract(
     tmp_path: Path, capsys
 ) -> None:
@@ -488,6 +509,31 @@ def test_cli_queue_inspect_prioritizes_runnable_work_over_cleanup(tmp_path: Path
     assert "cleanup=orphaned" in out
     assert "Next: splendor ingest --pending" in out
     assert "Next: splendor queue clean --orphaned --apply" not in out
+
+
+def test_cli_queue_inspect_reports_completed_cleanup_next_actions(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "done.md"
+    source.write_text("# Done\n\nAlready ingested.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    job_id = f"ingest-{source_id}"
+    queue_path = tmp_path / "state" / "queue" / f"{job_id}.json"
+    write_queue_item(
+        queue_path,
+        load_queue_item(queue_path).model_copy(update={"status": "done"}),
+    )
+    capsys.readouterr()
+
+    assert main(["--root", str(tmp_path), "queue", "inspect"]) == 0
+    out = capsys.readouterr().out
+    assert "cleanup=completed" in out
+    assert "Next: splendor queue clean --completed --apply" in out
+
+    assert main(["--root", str(tmp_path), "queue", "inspect", job_id]) == 0
+    out = capsys.readouterr().out
+    assert "Cleanup state: completed" in out
+    assert "Next: splendor queue clean --completed --apply" in out
 
 
 def test_cli_queue_retry_resets_failed_job(tmp_path: Path, capsys) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -3413,6 +3413,74 @@ def test_maintenance_guidance_preserves_dead_letter_repair_command(tmp_path: Pat
     assert f"splendor repair ingest {added.source_id}" in commands
 
 
+def test_agent_handoff_reports_orphan_queue_cleanup_without_displacing_work(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "task",
+            "create",
+            "Implement",
+            "handoff",
+            "cleanup",
+            "--id",
+            "task-handoff-cleanup",
+            "--status",
+            "in_progress",
+        ]
+    )
+    source = tmp_path / "orphan.md"
+    source.write_text("# Orphan\n\nQueue payload will be removed.\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    enqueue_ingest_job(tmp_path, added.source_id)
+    added.manifest_path.unlink()
+    capsys.readouterr()
+
+    brief_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "--no-git",
+            "implement",
+            "handoff",
+            "cleanup",
+            "--json",
+        ]
+    )
+    brief_payload = json.loads(capsys.readouterr().out)
+    suggest_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "--no-git",
+            "implement",
+            "handoff",
+            "cleanup",
+            "--json",
+        ]
+    )
+    suggest_payload = json.loads(capsys.readouterr().out)
+
+    assert brief_exit == 0
+    assert suggest_exit == 0
+    for payload in [brief_payload, suggest_payload]:
+        commands = {command["command"] for command in payload["maintenance_context"]["commands"]}
+        assert "splendor queue clean --orphaned" in commands
+        assert "splendor queue inspect" in commands
+        assert any(
+            action["category"] == "queue" and action["command"] == "splendor queue clean --orphaned"
+            for action in payload["maintenance_context"]["actions"]
+        )
+        assert payload["work_context"]["actions"]
+        assert all(action["category"] != "queue" for action in payload["work_context"]["actions"])
+
+
 def test_brief_skips_invalid_query_matches_without_failing(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
     bad_page = tmp_path / "wiki" / "topics" / "bad.md"


### PR DESCRIPTION
## Summary
- Add preview/apply `splendor queue clean` closure paths for orphaned, superseded, and completed ingest queue records.
- Expose additive queue `cleanup_state` in queue inspect JSON/text output and use cleanup-first next actions for closure-only queue drift.
- Surface orphaned/superseded queue cleanup under agent maintenance context without displacing work-first handoff.
- Update synchronized planning state and docs for M19-P3.1.

## Validation
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

Closes #149