### PR TITLE
M19-P4.1: Add v0.4 external review intake and response plan

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M19-P3.1`
-- Last action taken: `M19-P3.1` was squash-merged into main as commit `610c163`,
-  adding registry and queue cleanup closure paths for stale maintenance state.
-- Current planned slice: `v0.4.0 release preparation`
-- Current PR sub-slice: `v0.4.0-release-prep`
+- Previous completed PR sub-slice: `v0.4.0-release-prep`
+- Last action taken: `v0.4.0-release-prep` was squash-merged into main as commit `0239c42`,
+  preparing and tagging the `v0.4.0` release after the M19-P3.1 queue cleanup slice.
+- Current planned slice: `M19 post-v0.4 external review response`
+- Current PR sub-slice: `M19-P4.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 post-v1 product bets`
-- Next planned PR sub-slice: `M20-P1.1`
+- Next planned slice: `M19 legacy mutation safety`
+- Next planned PR sub-slice: `M19-P5.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -378,10 +378,26 @@
   - [x] Keep default implementation/planning handoff work-first
   - [x] Expose review-needed wiki, missing synthesis, queue, freshness, and generated-review commands
   - [x] Clarify task-list and wiki-status behavior for generated maintenance state
-- [ ] Implement `M19-P1.1`: generated-state reviewability and compact committed mode
+- [x] Implement `M19-P1.1`: generated-state reviewability and compact committed mode
   - [x] Add compact committed review groups to `splendor pr-summary`
   - [x] Keep generated runtime churn separate from maintained planning and wiki work
   - [x] Expose PR-summary review guidance from agent handoff maintenance context
+- [x] Implement `M19-P2.1`: agent-safe preview/apply consistency
+  - [x] Add deterministic mutation contracts to reviewed preview/apply and direct-write surfaces
+  - [x] Preserve existing proposal-hash guards and generated/maintained separation
+  - [x] Make human and JSON output label planned versus written mutations clearly
+- [x] Implement `M19-P3.1`: registry and queue cleanup closure paths
+  - [x] Add preview/apply `splendor queue clean` for orphaned, superseded, and completed records
+  - [x] Surface cleanup state in queue inspection and maintenance context
+  - [x] Keep cleanup maintenance discoverable without displacing work-first handoff
+- [x] Implement `v0.4.0-release-prep`: release v0.4.0 after M19-P3.1
+  - [x] Prepare release notes and version bump
+  - [x] Tag `v0.4.0` and publish the GitHub release
+- [ ] Implement `M19-P4.1`: post-v0.4 external review intake and sequencing
+  - [x] Record hocrgen, SynthBanshee, and hocrsyngen v0.4 trial materials
+  - [x] Add external review summary and findings register
+  - [x] Realign M19 before M20 around legacy mutation safety and current-state handoff inference
+  - [x] Publish the docs/planning PR with labels, milestone, and validation
 
 ## Context Pointers
 
@@ -494,5 +510,10 @@
 - `M19-P1.1` Generated-state reviewability and compact committed mode
 - `M19-P2.1` Agent-safe preview/apply consistency
 - `M19-P3.1` Registry and queue cleanup closure paths
+- `M19-P4.1` Post-v0.4 external review intake and sequencing
+- `M19-P5.1` Legacy preview/apply harmonization
+- `M19-P6.1` Completion-aware current-state handoff inference
+- `M19-P7.1` Multi-issue and policy-cited handoff breadth
+- `M19-P8.1` Cold-start adoption and PATH-safe git lookup
 - `M20-P1.1` Advanced semantic search or vector index
 - `M20-P2.1` Mutating web review workflows

--- a/README.md
+++ b/README.md
@@ -225,7 +225,9 @@ ambiguous `--current` selectors are rejected without rewriting manifests.
 
 `splendor ingest --pending --json` emits machine-readable pending-drain results with queue totals,
 processed/succeeded/failed/skipped counts, per-item outcomes, and deterministic next actions so
-agents do not need to parse human queue-drain text.
+agents do not need to parse human queue-drain text. This is still a direct drain verb in v0.4: it
+mutates queue, run, wiki, and index/log state when work is due. The post-v0.4 review findings make
+preview/apply harmonization for this and other legacy mutating verbs the next planned safety work.
 
 `splendor ingest --changed` is the narrower stale-ingest repair path for checksum-drifted curated
 workspace-backed sources when old ingest queue records are already `done`. It refreshes changed
@@ -314,16 +316,18 @@ the source manifest, and kept separate from parsed PDF artifacts.
 - [Product spec](docs/splendor_product_spec.md)
 - [Roadmap](docs/splendor_mvp_to_v1_roadmap.md)
 - [v0.4 external retry bar](docs/evaluations/v0_4_external_retry_bar.md)
+- [v0.4 external review summary](docs/evaluations/v0_4_external_review_round_summary.md)
+- [v0.4 external findings register](docs/evaluations/v0_4_external_findings_register.md)
 - [v0.4.0 release notes](docs/releases/v0_4_0_release_notes.md)
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M19-P3.1`
-- Current planned slice: `v0.4.0 release preparation`
-- Current PR sub-slice: `v0.4.0-release-prep`
+- Previous completed PR sub-slice: `v0.4.0-release-prep`
+- Current planned slice: `M19 post-v0.4 external review response`
+- Current PR sub-slice: `M19-P4.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 post-v1 product bets`
-- Next planned PR sub-slice: `M20-P1.1`
+- Next planned slice: `M19 legacy mutation safety`
+- Next planned PR sub-slice: `M19-P5.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -624,3 +628,12 @@ now expose a deterministic `mutation` object with `mode`, `mutates`, `planned`, 
 fields, while human output labels preview-only invocations and apply/direct write modes clearly.
 `M19-P3.1` adds preview/apply queue cleanup closure paths for orphaned, superseded, and completed
 ingest queue records, with additive cleanup state in queue inspection and maintenance handoff.
+
+`M19-P4.1` captures the post-v0.4 external review round before implementation work resumes. The
+raw hocrgen, SynthBanshee, and hocrsyngen trial materials are preserved under `docs/evaluations/`,
+with a review-round summary and findings register that identify the next durability gaps. The
+review round keeps M20 vector/search and mutating-web bets visible, but defers them until the
+remaining M19 workflow-safety and handoff-correctness issues are closed. The next planned
+implementation slice is `M19-P5.1`: legacy preview/apply harmonization for mutating maintenance and
+workflow commands such as `ingest --pending`, `source refresh`, `source update-path`, and
+`workspace refresh`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ workflow.
 - [v0.3 hocrgen evaluation](evaluations/v0_3_hocrgen_evaluation.md)
 - [v0.3 hocrgen follow-up](evaluations/v0_3_hocrgen_followup.md)
 - [v0.4 external retry bar](evaluations/v0_4_external_retry_bar.md)
+- [v0.4 external review round summary](evaluations/v0_4_external_review_round_summary.md)
+- [v0.4 external findings register](evaluations/v0_4_external_findings_register.md)
 - [Public mock client acceptance](evaluations/public_mock_client_acceptance.md)
 
 ## Releases

--- a/docs/evaluations/v0_4_external_findings_register.md
+++ b/docs/evaluations/v0_4_external_findings_register.md
@@ -39,17 +39,18 @@ Severity legend:
 
 The review round does not settle exact milestone names, but it does give a practical order:
 
-1. **Safety first:** address V04-F1, because mixed mutation semantics can destroy exploratory
-   handoff safety.
-2. **Handoff correctness second:** address V04-F2, because two partners failed the same
-   completed-slice-to-next-slice inference test.
-3. **Handoff breadth third:** address V04-F3 and V04-F6 together if scope allows.
-4. **Cold-start adoption fourth:** address V04-F4 plus the narrower V04-F5 robustness bug.
+1. **`M19-P5.1` safety first:** address V04-F1, because mixed mutation semantics can destroy
+   exploratory handoff safety.
+2. **`M19-P6.1` handoff correctness second:** address V04-F2, because two partners failed the
+   same completed-slice-to-next-slice inference test.
+3. **`M19-P7.1` handoff breadth third:** address V04-F3 and V04-F6 together if scope allows.
+4. **`M19-P8.1` cold-start adoption fourth:** address V04-F4 plus the narrower V04-F5 robustness
+   bug.
 5. **Polish later:** address V04-F7 through V04-F12 as scoped follow-ups or opportunistic fixes.
 
 ## Non-Decisions
 
-- This register does not choose the next PR sub-slice name.
+- This register records the accepted M19 sequencing but does not implement any of those slices.
 - This register does not update product or roadmap commitments.
 - This register does not change the v0.4.0 release notes.
 - This register does not decide whether raw external notes should remain unedited long term.

