### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,11 +3,11 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M19-P2.1`
-- Last action taken: `M19-P2.1` was squash-merged into main as commit `da6375d`,
-  adding agent-safe mutation contracts across preview/apply CLI surfaces.
-- Current planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Current PR sub-slice: `M19-P3.1`
+- Previous completed PR sub-slice: `M19-P3.1`
+- Last action taken: `M19-P3.1` was squash-merged into main as commit `610c163`,
+  adding registry and queue cleanup closure paths for stale maintenance state.
+- Current planned slice: `v0.4.0 release preparation`
+- Current PR sub-slice: `v0.4.0-release-prep`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M20 post-v1 product bets`
 - Next planned PR sub-slice: `M20-P1.1`

--- a/README.md
+++ b/README.md
@@ -314,12 +314,13 @@ the source manifest, and kept separate from parsed PDF artifacts.
 - [Product spec](docs/splendor_product_spec.md)
 - [Roadmap](docs/splendor_mvp_to_v1_roadmap.md)
 - [v0.4 external retry bar](docs/evaluations/v0_4_external_retry_bar.md)
+- [v0.4.0 release notes](docs/releases/v0_4_0_release_notes.md)
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M19-P2.1`
-- Current planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Current PR sub-slice: `M19-P3.1`
+- Previous completed PR sub-slice: `M19-P3.1`
+- Current planned slice: `v0.4.0 release preparation`
+- Current PR sub-slice: `v0.4.0-release-prep`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M20 post-v1 product bets`
 - Next planned PR sub-slice: `M20-P1.1`

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,4 +39,5 @@ workflow.
 
 - [v0.2.0 release notes](releases/v0_2_0_release_notes.md)
 - [v0.3.0 release notes](releases/v0_3_0_release_notes.md)
+- [v0.4.0 release notes](releases/v0_4_0_release_notes.md)
 - [v1 release handoff](releases/v1_release_handoff.md)

--- a/docs/operations/release_artifacts.md
+++ b/docs/operations/release_artifacts.md
@@ -5,8 +5,8 @@ publishing separate from Splendor runtime behavior.
 
 ## Canonical Trial Install
 
-For external v0.3 trial users, prefer the wheel attached to the matching GitHub Release. Start from
-the release page so the evaluator sees the release notes, validation status, and known limitations
+For external trial users, prefer the wheel attached to the matching GitHub Release. Start from the
+release page so the evaluator sees the release notes, validation status, and known limitations
 before installing:
 
 ```text

--- a/docs/releases/v0_4_0_release_notes.md
+++ b/docs/releases/v0_4_0_release_notes.md
@@ -1,0 +1,56 @@
+# v0.4.0 Work-First Agent Handoff Release Notes
+
+`v0.4.0` is the external retry release for validating Splendor as a practical Codex companion
+after the `v0.3.0` SynthBanshee and hocrgen trials. It is still not the public v1 tag. The purpose
+is to check whether agents now start with Splendor's local handoff surfaces before falling back to
+manual `git`, GitHub, and file inspection.
+
+## Release Purpose
+
+This release packages the v0.4 work-first handoff and pre-v1 workflow durability work:
+
+- `brief --agent-context` and `suggest-next` include git-aware work context from recent local commits
+  and promoted GitHub work threads.
+- Work items stay separated from maintenance state so stale generated or queue state does not
+  displace current implementation work.
+- Conventional planning, policy, and handoff files can appear as labeled inferred-authority context
+  without mutating source registries.
+- Maintenance guidance now points to explicit commands for wiki review state, source freshness,
+  generated review tasks, and queue cleanup without making those items the default top work.
+- `pr-summary --since <ref>` provides compact committed-state reviewability for Splendor-generated
+  and maintained artifacts before PR handoff.
+- Reviewed mutating commands expose deterministic JSON mutation contracts with `mode`, `mutates`,
+  `planned`, and `written` fields.
+- `splendor queue clean --orphaned|--superseded|--completed` gives stale ingest queue records an
+  explicit preview/apply closure path.
+
+## Trial Focus
+
+The next expected action after publishing `v0.4.0` is a fresh external retry against the accepted
+v0.4 bar in `docs/evaluations/v0_4_external_retry_bar.md`. The trial should explicitly check:
+
+- whether agents naturally start with `splendor brief --agent-context` and `splendor suggest-next`
+  before manual repo spelunking
+- whether current work stays ranked above stale generated review tasks, source freshness, and queue
+  cleanup
+- whether compact PR summaries are useful before handoff
+- whether preview/apply and JSON mutation contracts are clear enough for agent-safe operation
+- whether queue and registry maintenance now have deterministic closure paths
+
+## Validation Expectations
+
+Before tagging `v0.4.0` after this preparation PR merges, run the full local validation suite from
+the repository root and confirm green `main` CI:
+
+```bash
+uv run ruff format --check .
+uv run ruff check .
+uv run pytest
+uv run splendor lint
+uv run splendor health
+uv build
+```
+
+The package metadata for this preparation PR is `0.4.0` in both `pyproject.toml` and
+`src/splendor/__init__.py`. Create the `v0.4.0` tag only after the release-prep PR merges and
+`main` is green.

--- a/docs/releases/v0_4_0_release_notes.md
+++ b/docs/releases/v0_4_0_release_notes.md
@@ -21,8 +21,8 @@ This release packages the v0.4 work-first handoff and pre-v1 workflow durability
   and maintained artifacts before PR handoff.
 - Reviewed mutating commands expose deterministic JSON mutation contracts with `mode`, `mutates`,
   `planned`, and `written` fields.
-- `splendor queue clean --orphaned|--superseded|--completed` gives stale ingest queue records an
-  explicit preview/apply closure path.
+- `splendor queue clean` with one of `--orphaned`, `--superseded`, or `--completed` gives stale
+  ingest queue records an explicit preview/apply closure path.
 
 ## Trial Focus
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,9 +334,9 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M19-P2.1`
-- Current planned slice: `M19 pre-v1 workflow durability after v0.4`
-- Current PR sub-slice: `M19-P3.1`
+- Previous completed PR sub-slice: `M19-P3.1`
+- Current planned slice: `v0.4.0 release preparation`
+- Current PR sub-slice: `v0.4.0-release-prep`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M20 post-v1 product bets`
 - Next planned PR sub-slice: `M20-P1.1`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "splendor"
-version = "0.3.0"
+version = "0.4.0"
 description = "Local-first, git-native, schema-driven knowledge compiler for code-and-research repositories."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/splendor/__init__.py
+++ b/src/splendor/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "splendor"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "bleach" },


### PR DESCRIPTION
## Summary
- Bump package metadata from 0.3.0 to 0.4.0 in pyproject.toml, src/splendor/__init__.py, and uv.lock.
- Add v0.4.0 release notes for the work-first agent handoff external retry release.
- Update release documentation indexes, release artifact guidance, and synchronized planning state after M19-P3.1 merged.

## Validation
- /Users/shaypalachy/.local/bin/uv run ruff format --check .
- /Users/shaypalachy/.local/bin/uv run ruff check .
- /Users/shaypalachy/.local/bin/uv run pytest
- /Users/shaypalachy/.local/bin/uv run splendor lint
- /Users/shaypalachy/.local/bin/uv run splendor health
- /Users/shaypalachy/.local/bin/uv run splendor --version
- /Users/shaypalachy/.local/bin/uv build

## Notes
- This PR prepares the version metadata and release notes only. Create the v0.4.0 tag after this merges and main is green.