--- a/docs/evaluations/v0_4_external_findings_register.md
+++ b/docs/evaluations/v0_4_external_findings_register.md
@@ -1,0 +1,55 @@
+# Splendor v0.4 External Findings Register
+
+This register distills the v0.4.0 external review round into actionable findings. It should inform
+future design and planning updates, but it is not itself a committed roadmap.
+
+Severity legend:
+
+- `P1`: blocks safe or trustworthy agent handoff in at least one partner workflow.
+- `P2`: frequent workflow drag or adoption risk, but workaround exists.
+- `P3`: polish or clarity issue that should not block the next implementation slice.
+
+## Findings
+
+| ID | Finding | Evidence | Affected surface | Severity | Recommended next action |
+| --- | --- | --- | --- | --- | --- |
+| V04-F1 | Legacy mutating verbs still need preview/apply harmonization. | SynthBanshee v0.4 evaluation and follow-up. The reviewer singled out `ingest --pending`, `source refresh`, `source update-path`, and `workspace refresh`. | CLI mutation contracts, queue/ingest/source/workspace flows | P1 | Add preview-first/apply semantics or split/rename destructive forms. Treat as the next safety slice. |
+| V04-F2 | Completion-aware current-state inference is missing. | hocrgen expected `F4c` after completed `F3b`; hocrsyngen expected `S4d` after merged `S4c`. | `brief --agent-context`, `suggest-next`, planning inference | P1 | Combine git/GitHub merge state, dynamic planning docs, and roadmap ordering to infer the next open slice. |
+| V04-F3 | Work-thread issue surfacing is too narrow. | SynthBanshee surfaced issue `#91` correctly but missed related open ASR issues `#87`, `#88`, and `#92`. | GitHub issue context in handoff | P2 | Show the top 3-5 goal-relevant open issues/work threads, not only the single best match. |
+| V04-F4 | First-run state churn feels unsafe in cold-start repos. | hocrsyngen observed top-level Splendor directories and 80+ untracked files after minimal setup and seeding. | `init`, source seeding, generated/local state layout | P2 | Improve cold-start ergonomics: clearer state-location disclosure, local/hidden workspace option, or better review grouping. |
+| V04-F5 | PATH-unsafe subprocess git lookup can crash cold-start use. | hocrsyngen hit `NotADirectoryError: [Errno 20] Not a directory: 'git'` until `PATH` was sanitized. | Git subprocess discovery | P2 | Harden command lookup against non-directory `PATH` entries and add a regression test. |
+| V04-F6 | Policy-cited implementation files need ranking boosts. | SynthBanshee expected `synthbanshee/tts/renderer.py` and `tests/unit/test_effective_prosody_cap.py` because authority docs named `_EFFECTIVE_*` and cap policy. | Files-to-read ranking | P2 | Parse or boost paths/symbols cited by high-authority docs when assembling first-read files. |
+| V04-F7 | Trailing maintenance next-actions can undercut work-first separation. | SynthBanshee said top sections separated maintenance well, but bottom next-action lines still suggested maintenance commands. | Human `brief --agent-context` output | P3 | Keep maintenance commands only in the maintenance block unless the goal is maintenance. |
+| V04-F8 | `pr-summary --since main` no-diff state could be clearer. | SynthBanshee noted clean `main` produced a degenerate `changed_paths: 0` probe. | `pr-summary` human output | P3 | Detect `head == merge_base` and say explicitly that there is no diff against the selected base. |
+| V04-F9 | JSON mutation vocabulary is slightly inconsistent with release prose. | SynthBanshee saw deterministic `queue clean --json` output, but field names differed from release-note prose. | JSON mutation/reporting contracts | P3 | Align or document field names such as `mode`, `mutation`, `planned`, and `written` consistently. |
+| V04-F10 | Scan ranking can be too broad for first-run handoff. | hocrsyngen reported core handoff files competing with licenses, fixture corpora, and broad docs. | `repo scan`, first-use curation | P3 | Add stronger first-run ranking for `AGENTS.md`, `.agent-plan.md`, README, roadmap, and nearby tests/code. |
+| V04-F11 | Ingest needs progress feedback for long drains. | hocrsyngen observed `ingest --pending` remaining silent for roughly a minute. | Ingest command UX | P3 | Add deterministic progress/status output where it does not break JSON contracts. |
+| V04-F12 | Lint may report repo-relative README links as missing. | hocrsyngen reported false positives for links such as `docs/roadmap.md`. | `splendor lint` docs/link checks | P3 | Reproduce and fix link resolution, or narrow the diagnostic until it is reliable. |
+
+## Validated Improvements
+
+| ID | Improvement | Evidence | Follow-up |
+| --- | --- | --- | --- |
+| V04-S1 | Work-first handoff crossed the line for SynthBanshee. | SynthBanshee would now start with `splendor brief --agent-context`. | Preserve this behavior while fixing safety and breadth issues. |
+| V04-S2 | Queue orphan cleanup is now a real closure path. | SynthBanshee verified `queue clean --orphaned` previews all nine orphan records, including the v0.3 reproducer. | Preserve preview/apply and JSON contract behavior when harmonizing other verbs. |
+| V04-S3 | Maintenance separation is materially better. | SynthBanshee and hocrgen saw maintenance state separated from primary work more clearly than v0.3. | Avoid regressing this when adding more issue/context signals. |
+| V04-S4 | Provisional uncurated context is useful. | Partners noticed relevant uncurated docs appearing with curation hints. | Keep provisional labels clear and avoid silently promoting unreviewed sources to authority. |
+
+## Suggested Sequencing
+
+The review round does not settle exact milestone names, but it does give a practical order:
+
+1. **Safety first:** address V04-F1, because mixed mutation semantics can destroy exploratory
+   handoff safety.
+2. **Handoff correctness second:** address V04-F2, because two partners failed the same
+   completed-slice-to-next-slice inference test.
+3. **Handoff breadth third:** address V04-F3 and V04-F6 together if scope allows.
+4. **Cold-start adoption fourth:** address V04-F4 plus the narrower V04-F5 robustness bug.
+5. **Polish later:** address V04-F7 through V04-F12 as scoped follow-ups or opportunistic fixes.
+
+## Non-Decisions
+
+- This register does not choose the next PR sub-slice name.
+- This register does not update product or roadmap commitments.
+- This register does not change the v0.4.0 release notes.
+- This register does not decide whether raw external notes should remain unedited long term.

--- a/docs/evaluations/v0_4_external_review_round_summary.md
+++ b/docs/evaluations/v0_4_external_review_round_summary.md
@@ -89,13 +89,14 @@ hocrgen and hocrsyngen both selected completion-aware current-state inference as
 their next trial. Both failures involved the same pattern: recently completed work remained ranked as
 next work when the roadmap pointed to the following slice.
 
-The combined sequence suggested by the review round is:
+The combined sequence accepted for the remaining M19 durability track is:
 
-1. Legacy preview/apply harmonization for mutating maintenance/workflow verbs.
-2. Completion-aware current-state planning inference.
-3. Broader work-thread surfacing for related open issues.
-4. Cold-start/local-state ergonomics.
-5. Focused robustness and polish: PATH-safe git lookup, policy-cited path boosting, clearer no-diff
+1. `M19-P5.1`: legacy preview/apply harmonization for mutating maintenance/workflow verbs.
+2. `M19-P6.1`: completion-aware current-state planning inference.
+3. `M19-P7.1`: broader work-thread surfacing for related open issues and policy-cited
+   implementation surfaces.
+4. `M19-P8.1`: cold-start/local-state ergonomics and PATH-safe git lookup.
+5. Later scoped polish: ingest progress, scan ranking, lint link cleanup, clearer no-diff
    PR summaries, and removal of trailing maintenance next-actions.
 
 ## Out Of Scope For This PR

--- a/docs/evaluations/v0_4_external_review_round_summary.md
+++ b/docs/evaluations/v0_4_external_review_round_summary.md
@@ -1,0 +1,105 @@
+# Splendor v0.4 External Review Round Summary
+
+This document summarizes the v0.4.0 external review round before translating the findings into
+product design, roadmap, or planning-state changes. It is synthesis over the raw partner notes, not
+a new planning authority.
+
+## Source Materials
+
+- [hocrgen evaluation](v0_4_hocrgen_evaluation.md)
+- [hocrgen follow-up](v0_4_hocrgen_reply.md)
+- [hocrgen calibration reply](v0_4_hocrgen_calibration_reply.md)
+- [SynthBanshee prompt](v0_4_synthbanshee_prompt.md)
+- [SynthBanshee evaluation](v0_4_synthbanshee_reply.md)
+- [SynthBanshee follow-up reply](v0_4_synthbanshee_followup_reply.md)
+- [hocrsyngen prompt](v0_4_hocrsyngen_prompt.md)
+- [hocrsyngen evaluation](v0_4_hocrsyngen_reply.md)
+- [hocrsyngen follow-up reply](v0_4_hocrsyngen_followup_reply.md)
+
+## Review Scope
+
+The round tested v0.4.0 after the M18 work-first handoff slices and the M19 preview/apply,
+generated-state, and queue-cleanup slices. The partners covered three different adoption modes:
+
+- `hocrgen`: returning design partner, testing whether Splendor can infer the next current roadmap
+  slice after recently merged work.
+- `SynthBanshee`: returning design partner, testing whether v0.4.0 fixed the v0.3 git-blind and
+  maintenance-dominance handoff failures.
+- `hocrsyngen`: first-time partner, testing cold-start setup plus branch/PR/roadmap handoff in a
+  repository that had not adopted Splendor.
+
+## Partner Verdicts
+
+| Partner | Verdict | Main positive signal | Main failure signal |
+| --- | --- | --- | --- |
+| hocrgen | Not yet first tool | Better context pack; maintenance no longer dominated | Failed to infer `F4c` after completed `F3b` |
+| SynthBanshee | Crossed the line | `brief` and `suggest-next` led with issue `#91`; queue-clean orphans fixed | Legacy mutate-on-call commands remain unsafe |
+| hocrsyngen | Not ready for adoption | Useful file index and PR-context aggregator | Failed to infer `S4d` after merged `S4c`; first-run state churn felt unsafe |
+
+## What Improved Since v0.3
+
+- Git-aware handoff is materially better. SynthBanshee saw recent commits, PR context, and the next
+  open work thread ranked above maintenance.
+- Maintenance separation is mostly working. Source freshness, queue state, and wiki review state are
+  discoverable without crowding out work in the main handoff sections.
+- Queue cleanup closure is validated. `queue clean --orphaned` previewed the exact orphan records
+  that SynthBanshee previously could only remove manually.
+- Provisional uncurated context is useful. Partners noticed when important repo docs surfaced with
+  curation hints instead of being silently ignored.
+- Compact generated-state review and PR-summary caveats reduced some of the earlier reviewability
+  pain, though they did not eliminate cold-start state churn concerns.
+
+## What Still Failed
+
+- Current-state inference is not completion-aware enough. hocrgen and hocrsyngen both had enough
+  git/GitHub/roadmap evidence to infer the next slice, but Splendor still sent the handoff back to
+  recently merged work.
+- Preview/apply consistency is incomplete. New cleanup paths teach preview-first behavior, while
+  legacy verbs such as `ingest --pending` still mutate on call.
+- Work-thread surfacing is too narrow. SynthBanshee found that the top issue was correct, but the
+  related open parent and sibling issues did not appear.
+- Cold-start adoption is too noisy. hocrsyngen observed many visible top-level generated files after
+  first-run setup and minimal seeding.
+- Some implementation surfaces are missed even when authority docs name them. SynthBanshee expected
+  `synthbanshee/tts/renderer.py` and `tests/unit/test_effective_prosody_cap.py` to appear because
+  the ASR policy names their symbols.
+
+## Cross-Cutting Takeaways
+
+1. v0.4.0 validated the M18 direction: work-first, git-aware handoff can make Splendor the first
+   command an external coding agent runs.
+2. The next safety gap is legacy mutation behavior. The new queue cleanup command makes the old
+   mutate-on-call commands more surprising, not less, because the CLI now teaches mixed semantics.
+3. The next handoff-quality gap is completion-aware planning inference: merged slice plus ordered
+   roadmap should imply the next open slice, even when dynamic planning docs are stale.
+4. Cold-start ergonomics matter separately from handoff correctness. A first-time repo can tolerate
+   less state only if Splendor clearly explains where that state will live and how to review or
+   discard it.
+5. The raw evaluation notes are evidence, not planning state. Product/design changes should cite
+   them through a findings register or roadmap update rather than treating the raw partner replies
+   as durable requirements.
+
+## Agreed Priority Signals
+
+SynthBanshee chose legacy preview/apply harmonization first, then multi-issue work-thread surfacing,
+then polish. Its reason was safety: v0.4.0 made the preview/apply asymmetry more dangerous by adding
+new preview-first commands next to older drain verbs.
+
+hocrgen and hocrsyngen both selected completion-aware current-state inference as the blocker for
+their next trial. Both failures involved the same pattern: recently completed work remained ranked as
+next work when the roadmap pointed to the following slice.
+
+The combined sequence suggested by the review round is:
+
+1. Legacy preview/apply harmonization for mutating maintenance/workflow verbs.
+2. Completion-aware current-state planning inference.
+3. Broader work-thread surfacing for related open issues.
+4. Cold-start/local-state ergonomics.
+5. Focused robustness and polish: PATH-safe git lookup, policy-cited path boosting, clearer no-diff
+   PR summaries, and removal of trailing maintenance next-actions.
+
+## Out Of Scope For This PR
+
+This intake PR intentionally does not update `.agent-plan.md`, roadmap planning state, product
+specs, command behavior, or tests. Those changes should land in follow-up implementation/design PRs
+with their own scoped validation.

--- a/docs/evaluations/v0_4_external_review_round_summary.md
+++ b/docs/evaluations/v0_4_external_review_round_summary.md
@@ -101,6 +101,6 @@ The combined sequence accepted for the remaining M19 durability track is:
 
 ## Out Of Scope For This PR
 
-This intake PR intentionally does not update `.agent-plan.md`, roadmap planning state, product
-specs, command behavior, or tests. Those changes should land in follow-up implementation/design PRs
-with their own scoped validation.
+This intake PR intentionally does not change runtime command behavior or add implementation tests.
+It records the external review materials, synthesizes findings, and updates planning/spec/guide
+documents so the follow-up implementation slices have an explicit target and validation frame.

--- a/docs/evaluations/v0_4_hocrgen_calibration_reply.md
+++ b/docs/evaluations/v0_4_hocrgen_calibration_reply.md
@@ -6,10 +6,10 @@ Goal string: `Resume hocrgen planning after F3b`
 Expected top work item: `F4c: Add deeper Hebrew rendering/provider metadata gates for hocrsyngen batches`
 
 Expected current-state authority:
-- [.agent-plan.md](/Users/shaypalachy/clones/hocrgen/.agent-plan.md:8): last completed action is `F3b`
-- [.agent-plan.md](/Users/shaypalachy/clones/hocrgen/.agent-plan.md:20): next critical-path implementation moves to `F4c`
-- [docs/HeOCR_hocrgen_long_term_roadmap.md](/Users/shaypalachy/clones/hocrgen/docs/HeOCR_hocrgen_long_term_roadmap.md:197): current critical path after `F3b`
-- [docs/HeOCR_hocrgen_long_term_roadmap.md](/Users/shaypalachy/clones/hocrgen/docs/HeOCR_hocrgen_long_term_roadmap.md:203): move next to `F4c`
+- hocrgen `.agent-plan.md` line 8: last completed action is `F3b`
+- hocrgen `.agent-plan.md` line 20: next critical-path implementation moves to `F4c`
+- hocrgen `docs/HeOCR_hocrgen_long_term_roadmap.md` line 197: current critical path after `F3b`
+- hocrgen `docs/HeOCR_hocrgen_long_term_roadmap.md` line 203: move next to `F4c`
 
 Expected recent PR/git context placement: PR #64 / commit `da1a1b6` F3b should be background context under “recently completed / read for predecessor context,” not a work action.
 

--- a/docs/evaluations/v0_4_hocrgen_calibration_reply.md
+++ b/docs/evaluations/v0_4_hocrgen_calibration_reply.md
@@ -1,0 +1,71 @@
+Here are three acceptance examples I would turn into tests.
+
+**Example 1**
+Goal string: `Resume hocrgen planning after F3b`
+
+Expected top work item: `F4c: Add deeper Hebrew rendering/provider metadata gates for hocrsyngen batches`
+
+Expected current-state authority:
+- [.agent-plan.md](/Users/shaypalachy/clones/hocrgen/.agent-plan.md:8): last completed action is `F3b`
+- [.agent-plan.md](/Users/shaypalachy/clones/hocrgen/.agent-plan.md:20): next critical-path implementation moves to `F4c`
+- [docs/HeOCR_hocrgen_long_term_roadmap.md](/Users/shaypalachy/clones/hocrgen/docs/HeOCR_hocrgen_long_term_roadmap.md:197): current critical path after `F3b`
+- [docs/HeOCR_hocrgen_long_term_roadmap.md](/Users/shaypalachy/clones/hocrgen/docs/HeOCR_hocrgen_long_term_roadmap.md:203): move next to `F4c`
+
+Expected recent PR/git context placement: PR #64 / commit `da1a1b6` F3b should be background context under “recently completed / read for predecessor context,” not a work action.
+
+Expected files/tests to read first:
+- `.agent-plan.md`
+- `docs/HeOCR_hocrgen_long_term_roadmap.md`
+- `README.md`
+- `docs/synthetic_asset_contribution_guide.md`
+- `src/hocrgen/fetchers/hocrsyngen_manifest.py`
+- `tests/test_hocrsyngen_manifest.py`
+- `tests/test_source_ops.py`
+
+Must not outrank top item: `Review PR #64: F3b...`
+
+**Example 2**
+Goal string: `Continue hocrgen roadmap work from current main`
+
+Expected top work item: `F4c: Add deeper Hebrew rendering/provider metadata gates for hocrsyngen batches`
+
+Expected current-state authority:
+- `.agent-plan.md` current system state says last completed roadmap action is `F3b`
+- `.agent-plan.md` active breakdown has `F4c` unchecked after completed `F4b`
+- roadmap milestone table marks `F4b` completed and `F4c` planned after `F4b`
+- roadmap current critical path says move next to `F4c`
+
+Expected recent PR/git context placement: recent F3b/F3a commits should appear after the inferred next task as “recent merged context.” They should help explain why F3 is done, not become actions.
+
+Expected files/tests to read first:
+- `.agent-plan.md`
+- `docs/HeOCR_hocrgen_long_term_roadmap.md`
+- `README.md`
+- `src/hocrgen/fetchers/hocrsyngen_manifest.py`
+- `tests/test_hocrsyngen_manifest.py`
+- `src/hocrgen/data/hocrsyngen/contracts/generation_manifest_v1/fixture-batch/generation_manifest.json`
+
+Must not outrank top item: `splendor wiki status`, `source freshness`, or “review latest commit.”
+
+**Example 3**
+Goal string: `Start the next hocrsyngen provider-gate implementation work`
+
+Expected top work item: `F4c: Add deeper Hebrew rendering/provider metadata gates for hocrsyngen batches`
+
+Expected current-state authority:
+- roadmap F4 table: `F4b` completed, `F4c` planned after `F4b`
+- `.agent-plan.md`: `F4b` completed and `F4c` planned follow-up
+- README hocrsyngen/provider section describing current manifest-backed source and missing deeper gates
+- synthetic contribution guide allowing provider metadata and validation rules that improve Hebrew rendering/provenance/export checks
+
+Expected recent PR/git context placement: F4b commit/PR context should be “predecessor implementation context.” Useful, but below the current `F4c` work item.
+
+Expected files/tests to read first:
+- `src/hocrgen/fetchers/hocrsyngen_manifest.py`
+- `tests/test_hocrsyngen_manifest.py`
+- `tests/test_source_ops.py`
+- `README.md`
+- `docs/synthetic_asset_contribution_guide.md`
+- hocrsyngen fixture manifest under `src/hocrgen/data/hocrsyngen/...`
+
+Must not outrank top item: historical spinout amendment docs or legacy `src/hocrgen/synthetic/generator.py` work. Those can be supporting context, not the handoff target.

--- a/docs/evaluations/v0_4_hocrgen_evaluation.md
+++ b/docs/evaluations/v0_4_hocrgen_evaluation.md
@@ -1,5 +1,5 @@
 **1. Verdict**
-I would still start hocrgen work with direct `rg`, git, and docs. Splendor v0.4.0 is better as a context pack than v0.3, but it did not cross the line: for the actual resume task it failed the core test. It surfaced F3b/F3a history and some right authority docs, but it did not identify `F4c` as the next implementation task even though that is explicit in [.agent-plan.md](/Users/shaypalachy/clones/hocrgen/.agent-plan.md:20) and the roadmap.
+I would still start hocrgen work with direct `rg`, git, and docs. Splendor v0.4.0 is better as a context pack than v0.3, but it did not cross the line: for the actual resume task it failed the core test. It surfaced F3b/F3a history and some right authority docs, but it did not identify `F4c` as the next implementation task even though that is explicit in hocrgen `.agent-plan.md` line 20 and the roadmap.
 
 Verified install: `/tmp/splendor-v040/bin/splendor --version` returned `splendor 0.4.0` from the GitHub release wheel.
 
@@ -32,10 +32,10 @@ Neither command explicitly identified `F4c` as the next implementation task.
 Ideal top 5 should have been:
 
 1. `F4c`: add deeper Hebrew rendering/provider metadata gates for hocrsyngen batches.
-2. [.agent-plan.md](/Users/shaypalachy/clones/hocrgen/.agent-plan.md:20) and roadmap current critical path as primary authority.
-3. [docs/HeOCR_hocrgen_long_term_roadmap.md](/Users/shaypalachy/clones/hocrgen/docs/HeOCR_hocrgen_long_term_roadmap.md:190) / [line 203](/Users/shaypalachy/clones/hocrgen/docs/HeOCR_hocrgen_long_term_roadmap.md:203) for F4c sequence.
-4. README hocrsyngen/provider sections and [docs/synthetic_asset_contribution_guide.md](/Users/shaypalachy/clones/hocrgen/docs/synthetic_asset_contribution_guide.md:39).
-5. Implementation surface: [src/hocrgen/fetchers/hocrsyngen_manifest.py](/Users/shaypalachy/clones/hocrgen/src/hocrgen/fetchers/hocrsyngen_manifest.py:29), [tests/test_hocrsyngen_manifest.py](/Users/shaypalachy/clones/hocrgen/tests/test_hocrsyngen_manifest.py:44), fixture manifest, source-health tests.
+2. hocrgen `.agent-plan.md` line 20 and roadmap current critical path as primary authority.
+3. hocrgen `docs/HeOCR_hocrgen_long_term_roadmap.md` lines 190 and 203 for the F4c sequence.
+4. README hocrsyngen/provider sections and hocrgen `docs/synthetic_asset_contribution_guide.md` line 39.
+5. Implementation surface: hocrgen `src/hocrgen/fetchers/hocrsyngen_manifest.py` line 29, hocrgen `tests/test_hocrsyngen_manifest.py` line 44, fixture manifest, source-health tests.
 
 What it got right: F3b/F3a were recent and relevant; roadmap and README were high; maintenance state was labeled as maintenance; external spinout reviews are now more relevant than before.
 

--- a/docs/evaluations/v0_4_hocrgen_evaluation.md
+++ b/docs/evaluations/v0_4_hocrgen_evaluation.md
@@ -1,0 +1,80 @@
+**1. Verdict**
+I would still start hocrgen work with direct `rg`, git, and docs. Splendor v0.4.0 is better as a context pack than v0.3, but it did not cross the line: for the actual resume task it failed the core test. It surfaced F3b/F3a history and some right authority docs, but it did not identify `F4c` as the next implementation task even though that is explicit in [.agent-plan.md](/Users/shaypalachy/clones/hocrgen/.agent-plan.md:20) and the roadmap.
+
+Verified install: `/tmp/splendor-v040/bin/splendor --version` returned `splendor 0.4.0` from the GitHub release wheel.
+
+**2. Actual Top Handoff**
+`brief --agent-context` first visible handoff items:
+
+1. Review PR #64: `F3b: Implement bounded modern handwriting acquisition workflow`
+2. Review PR #63: `F3a: Define rights-clean modern handwritten acquisition policy`
+3. Review commit `da1a1b6`: F3b
+4. Review commit `821c244`: D2a source-health paths
+5. Review commit `b10c78d`: E4a governance controls
+6. Read `docs/HeOCR_hocrgen_long_term_roadmap.md`
+7. Read `docs/hocrgen_design_and_spec.md`
+8. Read `src/hocrgen/cli.py`
+
+`suggest-next` first 8:
+
+1. Review PR #64 F3b
+2. Review PR #63 F3a
+3. Review commit `da1a1b6` F3b
+4. Review commit `821c244` D2a
+5. Review commit `b10c78d` E4a
+6. Read `README.md`
+7. Read `docs/HeOCR_hocrgen_long_term_roadmap.md`
+8. Read provisional doc `tests/test_planning_docs.py`
+
+Neither command explicitly identified `F4c` as the next implementation task.
+
+**3. Compare To Expected**
+Ideal top 5 should have been:
+
+1. `F4c`: add deeper Hebrew rendering/provider metadata gates for hocrsyngen batches.
+2. [.agent-plan.md](/Users/shaypalachy/clones/hocrgen/.agent-plan.md:20) and roadmap current critical path as primary authority.
+3. [docs/HeOCR_hocrgen_long_term_roadmap.md](/Users/shaypalachy/clones/hocrgen/docs/HeOCR_hocrgen_long_term_roadmap.md:190) / [line 203](/Users/shaypalachy/clones/hocrgen/docs/HeOCR_hocrgen_long_term_roadmap.md:203) for F4c sequence.
+4. README hocrsyngen/provider sections and [docs/synthetic_asset_contribution_guide.md](/Users/shaypalachy/clones/hocrgen/docs/synthetic_asset_contribution_guide.md:39).
+5. Implementation surface: [src/hocrgen/fetchers/hocrsyngen_manifest.py](/Users/shaypalachy/clones/hocrgen/src/hocrgen/fetchers/hocrsyngen_manifest.py:29), [tests/test_hocrsyngen_manifest.py](/Users/shaypalachy/clones/hocrgen/tests/test_hocrsyngen_manifest.py:44), fixture manifest, source-health tests.
+
+What it got right: F3b/F3a were recent and relevant; roadmap and README were high; maintenance state was labeled as maintenance; external spinout reviews are now more relevant than before.
+
+What was wrong: it stopped at “review F3b” instead of inferring “F3b is complete, next is F4c”; `.agent-plan.md` ranked below README and historical spinout amendments; it did not surface `src/hocrgen/fetchers/hocrsyngen_manifest.py` or `tests/test_hocrsyngen_manifest.py` in the first-read list.
+
+**4. Old Gaps**
+- Work-first behavior: still weak. It produced review/history tasks, not the next work.
+- Authority ranking: partially fixed, still wrong. Roadmap/README are high, but `.agent-plan.md` should outrank spinout amendments for current state.
+- Provisional uncurated docs: useful and clearly labeled. `tests/test_planning_docs.py` was noisy but defensible.
+- Maintenance separation: fixed enough. Queue/wiki/freshness stayed out of the main task list.
+- Git/PR context: useful but over-dominant. It identified F3b/F3a, but did not use them to transition.
+- `pr-summary --since main`: still useful, no regression. It correctly said no diff from main and warned local lint/health reports are not tied to HEAD.
+
+**5. Current hocrgen Needs**
+Splendor did not understand the F3b to F4c transition. It surfaced synthetic-provider/spinout context but not the actual implementation handoff: deeper Hebrew rendering/provider metadata gates around the hocrsyngen manifest path. It also missed the key files/tests for doing the work: `hocrsyngen_manifest.py`, `tests/test_hocrsyngen_manifest.py`, fixture `generation_manifest.json`, and source-health coverage.
+
+**6. Smallest Reproducible Failures**
+```bash
+/tmp/splendor-v040/bin/splendor suggest-next "Resume hocrgen planning after F3b"
+```
+Failure: top item is “Review PR #64 F3b”; expected `F4c`. It displaced the explicit current task from `.agent-plan.md`.
+
+```bash
+/tmp/splendor-v040/bin/splendor brief --agent-context "Resume hocrgen planning after F3b"
+```
+Failure: “Files to read first” includes `src/hocrgen/cli.py` and config files, but omits `src/hocrgen/fetchers/hocrsyngen_manifest.py` and `tests/test_hocrsyngen_manifest.py`.
+
+```bash
+/tmp/splendor-v040/bin/splendor suggest-next "Resume hocrgen planning after F3b"
+```
+Ranking failure: historical `docs/2026_05_02_heocrsyn_spinout/...` authority scored above `.agent-plan.md`; current state should win.
+
+**7. Recommendations**
+Must fix before I would use it first:
+
+1. Add completion-aware planning inference: if F3b is merged/current complete, use `.agent-plan.md` and roadmap “current critical path” language to propose the next unchecked notation, here `F4c`.
+2. Promote current-state authority above historical amendments: `.agent-plan.md` plus roadmap current critical path must outrank outside/spinout reviews unless the query asks for historical review input.
+
+Nice later:
+
+1. Add implementation-surface discovery from roadmap terms: `F4c + hocrsyngen + manifest + tests` should pull `hocrsyngen_manifest.py`, fixture manifests, and matching tests.
+2. Keep PR/git context, but demote merged PRs from “next action” to “background context” when the user asks to resume after that PR.

--- a/docs/evaluations/v0_4_hocrgen_reply.md
+++ b/docs/evaluations/v0_4_hocrgen_reply.md
@@ -1,0 +1,46 @@
+Yes. The next Splendor slice should be “current-state planning inference.” Not maintenance.
+
+1. Mostly parser/ranker first, schema later.
+
+For hocrgen, a schema would be cleaner long term, but requiring explicit config before Splendor can read obvious current-state docs would miss the point. The repo already has strong planning language:
+
+- `Last completed roadmap action`
+- `next planned critical-path implementation should move to`
+- unchecked task list rows
+- roadmap status tables with `completed` / `planned`
+- “Move next to `F4c`”
+
+Splendor should parse those as high-confidence planning signals. That is not brittle regex if implemented as a layered extractor with evidence spans and confidence, not one-off string matching. It can detect common planning idioms, quote the source line internally, and only promote when multiple signals agree.
+
+I’d add schema/config later as an override, not as the foundation. Something like `planning_authority: .agent-plan.md` and `roadmap_status_patterns` is useful for weird repos, but hocrgen should work without it because the current docs are explicit.
+
+The behavior should be:
+
+- If goal says “after F3b”, resolve `F3b` status from current authority.
+- If `F3b` is completed and current authority says next is `F4c`, top work item becomes `Implement F4c...`.
+- Merged PRs for F3b become “recent context to read if needed,” not actionable next steps.
+- Historical docs can support why F4c exists, but cannot outrank current-state docs.
+
+2. Implementation-surface discovery should use both roadmap/doc references and source search.
+
+Roadmap/test references alone are too sparse. Broad source search alone is noisy. The right approach is a two-stage retrieval:
+
+- Extract slice terms: `F4c`, `hocrsyngen`, `Hebrew rendering`, `provider metadata`, `manifest`, `generation_manifest`, maybe `synthetic`.
+- Expand from authoritative text: docs and `.agent-plan.md` identify the domain and constraints.
+- Search indexed paths/content for those terms.
+- Rank by combined signals:
+  - source/test role: `src/`, `tests/`, fixtures, config
+  - exact token overlap: `hocrsyngen`, `manifest`
+  - existing ownership boundary: fetcher/source adapter/test names
+  - recent changed files from F4b, if available
+  - negative weight for generic docs unless the question is planning-only
+
+For F4c, the expected surfaced implementation set is obvious:
+
+- `src/hocrgen/fetchers/hocrsyngen_manifest.py`
+- `tests/test_hocrsyngen_manifest.py`
+- `src/hocrgen/data/hocrsyngen/.../generation_manifest.json`
+- source-health tests around hocrsyngen
+- README / synthetic asset guide as policy references
+
+So your P list is right, with one adjustment: merged PR demotion is part of P1, not P2. The failure mode is not just ranking polish; it directly caused the wrong handoff.

--- a/docs/evaluations/v0_4_hocrsyngen_followup_reply.md
+++ b/docs/evaluations/v0_4_hocrsyngen_followup_reply.md
@@ -1,0 +1,14 @@
+Pick **A first**.
+
+For the hocrsyngen trial, the decisive failure was not noise or setup friction; it was that Splendor had the available signals and still gave the wrong handoff. A tool meant for agent continuity has to reconcile stale dynamic docs against git/GitHub reality and roadmap order. If S4c is merged and S4d is the next roadmap item, the brief should say that plainly.
+
+B is a close second because first-run repo churn made the tool feel unsafe. But I can work around noisy state with a throwaway branch/worktree. I cannot safely rely on a handoff tool that over-trusts stale `.agent-plan.md` and sends the next agent back to already-merged work.
+
+C should be split: the PATH crash is a real bug, not polish, but it is narrower than A. Ingest progress, scan ranking, and lint false positives can follow.
+
+My priority order for a second hocrsyngen trial:
+
+1. **A:** current-state reasoning.
+2. **B:** cold-start/local state ergonomics.
+3. **C-critical:** PATH-safe git lookup.
+4. **C-polish:** progress, ranking, lint cleanup.

--- a/docs/evaluations/v0_4_hocrsyngen_prompt.md
+++ b/docs/evaluations/v0_4_hocrsyngen_prompt.md
@@ -1,0 +1,184 @@
+# Splendor v0.4.0 Trial Prompt - hocrsyngen
+
+Prompt for `codex@hocrsyngen`.
+
+```markdown
+You are doing a first-time trial of Splendor v0.4.0 in `hocrsyngen`.
+
+You have never used Splendor before. Treat that as part of the evaluation: I
+want to know whether Splendor is discoverable and useful from a cold start, not
+whether you can guess its intended workflow.
+
+## What Splendor Is
+
+Splendor is a local-first, git-native knowledge compiler and agent handoff tool.
+It is supposed to help coding agents understand current repo state, roadmap
+state, PR context, and next work without replacing direct code/docs inspection.
+
+This repo has not historically used Splendor, so expect no existing Splendor
+workspace state unless someone already initialized it.
+
+## Trial Goal
+
+Evaluate whether Splendor can help a new agent understand and review the current
+`hocrsyngen` work:
+
+> Review the current S4c condition-control bundle branch/PR, identify whether
+> the handoff is coherent, and say what the next roadmap work should be after
+> S4c.
+
+Do not implement product changes unless you find an urgent local issue. This is
+primarily a Splendor adoption/review trial.
+
+## Protect The Repo
+
+Start by recording the current git state. If you initialize Splendor or run
+mutating commands, do it on a throwaway branch or worktree so the active PR
+branch is not polluted.
+
+Recommended:
+
+```bash
+git status --short --branch
+git log --oneline --decorate -12
+git switch -c trial/splendor-v0.4-first-pass
+```
+
+Do not commit or push Splendor trial state unless explicitly asked.
+
+## Current Ground Truth To Compare Against
+
+You should be able to discover these facts from normal repo inspection, and
+ideally Splendor should help surface them:
+
+- Current branch: `feature/s4c-condition-control-bundles`
+- Active PR: `#37`
+- Active roadmap item: `S4c: Condition control bundles`
+- Last completed roadmap/PR: `S4b: Add deterministic style parameter bundles`,
+  PR `#36`
+- Current phase: Phase S4, Persona/Style/Condition Controls
+- Likely next roadmap item after S4c: `S4d: Style consistency checks`
+- Important files:
+  - `.agent-plan.md`
+  - `AGENTS.md`
+  - `README.md`
+  - `docs/roadmap.md`
+  - `docs/generation_manifest_v1.md`
+  - `docs/hocrgen_integration.md`
+  - `docs/decisions/0005-persona-style-condition-semantics.md`
+  - `src/hocrsyngen/generator.py`
+  - `src/hocrsyngen/cli.py`
+  - `src/hocrsyngen/validation.py`
+  - `tests/test_generation.py`
+  - `tests/test_cli.py`
+
+A good handoff should prioritize S4c review/closure and then S4d. It should not
+bury that under generic maintenance, stale history, or broad repo scanning
+noise.
+
+## Baseline Without Splendor
+
+First, establish what a normal agent would see:
+
+```bash
+git status --short --branch
+git diff --stat main...HEAD
+git log --oneline --decorate -12
+rg -n "S4c|S4d|condition|controls.condition|condition bundle|style consistency|Phase S4" .agent-plan.md README.md docs src tests
+```
+
+Briefly note the baseline answer you would give without Splendor.
+
+## Splendor Cold Start
+
+Use Splendor v0.4.0. If it is not installed, install it however your
+environment normally installs CLI tools, preferably from the `v0.4.0`
+release/tag. Record any installation friction.
+
+Run:
+
+```bash
+splendor --version
+splendor --help
+splendor init
+splendor health
+```
+
+Then try to discover the repo without assuming prior Splendor knowledge:
+
+```bash
+splendor repo scan --class documentation --json
+splendor repo scan --class configuration --json
+splendor repo scan --class code --json
+```
+
+Evaluate whether the scan results point to the right files or produce too much
+noise.
+
+If you need to seed a useful minimal workspace, register only the core handoff
+sources:
+
+```bash
+splendor add-source AGENTS.md --capture-source-commit
+splendor add-source .agent-plan.md --capture-source-commit
+splendor add-source README.md --capture-source-commit
+splendor add-source docs/roadmap.md --capture-source-commit
+splendor add-source docs/generation_manifest_v1.md --capture-source-commit
+splendor add-source docs/hocrgen_integration.md --capture-source-commit
+splendor add-source docs/decisions/0005-persona-style-condition-semantics.md --capture-source-commit
+splendor add-source src/hocrsyngen/generator.py --capture-source-commit
+splendor add-source src/hocrsyngen/cli.py --capture-source-commit
+splendor add-source src/hocrsyngen/validation.py --capture-source-commit
+splendor add-source tests/test_generation.py --capture-source-commit
+splendor add-source tests/test_cli.py --capture-source-commit
+splendor ingest --pending
+```
+
+Then run:
+
+```bash
+splendor brief --agent-context "Review the current S4c condition-control bundle branch and identify remaining PR handoff work"
+splendor suggest-next "Continue hocrsyngen roadmap work after S4c"
+splendor pr-summary --since main
+splendor queue inspect
+splendor lint
+```
+
+If a command fails, keep going and report the exact failure.
+
+## What To Review
+
+Please answer these directly:
+
+1. Would you use Splendor again in `hocrsyngen` after this first trial? Why or
+   why not?
+2. Was cold-start setup obvious enough for a repo that had never used Splendor?
+3. Did Splendor correctly surface the current S4c branch/PR and the S4d next
+   step?
+4. Did it understand `.agent-plan.md` as current dynamic state rather than
+   treating roadmap history as equally current?
+5. Did it help with PR review, or was direct `git diff`/`rg` still better?
+6. Did generated Splendor state or queue/maintenance output create confusing
+   repo noise?
+7. Did `brief --agent-context` and `suggest-next` keep actual work ahead of
+   maintenance?
+8. What are the top two Splendor fixes needed before you would recommend adding
+   it to this repo?
+
+## Report Format
+
+Return:
+
+- Verdict
+- Commands run
+- Baseline answer without Splendor
+- Splendor answer/handoff summary
+- Ground-truth match table
+- First-use friction
+- State/worktree churn observed
+- Must-fix issues
+- Nice-to-have improvements
+
+Be blunt. The useful feedback is where Splendor failed, confused you, or
+required too much ceremony.
+```

--- a/docs/evaluations/v0_4_hocrsyngen_reply.md
+++ b/docs/evaluations/v0_4_hocrsyngen_reply.md
@@ -69,7 +69,7 @@ But it still suggested “Review PR #37” as the top next action and pulled in 
 | `.agent-plan.md` as dynamic current state | Yes, but checked against git/PR | Not enough; over-trusted stale state |
 
 **First-Use Friction**
-`splendor` was not on `PATH`; I found `/Users/shaypalachy/.local/bin/splendor`. PyPI had no `splendor` package. `npm`, `uv`, `pipx`, and `brew` were unavailable on PATH.
+`splendor` was not on `PATH`; I found `~/.local/bin/splendor`. PyPI had no `splendor` package. `npm`, `uv`, `pipx`, and `brew` were unavailable on PATH.
 
 `add-source --capture-source-commit` initially crashed with:
 
@@ -98,5 +98,3 @@ I removed the Splendor trial files I created and switched back to `main`; final 
 - Fix lint false positives: it reported README links like `docs/roadmap.md` as missing even though they exist.
 - Make scan ranking more opinionated: core handoff files should outrank licenses, fixture corpora, and broad docs.
 - Mark generated contradiction tasks as secondary unless they block the user’s stated goal.
-
-::git-create-branch{cwd="/Users/shaypalachy/clones/hocrsyngen" branch="trial/splendor-v0.4-first-pass"}

--- a/docs/evaluations/v0_4_hocrsyngen_reply.md
+++ b/docs/evaluations/v0_4_hocrsyngen_reply.md
@@ -1,0 +1,102 @@
+**Verdict**
+I would not recommend adding Splendor to `hocrsyngen` yet. It was somewhat useful as a file index and PR-context aggregator, but it failed the core trial: it did not reliably conclude “S4c is merged/done; S4d is next.” Direct `git`, GitHub MCP, and `rg` were faster, clearer, and less noisy.
+
+**Commands Run**
+Recorded/protected repo state:
+
+```bash
+git status --short --branch
+git log --oneline --decorate -12
+git switch -c trial/splendor-v0.4-first-pass
+```
+
+Baseline:
+
+```bash
+git diff --stat main...HEAD
+rg -n "S4c|S4d|condition|controls.condition|condition bundle|style consistency|Phase S4" .agent-plan.md README.md docs src tests
+```
+
+GitHub MCP:
+
+```text
+_get_pr_info HeOCR/hocrsyngen #37
+_list_pr_changed_filenames HeOCR/hocrsyngen #37
+_fetch_pr_comments HeOCR/hocrsyngen #37
+```
+
+Splendor:
+
+```bash
+splendor --version
+splendor --help
+splendor init
+splendor health
+splendor repo scan --class documentation --json
+splendor repo scan --class configuration --json
+splendor repo scan --class code --json
+splendor add-source ... --capture-source-commit
+splendor ingest --pending
+splendor brief --agent-context "Review the current S4c condition-control bundle PR and identify remaining handoff work"
+splendor suggest-next "Continue hocrsyngen roadmap work after S4c"
+splendor pr-summary --since main
+splendor queue inspect
+splendor lint
+splendor query "S4d style consistency checks"
+splendor query "current roadmap item after S4c"
+```
+
+**Baseline Answer Without Splendor**
+Normal inspection says the user-provided ground truth is now stale in this checkout. Initial branch was `main`, not `feature/s4c-condition-control-bundles`. GitHub MCP says PR `#37` is closed and merged, non-draft, with merge commit `4666b65`.
+
+Handoff coherence: the S4c PR body is coherent and the changed-file set matches the stated work. But repo handoff docs are stale after merge: `.agent-plan.md` still says active branch/PR/item is S4c, and `docs/roadmap.md` still says S4c is current. The next roadmap work should be `S4d: Style consistency checks`.
+
+**Splendor Answer/Handoff Summary**
+Splendor correctly found PR `#37`, recent commit `4666b65`, `.agent-plan.md`, `README.md`, `docs/roadmap.md`, manifest docs, and integration docs. The `brief` output was useful as a reading list.
+
+But it still suggested “Review PR #37” as the top next action and pulled in older PRs like `#35`, `#36`, `#17`. `suggest-next` did not surface S4d at all. A direct `splendor query "current roadmap item after S4c"` found the roadmap page, but still did not answer “S4d.”
+
+**Ground-Truth Match Table**
+| Fact | Direct Inspection | Splendor |
+|---|---:|---:|
+| Current branch is feature branch | No, checkout was `main` | No, saw trial branch |
+| Active PR is `#37` | No, `#37` is merged | Found `#37`, but still treated review as next |
+| Active roadmap item S4c | Docs say yes, reality says stale | Treated S4c as current |
+| Last completed PR S4b/#36 | Stale; S4c/#37 is now completed | Did not correct this |
+| Phase S4 | Yes | Yes |
+| Next should be S4d | Yes via roadmap/direct reasoning | No |
+| Important files surfaced | Yes | Mostly yes, with noise |
+| `.agent-plan.md` as dynamic current state | Yes, but checked against git/PR | Not enough; over-trusted stale state |
+
+**First-Use Friction**
+`splendor` was not on `PATH`; I found `/Users/shaypalachy/.local/bin/splendor`. PyPI had no `splendor` package. `npm`, `uv`, `pipx`, and `brew` were unavailable on PATH.
+
+`add-source --capture-source-commit` initially crashed with:
+
+```text
+NotADirectoryError: [Errno 20] Not a directory: 'git'
+```
+
+Cause: the Codex `PATH` included a non-directory arg0 shim before `/usr/bin`; Splendor’s subprocess git lookup did not tolerate that. Sanitizing `PATH` fixed it.
+
+`ingest --pending` was silent for roughly a minute, then succeeded.
+
+**State/Worktree Churn Observed**
+`splendor init` created top-level `derived/`, `planning/`, `raw/`, `reports/`, `state/`, `wiki/`, and `splendor.yaml`.
+
+After minimal seeding/ingest, Splendor created 87 untracked files. Queue records stayed present even after completion. `pr-summary --since main` reported 86 changed paths, almost entirely Splendor state.
+
+I removed the Splendor trial files I created and switched back to `main`; final worktree is clean.
+
+**Must-Fix Issues**
+1. Next-work ranking must combine git/GitHub state with roadmap state. If PR `#37` is merged and the roadmap lists `S4d` after `S4c`, `suggest-next` should say S4d, not older PR review.
+2. First-run state should not explode into visible top-level repo churn by default. Use a hidden/local ignored workspace, or make the commit-vs-local state model explicit before writing 80+ files.
+
+**Nice-To-Have Improvements**
+- Fix `PATH`/subprocess git lookup robustness.
+- Add progress output for ingest.
+- Fix lint false positives: it reported README links like `docs/roadmap.md` as missing even though they exist.
+- Make scan ranking more opinionated: core handoff files should outrank licenses, fixture corpora, and broad docs.
+- Mark generated contradiction tasks as secondary unless they block the user’s stated goal.
+
+::git-create-branch{cwd="/Users/shaypalachy/clones/hocrsyngen" branch="trial/splendor-v0.4-first-pass"}

--- a/docs/evaluations/v0_4_synthbanshee_followup_reply.md
+++ b/docs/evaluations/v0_4_synthbanshee_followup_reply.md
@@ -1,0 +1,16 @@
+⏺ A — but the choice is closer than the safety/quality framing makes it look.
+
+  By frequency of workflow drag, B wins: every M17 handoff today still needs a follow-up gh issue list because #87 (parent), #88, #92 don't surface.
+  That's friction on every session. A's failure mode is rare but catastrophic — drain the queue once and recovery means git-revert + careful
+  re-ingest.
+
+  I'd still pick A first, for two reasons that aren't in your framing:
+
+  1. v0.4.0 made the asymmetry worse, not better. queue clean now previews by default — so an agent that learned "v0.4 commands preview" will reach
+  for ingest --pending --json expecting the same and drain the queue. The convention used to cover a uniformly-mutating surface; now it has to cover a
+   half-mutating one — harder to remember, easier to violate.
+  2. The convention is load-bearing on memory I just wrote. Both the v0.3.0 and v0.4.0 splendor memos contain the exact warning "ingest --pending is a
+   drain verb, not a preview." Every fresh agent, every compressed session, every external caller has to relearn it. A removes that
+  institutional-memory tax outright; B and C don't replace any existing mitigation.
+
+  Sequence: A → B → C. B isn't polish — it's the frequency-weighted handoff-quality fix and belongs second, not bundled with C.

--- a/docs/evaluations/v0_4_synthbanshee_prompt.md
+++ b/docs/evaluations/v0_4_synthbanshee_prompt.md
@@ -1,0 +1,151 @@
+# Splendor v0.4.0 Trial Prompt - SynthBanshee
+
+Prompt for `claude@synthbanshee`.
+
+```markdown
+You are doing a follow-up trial of Splendor v0.4.0 in the SynthBanshee repo.
+
+This is not a first trial. In the v0.3.0 trial, Splendor was useful for source
+freshness, repo-scan safety, queue inspection, generated-review surfacing, and
+some PR-summary behavior, but it failed the main handoff task because
+`brief --agent-context` and `suggest-next` were effectively git-blind and let
+maintenance/housekeeping outrank the real M17 ASR work.
+
+Be blunt. The question is whether v0.4.0 is now good enough to use as a coding
+agent handoff surface in SynthBanshee.
+
+## Trial Goal
+
+Evaluate this task:
+
+> Pick up M17 ASR work after the effective-prosody cap landed; identify the next
+> open work, the relevant files/policies, and what a coding agent should do next.
+
+Do not implement the ASR follow-up. This is a Splendor evaluation and handoff
+review, not a product-change request.
+
+## Protect The Repo
+
+Start by recording the current state:
+
+```bash
+git status --short --branch
+git log --oneline --decorate -12
+```
+
+Use the explicit v0.4.0 Splendor binary if the project venv shadows it. The
+previous trial hit this trap.
+
+```bash
+which splendor
+splendor --version
+~/.local/bin/splendor --version
+```
+
+Do not commit or push Splendor state changes. If a command mutates state during
+exploration, record that fact and clean it up before ending.
+
+## Current Ground Truth To Compare Against
+
+You should verify this from local git/GitHub/repo inspection before judging
+Splendor:
+
+- PR #90 is merged: `fix(tts): #87 partial - effective-prosody cap addresses Whisper backdoor + helium range`.
+- Local `main` should include commit `37c5f62`.
+- PR #90 reduced the #87 Whisper backdoor failure but did not fully restore the
+  `sp_it_a_0001` WER gap.
+- The next open follow-up should be issue #91:
+  `fix(tts): #87 follow-up - test rate-floor lift to address residual sp_it WER gap (R)`.
+- The likely concrete work is to test raising `_EFFECTIVE_RATE_MIN` from `0.85`
+  to `0.95`, while keeping PR #90's pitch cap unchanged.
+- The key implementation/policy files are:
+  - `AGENTS.md`
+  - `CLAUDE.md`
+  - `docs/m17_phase_a_validation_report.md`
+  - `docs/audio_generation_v3_design.md`
+  - `synthbanshee/tts/renderer.py`
+  - `synthbanshee/package/asr_sanity.py`
+  - `tests/unit/test_effective_prosody_cap.py`
+  - `tests/unit/test_asr_sanity.py`
+  - `tests/unit/test_qa.py`
+
+Important wrinkle: `.agent-plan.md` may contain older milestone state. A good
+handoff should notice when recent GitHub/git authority supersedes stale planning
+state rather than blindly telling an agent to do old work.
+
+## Baseline Without Splendor
+
+First answer the task using normal tools:
+
+```bash
+git status --short --branch
+git log --oneline --decorate -12
+gh pr view 90 --json number,title,state,mergedAt,url,body,labels,milestone
+gh issue view 91 --json number,title,state,url,body,labels,milestone
+rg -n "M17|ASR|Whisper|rate-floor|sp_it|effective-prosody|prosody cap|#91|#90|helium|backdoor" AGENTS.md CLAUDE.md README.md docs synthbanshee tests .agent-plan.md
+```
+
+Write the baseline handoff you would give without Splendor.
+
+## Splendor Commands To Evaluate
+
+Run these with Splendor v0.4.0:
+
+```bash
+splendor health
+splendor lint
+splendor queue inspect
+splendor brief --agent-context "Pick up M17 ASR work after the effective-prosody cap landed"
+splendor suggest-next "Pick up M17 ASR work after the effective-prosody cap landed"
+splendor pr-summary --since main
+```
+
+If the repo has stale queue records, also inspect whether v0.4.0 exposes a
+preview/apply cleanup path clearly:
+
+```bash
+splendor queue inspect --json
+splendor queue clean --orphaned
+splendor queue clean --superseded
+```
+
+Only use `--apply` if you intentionally want to test mutation behavior and can
+cleanly restore the repo afterward.
+
+## What To Judge
+
+Please answer these directly:
+
+1. Did `brief --agent-context` and `suggest-next` identify issue #91 as the next
+   real work after PR #90, or did they get distracted by stale `.agent-plan.md`
+   state, merged PR history, or maintenance?
+2. Did Splendor surface the right policy constraints from `AGENTS.md`/`CLAUDE.md`
+   around the ASR sanity check and paired listening test?
+3. Did it name the right implementation and test files for the rate-floor
+   follow-up?
+4. Did maintenance remain discoverable without displacing the real work-first
+   handoff?
+5. Did the new queue cleanup surface fix the orphan/stale queue problem you saw
+   in the v0.3 trial?
+6. Is `pr-summary --since main` useful on this current state, and does it avoid
+   misleading curated/generated classifications?
+7. Would you now use Splendor first for a SynthBanshee handoff? If not, what is
+   still missing?
+
+## Report Format
+
+Return:
+
+- Verdict
+- Commands run
+- Baseline handoff without Splendor
+- Splendor handoff summary
+- Ground-truth match table
+- Old v0.3 gaps: fixed / partially fixed / still broken
+- Any state mutation or worktree churn
+- Must-fix issues before another trial
+- Nice-to-have improvements
+
+Keep the critique concrete. Include smallest reproducible commands for each
+failure.
+```

--- a/docs/evaluations/v0_4_synthbanshee_reply.md
+++ b/docs/evaluations/v0_4_synthbanshee_reply.md
@@ -124,7 +124,7 @@ Notes: `queue clean --orphaned --json` returns `{applied: false, selectors: [...
 
 gh issue list --state open --search "ASR OR Whisper OR WER OR sp_it"
 # Output: #87, #91, #88, #92 (four open ASR issues)
-````
+```
 
 Missing items displaced by: nothing — there's just one slot under Recent issues and PRs. Parent issue #87 is the most defensible miss (it's the anchor #91 references).
 

--- a/docs/evaluations/v0_4_synthbanshee_reply.md
+++ b/docs/evaluations/v0_4_synthbanshee_reply.md
@@ -1,0 +1,179 @@
+# Splendor v0.4.0 — SynthBanshee External-Retry Verdict
+
+Install: `~/.local/bin/splendor` is now `0.4.0` (uv tool, sha256 verified `af5bccc378763d4e2c6df560df78a5cb98684e9c17c39a87b8d0ca382ad879f7`).
+`.venv/bin/splendor` left at `0.2.0`.
+
+## 1. Verdict
+
+Yes — for SynthBanshee work I would now start with `splendor brief --agent-context` before `git log` / `gh issue list` / `rg`. v0.4.0 crossed the line. The git-blind gap is fixed: `brief` opens with the next ASR work-thread (#91) and the three commits that landed before it (#90/37c5f62, #82/94086a8, #77/2408757), authority docs (`AGENTS.md`, `docs/implementation_plan.md`), the right code/policy files (`asr_sanity.py`, `test_asr_sanity.py`, `m17_phase_a_validation_report.md`), and Splendor maintenance is now structurally below the work — not crowding it. The orphan-queue-payload gap from v0.3.0 is fully closed (`queue clean --orphaned` previews all 9 orphans, including the v0.3.0 reproducer `src-24d3518a…`, and exposes a clean JSON contract). It's not perfect — `brief` only surfaced one of four open ASR issues, missed `synthbanshee/tts/renderer.py` from "Files to read first" despite both `AGENTS.md` and `CLAUDE.md` calling it out by symbol name, and the four legacy mutate-immediately verbs (`ingest --pending`, `source refresh`, `source update-path`, `workspace refresh`) still have no `--apply` flag — but it's now the right first tool to run, with manual `gh issue list` and policy-file reads as a deliberate second pass, not a corrective one.
+
+## 2. Actual top handoff
+
+`brief --agent-context "pick up M17 ASR work"` — Suggested next (top 5):
+1. `[high/work-thread]` Review issue #91 — `fix(tts): #87 follow-up rate-floor lift for residual sp_it WER gap (R)` ← `url=…/issues/91`
+2. `[medium/git-context]` Review commit `37c5f62` — `#87 partial: effective-prosody cap (#90)`
+3. `[medium/git-context]` Review commit `94086a8` — `#78 loudness contract + metadata trail (#82)`
+4. `[medium/git-context]` Review commit `2408757` — `M17 Phase A validation (Whisper + UTMOS) (#77)`
+5. `[medium/authority]` Read authority doc `AGENTS.md`
+
+`suggest-next "pick up M17 ASR work"` (top 8): identical 1-5, then `CLAUDE.md` (provisional-uncurated, with `Curate:` hint), `docs/implementation_plan.md`, `wiki/topics/audio-quality-issues.md` (score 1).
+
+Did either lead with the next open ASR issue? Yes — both put issue #91 first, with the `[high/work-thread]` tag separating it from the medium-priority git/authority context.
+
+## 3. Compare to expected
+
+Ideal top 5-8 (ground truth from the parallel `gh`/`git`/`rg` baseline):
+1. issue #91 (rate-floor lift — immediate next)
+2. issue #87 (parent thread: Whisper WER on I3+ Tier A — still open!)
+3. issue #88 (`qa-report --asr` CI plan — open)
+4. issue #92 (naturalness backlog from 2026-05-06 — open)
+5. PR #90 / commit `37c5f62` (effective-prosody cap)
+6. ASR sanity policy section in `AGENTS.md` (lines 89-102, 174-175)
+7. `synthbanshee/tts/renderer.py` (`_apply_effective_prosody_cap`, `_EFFECTIVE_PITCH_*`, `_EFFECTIVE_RATE_*`)
+8. `tests/unit/test_effective_prosody_cap.py` + `synthbanshee/package/asr_sanity.py` + `tests/unit/test_asr_sanity.py` + `docs/m17_phase_a_validation_report.md`
+
+### What Splendor got right
+
+- `#91` first as `[high/work-thread]` — exact match.
+- Three correct git-context commits with sensible decay (`#90 → #82 → #77`).
+- `AGENTS.md` as primary authority + `CLAUDE.md` correctly classified provisional-uncurated with curation command. `docs/implementation_plan.md` second.
+- `docs/m17_phase_a_validation_report.md`, `synthbanshee/package/asr_sanity.py`, `tests/unit/test_asr_sanity.py`, `scripts/m17_phase_a_validation.py` in "Files to read first".
+- Maintenance state clearly fenced: separate Splendor maintenance block + Maintenance commands + Maintenance notes. Wiki topic matches scored 1 vs commits scored 60-63 — token-similar matches genuinely demoted.
+- `branch=main head=37c5f62 base=origin/main merge_base=…` git context block.
+
+### What was wrong / missing / stale
+
+- Issue surfacing too narrow. Recent issues and PRs listed only `#91`. Three other open ASR-relevant issues (`#87`, `#88`, `#92`) were missed entirely despite being labeled `comp: tts` and matching the goal terms. For a goal phrased `"pick up M17 ASR work"`, the parent issue `#87` — open, the literal anchor of `#91` — is a meaningful miss.
+- `renderer.py` and `test_effective_prosody_cap.py` missing from "Files to read first". Both `AGENTS.md` line 174 and `CLAUDE.md` line 174 explicitly name `synthbanshee/tts/renderer.py` and `_EFFECTIVE_PITCH_*` / `_EFFECTIVE_RATE_*` as the don't-touch-without-Tier-3 surface. The cap test file is the unit-test floor named in the policy. Both should rank above `scripts/m17_phase_a_validation.py`.
+- Two stale `Next actions` lines at the very bottom mix maintenance into work:
+       - `Run splendor ingest --pending` to drain pending source ingests (drain verb!)
+       - `Run splendor wiki suggest <source-id>`
+  The top sections cleanly separated work from maintenance; the trailing `Next actions` undoes that separation.
+- `pr-summary --since main` is degenerate on a clean `main` (`changed_paths: 0`, `head == merge_base`). Probe limitation, not a Splendor bug — but worth noting it's untested for branch-vs-main here. The `Latest local maintenance reports (not tied to current HEAD)` caveat is correctly worded.
+
+## 4. Specific old-gap status
+
+Gap: Git-aware handoff
+v0.3.0: git-blind
+v0.4.0: fixed
+Notes: `brief` shows `head/base/merge_base` + 3 ranked commits + work-thread issue first
+
+────────────────────────────────────────
+
+Gap: Housekeeping demotion
+v0.3.0: crowded out work
+v0.4.0: fixed
+Notes: Splendor maintenance block is structurally below work context; only the trailing `Next actions` mixes it back in
+
+────────────────────────────────────────
+
+Gap: Authority ranking (ASR policy + validation)
+v0.3.0: mixed
+v0.4.0: fixed
+Notes: `AGENTS.md` (curated, score 156), `docs/implementation_plan.md` (score 141) above wiki/topic (score 1)
+
+────────────────────────────────────────
+
+Gap: Provisional uncurated docs
+v0.3.0: invisible
+v0.4.0: new + good
+Notes: `CLAUDE.md`, `README.md`, `.agent-plan.md`, `docs/wet_testing_plan.md` all surface as provisional-uncurated with explicit `Curate:` command
+
+────────────────────────────────────────
+
+Gap: Queue cleanup (orphans)
+v0.3.0: no path
+v0.4.0: fixed
+Notes: `queue clean --orphaned` previews all 9 orphans (including v0.3.0 reproducer `src-24d3518a…`); apply path is `--apply`; non-mutating without it (verified: residual file still on disk after preview run)
+
+────────────────────────────────────────
+
+Gap: Preview/apply consistency
+v0.3.0: inconsistent
+v0.4.0: partial
+Notes: `queue clean` got the new contract. `ingest --pending`, `source refresh`, `source update-path`, `workspace refresh` still have NO `--apply` flag (verified via `--help`) — they remain mutate-on-call. Release notes claimed `"Reviewed mutating commands expose deterministic JSON mutation contracts"` — that was scoped to new commands, not legacy harmonization. Most acute risk: `ingest --pending` is still a drain verb with no preview gate.
+
+────────────────────────────────────────
+
+Gap: `pr-summary` cross-reference
+v0.3.0: one-way
+v0.4.0: untested
+Notes: Trial `branch=main` with no diff; cannot exercise.
+
+────────────────────────────────────────
+
+Gap: JSON mutation contract
+v0.3.0: absent
+v0.4.0: fixed for new commands
+Notes: `queue clean --orphaned --json` returns `{applied: false, selectors: [...], summary: {planned, written, skipped}, actions: [{job_id, path, source_id, cleanup_state, status, reason}, …]}`. Field names differ slightly from the release-note prose (`applied` vs `mode`, `mutates` not present) but the semantics are deterministic.
+
+## 5. Current-task understanding (post-#90/#87)
+
+- Did Splendor understand the post-#90 / #87 follow-up situation? Yes — issue #91 is correctly identified as the next thread, and `Reason: Spawned from` in `suggest-next` is wired to the parent (the body cuts off there but the work-thread ranking is right).
+- Rate-floor / residual `sp_it` WER gap? Yes — issue #91's full title surfaces verbatim: `"test rate-floor lift to address residual sp_it WER gap (R)"`.
+- ASR sanity policy + don't-touch-rendering-without-Tier-3 constraint? Partially. `synthbanshee/package/asr_sanity.py` and `tests/unit/test_asr_sanity.py` are in "Files to read first", and `AGENTS.md` is the top authority. But the actual `qa-report --asr` policy block inside `AGENTS.md` lines 89-102 and the don't-merge constraint at lines 174-175 are not directly cited — Splendor names the file but doesn't anchor to the policy section. For an agent that reads `AGENTS.md` end-to-end this is fine; for one that just scans the brief output, the constraint is one indirection away.
+- Did it distinguish work vs Splendor's own state? Yes — `Splendor maintenance: sources=16 pages=20 queue_pending=1 review_needed=16` is its own labeled block, and the Maintenance notes explicitly say `"Wiki review-needed pages and missing synthesis are maintenance state, not default active human tasks."` Big improvement.
+
+## 6. Smallest reproducible failures
+
+### Failure 1 — open-issue surfacing is incomplete
+
+```bash
+~/.local/bin/splendor brief --agent-context "pick up M17 ASR work" | grep "issue #"
+# Output: only #91
+
+gh issue list --state open --search "ASR OR Whisper OR WER OR sp_it"
+# Output: #87, #91, #88, #92 (four open ASR issues)
+````
+
+Missing items displaced by: nothing — there's just one slot under Recent issues and PRs. Parent issue #87 is the most defensible miss (it's the anchor #91 references).
+
+### Failure 2 — `renderer.py` not in "Files to read first"
+
+```bash
+~/.local/bin/splendor brief --agent-context "pick up M17 ASR work" | sed -n '/Files to read first/,/Relevant matches/p'
+#   - synthbanshee/package/asr_sanity.py
+#   - tests/unit/test_asr_sanity.py
+#   - docs/m17_phase_a_validation_report.md
+#   - scripts/m17_phase_a_validation.py
+#   - AGENTS.md
+
+rg -l "_apply_effective_prosody_cap|_EFFECTIVE_PITCH_|_EFFECTIVE_RATE_" synthbanshee tests
+# synthbanshee/tts/renderer.py
+# tests/unit/test_effective_prosody_cap.py
+```
+
+The cap symbol `AGENTS.md` / `CLAUDE.md` call out by name lives in two files that don't appear in the list.
+
+### Failure 3 — apply-gate not harmonized
+
+```bash
+~/.local/bin/splendor ingest --help | grep -E "apply|pending"
+#   --pending   Drain pending ingestion jobs from the queue.
+# (no --apply, no --plan, no --dry-run)
+```
+
+Same shape for `source refresh`, `source update-path`, `workspace refresh`. The `queue clean` contract was applied to new commands only.
+
+## 7. Recommendations
+
+Must fix before next trial (blockers):
+
+1. Harmonize `--apply` across the four legacy mutating verbs: `ingest --pending`, `source refresh`, `source update-path`, `workspace refresh`. Either add `--apply` (preview-by-default) or rename the destructive form (e.g. `ingest drain`). Right now the surface is half-modernized: `queue clean` previews safely, `ingest --pending` drains immediately. An agent that internalized "v0.4.0 commands are preview-by-default" can still mutate manifests with `ingest --pending --json`. This is the same trap that bit the v0.3.0 trial.
+2. Surface ≥3-5 work-relevant open issues in `brief` / `suggest-next`, not just the highest-scoring one. `comp: tts` + goal-keyword matches are abundant (#87, #88, #92 here). A single-issue ceiling makes `brief` a worse first stop than `gh issue list` whenever there are multiple parallel threads.
+
+Nice but later:
+
+3. Add `synthbanshee/tts/renderer.py` (and any file referenced by `_EFFECTIVE_*` symbols inside curated authority docs) to "Files to read first" via a "policy-doc-cited path" boost.
+4. Drop the trailing maintenance lines in `brief`'s "Next actions" footer — keep maintenance in its own block as v0.4.0 already does at the top.
+5. Anchor cited authority sections (e.g. `AGENTS.md#asr-sanity-check-policy`, `AGENTS.md#what-not-to-do`) instead of just the file path, when the policy block is the actionable piece.
+6. Make `pr-summary --since main` recognize the `head == merge_base` case and emit `(no diff vs <ref>)` more loudly than the current `Changed paths: 0` line.
+7. Tighten the JSON contract field names to the release-note prose (`mode`, `mutates`) for grep-friendliness.
+
+---
+
+## What I did NOT do
+
+Per privacy default — no upstream issues filed, no public writeup drafted. Wheel install was scoped to `~/.local/bin/splendor` via uv tool; `.venv/bin/splendor` untouched. No `splendor … --apply` invoked anywhere; queue is unchanged (9 orphans still on disk). Forensic-fixture decision deferred to you (q3 from prior message).
+
+Standing by for direction on (a) whether to memo-update the v0.3.0/v0.4.0 splendor memory, (b) whether to publish, (c) whether to bundle a v0.4.0 forensic fixture.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -164,6 +164,10 @@ uv run splendor --root /tmp/demo-repo ingest --pending
 `ingest --pending` also handles due failed retries and expired ingest leases. Failed jobs wait until
 their persisted `next_attempt_at` backoff time, and exhausted jobs move to `dead_letter` until an
 operator runs `splendor queue retry <job-id>` or `splendor repair ingest <source-id>`.
+Unlike preview-first cleanup commands such as `queue clean`, `ingest --pending` is currently a
+direct drain verb: it writes source-summary, queue, run, and index/log state when work is due. The
+post-v0.4 durability plan is to harmonize this with explicit preview/apply behavior; until then,
+run it only when you intend to process queued ingest work.
 
 This creates:
 
@@ -264,6 +268,9 @@ generated-summary pruning, and maintained-page topic-ref migration can run stand
 `workspace refresh --changed --ingest --prune-superseded --update-topic-refs --rebuild-index`.
 If pruning runs before successor source-summary pages exist, rerun
 `workspace refresh --prune-superseded` after the refreshed sources are ingested.
+These refresh commands are also part of the post-v0.4 preview/apply harmonization plan. Review
+`source freshness`, `queue inspect`, and `pr-summary` before using them in a shared branch if you
+only intended to inspect state.
 
 ## 5. Add a planning record
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -272,6 +272,10 @@ Implemented fields:
 - `splendor ingest --pending --json` emits the same pending queue drain contract as human output in
   structured form: queue total, processed/succeeded/failed/skipped summary counts, per-item source
   IDs, workspace-relative queue paths, outcomes, messages, and deterministic next actions.
+  As of the v0.4 external review, this remains a legacy direct-drain command: it mutates queue,
+  source-summary, run, and index/log state when work is available. The planned durability contract
+  is to give this flow the same agent-safe preview/apply clarity as newer cleanup commands, or to
+  expose an explicitly named destructive drain form so inspection and mutation cannot be confused.
 - `splendor wiki compile <source-id|title|path>` remains non-mutating unless a maintained target
   page is selected and `--apply --proposal-hash <hash>` is supplied. Without `--page`, it reports
   the review-gated contract plus ranked maintained-page suggestions and ready-to-run
@@ -293,6 +297,11 @@ Implemented fields:
   deterministic planned write/delete records for preview mode, and `mutation.written` lists
   deterministic write/delete records for apply or direct-write mode. Records include `action`,
   `path`, `kind`, and `source_id` when source-scoped.
+- Post-v0.4 contract debt: legacy mutating commands must not rely on agents remembering bespoke
+  safety semantics. `ingest --pending`, `source refresh`, `source update-path`, and
+  `workspace refresh` should either become preview-first with explicit `--apply`, or expose
+  deterministic mutation objects and human output that make direct writes unmistakable before the
+  command is run from handoff guidance.
 - `splendor pr-summary --since main` is a read-only PR handoff view over local git diff/status and
   existing report files. It diffs from the merge base between `HEAD` and the base ref, respects
   configured workspace layout directories, and groups curated source manifests, generated
@@ -325,6 +334,18 @@ Implemented fields:
   maintenance goals rank work context before Splendor maintenance. Goal relevance is scored
   deterministically from weighted title/path/record/scope matches, supporting refs, snippets,
   git/GitHub text, and review/authority lifecycle signals before category caps are applied.
+- Planned handoff inference contract: when runtime git/GitHub state indicates that a referenced
+  PR, issue thread, or roadmap slice is merged or complete, and an ordered roadmap or current-state
+  authority names a successor slice, handoff should demote the completed work to supporting context
+  and rank the successor as the next work item. Stale `.agent-plan.md` or roadmap "current" text is
+  still useful evidence, but it should be reconciled against merge state and explicit roadmap order
+  before becoming the top suggested action.
+- Work-thread surfacing should preserve breadth. The JSON and human handoff can lead with the best
+  open issue or PR, but should also include a bounded set of related open parent/sibling threads
+  when goal terms, labels, issue references, or recent merged PR bodies connect them.
+- Files-to-read ranking may use high-authority path and symbol references as deterministic hints.
+  Paths and tests named by authority docs should rank above broad historical docs when they are
+  directly tied to the goal.
 - Text-bearing PDF sources are routed through source-type dispatch during ingest. The source
   manifest keeps the same `source_ref`, `source_ref_kind`, and `storage_mode` contract as
   text-native sources, while extracted text artifacts are recorded in `derived_artifacts`.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M19-P3.1`
-- Current planned slice: `v0.4.0 release preparation`
-- Current PR sub-slice: `v0.4.0-release-prep`
+- Previous completed PR sub-slice: `v0.4.0-release-prep`
+- Current planned slice: `M19 post-v0.4 external review response`
+- Current PR sub-slice: `M19-P4.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 post-v1 product bets`
-- Next planned PR sub-slice: `M20-P1.1`
+- Next planned slice: `M19 legacy mutation safety`
+- Next planned PR sub-slice: `M19-P5.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1265,6 +1265,11 @@ and consistently safe enough for public v1.
 - Orphan queue cleanup and closeable provenance-missing acknowledgements.
 - Reverse curated-source classification in `pr-summary`.
 - Public acceptance coverage for the SynthBanshee and hocrgen v0.4 retry bars.
+- Post-v0.4 external review intake, synthesis, and M19 sequencing.
+- Legacy preview/apply harmonization for older mutating maintenance/workflow commands.
+- Completion-aware current-state inference for recently merged roadmap slices.
+- Broader work-thread and policy-cited implementation-surface surfacing in handoff.
+- Cold-start/local-state ergonomics and narrow robustness fixes for first-time repos.
 
 ### Milestone 19 status
 
@@ -1290,11 +1295,35 @@ Queue inspection now exposes additive cleanup state, and agent handoff keeps the
 discoverable under maintenance context without promoting generated queue cleanup above work-first
 handoff.
 
+`M19-P4.1` records the post-v0.4 external review round and realigns the remaining pre-v1 durability
+work. SynthBanshee validated the M18 work-first direction and verified the M19-P3.1 queue-cleanup
+closure path, but prioritized legacy preview/apply harmonization because mixed semantics make
+exploratory agent sessions unsafe. hocrgen and hocrsyngen both failed the same handoff pattern:
+Splendor had git/GitHub and roadmap evidence that a slice was merged, but still ranked recently
+completed work above the next roadmap item. The review findings are summarized in
+`docs/evaluations/v0_4_external_review_round_summary.md` and registered in
+`docs/evaluations/v0_4_external_findings_register.md`.
+
+The remaining M19 sequence is therefore:
+
+- `M19-P5.1` Legacy preview/apply harmonization for mutating commands that still write or drain
+  immediately, especially `ingest --pending`, `source refresh`, `source update-path`, and
+  `workspace refresh`.
+- `M19-P6.1` Completion-aware current-state handoff inference: reconcile stale dynamic planning
+  docs against git/GitHub merge state and ordered roadmap items so completed slices lead to the
+  next open slice.
+- `M19-P7.1` Handoff breadth and policy-cited implementation surfacing: show multiple relevant
+  open work threads and boost files/symbols named by high-authority docs.
+- `M19-P8.1` Cold-start adoption and focused robustness: make first-run state location/review
+  explicit and fix the PATH-safe git lookup failure seen in the hocrsyngen trial.
+
 ## Milestone 20 — post-v1 product bets
 
 ### Goal
 Keep larger product bets visible without treating them as the next blocker. Current external
-feedback points to handoff shape and workflow safety before search infrastructure.
+feedback points to handoff shape and workflow safety before search infrastructure. After the v0.4
+external review round, Milestone 20 remains deferred until the remaining M19 durability sequence is
+closed or explicitly reprioritized.
 
 ### Candidate PR slices
 - `M20-P1.1` Add advanced semantic search or a vector index (#118).

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -877,6 +877,10 @@ Current implementation:
 - `splendor ingest --pending` prints the next `wiki suggest` command when exactly one source was
   ingested, or points back to `wiki status` for batch follow-up. `--json` emits queue totals,
   processed/succeeded/failed/skipped counts, per-item outcomes, and deterministic next actions.
+  The v0.4 external review round identified this as legacy mutate-on-call behavior: unlike newer
+  preview-first cleanup commands, `ingest --pending` drains the queue as soon as it runs. The next
+  durability update should either make this flow preview/apply-compatible or split the destructive
+  drain form from inspection so exploratory agent sessions are safe by default.
 - `splendor wiki status` reports source, page, queue, run, review, contested, stale,
   machine-generated, invalid-page, actionable synthesis-review, and missing
   synthesis-follow-up counts, with optional JSON output.
@@ -898,6 +902,11 @@ Current implementation:
   JSON include `mutation.mode`, `mutation.mutates`, `mutation.planned`, and `mutation.written`;
   human output labels preview mode as non-mutating and apply/direct mode as writing workspace
   state.
+- Post-v0.4 external reviews tightened the target: agent-facing maintenance and workflow commands
+  should not require per-command memory to know whether they mutate. Legacy direct-write surfaces
+  such as `ingest --pending`, `source refresh`, `source update-path`, and `workspace refresh`
+  should move toward explicit preview/apply or equally clear direct-write contracts before larger
+  post-v1 product bets such as vector search or mutating web review.
 - `splendor wiki rebuild-index` rewrites `wiki/index.md` from validated wiki page frontmatter,
   including maintained synthesis pages and generated source-summary pages, without mutating the
   pages themselves.
@@ -1142,6 +1151,9 @@ Current implementation:
   Maintenance-focused goals can keep maintenance actions first. Handoff ranking uses deterministic
   relevance scoring over weighted title/path/record/scope fields, supporting refs, snippets,
   git/GitHub text, and review/authority lifecycle signals without introducing vector search.
+  A correct handoff should also reconcile current-state conflicts: when git/GitHub state shows that
+  a PR or slice has merged, and an ordered roadmap names the next slice, stale dynamic planning
+  docs should not send the agent back to already-completed work.
 - Git-aware `brief --agent-context` and `suggest-next` include the `splendor pr-summary --since
   <base>` command under Splendor maintenance context when a branch has Splendor-specific compact
   review groups or attention diagnostics. This keeps compact committed generated-state review
@@ -1173,6 +1185,12 @@ Current implementation:
   records. Accepted decision records are included as goal-relevant reviewed authority; superseded
   decisions are retained below current decisions as historical context. This extends schema version
   `1` through optional fields only.
+- Open work-thread surfacing should be broad enough for agent handoff. The top-ranked issue or PR
+  can remain first, but related open parent/sibling issues and review threads should remain visible
+  when they match the goal, labels, linked references, or recent merged PR context.
+- Files-to-read ranking should treat high-authority path and symbol references as implementation
+  surface hints. If authority docs name a concrete file, test, command, or symbol involved in the
+  requested work, that surface should receive a deterministic boost without needing vector search.
 - Briefing is read-only and does not replace `splendor query`; query finds records, while briefing
   packages the surrounding project state needed to resume work.
 
@@ -1193,6 +1211,15 @@ v0.4 direction from external trials:
   `CLAUDE.md`, `README.md`, roadmap-like docs, and planning tests.
 - Important uncurated documentation may be used as provisional context only when clearly labeled
   as uncurated and paired with an exact curation command.
+- Post-v0.4 hocrgen and hocrsyngen trials add a stronger acceptance target: completed-slice to
+  next-slice inference should work even when `.agent-plan.md` or roadmap status text is stale after
+  a merge. Git/GitHub merge state, PR titles/bodies, recent commit subjects, and roadmap ordering
+  should be considered together before ranking "review recently merged PR" above "start next
+  planned slice."
+- First-run adoption should be explicit about state churn. `splendor init` may create a
+  repository-local workspace, but the CLI and docs should make the state location, review burden,
+  and local/throwaway-worktree strategy clear before a first-time agent creates many visible
+  top-level files.
 
 `M18-P1.1` implements the git-aware work-first ranking and work/maintenance separation while
 keeping all new context runtime-only. `M18-P2.1` implements inferred-authority and provisional


### PR DESCRIPTION
## Summary

Adds the collected v0.4.0 external trial intake materials from the latest design-partner round, plus the first synthesis and planning response layer.

Included raw/intake materials:

- hocrgen verdict, follow-up, and calibration reply
- SynthBanshee trial prompt, verdict, and follow-up calibration
- hocrsyngen cold-start trial prompt, verdict, and follow-up calibration

Included synthesis docs:

- `docs/evaluations/v0_4_external_review_round_summary.md`
- `docs/evaluations/v0_4_external_findings_register.md`

Included planning/spec impact:

- Synchronizes planning state around `M19-P4.1` and sets `M19-P5.1` as the next implementation slice.
- Updates the roadmap to keep M19 open for legacy mutation safety, completion-aware current-state inference, broader work-thread surfacing, and cold-start adoption before M20 product bets.
- Updates product/spec/schema docs with post-v0.4 requirements for preview/apply harmonization, completed-slice to next-slice inference, broader issue surfacing, and first-run state clarity.
- Adds README/quickstart guidance that `ingest --pending` remains a direct drain verb until the next safety slice lands.

## Why

These notes preserve the raw external feedback that should inform the next post-v0.4 M19 slices and translate that feedback into the planning/design layer without changing runtime behavior.

Key signals:

- SynthBanshee now considers v0.4.0 good enough as a first handoff tool, but prioritizes legacy preview/apply harmonization next.
- hocrgen and hocrsyngen both identify completion-aware current-state inference as the next major handoff blocker.
- hocrsyngen also surfaced cold-start state churn and PATH-safe git lookup as follow-up adoption/robustness concerns.

## Validation

- `git commit` pre-commit hooks passed: merge-conflict check, EOF fixer, trailing whitespace, ruff hooks where applicable.
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .` passed.
- `/Users/shaypalachy/.local/bin/uv run ruff check .` passed.
- `/Users/shaypalachy/.local/bin/uv run splendor lint` passed.

## Notes

Docs/planning/spec-only PR. No product behavior changes in this branch.
