### PR TITLE
M19-P5.1: Legacy preview/apply harmonization

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `v0.4.0-release-prep`
-- Last action taken: `v0.4.0-release-prep` was squash-merged into main as commit `0239c42`,
-  preparing and tagging the `v0.4.0` release after the M19-P3.1 queue cleanup slice.
-- Current planned slice: `M19 post-v0.4 external review response`
-- Current PR sub-slice: `M19-P4.1`
+- Previous completed PR sub-slice: `M19-P4.1`
+- Last action taken: `M19-P4.1` was squash-merged into main as commit `80b2de0`,
+  adding the v0.4 external review intake and response plan.
+- Current planned slice: `M19 legacy mutation safety`
+- Current PR sub-slice: `M19-P5.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 legacy mutation safety`
-- Next planned PR sub-slice: `M19-P5.1`
+- Next planned slice: `M19 completion-aware current-state handoff inference`
+- Next planned PR sub-slice: `M19-P6.1`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -176,28 +176,29 @@ and prints exact `source refresh`/`ingest --pending` next commands for stale pat
 the same preview for machine handoff, and `--report PATH` writes only an explicit freshness report.
 Relative report paths use the current working directory.
 `splendor workspace refresh --changed` composes that freshness view with the existing
-supersession-aware refresh path for changed curated workspace-backed sources. Add `--ingest` to
-ingest only queue jobs created or reused for the refreshed sources; unrelated pending ingest jobs
-remain queued. `--rebuild-index`, `--prune-superseded`, and `--update-topic-refs` can run
-standalone or in the same maintenance invocation. A one-pass changed-source cleanup can use
-`workspace refresh --changed --ingest --prune-superseded --update-topic-refs --rebuild-index`;
-pruning still reports skipped candidates when successor source-summary pages do not exist yet, so
-interrupted workflows can rerun `workspace refresh --prune-superseded` after successors are
-ingested. JSON output reports both initial and final freshness counts, skipped unresolved curated
-sources, failed changed-source refreshes, targeted ingest results, index rebuilds, pruning, and
-topic-ref migrations. The command does not discover or register uncurated files or mutate
-maintained synthesis content beyond explicit source-ref migration.
+supersession-aware refresh path for changed curated workspace-backed sources. It now previews by
+default and requires `--apply` before writing manifests, queue records, source summaries, index/log
+state, pruning changes, or maintained topic-ref migrations. Add `--ingest` to plan/apply ingest
+only for queue jobs created or reused for refreshed sources; unrelated pending ingest jobs remain
+queued. `--rebuild-index`, `--prune-superseded`, and `--update-topic-refs` can run standalone or in
+the same maintenance invocation. A one-pass changed-source cleanup can use
+`workspace refresh --changed --ingest --prune-superseded --update-topic-refs --rebuild-index
+--apply`; without `--apply`, the same command reports planned writes only. JSON output reports
+both initial/final freshness counts, skipped unresolved curated sources, failed changed-source
+refreshes, targeted ingest results, index rebuilds, pruning, topic-ref migrations, and a
+`mutation` object with planned or written paths. The command does not discover or register
+uncurated files or mutate maintained synthesis content beyond explicit source-ref migration.
 `splendor source update-path <source-id|logical-id|title|path> <new-path>` is the explicit repair
 path for moved active curated workspace sources. By default it requires the old workspace path to
 be missing; `--force` is available for deliberate reparenting while the old file still exists. It
 validates that the new path is a supported file inside the workspace, rejects targets already
-curated by another active source, updates the source manifest's workspace ref and compatibility
-path fields, preserves the stable logical ID and old path alias, adds the new path alias, and
-reports manifest/current checksums plus next commands. Same-byte moves queue a re-ingest so
-generated source-summary provenance can refresh. Changed-byte moves are
-reported as partial repairs with a non-zero exit and an explicit `source refresh` next command. The
-command does not discover/register uncurated files, rewrite historical run records, or mutate
-maintained synthesis pages.
+curated by another active source, and reports the source manifest/queue writes it would perform.
+Add `--apply` to update the manifest's workspace ref and compatibility path fields, preserve the
+stable logical ID and old path alias, add the new path alias, and queue same-byte re-ingest so
+generated source-summary provenance can refresh. Changed-byte moves are reported as partial repairs
+with a non-zero exit and an explicit `source refresh` next command. The command does not
+discover/register uncurated files, rewrite historical run records, or mutate maintained synthesis
+pages.
 
 `splendor source forget` is the explicit polluted-registry recovery path. It previews by default
 and requires `--apply` before deleting anything. Single-source cleanup accepts exact source IDs,
@@ -223,11 +224,11 @@ provided, and reports the manifest lifecycle edits needed to complete one-way or
 active versions as superseded by the selected current version. Cross-canonical selections and
 ambiguous `--current` selectors are rejected without rewriting manifests.
 
-`splendor ingest --pending --json` emits machine-readable pending-drain results with queue totals,
-processed/succeeded/failed/skipped counts, per-item outcomes, and deterministic next actions so
-agents do not need to parse human queue-drain text. This is still a direct drain verb in v0.4: it
-mutates queue, run, wiki, and index/log state when work is due. The post-v0.4 review findings make
-preview/apply harmonization for this and other legacy mutating verbs the next planned safety work.
+`splendor ingest --pending` previews actionable queue work by default. Human and JSON output list
+planned queue/run/source-summary/index/log writes with `mutation.mode: preview`; add `--apply` to
+drain the queue and write the reported runtime and wiki state. JSON output includes queue totals,
+processed/succeeded/failed/skipped counts, per-item outcomes, deterministic next actions, and the
+shared mutation object so agents do not need to parse human queue-drain text.
 
 `splendor ingest --changed` is the narrower stale-ingest repair path for checksum-drifted curated
 workspace-backed sources when old ingest queue records are already `done`. It refreshes changed
@@ -322,12 +323,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `v0.4.0-release-prep`
-- Current planned slice: `M19 post-v0.4 external review response`
-- Current PR sub-slice: `M19-P4.1`
+- Previous completed PR sub-slice: `M19-P4.1`
+- Current planned slice: `M19 legacy mutation safety`
+- Current PR sub-slice: `M19-P5.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 legacy mutation safety`
-- Next planned PR sub-slice: `M19-P5.1`
+- Next planned slice: `M19 completion-aware current-state handoff inference`
+- Next planned PR sub-slice: `M19-P6.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -633,7 +634,10 @@ ingest queue records, with additive cleanup state in queue inspection and mainte
 raw hocrgen, SynthBanshee, and hocrsyngen trial materials are preserved under `docs/evaluations/`,
 with a review-round summary and findings register that identify the next durability gaps. The
 review round keeps M20 vector/search and mutating-web bets visible, but defers them until the
-remaining M19 workflow-safety and handoff-correctness issues are closed. The next planned
-implementation slice is `M19-P5.1`: legacy preview/apply harmonization for mutating maintenance and
-workflow commands such as `ingest --pending`, `source refresh`, `source update-path`, and
-`workspace refresh`.
+remaining M19 workflow-safety and handoff-correctness issues are closed.
+
+`M19-P5.1` implements legacy preview/apply harmonization for mutating maintenance and workflow
+commands. `ingest --pending`, `source refresh`, `source update-path`, and `workspace refresh` now
+preview by default, report planned writes through the shared mutation contract, and require
+explicit `--apply` before draining queue jobs or writing manifests, source summaries, queue/run
+records, index/log state, pruning changes, or topic-ref migrations.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -159,15 +159,14 @@ Drain the pending ingest queue:
 
 ```bash
 uv run splendor --root /tmp/demo-repo ingest --pending
+uv run splendor --root /tmp/demo-repo ingest --pending --apply
 ```
 
 `ingest --pending` also handles due failed retries and expired ingest leases. Failed jobs wait until
 their persisted `next_attempt_at` backoff time, and exhausted jobs move to `dead_letter` until an
 operator runs `splendor queue retry <job-id>` or `splendor repair ingest <source-id>`.
-Unlike preview-first cleanup commands such as `queue clean`, `ingest --pending` is currently a
-direct drain verb: it writes source-summary, queue, run, and index/log state when work is due. The
-post-v0.4 durability plan is to harmonize this with explicit preview/apply behavior; until then,
-run it only when you intend to process queued ingest work.
+`ingest --pending` previews by default and writes nothing; review the planned queue, run,
+source-summary, index, and log writes before rerunning with `--apply` to process queued ingest work.
 
 This creates:
 
@@ -224,7 +223,8 @@ uv run splendor --root /tmp/demo-repo source freshness
 uv run splendor --root /tmp/demo-repo source freshness --json
 uv run splendor --root /tmp/demo-repo source freshness --report /tmp/demo-repo/reports/source-freshness.json
 uv run splendor --root /tmp/demo-repo source refresh product-note.md
-uv run splendor --root /tmp/demo-repo ingest --pending
+uv run splendor --root /tmp/demo-repo source refresh product-note.md --apply
+uv run splendor --root /tmp/demo-repo ingest --pending --apply
 ```
 
 `source freshness` is a safe preview. By default it writes nothing and reports unchanged, changed,
@@ -258,19 +258,20 @@ they support the workspace update under review. They are deterministic state, no
 analysis. Failed or exploratory local reports do not need to be committed unless the report itself
 is the artifact being reviewed.
 
-`source refresh` creates a new canonical content-addressed source version when bytes change.
-Workspace-backed sources keep stable logical IDs, and `workspace refresh --changed` can combine
-changed-source refresh with targeted ingest. `--changed --ingest` drains only queue jobs created or
-reused for refreshed sources, leaving unrelated pending jobs alone. Index rebuilds, superseded
-generated-summary pruning, and maintained-page topic-ref migration can run standalone with
+`source refresh` previews by default and creates a new canonical content-addressed source version
+only when rerun with `--apply`. Workspace-backed sources keep stable logical IDs, and
+`workspace refresh --changed` can preview or apply changed-source refresh with targeted ingest.
+`--changed --ingest --apply` drains only queue jobs created or reused for refreshed sources, leaving
+unrelated pending jobs alone. Index rebuilds, superseded generated-summary pruning, and
+maintained-page topic-ref migration can run standalone with
 `workspace refresh --rebuild-index`, `workspace refresh --prune-superseded`, or
 `workspace refresh --update-topic-refs`, or in one pass with
-`workspace refresh --changed --ingest --prune-superseded --update-topic-refs --rebuild-index`.
+`workspace refresh --changed --ingest --prune-superseded --update-topic-refs --rebuild-index
+--apply`.
 If pruning runs before successor source-summary pages exist, rerun
-`workspace refresh --prune-superseded` after the refreshed sources are ingested.
-These refresh commands are also part of the post-v0.4 preview/apply harmonization plan. Review
-`source freshness`, `queue inspect`, and `pr-summary` before using them in a shared branch if you
-only intended to inspect state.
+`workspace refresh --prune-superseded --apply` after the refreshed sources are ingested. Review
+default previews, `source freshness`, `queue inspect`, and `pr-summary` before applying state
+changes in a shared branch.
 
 ## 5. Add a planning record
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -180,25 +180,26 @@ Implemented fields:
   IDs, exact logical IDs, exact path aliases/source refs, or exact unambiguous titles; substring
   matches remain limited to read-only lookup surfaces.
 - `splendor source refresh <source-id|logical-id|title|path>` resolves the tracked workspace or
-  external path, compares current bytes to the manifest checksum, registers changed content as a
-  new canonical source version, preserves `source_commit_capture` intent, links the old and new
-  versions with `supersedes` / `superseded_by`, and queues ingest through the same queue handoff
-  used by `add-source`.
+  external path, compares current bytes to the manifest checksum, and previews the manifest,
+  source-artifact, and queue writes needed for changed or stale content. It requires `--apply` to
+  register changed content as a new canonical source version, preserve `source_commit_capture`
+  intent, link the old and new versions with `supersedes` / `superseded_by`, and queue ingest
+  through the same queue handoff used by `add-source`.
 - `splendor source update-path <source-id|logical-id|title|path> <new-path>` repairs the manifest
   for an active curated workspace-backed source after an intentional file move. The first
   implementation supports `storage_mode: none` and `storage_mode: copy` workspace sources. By
   default it requires the old workspace path to be missing; `--force` allows explicit reparenting
   while the old path still exists. It validates that the target is a supported file inside the
   workspace, rejects paths already curated by another active source, preserves the stable
-  `logical_id` and original-path alias, adds the new path alias, updates `source_ref`, and updates
-  the compatibility `path` field for `storage_mode: none`, then validates and rewrites the
-  schema-bound manifest. Same-byte repairs
-  mark previously ingested source records as needing ingest and queue the existing source ID so
-  generated source-summary provenance can refresh. Changed-byte repairs return `status: partial`,
-  do not queue ingest, and point operators to `splendor source refresh <new-path>`. Human and JSON
-  output report source ID, old path, new path, status, manifest/current checksums, checksum match
-  status, manifest path, queue path when present, and next commands. It does not discover or
-  register uncurated files, rewrite historical run records, or mutate maintained synthesis pages.
+  `logical_id` and original-path alias, adds the new path alias, and previews the `source_ref` and
+  compatibility `path` field changes. `--apply` validates and rewrites the schema-bound manifest.
+  Same-byte repairs mark previously ingested source records as needing ingest and queue the existing
+  source ID so generated source-summary provenance can refresh. Changed-byte repairs return
+  `status: partial`, do not queue ingest, and point operators to `splendor source refresh
+  <new-path>`. Human and JSON output report source ID, old path, new path, status,
+  manifest/current checksums, checksum match status, manifest path, queue path when present, next
+  commands, and a preview/apply mutation object. It does not discover or register uncurated files,
+  rewrite historical run records, or mutate maintained synthesis pages.
 - `splendor source forget <source-id|logical-id|title|path>` and
   `splendor source forget --matching <workspace-relative-glob>` provide preview-first registry
   cleanup for polluted source manifests. The command requires exactly one selection mode, previews
@@ -238,14 +239,15 @@ Implemented fields:
   artifacts, queue records, run records, or reports.
 - Refresh uses the queue ledger directly, so active leases remain protected and dead-lettered jobs
   still require `splendor queue retry <job-id>` or `splendor repair ingest <source-id>`.
-- `splendor workspace refresh --changed` is the safe workspace-level mutating path over curated
-  workspace-backed source manifests. It uses `source freshness` to select changed active manifests,
-  reports missing or unsupported active curated workspace sources as skipped unresolved diagnostics,
-  refreshes each changed source through the supersession-aware source refresh path, records
-  per-source refresh failures instead of aborting the whole command, and can ingest only the queue
-  records created or reused for successful refreshed sources with `--ingest`. The command exits
-  non-zero when unresolved skipped sources, failed source refreshes, or targeted ingest failures
-  remain, while preserving successful refresh and ingest work.
+- `splendor workspace refresh --changed` is the safe workspace-level preview/apply path over
+  curated workspace-backed source manifests. It uses `source freshness` to select changed active
+  manifests, reports missing or unsupported active curated workspace sources as skipped unresolved
+  diagnostics, previews each changed source through the supersession-aware source refresh path,
+  records per-source refresh failures instead of aborting the whole command, and can plan ingest
+  only for queue records created or reused for successful refreshed sources with `--ingest`.
+  `--apply` writes the planned refresh, targeted ingest, index, pruning, and topic-ref migration
+  changes. The command exits non-zero when unresolved skipped sources, failed source refreshes, or
+  targeted ingest failures remain, while preserving successful apply work.
 - `splendor workspace refresh --rebuild-index` rebuilds `wiki/index.md` as standalone maintenance
   or after any requested changed-source refresh, targeted ingest, pruning, or topic-ref migration.
   `--changed --ingest` drains only refreshed-source queue records, not unrelated pending ingest
@@ -269,13 +271,12 @@ Implemented fields:
   reports a clean no-op when no curated workspace-backed source bytes changed. `--json` emits
   initial and final freshness counts, missing-source diagnostics, refreshed source IDs, targeted
   queue outcomes, and summary counts.
-- `splendor ingest --pending --json` emits the same pending queue drain contract as human output in
+- `splendor ingest --pending --json` emits the same pending queue contract as human output in
   structured form: queue total, processed/succeeded/failed/skipped summary counts, per-item source
-  IDs, workspace-relative queue paths, outcomes, messages, and deterministic next actions.
-  As of the v0.4 external review, this remains a legacy direct-drain command: it mutates queue,
-  source-summary, run, and index/log state when work is available. The planned durability contract
-  is to give this flow the same agent-safe preview/apply clarity as newer cleanup commands, or to
-  expose an explicitly named destructive drain form so inspection and mutation cannot be confused.
+  IDs, workspace-relative queue paths, outcomes, messages, deterministic next actions, and the
+  shared mutation object. Without `--apply`, actionable jobs are reported as planned and no queue,
+  source-summary, run, index, or log state is written. `--apply` drains eligible jobs and reports
+  actual written records in `mutation.written`.
 - `splendor wiki compile <source-id|title|path>` remains non-mutating unless a maintained target
   page is selected and `--apply --proposal-hash <hash>` is supplied. Without `--page`, it reports
   the review-gated contract plus ranked maintained-page suggestions and ready-to-run
@@ -297,11 +298,11 @@ Implemented fields:
   deterministic planned write/delete records for preview mode, and `mutation.written` lists
   deterministic write/delete records for apply or direct-write mode. Records include `action`,
   `path`, `kind`, and `source_id` when source-scoped.
-- Post-v0.4 contract debt: legacy mutating commands must not rely on agents remembering bespoke
-  safety semantics. `ingest --pending`, `source refresh`, `source update-path`, and
-  `workspace refresh` should either become preview-first with explicit `--apply`, or expose
-  deterministic mutation objects and human output that make direct writes unmistakable before the
-  command is run from handoff guidance.
+- `M19-P5.1` closes the V04-F1 contract debt for legacy mutating workflow commands:
+  `ingest --pending`, `source refresh`, `source update-path`, and `workspace refresh` are
+  preview-first surfaces with explicit `--apply`, deterministic mutation objects, and human output
+  that labels preview versus apply state before agents run destructive maintenance from handoff
+  guidance.
 - `splendor pr-summary --since main` is a read-only PR handoff view over local git diff/status and
   existing report files. It diffs from the merge base between `HEAD` and the base ref, respects
   configured workspace layout directories, and groups curated source manifests, generated

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `v0.4.0-release-prep`
-- Current planned slice: `M19 post-v0.4 external review response`
-- Current PR sub-slice: `M19-P4.1`
+- Previous completed PR sub-slice: `M19-P4.1`
+- Current planned slice: `M19 legacy mutation safety`
+- Current PR sub-slice: `M19-P5.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 legacy mutation safety`
-- Next planned PR sub-slice: `M19-P5.1`
+- Next planned slice: `M19 completion-aware current-state handoff inference`
+- Next planned PR sub-slice: `M19-P6.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1304,11 +1304,16 @@ completed work above the next roadmap item. The review findings are summarized i
 `docs/evaluations/v0_4_external_review_round_summary.md` and registered in
 `docs/evaluations/v0_4_external_findings_register.md`.
 
+`M19-P5.1` closes the highest-priority V04-F1 safety gap by harmonizing the legacy mutating
+workflow verbs called out by external reviewers. `ingest --pending`, `source refresh`,
+`source update-path`, and `workspace refresh` now preview by default, expose the shared
+`mutation.mode` / `mutation.mutates` / `mutation.planned` / `mutation.written` JSON contract, and
+require explicit `--apply` before draining queue jobs or writing source manifests, source-summary
+pages, run records, queue records, wiki index/log state, pruning changes, or maintained topic-ref
+migrations.
+
 The remaining M19 sequence is therefore:
 
-- `M19-P5.1` Legacy preview/apply harmonization for mutating commands that still write or drain
-  immediately, especially `ingest --pending`, `source refresh`, `source update-path`, and
-  `workspace refresh`.
 - `M19-P6.1` Completion-aware current-state handoff inference: reconcile stale dynamic planning
   docs against git/GitHub merge state and ordered roadmap items so completed slices lead to the
   next open slice.

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -786,22 +786,23 @@ Current implementation:
 - Mutating source commands use stricter selector resolution than lookup. Direct ingest accepts exact
   source IDs, exact logical IDs, exact path aliases/source refs, or exact unambiguous titles, not
   substring matches that can silently select the wrong source.
-- `splendor source refresh <source-id|title|path>` detects changed source content, registers the
-  current bytes as a new canonical source version when the checksum changed, and queues ingest via
-  the existing queue ledger while preserving active-lease and dead-letter protections.
+- `splendor source refresh <source-id|title|path>` detects changed source content and previews the
+  source manifest/artifact and queue writes needed to register current bytes as a new canonical
+  source version. Add `--apply` to write the new version and queue ingest via the existing queue
+  ledger while preserving active-lease and dead-letter protections.
   Stable logical source identities now remain constant for workspace-backed source paths across
   those content-addressed versions. Refresh also links changed versions with `supersedes` and
   `superseded_by` so health treats older workspace-backed manifests as historical records instead
   of active current-byte targets.
-- `splendor source update-path <source-id|logical-id|title|path> <new-path>` repairs an active
+- `splendor source update-path <source-id|logical-id|title|path> <new-path>` previews repair for an active
   `none`/`copy` storage workspace-backed source manifest after a curated file moves. It validates
   that the old path is missing unless `--force` is supplied, validates that the target is a
-  supported in-workspace file, rejects targets already curated by another active source, updates
-  the manifest's path/logical identity fields, and reports manifest/current checksums plus next
-  commands. Same-byte moves queue re-ingest for the existing source ID so generated provenance can
-  refresh; changed-byte moves are reported as partial repairs and point to `source refresh`. It
-  does not perform broad discovery, register uncurated files, rewrite historical run records, or
-  mutate maintained synthesis pages.
+  supported in-workspace file, rejects targets already curated by another active source, and reports
+  planned manifest/queue writes, manifest/current checksums, and next commands. Add `--apply` to
+  update the manifest's path/logical identity fields. Same-byte moves queue re-ingest for the
+  existing source ID so generated provenance can refresh; changed-byte moves are reported as
+  partial repairs and point to `source refresh`. It does not perform broad discovery, register
+  uncurated files, rewrite historical run records, or mutate maintained synthesis pages.
 - `splendor source forget <source-id|logical-id|title|path>` and
   `splendor source forget --matching <workspace-relative-glob>` are the CLI-first recovery path for
   polluted source registries. They preview by default and require `--apply` for destructive
@@ -826,14 +827,15 @@ Current implementation:
   `supersedes`/`superseded_by` manifest updates. It also repairs same-canonical one-way lifecycle
   links around the selected current version so interrupted reconciliation can be rerun. It rejects
   ambiguous selectors and cross-canonical reconciliation attempts instead of guessing.
-- `splendor workspace refresh --changed` safely refreshes only changed curated workspace-backed
+- `splendor workspace refresh --changed` safely previews refresh for changed curated workspace-backed
   sources by composing `source freshness` with the supersession-aware `source refresh` path. It
   reports missing or unsupported active curated workspace sources as skipped unresolved diagnostics,
   records per-source refresh failures without aborting the whole command, and can ingest only
-  refreshed sources' queue jobs with `--ingest`. Valid changed sources still refresh and ingest
-  even when unrelated curated sources are unresolved; the command exits non-zero while skipped
-  sources, failed refreshes, or targeted ingest failures remain. JSON output reports both initial
-  and final freshness counts plus skipped-source and failed-refresh diagnostics.
+  refreshed sources' queue jobs with `--ingest`. Add `--apply` to write the planned refresh,
+  targeted ingest, index, pruning, and topic-ref migration changes. Valid changed sources still
+  refresh and ingest even when unrelated curated sources are unresolved; the command exits non-zero
+  while skipped sources, failed refreshes, or targeted ingest failures remain. JSON output reports
+  both initial and final freshness counts plus skipped-source and failed-refresh diagnostics.
   `--rebuild-index`, `--prune-superseded`, and `--update-topic-refs` can run standalone or in the
   same invocation as changed-source refresh. A one-pass cleanup can run
   `workspace refresh --changed --ingest --prune-superseded --update-topic-refs --rebuild-index`,
@@ -874,13 +876,12 @@ Current implementation:
   image sources only enter OCR when `sources.ocr_enabled` is true; the current local provider reads
   adjacent sidecar text files named with `sources.ocr_sidecar_suffix` and writes normalized output
   under `derived/ocr/` plus sidecar checksum metadata under `derived/metadata/`.
-- `splendor ingest --pending` prints the next `wiki suggest` command when exactly one source was
-  ingested, or points back to `wiki status` for batch follow-up. `--json` emits queue totals,
-  processed/succeeded/failed/skipped counts, per-item outcomes, and deterministic next actions.
-  The v0.4 external review round identified this as legacy mutate-on-call behavior: unlike newer
-  preview-first cleanup commands, `ingest --pending` drains the queue as soon as it runs. The next
-  durability update should either make this flow preview/apply-compatible or split the destructive
-  drain form from inspection so exploratory agent sessions are safe by default.
+- `splendor ingest --pending` previews actionable queue jobs by default and points to
+  `splendor ingest --pending --apply` when planned writes exist. `--json` emits queue totals,
+  processed/succeeded/failed/skipped counts, per-item outcomes, deterministic next actions, and a
+  `mutation` object. `--apply` drains the queue, writes source-summary/run/source/index/log state,
+  and prints the next `wiki suggest` command when exactly one source was ingested, or points back to
+  `wiki status` for batch follow-up.
 - `splendor wiki status` reports source, page, queue, run, review, contested, stale,
   machine-generated, invalid-page, actionable synthesis-review, and missing
   synthesis-follow-up counts, with optional JSON output.
@@ -898,15 +899,13 @@ Current implementation:
   agents can distinguish preview-only proposals, apply no-ops, and applied writes without parsing
   prose.
 - Preview/apply and direct-write CLI surfaces expose consistent mutation signals where natural:
-  `source forget`, `source reconcile`, `source refresh`, `workspace refresh`, and `queue clean`
-  JSON include `mutation.mode`, `mutation.mutates`, `mutation.planned`, and `mutation.written`;
-  human output labels preview mode as non-mutating and apply/direct mode as writing workspace
-  state.
-- Post-v0.4 external reviews tightened the target: agent-facing maintenance and workflow commands
-  should not require per-command memory to know whether they mutate. Legacy direct-write surfaces
-  such as `ingest --pending`, `source refresh`, `source update-path`, and `workspace refresh`
-  should move toward explicit preview/apply or equally clear direct-write contracts before larger
-  post-v1 product bets such as vector search or mutating web review.
+  `ingest --pending`, `source forget`, `source reconcile`, `source refresh`,
+  `source update-path`, `workspace refresh`, and `queue clean` JSON include `mutation.mode`,
+  `mutation.mutates`, `mutation.planned`, and `mutation.written`; human output labels preview mode
+  as non-mutating and apply/direct mode as writing workspace state.
+- `M19-P5.1` harmonizes the legacy V04-F1 direct-write surfaces named by external reviewers:
+  `ingest --pending`, `source refresh`, `source update-path`, and `workspace refresh` are
+  preview-first and require explicit `--apply` for state-changing workflow maintenance.
 - `splendor wiki rebuild-index` rewrites `wiki/index.md` from validated wiki page frontmatter,
   including maintained synthesis pages and generated source-summary pages, without mutating the
   pages themselves.

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -26,6 +26,9 @@ from splendor.commands.ingest import (
     drain_pending_ingest_jobs,
     enqueue_ingest_job,
     ingest_source,
+    pending_ingest_planned_records,
+    pending_ingest_written_records,
+    preview_pending_ingest_jobs,
     render_pending_ingest_json,
 )
 from splendor.commands.init import initialize_workspace
@@ -83,6 +86,7 @@ from splendor.commands.source import (
     render_stale_ingest_json,
     resolve_source_query_exact,
     scan_source_freshness,
+    source_path_update_mutation_records,
     source_reconcile_next_commands,
     source_refresh_written_records,
     update_source_path,
@@ -247,6 +251,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     source_refresh_parser.add_argument("query", help="Source ID, title, or path to refresh")
     source_refresh_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "Write refreshed source manifests and queue ingest work. "
+            "Without this flag, preview only."
+        ),
+    )
+    source_refresh_parser.add_argument(
         "--json",
         action="store_true",
         dest="json_output",
@@ -263,6 +275,14 @@ def build_parser() -> argparse.ArgumentParser:
         "new_path",
         type=Path,
         help="New workspace path for the curated source file",
+    )
+    source_update_path_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "Write the repaired source manifest and queue ingest work. "
+            "Without this flag, preview only."
+        ),
     )
     source_update_path_parser.add_argument(
         "--json",
@@ -351,7 +371,12 @@ def build_parser() -> argparse.ArgumentParser:
     ingest_parser.add_argument(
         "--pending",
         action="store_true",
-        help="Drain pending ingestion jobs from the queue.",
+        help="Preview pending ingestion jobs from the queue.",
+    )
+    ingest_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Drain pending ingestion jobs. Without this flag, --pending only previews.",
     )
     ingest_parser.add_argument(
         "--changed",
@@ -531,6 +556,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--update-topic-refs",
         action="store_true",
         help="Rewrite maintained wiki source_refs from superseded source IDs to active versions.",
+    )
+    workspace_refresh_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write the planned workspace maintenance changes. Without this flag, preview only.",
     )
     workspace_refresh_parser.add_argument(
         "--json",
@@ -1143,7 +1173,7 @@ def handle_source_lookup(args: argparse.Namespace) -> int:
 def handle_source_refresh(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     try:
-        result = refresh_source(root, args.query)
+        result = refresh_source(root, args.query, apply=args.apply)
     except (FileNotFoundError, RuntimeError, ValueError) as exc:
         return _print_error(exc)
     if args.json_output:
@@ -1151,7 +1181,9 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
         return 0
 
     if result.changed:
-        print("Mutation mode: apply")
+        print(f"Mutation mode: {'apply' if result.applied else 'preview'}")
+        if not result.applied:
+            print("Preview only: no source manifests or queue records written.")
         print(f"Detected changed source content for {canonical_source_ref(result.requested)}")
         print(f"Requested source ID: {result.requested.source_id}")
         if result.refreshed.record.source_id != result.requested.source_id:
@@ -1164,7 +1196,9 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
                 f"{result.requested.source_id} -> {result.refreshed.record.source_id}"
             )
     else:
-        print("Mutation mode: apply")
+        print(f"Mutation mode: {'apply' if result.applied else 'preview'}")
+        if not result.applied:
+            print("Preview only: no source manifests or queue records written.")
         print(f"No source content change detected for {canonical_source_ref(result.requested)}")
         print(f"Source ID: {result.requested.source_id}")
     print(f"Source ref: {result.refreshed.source_ref}")
@@ -1176,19 +1210,29 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
     if result.refreshed.record.superseded_by is not None:
         print(f"Superseded by: {result.refreshed.record.superseded_by}")
     if result.queued and result.queue_path is not None:
-        print(f"Queued ingest: {result.queue_path}")
-        print("Next: splendor ingest --pending")
+        label = "Queued ingest" if result.applied else "Planned queue ingest"
+        print(f"{label}: {result.queue_path}")
+        if result.applied:
+            print("Next: splendor ingest --pending")
+        else:
+            print(f"Next: splendor source refresh {shlex.quote(args.query)} --apply")
     else:
         print(f"Refresh skipped: {result.message}")
         print(f"Next: splendor wiki suggest {result.refreshed.record.source_id}")
-    _print_mutation_written_paths(source_refresh_written_records(root, result))
+    records = source_refresh_written_records(root, result)
+    if result.applied:
+        _print_mutation_written_paths(records)
+    else:
+        _print_mutation_planned_paths(records)
     return 0
 
 
 def handle_source_update_path(args: argparse.Namespace) -> int:
     root = args.root.resolve()
     try:
-        result = update_source_path(root, args.query, args.new_path, force=args.force)
+        result = update_source_path(
+            root, args.query, args.new_path, force=args.force, apply=args.apply
+        )
     except (FileNotFoundError, IsADirectoryError, RuntimeError, ValueError) as exc:
         return _print_error(exc)
 
@@ -1196,6 +1240,10 @@ def handle_source_update_path(args: argparse.Namespace) -> int:
         print(render_source_path_update_json(root, result))
         return 0 if result.status == "repaired" else 1
 
+    print(f"Source path update {'applied' if result.applied else 'preview'}")
+    print(f"Mutation mode: {'apply' if result.applied else 'preview'}")
+    if not result.applied:
+        print("Preview only: no source manifest or queue record written.")
     print(f"Updated source path for {result.source.source_id}")
     print(f"Status: {result.status}")
     print(f"Old path: {result.old_path}")
@@ -1215,6 +1263,10 @@ def handle_source_update_path(args: argparse.Namespace) -> int:
         print("Path was updated, but content refresh is still required.")
     for command in result.next_commands:
         print(f"Next: {command}")
+    if result.applied:
+        _print_mutation_written_paths(source_path_update_mutation_records(root, result))
+    else:
+        _print_mutation_planned_paths(source_path_update_mutation_records(root, result))
     return 0 if result.status == "repaired" else 1
 
 
@@ -1341,18 +1393,31 @@ def handle_ingest(args: argparse.Namespace) -> int:
 
     if args.pending:
         try:
-            result = drain_pending_ingest_jobs(root)
+            result = (
+                drain_pending_ingest_jobs(root) if args.apply else preview_pending_ingest_jobs(root)
+            )
         except (FileNotFoundError, RuntimeError, ValueError) as exc:
             return _print_error(exc)
 
         if args.json_output:
-            print(render_pending_ingest_json(root, result))
+            print(
+                render_pending_ingest_json(
+                    root,
+                    result,
+                    mode="apply" if args.apply else "preview",
+                )
+            )
             return 1 if result.failed else 0
 
         if result.total == 0:
             print("No pending ingest jobs")
+            print(f"Mutation mode: {'apply' if args.apply else 'preview'}")
             return 0
 
+        print("Pending ingest apply" if args.apply else "Pending ingest preview")
+        print(f"Mutation mode: {'apply' if args.apply else 'preview'}")
+        if not args.apply:
+            print("Preview only: no queue, run, source, or wiki records written.")
         for item in result.items:
             print(f"{item.source_id}: {item.outcome} ({item.message})")
         print(
@@ -1362,6 +1427,14 @@ def handle_ingest(args: argparse.Namespace) -> int:
             f"failed={result.failed} "
             f"skipped={result.skipped}"
         )
+        if args.apply:
+            _print_mutation_written_paths(pending_ingest_written_records(result))
+        else:
+            planned_records = pending_ingest_planned_records(root, result)
+            _print_mutation_planned_paths(planned_records)
+            if planned_records:
+                print("Next: splendor ingest --pending --apply")
+                return 0
         succeeded_source_ids = [
             item.source_id for item in result.items if item.outcome == "succeeded"
         ]
@@ -1929,6 +2002,7 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
             rebuild_index=args.rebuild_index,
             prune_superseded=args.prune_superseded,
             update_topic_refs=args.update_topic_refs,
+            apply=args.apply,
         )
     except (FileNotFoundError, RuntimeError, ValueError) as exc:
         return _print_error(exc)
@@ -1944,7 +2018,9 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
         return 0
 
     print("Workspace refresh")
-    print("Mutation mode: apply")
+    print(f"Mutation mode: {'apply' if result.applied else 'preview'}")
+    if not result.applied:
+        print("Preview only: no workspace maintenance changes written.")
     print(
         "Initial freshness: "
         f"total={result.initial_freshness.total} "
@@ -2024,7 +2100,11 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
         f"unsupported={result.final_freshness.unsupported} "
         f"historical={result.final_freshness.historical}"
     )
-    _print_mutation_written_paths(workspace_refresh_written_records(root, result))
+    records = workspace_refresh_written_records(root, result)
+    if result.applied:
+        _print_mutation_written_paths(records)
+    else:
+        _print_mutation_planned_paths(records)
 
     if result.ingest is not None and result.ingest.failed:
         print("Next: splendor queue inspect")
@@ -2033,7 +2113,10 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
         print("Workspace refresh completed with unresolved curated sources.")
         print("Next: splendor source freshness")
         return 1
-    if result.ingest is None and result.refreshed:
+    if not result.applied and records:
+        command = _workspace_refresh_apply_command(args)
+        print(f"Next: {command}")
+    elif result.ingest is None and result.refreshed:
         if result.index is not None:
             print("Next: splendor ingest --pending, then splendor wiki rebuild-index")
         else:
@@ -2052,6 +2135,30 @@ def _print_mutation_written_paths(records: list[dict[str, str]]) -> None:
     print("Written paths:")
     for record in records:
         print(f"- {record['action']}: {record['kind']} {record['path']}")
+
+
+def _print_mutation_planned_paths(records: list[dict[str, str]]) -> None:
+    if not records:
+        print("Planned paths: none")
+        return
+    print("Planned paths:")
+    for record in records:
+        print(f"- {record['action']}: {record['kind']} {record['path']}")
+
+
+def _workspace_refresh_apply_command(args: argparse.Namespace) -> str:
+    flags = []
+    for attr, flag in [
+        ("changed", "--changed"),
+        ("ingest", "--ingest"),
+        ("rebuild_index", "--rebuild-index"),
+        ("prune_superseded", "--prune-superseded"),
+        ("update_topic_refs", "--update-topic-refs"),
+    ]:
+        if getattr(args, attr):
+            flags.append(flag)
+    flags.append("--apply")
+    return "splendor workspace refresh " + " ".join(flags)
 
 
 def handle_pr_summary(args: argparse.Namespace) -> int:
@@ -2976,6 +3083,8 @@ def main(argv: list[str] | None = None) -> int:
             parser.error("ingest requires exactly one of <source_id>, --pending, or --changed")
         if args.json_output and not (args.changed or args.pending):
             parser.error("ingest --json is currently supported only with --pending or --changed")
+        if args.apply and not args.pending:
+            parser.error("ingest --apply is supported only with --pending")
     return args.handler(args)
 
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -1213,7 +1213,7 @@ def handle_source_refresh(args: argparse.Namespace) -> int:
         label = "Queued ingest" if result.applied else "Planned queue ingest"
         print(f"{label}: {result.queue_path}")
         if result.applied:
-            print("Next: splendor ingest --pending")
+            print("Next: splendor ingest --pending --apply")
         else:
             print(f"Next: splendor source refresh {shlex.quote(args.query)} --apply")
     else:
@@ -2118,9 +2118,9 @@ def handle_workspace_refresh(args: argparse.Namespace) -> int:
         print(f"Next: {command}")
     elif result.ingest is None and result.refreshed:
         if result.index is not None:
-            print("Next: splendor ingest --pending, then splendor wiki rebuild-index")
+            print("Next: splendor ingest --pending --apply, then splendor wiki rebuild-index")
         else:
-            print("Next: splendor ingest --pending")
+            print("Next: splendor ingest --pending --apply")
     elif result.index is None and result.ingest is not None and result.ingest.succeeded:
         print("Next: splendor wiki rebuild-index")
     else:

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -1753,7 +1753,10 @@ def _next_actions(
             for action in suggested_actions[:5]
         )
     if status.queue_status_counts.get("pending", 0):
-        actions.append("Run `splendor ingest --pending` to drain pending source ingests.")
+        actions.append(
+            "Run `splendor ingest --pending` to preview pending source ingests, then add "
+            "`--apply` after review."
+        )
     if status.invalid_pages:
         actions.append("Fix invalid wiki pages before relying on synthesis or query output.")
     if status.sources_missing_synthesis:

--- a/src/splendor/commands/health.py
+++ b/src/splendor/commands/health.py
@@ -149,13 +149,16 @@ def _source_health_remediation_hint(source: SourceRecord | None, message: str) -
             )
         if source_checksum_mismatch:
             return (
-                f"Run splendor source refresh {selector}, then splendor ingest --pending; "
+                f"Run splendor source refresh {selector}, then "
+                f"splendor source refresh {selector} --apply, then "
+                "splendor ingest --pending --apply; "
                 "for all changed curated workspace sources run splendor ingest --changed."
             )
     if storage_mode in {"copy", "pointer", "symlink"} and "checksum mismatch" in message:
         return (
-            f"Run splendor source refresh {selector}, then splendor ingest --pending if a "
-            "new queue job is created."
+            f"Run splendor source refresh {selector}, then "
+            f"splendor source refresh {selector} --apply if the preview plans work, then "
+            "splendor ingest --pending --apply if a new queue job is created."
         )
     return None
 

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from splendor import __version__
-from splendor.commands.mutation import mutation_record
+from splendor.commands.mutation import mutation_contract, mutation_record
 from splendor.config import load_config
 from splendor.ingest_dispatch import IMAGE_SOURCE_TYPES, dispatch_source_content
 from splendor.layout import resolve_layout
@@ -110,7 +110,9 @@ class DrainResult:
     items: list[DrainItemResult]
 
 
-def render_pending_ingest_json(root: Path, result: DrainResult) -> str:
+def render_pending_ingest_json(root: Path, result: DrainResult, *, mode: str = "apply") -> str:
+    planned_records = pending_ingest_planned_records(root, result) if mode == "preview" else []
+    written_records = pending_ingest_written_records(result) if mode == "apply" else []
     return json.dumps(
         {
             "total": result.total,
@@ -122,6 +124,11 @@ def render_pending_ingest_json(root: Path, result: DrainResult) -> str:
             },
             "items": [_drain_item_payload(root, item) for item in result.items],
             "next_actions": pending_ingest_next_actions(result),
+            "mutation": mutation_contract(
+                mode=mode,
+                planned=planned_records,
+                written=written_records,
+            ),
         },
         indent=2,
     )
@@ -149,6 +156,53 @@ def _drain_item_payload(root: Path, item: DrainItemResult) -> dict[str, object]:
         "message": item.message,
         "written_records": item.written_records,
     }
+
+
+def pending_ingest_planned_records(root: Path, result: DrainResult) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    for item in result.items:
+        if item.outcome != "planned":
+            continue
+        queue_ref = _relative_to_root(root, item.queue_path)
+        source_id = item.source_id
+        records.extend(
+            [
+                mutation_record(
+                    action="write",
+                    path=queue_ref,
+                    kind="queue_record",
+                    source_id=source_id,
+                ),
+                mutation_record(
+                    action="write",
+                    path=f"state/runs/<new-run-for-{source_id}>.json",
+                    kind="run_record",
+                    source_id=source_id,
+                ),
+                mutation_record(
+                    action="write",
+                    path=f"state/manifests/sources/{source_id}.json",
+                    kind="source_manifest",
+                    source_id=source_id,
+                ),
+                mutation_record(
+                    action="write",
+                    path=f"wiki/sources/{source_id}.md",
+                    kind="source_summary_page",
+                    source_id=source_id,
+                ),
+                mutation_record(action="write", path="wiki/index.md", kind="wiki_index"),
+                mutation_record(action="write", path="wiki/log.md", kind="wiki_log"),
+            ]
+        )
+    return records
+
+
+def pending_ingest_written_records(result: DrainResult) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    for item in result.items:
+        records.extend(item.written_records)
+    return records
 
 
 def _make_run_id(source_id: str) -> str:
@@ -1453,6 +1507,52 @@ def drain_pending_ingest_jobs(root: Path) -> DrainResult:
         processed=processed,
         succeeded=succeeded,
         failed=failed,
+        skipped=skipped,
+        items=item_results,
+    )
+
+
+def preview_pending_ingest_jobs(root: Path) -> DrainResult:
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    queue_items: list[tuple[Path, QueueItemRecord]] = []
+    for queue_path in sorted(layout.queue_dir.glob("*.json")):
+        queue_items.append((queue_path, load_queue_item(queue_path)))
+
+    now = _utc_now()
+    ordered_items = sorted(queue_items, key=lambda item: (item[1].created_at, item[1].job_id))
+
+    skipped = 0
+    item_results: list[DrainItemResult] = []
+    for queue_path, queue_item in ordered_items:
+        source_id = source_id_from_ingest_job_id(queue_item.job_id) or queue_item.job_id
+        if not _is_queue_eligible(queue_item, now):
+            skipped += 1
+            item_results.append(
+                DrainItemResult(
+                    source_id=source_id,
+                    queue_path=queue_path,
+                    outcome="skipped",
+                    message=_skip_message(queue_item, now),
+                    written_records=[],
+                )
+            )
+            continue
+        item_results.append(
+            DrainItemResult(
+                source_id=source_id,
+                queue_path=queue_path,
+                outcome="planned",
+                message="would run ingest job with --apply",
+                written_records=[],
+            )
+        )
+
+    return DrainResult(
+        total=len(ordered_items),
+        processed=0,
+        succeeded=0,
+        failed=0,
         skipped=skipped,
         items=item_results,
     )

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -140,6 +140,10 @@ def pending_ingest_next_actions(result: DrainResult) -> list[str]:
     if result.failed:
         return ["splendor queue inspect"]
 
+    planned_source_ids = [item.source_id for item in result.items if item.outcome == "planned"]
+    if planned_source_ids:
+        return ["splendor ingest --pending --apply"]
+
     succeeded_source_ids = [item.source_id for item in result.items if item.outcome == "succeeded"]
     if len(succeeded_source_ids) == 1:
         return [f"splendor wiki suggest {succeeded_source_ids[0]}"]
@@ -165,35 +169,13 @@ def pending_ingest_planned_records(root: Path, result: DrainResult) -> list[dict
             continue
         queue_ref = _relative_to_root(root, item.queue_path)
         source_id = item.source_id
-        records.extend(
-            [
-                mutation_record(
-                    action="write",
-                    path=queue_ref,
-                    kind="queue_record",
-                    source_id=source_id,
-                ),
-                mutation_record(
-                    action="write",
-                    path=f"state/runs/<new-run-for-{source_id}>.json",
-                    kind="run_record",
-                    source_id=source_id,
-                ),
-                mutation_record(
-                    action="write",
-                    path=f"state/manifests/sources/{source_id}.json",
-                    kind="source_manifest",
-                    source_id=source_id,
-                ),
-                mutation_record(
-                    action="write",
-                    path=f"wiki/sources/{source_id}.md",
-                    kind="source_summary_page",
-                    source_id=source_id,
-                ),
-                mutation_record(action="write", path="wiki/index.md", kind="wiki_index"),
-                mutation_record(action="write", path="wiki/log.md", kind="wiki_log"),
-            ]
+        records.append(
+            mutation_record(
+                action="write",
+                path=queue_ref,
+                kind="queue_record",
+                source_id=source_id,
+            )
         )
     return records
 
@@ -952,19 +934,22 @@ def _extra_write_is_source_scoped(root: Path, path: Path) -> bool:
     return relpath.startswith(("derived/", "wiki/sources/"))
 
 
-def enqueue_ingest_job(root: Path, source_id: str) -> Path:
+def preflight_enqueue_ingest_job(
+    root: Path, source_id: str, *, require_manifest: bool = True
+) -> Path:
     config = load_config(root)
     layout = resolve_layout(root, config)
     _validate_workspace_files(layout)
     manifest_path = manifest_path_for(root, source_id)
-    if not manifest_path.exists():
+    if require_manifest and not manifest_path.exists():
         msg = f"Unknown source ID: {source_id}"
         raise FileNotFoundError(msg)
 
-    source = load_source_record(manifest_path)
-    if source.source_id != source_id:
-        msg = f"Source manifest ID does not match requested source: {source_id}"
-        raise ValueError(msg)
+    if manifest_path.exists():
+        source = load_source_record(manifest_path)
+        if source.source_id != source_id:
+            msg = f"Source manifest ID does not match requested source: {source_id}"
+            raise ValueError(msg)
 
     now = _utc_now()
     queue_path = queue_item_path_for(layout, ingest_job_id(source_id))
@@ -980,6 +965,15 @@ def enqueue_ingest_job(root: Path, source_id: str) -> Path:
         msg = f"Queue item is already leased: {existing_queue.job_id}"
         raise RuntimeError(msg)
 
+    return queue_path
+
+
+def enqueue_ingest_job(root: Path, source_id: str) -> Path:
+    config = load_config(root)
+    manifest_path = manifest_path_for(root, source_id)
+    queue_path = preflight_enqueue_ingest_job(root, source_id)
+    existing_queue = load_queue_item(queue_path) if queue_path.exists() else None
+    now = _utc_now()
     created_at = now.isoformat()
     if existing_queue is not None and existing_queue.status in {"pending", "leased"}:
         created_at = existing_queue.created_at
@@ -1523,6 +1517,7 @@ def preview_pending_ingest_jobs(root: Path) -> DrainResult:
     ordered_items = sorted(queue_items, key=lambda item: (item[1].created_at, item[1].job_id))
 
     skipped = 0
+    failed = 0
     item_results: list[DrainItemResult] = []
     for queue_path, queue_item in ordered_items:
         source_id = source_id_from_ingest_job_id(queue_item.job_id) or queue_item.job_id
@@ -1538,23 +1533,58 @@ def preview_pending_ingest_jobs(root: Path) -> DrainResult:
                 )
             )
             continue
-        item_results.append(
-            DrainItemResult(
-                source_id=source_id,
-                queue_path=queue_path,
-                outcome="planned",
-                message="would run ingest job with --apply",
-                written_records=[],
+        try:
+            preview = _preview_ingest_job(root, layout, queue_path, queue_item)
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            failed += 1
+            item_results.append(
+                DrainItemResult(
+                    source_id=source_id,
+                    queue_path=queue_path,
+                    outcome="failed",
+                    message=str(exc),
+                    written_records=[],
+                )
             )
-        )
+            continue
+        if preview.outcome == "skipped":
+            skipped += 1
+        item_results.append(preview)
+
+    planned = sum(1 for item in item_results if item.outcome == "planned")
 
     return DrainResult(
         total=len(ordered_items),
-        processed=0,
+        processed=planned + failed,
         succeeded=0,
-        failed=0,
+        failed=failed,
         skipped=skipped,
         items=item_results,
+    )
+
+
+def _preview_ingest_job(
+    root: Path, layout, queue_path: Path, queue_item: QueueItemRecord
+) -> DrainItemResult:
+    if queue_item.job_type != "ingest_source":
+        msg = f"Unsupported queue job type for ingest worker: {queue_item.job_type}"
+        raise ValueError(msg)
+    _validate_workspace_files(layout)
+    _manifest_path, source = _load_source_for_queue(root, queue_item)
+    if _is_no_op(root, layout, source):
+        return DrainItemResult(
+            source_id=source.source_id,
+            queue_path=queue_path,
+            outcome="skipped",
+            message="already ingested for the current pipeline version",
+            written_records=[],
+        )
+    return DrainItemResult(
+        source_id=source.source_id,
+        queue_path=queue_path,
+        outcome="planned",
+        message="would run ingest job with --apply",
+        written_records=[],
     )
 
 

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -7,6 +7,7 @@ import shlex
 from dataclasses import dataclass, replace
 from pathlib import Path
 
+from splendor import __version__
 from splendor.commands.ingest import enqueue_ingest_job, is_ingest_current, run_ingest_job
 from splendor.commands.mutation import mutation_contract, mutation_record
 from splendor.config import load_config
@@ -14,7 +15,7 @@ from splendor.ingest_dispatch import SUPPORTED_SOURCE_TYPES
 from splendor.layout import resolve_layout
 from splendor.schemas import SourceRecord
 from splendor.state.paths import resolve_workspace_path
-from splendor.state.runtime import ingest_job_id
+from splendor.state.runtime import ingest_job_id, queue_item_path_for
 from splendor.state.source_compat import (
     canonical_source_ref,
     effective_aliases,
@@ -26,11 +27,14 @@ from splendor.state.source_compat import (
 from splendor.state.source_registry import (
     RegisteredSource,
     load_source_record,
+    manifest_original_path,
     register_source,
     resolve_manifest_storage_path,
     write_source_record,
 )
 from splendor.utils.hashing import sha256_file
+from splendor.utils.ids import stable_source_id
+from splendor.utils.time import utc_now_iso
 
 
 @dataclass(frozen=True)
@@ -48,6 +52,7 @@ class SourceRefreshResult:
     queued: bool
     queue_path: Path | None
     message: str
+    applied: bool = True
 
 
 @dataclass(frozen=True)
@@ -63,6 +68,8 @@ class SourcePathUpdateResult:
     updated: bool
     queue_path: Path | None
     next_commands: list[str]
+    applied: bool = True
+    selector: str | None = None
 
 
 @dataclass(frozen=True)
@@ -295,13 +302,45 @@ def source_commit_capture_intent(source: SourceRecord) -> bool | None:
     return None
 
 
-def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
+def refresh_source(root: Path, source_query: str, *, apply: bool = True) -> SourceRefreshResult:
     requested_match = resolve_source_query(root, source_query)
 
     requested = requested_match.source
     current_path = _refreshable_source_path(root, requested)
     current_checksum = sha256_file(current_path)
     changed = current_checksum != requested.checksum
+    layout = resolve_layout(root, load_config(root))
+
+    if not apply:
+        refreshed = _preview_refreshed_registration(
+            root,
+            layout=layout,
+            requested_match=requested_match,
+            current_path=current_path,
+            current_checksum=current_checksum,
+            changed=changed,
+        )
+        queued = not is_ingest_current(root, layout, refreshed.record)
+        queue_path = (
+            queue_item_path_for(layout, ingest_job_id(refreshed.record.source_id))
+            if queued
+            else None
+        )
+        message = (
+            "would queue ingest with --apply"
+            if queued
+            else "source is already ingested for the current pipeline version"
+        )
+        return SourceRefreshResult(
+            requested=requested,
+            requested_manifest_path=requested_match.manifest_path,
+            refreshed=refreshed,
+            changed=changed,
+            queued=queued,
+            queue_path=queue_path,
+            message=message,
+            applied=False,
+        )
 
     if changed:
         refreshed = register_source(
@@ -328,7 +367,6 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
             already_registered=True,
         )
 
-    layout = resolve_layout(root, load_config(root))
     if is_ingest_current(root, layout, refreshed.record):
         return SourceRefreshResult(
             requested=requested,
@@ -338,6 +376,7 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
             queued=False,
             queue_path=None,
             message="source is already ingested for the current pipeline version",
+            applied=True,
         )
 
     queue_path = enqueue_ingest_job(root, refreshed.record.source_id)
@@ -349,11 +388,106 @@ def refresh_source(root: Path, source_query: str) -> SourceRefreshResult:
         queued=True,
         queue_path=queue_path,
         message="queued ingest",
+        applied=True,
+    )
+
+
+def _preview_refreshed_registration(
+    root: Path,
+    *,
+    layout,
+    requested_match: SourceLookupResult,
+    current_path: Path,
+    current_checksum: str,
+    changed: bool,
+) -> RegisteredSource:
+    requested = requested_match.source
+    if not changed:
+        return RegisteredSource(
+            record=requested,
+            manifest_path=requested_match.manifest_path,
+            stored_path=_existing_materialized_path(root, requested),
+            storage_mode=effective_storage_mode(requested),
+            source_ref=canonical_source_ref(requested),
+            copied=False,
+            already_registered=True,
+        )
+
+    source_id = stable_source_id(current_checksum)
+    manifest_path = layout.source_records_dir / f"{source_id}.json"
+    if manifest_path.exists():
+        existing = load_source_record(manifest_path)
+        record = existing
+        if existing.source_id != requested.source_id:
+            supersedes = _dedupe_aliases([*existing.supersedes, requested.source_id])
+            update_fields: dict[str, object] = {"supersedes": supersedes}
+            if existing.superseded_by is not None:
+                update_fields["superseded_by"] = None
+            record = SourceRecord.model_validate(existing.model_dump(mode="json") | update_fields)
+        return RegisteredSource(
+            record=record,
+            manifest_path=manifest_path,
+            stored_path=_existing_materialized_path(root, record),
+            storage_mode=effective_storage_mode(record),
+            source_ref=canonical_source_ref(record),
+            copied=False,
+            already_registered=True,
+        )
+
+    try:
+        source_ref = current_path.relative_to(root.resolve()).as_posix()
+        source_ref_kind = "workspace_path"
+    except ValueError:
+        source_ref = str(current_path)
+        source_ref_kind = "external_path"
+    storage_mode = effective_storage_mode(requested)
+    stored_path = None
+    if storage_mode in {"copy", "symlink"}:
+        stored_path = layout.raw_sources_dir / source_id / current_path.name
+    elif storage_mode == "pointer":
+        stored_path = root / "raw" / "sources" / source_id / "pointer.json"
+
+    stored_ref = None if stored_path is None else stored_path.relative_to(root).as_posix()
+    record = SourceRecord(
+        source_id=source_id,
+        title=current_path.stem.replace("_", " ").replace("-", " ").strip() or current_path.name,
+        source_type=current_path.suffix.lstrip(".") or "file",
+        path=stored_ref or source_ref,
+        checksum=current_checksum,
+        added_at=utc_now_iso(),
+        pipeline_version=__version__,
+        original_path=manifest_original_path(root, current_path),
+        source_ref=source_ref,
+        source_ref_kind=source_ref_kind,
+        storage_mode=storage_mode,
+        storage_path=stored_ref,
+        materialized_at=utc_now_iso() if stored_ref is not None else None,
+        logical_id=effective_logical_id(requested),
+        aliases=_dedupe_aliases([*requested.aliases, source_ref]),
+        supersedes=[requested.source_id] if requested.source_id != source_id else [],
+        source_commit_capture=source_commit_capture_intent(requested),
+        source_class=requested.source_class,
+        source_labels=list(requested.source_labels),
+        discovered_by=requested.discovered_by,
+    )
+    return RegisteredSource(
+        record=record,
+        manifest_path=manifest_path,
+        stored_path=stored_path,
+        storage_mode=storage_mode,
+        source_ref=source_ref,
+        copied=storage_mode == "copy",
+        already_registered=False,
     )
 
 
 def update_source_path(
-    root: Path, source_query: str, new_path: Path, *, force: bool = False
+    root: Path,
+    source_query: str,
+    new_path: Path,
+    *,
+    force: bool = False,
+    apply: bool = True,
 ) -> SourcePathUpdateResult:
     source_match = resolve_source_query_exact(root, source_query)
     source = source_match.source
@@ -427,18 +561,34 @@ def update_source_path(
 
     updated_source = SourceRecord.model_validate(source.model_dump(mode="json") | updated_fields)
     updated = updated_source != source
-    if updated:
+    if updated and apply:
         write_source_record(source_match.manifest_path, updated_source)
 
-    queue_path = enqueue_ingest_job(root, updated_source.source_id) if checksum_matches else None
+    layout = resolve_layout(root, load_config(root))
+    queue_path = None
+    if checksum_matches:
+        queue_path = (
+            enqueue_ingest_job(root, updated_source.source_id)
+            if apply
+            else queue_item_path_for(layout, ingest_job_id(updated_source.source_id))
+        )
     status = "repaired" if checksum_matches else "partial"
-    next_commands = [
-        "splendor ingest --pending",
-        "splendor source freshness",
-    ]
-    if not checksum_matches:
+    if not apply:
+        command = (
+            "splendor source update-path "
+            f"{shlex.quote(source_query)} {shlex.quote(new_ref)} --apply"
+        )
+        if force:
+            command += " --force"
+        next_commands = [command]
+    elif not checksum_matches:
         next_commands = [
             f"splendor source refresh {shlex.quote(new_ref)}",
+            "splendor ingest --pending",
+            "splendor source freshness",
+        ]
+    else:
+        next_commands = [
             "splendor ingest --pending",
             "splendor source freshness",
         ]
@@ -454,6 +604,8 @@ def update_source_path(
         updated=updated,
         queue_path=queue_path,
         next_commands=next_commands,
+        applied=apply,
+        selector=source_query,
     )
 
 
@@ -838,6 +990,7 @@ def render_source_lookup_json(root: Path, results: list[SourceLookupResult]) -> 
 
 
 def render_source_refresh_json(root: Path, result: SourceRefreshResult) -> str:
+    mutation_records = source_refresh_written_records(root, result)
     return json.dumps(
         {
             "requested_source_id": result.requested.source_id,
@@ -861,8 +1014,9 @@ def render_source_refresh_json(root: Path, result: SourceRefreshResult) -> str:
             ),
             "message": result.message,
             "mutation": mutation_contract(
-                mode="apply",
-                written=source_refresh_written_records(root, result),
+                mode="apply" if result.applied else "preview",
+                planned=[] if result.applied else mutation_records,
+                written=mutation_records if result.applied else [],
             ),
         },
         indent=2,
@@ -870,8 +1024,10 @@ def render_source_refresh_json(root: Path, result: SourceRefreshResult) -> str:
 
 
 def render_source_path_update_json(root: Path, result: SourcePathUpdateResult) -> str:
+    mutation_records = source_path_update_mutation_records(root, result)
     return json.dumps(
         {
+            "applied": result.applied,
             "source_id": result.source.source_id,
             "logical_id": effective_logical_id(result.source),
             "old_path": result.old_path,
@@ -888,6 +1044,11 @@ def render_source_path_update_json(root: Path, result: SourcePathUpdateResult) -
             if result.queue_path is None
             else result.queue_path.relative_to(root).as_posix(),
             "next_commands": result.next_commands,
+            "mutation": mutation_contract(
+                mode="apply" if result.applied else "preview",
+                planned=[] if result.applied else mutation_records,
+                written=mutation_records if result.applied else [],
+            ),
         },
         indent=2,
     )
@@ -974,6 +1135,31 @@ def source_refresh_written_records(root: Path, result: SourceRefreshResult) -> l
                 path=result.queue_path.relative_to(root).as_posix(),
                 kind="queue_record",
                 source_id=result.refreshed.record.source_id,
+            )
+        )
+    return sorted(records, key=lambda item: (item["kind"], item["path"], item["action"]))
+
+
+def source_path_update_mutation_records(
+    root: Path, result: SourcePathUpdateResult
+) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    if result.updated:
+        records.append(
+            mutation_record(
+                action="write",
+                path=result.manifest_path.relative_to(root).as_posix(),
+                kind="source_manifest",
+                source_id=result.source.source_id,
+            )
+        )
+    if result.queue_path is not None:
+        records.append(
+            mutation_record(
+                action="write",
+                path=result.queue_path.relative_to(root).as_posix(),
+                kind="queue_record",
+                source_id=result.source.source_id,
             )
         )
     return sorted(records, key=lambda item: (item["kind"], item["path"], item["action"]))

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -8,14 +8,19 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from splendor import __version__
-from splendor.commands.ingest import enqueue_ingest_job, is_ingest_current, run_ingest_job
+from splendor.commands.ingest import (
+    enqueue_ingest_job,
+    is_ingest_current,
+    preflight_enqueue_ingest_job,
+    run_ingest_job,
+)
 from splendor.commands.mutation import mutation_contract, mutation_record
 from splendor.config import load_config
 from splendor.ingest_dispatch import SUPPORTED_SOURCE_TYPES
 from splendor.layout import resolve_layout
 from splendor.schemas import SourceRecord
 from splendor.state.paths import resolve_workspace_path
-from splendor.state.runtime import ingest_job_id, queue_item_path_for
+from splendor.state.runtime import ingest_job_id
 from splendor.state.source_compat import (
     canonical_source_ref,
     effective_aliases,
@@ -322,7 +327,11 @@ def refresh_source(root: Path, source_query: str, *, apply: bool = True) -> Sour
         )
         queued = not is_ingest_current(root, layout, refreshed.record)
         queue_path = (
-            queue_item_path_for(layout, ingest_job_id(refreshed.record.source_id))
+            preflight_enqueue_ingest_job(
+                root,
+                refreshed.record.source_id,
+                require_manifest=refreshed.manifest_path.exists(),
+            )
             if queued
             else None
         )
@@ -564,13 +573,12 @@ def update_source_path(
     if updated and apply:
         write_source_record(source_match.manifest_path, updated_source)
 
-    layout = resolve_layout(root, load_config(root))
     queue_path = None
     if checksum_matches:
         queue_path = (
             enqueue_ingest_job(root, updated_source.source_id)
             if apply
-            else queue_item_path_for(layout, ingest_job_id(updated_source.source_id))
+            else preflight_enqueue_ingest_job(root, updated_source.source_id)
         )
     status = "repaired" if checksum_matches else "partial"
     if not apply:
@@ -584,12 +592,12 @@ def update_source_path(
     elif not checksum_matches:
         next_commands = [
             f"splendor source refresh {shlex.quote(new_ref)}",
-            "splendor ingest --pending",
+            "splendor ingest --pending --apply",
             "splendor source freshness",
         ]
     else:
         next_commands = [
-            "splendor ingest --pending",
+            "splendor ingest --pending --apply",
             "splendor source freshness",
         ]
     return SourcePathUpdateResult(
@@ -1413,7 +1421,8 @@ def _workspace_freshness_items(
                 message="canonical workspace source differs from latest manifest checksum",
                 next_commands=[
                     _source_refresh_command(source_ref),
-                    "splendor ingest --pending",
+                    f"{_source_refresh_command(source_ref)} --apply",
+                    "splendor ingest --pending --apply",
                 ],
             )
         )

--- a/src/splendor/commands/source.py
+++ b/src/splendor/commands/source.py
@@ -29,6 +29,7 @@ from splendor.state.source_compat import (
     effective_storage_mode,
     logical_source_id_for_ref,
 )
+from splendor.state.source_pointer import pointer_artifact_path
 from splendor.state.source_registry import (
     RegisteredSource,
     load_source_record,
@@ -454,7 +455,7 @@ def _preview_refreshed_registration(
     if storage_mode in {"copy", "symlink"}:
         stored_path = layout.raw_sources_dir / source_id / current_path.name
     elif storage_mode == "pointer":
-        stored_path = root / "raw" / "sources" / source_id / "pointer.json"
+        stored_path = pointer_artifact_path(layout, source_id)
 
     stored_ref = None if stored_path is None else stored_path.relative_to(root).as_posix()
     record = SourceRecord(
@@ -1110,7 +1111,10 @@ def source_reconcile_next_commands(result: SourceReconcileResult) -> list[str]:
 def source_refresh_written_records(root: Path, result: SourceRefreshResult) -> list[dict[str, str]]:
     records: list[dict[str, str]] = []
     if result.changed:
-        if result.refreshed.copied and result.refreshed.stored_path is not None:
+        if (
+            result.refreshed.storage_mode in {"copy", "pointer", "symlink"}
+            and result.refreshed.stored_path is not None
+        ):
             records.append(
                 mutation_record(
                     action="write",

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -352,6 +352,19 @@ def add_topic_page(
 
 
 def plan_wiki_index_rebuild(root: Path) -> WikiIndexRebuildResult:
+    _entries, result = _planned_wiki_index_rebuild(root)
+    return result
+
+
+def rebuild_wiki_index(root: Path) -> WikiIndexRebuildResult:
+    entries, result = _planned_wiki_index_rebuild(root)
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    write_text_atomic(layout.index_file, _render_rebuilt_index(entries))
+    return result
+
+
+def _planned_wiki_index_rebuild(root: Path) -> tuple[list[WikiIndexEntry], WikiIndexRebuildResult]:
     config = load_config(root)
     layout = resolve_layout(root, config)
     pages, invalid_pages = load_wiki_pages(root, layout)
@@ -372,32 +385,12 @@ def plan_wiki_index_rebuild(root: Path) -> WikiIndexRebuildResult:
     ]
     entries.sort(key=lambda entry: (entry.kind, entry.title.casefold(), entry.path))
     section_counts = Counter(entry.kind for entry in entries)
-    return WikiIndexRebuildResult(
+    result = WikiIndexRebuildResult(
         path=_relative(root, layout.index_file),
         page_count=len(entries),
         sections={kind: section_counts[kind] for kind in _INDEX_KIND_ORDER if section_counts[kind]},
     )
-
-
-def rebuild_wiki_index(root: Path) -> WikiIndexRebuildResult:
-    result = plan_wiki_index_rebuild(root)
-    config = load_config(root)
-    layout = resolve_layout(root, config)
-    pages, _invalid_pages = load_wiki_pages(root, layout)
-    entries = [
-        WikiIndexEntry(
-            kind=page.frontmatter.kind,
-            title=page.frontmatter.title,
-            page_id=page.frontmatter.page_id,
-            path=page.path,
-            status=page.frontmatter.status,
-            review_state=page.frontmatter.review_state,
-        )
-        for page in pages
-    ]
-    entries.sort(key=lambda entry: (entry.kind, entry.title.casefold(), entry.path))
-    write_text_atomic(layout.index_file, _render_rebuilt_index(entries))
-    return result
+    return entries, result
 
 
 def _render_rebuilt_index(entries: list[WikiIndexEntry]) -> str:

--- a/src/splendor/commands/wiki.py
+++ b/src/splendor/commands/wiki.py
@@ -351,7 +351,7 @@ def add_topic_page(
     )
 
 
-def rebuild_wiki_index(root: Path) -> WikiIndexRebuildResult:
+def plan_wiki_index_rebuild(root: Path) -> WikiIndexRebuildResult:
     config = load_config(root)
     layout = resolve_layout(root, config)
     pages, invalid_pages = load_wiki_pages(root, layout)
@@ -371,14 +371,33 @@ def rebuild_wiki_index(root: Path) -> WikiIndexRebuildResult:
         for page in pages
     ]
     entries.sort(key=lambda entry: (entry.kind, entry.title.casefold(), entry.path))
-    content = _render_rebuilt_index(entries)
-    write_text_atomic(layout.index_file, content)
     section_counts = Counter(entry.kind for entry in entries)
     return WikiIndexRebuildResult(
         path=_relative(root, layout.index_file),
         page_count=len(entries),
         sections={kind: section_counts[kind] for kind in _INDEX_KIND_ORDER if section_counts[kind]},
     )
+
+
+def rebuild_wiki_index(root: Path) -> WikiIndexRebuildResult:
+    result = plan_wiki_index_rebuild(root)
+    config = load_config(root)
+    layout = resolve_layout(root, config)
+    pages, _invalid_pages = load_wiki_pages(root, layout)
+    entries = [
+        WikiIndexEntry(
+            kind=page.frontmatter.kind,
+            title=page.frontmatter.title,
+            page_id=page.frontmatter.page_id,
+            path=page.path,
+            status=page.frontmatter.status,
+            review_state=page.frontmatter.review_state,
+        )
+        for page in pages
+    ]
+    entries.sort(key=lambda entry: (entry.kind, entry.title.casefold(), entry.path))
+    write_text_atomic(layout.index_file, _render_rebuilt_index(entries))
+    return result
 
 
 def _render_rebuilt_index(entries: list[WikiIndexEntry]) -> str:

--- a/src/splendor/commands/workspace.py
+++ b/src/splendor/commands/workspace.py
@@ -57,6 +57,7 @@ class PruneSupersededResult:
     candidates: int
     pruned: list[PrunedSourceSummary]
     skipped: list[SkippedPruneSourceSummary]
+    applied: bool = True
 
 
 @dataclass(frozen=True)
@@ -69,6 +70,7 @@ class TopicRefMigration:
 class TopicRefMigrationResult:
     candidates: int
     updated: list[TopicRefMigration]
+    applied: bool = True
 
 
 @dataclass(frozen=True)
@@ -248,7 +250,12 @@ def prune_superseded_source_summaries(root: Path, *, apply: bool = True) -> Prun
             )
         )
 
-    return PruneSupersededResult(candidates=candidates, pruned=pruned, skipped=skipped)
+    return PruneSupersededResult(
+        candidates=candidates,
+        pruned=pruned,
+        skipped=skipped,
+        applied=apply,
+    )
 
 
 def migrate_superseded_topic_refs(root: Path, *, apply: bool = True) -> TopicRefMigrationResult:
@@ -258,7 +265,7 @@ def migrate_superseded_topic_refs(root: Path, *, apply: bool = True) -> TopicRef
     updated: list[TopicRefMigration] = []
     candidates = 0
     if not replacements:
-        return TopicRefMigrationResult(candidates=0, updated=[])
+        return TopicRefMigrationResult(candidates=0, updated=[], applied=apply)
 
     for page_path in sorted(layout.wiki_dir.rglob("*.md")):
         if page_path.name == ".gitkeep" or page_path in {layout.index_file, layout.log_file}:
@@ -302,7 +309,7 @@ def migrate_superseded_topic_refs(root: Path, *, apply: bool = True) -> TopicRef
             )
         )
 
-    return TopicRefMigrationResult(candidates=candidates, updated=updated)
+    return TopicRefMigrationResult(candidates=candidates, updated=updated, applied=apply)
 
 
 def render_workspace_refresh_json(root: Path, result: WorkspaceRefreshResult) -> str:

--- a/src/splendor/commands/workspace.py
+++ b/src/splendor/commands/workspace.py
@@ -6,7 +6,12 @@ import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
-from splendor.commands.ingest import DrainItemResult, DrainResult, run_ingest_job
+from splendor.commands.ingest import (
+    DrainItemResult,
+    DrainResult,
+    pending_ingest_planned_records,
+    run_ingest_job,
+)
 from splendor.commands.mutation import dedupe_mutation_records, mutation_contract, mutation_record
 from splendor.commands.source import (
     SourceFreshnessItem,
@@ -16,7 +21,11 @@ from splendor.commands.source import (
     scan_source_freshness,
     source_refresh_written_records,
 )
-from splendor.commands.wiki import WikiIndexRebuildResult, rebuild_wiki_index
+from splendor.commands.wiki import (
+    WikiIndexRebuildResult,
+    plan_wiki_index_rebuild,
+    rebuild_wiki_index,
+)
 from splendor.config import load_config
 from splendor.layout import resolve_layout
 from splendor.schemas import SourceRecord
@@ -84,6 +93,7 @@ class WorkspaceRefreshResult:
     index: WikiIndexRebuildResult | None
     pruning: PruneSupersededResult | None
     topic_ref_migration: TopicRefMigrationResult | None
+    applied: bool = True
 
 
 def refresh_workspace(
@@ -94,6 +104,7 @@ def refresh_workspace(
     rebuild_index: bool = False,
     prune_superseded: bool = False,
     update_topic_refs: bool = False,
+    apply: bool = True,
 ) -> WorkspaceRefreshResult:
     if ingest and not changed:
         msg = "workspace refresh --ingest requires --changed"
@@ -110,15 +121,19 @@ def refresh_workspace(
     changed_items = (
         [item for item in initial_freshness.sources if item.status == "changed"] if changed else []
     )
-    refreshed, failed_sources = _refresh_changed_items(root, changed_items)
+    refreshed, failed_sources = _refresh_changed_items(root, changed_items, apply=apply)
 
-    ingest_result = _drain_refreshed_ingest_jobs(root, refreshed) if ingest else None
-    topic_ref_migration_result = migrate_superseded_topic_refs(root) if update_topic_refs else None
-    pruning_result = prune_superseded_source_summaries(root) if prune_superseded else None
+    ingest_result = _drain_refreshed_ingest_jobs(root, refreshed, apply=apply) if ingest else None
+    topic_ref_migration_result = (
+        migrate_superseded_topic_refs(root, apply=apply) if update_topic_refs else None
+    )
+    pruning_result = (
+        prune_superseded_source_summaries(root, apply=apply) if prune_superseded else None
+    )
     index_result = None
     if rebuild_index and (ingest_result is None or ingest_result.failed == 0):
-        index_result = rebuild_wiki_index(root)
-    final_freshness = scan_source_freshness(root)
+        index_result = rebuild_wiki_index(root) if apply else plan_wiki_index_rebuild(root)
+    final_freshness = scan_source_freshness(root) if apply else initial_freshness
 
     return WorkspaceRefreshResult(
         initial_freshness=initial_freshness,
@@ -130,10 +145,11 @@ def refresh_workspace(
         index=index_result,
         pruning=pruning_result,
         topic_ref_migration=topic_ref_migration_result,
+        applied=apply,
     )
 
 
-def prune_superseded_source_summaries(root: Path) -> PruneSupersededResult:
+def prune_superseded_source_summaries(root: Path, *, apply: bool = True) -> PruneSupersededResult:
     layout = resolve_layout(root, load_config(root))
     sources = _load_sources_by_id(layout)
     pruned: list[PrunedSourceSummary] = []
@@ -220,8 +236,9 @@ def prune_superseded_source_summaries(root: Path) -> PruneSupersededResult:
             )
             continue
 
-        _remove_pruned_page_links(manifest_path, source, page_relpath)
-        page_path.unlink()
+        if apply:
+            _remove_pruned_page_links(manifest_path, source, page_relpath)
+            page_path.unlink()
         pruned.append(
             PrunedSourceSummary(
                 path=page_relpath,
@@ -234,7 +251,7 @@ def prune_superseded_source_summaries(root: Path) -> PruneSupersededResult:
     return PruneSupersededResult(candidates=candidates, pruned=pruned, skipped=skipped)
 
 
-def migrate_superseded_topic_refs(root: Path) -> TopicRefMigrationResult:
+def migrate_superseded_topic_refs(root: Path, *, apply: bool = True) -> TopicRefMigrationResult:
     layout = resolve_layout(root, load_config(root))
     sources = _load_sources_by_id(layout)
     replacements = _superseded_source_replacements(sources)
@@ -276,7 +293,8 @@ def migrate_superseded_topic_refs(root: Path) -> TopicRefMigrationResult:
             update={"source_refs": _dedupe_preserve_order(migrated_refs)}
         )
         content = f"---\n{render_frontmatter(frontmatter)}\n---\n{body}"
-        write_text_atomic(page_path, content)
+        if apply:
+            write_text_atomic(page_path, content)
         updated.append(
             TopicRefMigration(
                 path=page_path.relative_to(root).as_posix(),
@@ -288,6 +306,7 @@ def migrate_superseded_topic_refs(root: Path) -> TopicRefMigrationResult:
 
 
 def render_workspace_refresh_json(root: Path, result: WorkspaceRefreshResult) -> str:
+    mutation_records = workspace_refresh_written_records(root, result)
     return json.dumps(
         {
             "initial_freshness": _freshness_counts(result.initial_freshness),
@@ -304,8 +323,9 @@ def render_workspace_refresh_json(root: Path, result: WorkspaceRefreshResult) ->
                 None if result.topic_ref_migration is None else asdict(result.topic_ref_migration)
             ),
             "mutation": mutation_contract(
-                mode="apply",
-                written=workspace_refresh_written_records(root, result),
+                mode="apply" if result.applied else "preview",
+                planned=[] if result.applied else mutation_records,
+                written=mutation_records if result.applied else [],
             ),
         },
         indent=2,
@@ -457,18 +477,22 @@ def _dedupe_preserve_order(values: list[str]) -> list[str]:
     return deduped
 
 
-def _refresh_changed_item(root: Path, item: SourceFreshnessItem) -> SourceRefreshResult:
-    return refresh_source(root, item.canonical_path)
+def _refresh_changed_item(
+    root: Path, item: SourceFreshnessItem, *, apply: bool = True
+) -> SourceRefreshResult:
+    if apply:
+        return refresh_source(root, item.canonical_path)
+    return refresh_source(root, item.canonical_path, apply=False)
 
 
 def _refresh_changed_items(
-    root: Path, items: list[SourceFreshnessItem]
+    root: Path, items: list[SourceFreshnessItem], *, apply: bool = True
 ) -> tuple[list[SourceRefreshResult], list[FailedWorkspaceRefreshSource]]:
     refreshed: list[SourceRefreshResult] = []
     failed: list[FailedWorkspaceRefreshSource] = []
     for item in items:
         try:
-            refreshed.append(_refresh_changed_item(root, item))
+            refreshed.append(_refresh_changed_item(root, item, apply=apply))
         except (FileNotFoundError, RuntimeError, ValueError) as exc:
             failed.append(_failed_refresh_source(root, item=item, reason=str(exc)))
     return refreshed, failed
@@ -499,7 +523,9 @@ def _failed_refresh_source(
     )
 
 
-def _drain_refreshed_ingest_jobs(root: Path, refreshed: list[SourceRefreshResult]) -> DrainResult:
+def _drain_refreshed_ingest_jobs(
+    root: Path, refreshed: list[SourceRefreshResult], *, apply: bool = True
+) -> DrainResult:
     queue_paths = [
         result.queue_path for result in refreshed if result.queued and result.queue_path is not None
     ]
@@ -511,6 +537,17 @@ def _drain_refreshed_ingest_jobs(root: Path, refreshed: list[SourceRefreshResult
 
     for queue_path in queue_paths:
         source_id = queue_path.stem.removeprefix("ingest-")
+        if not apply:
+            item_results.append(
+                DrainItemResult(
+                    source_id=source_id,
+                    queue_path=queue_path,
+                    outcome="planned",
+                    message="would run refreshed ingest job with --apply",
+                    written_records=[],
+                )
+            )
+            continue
         try:
             result = run_ingest_job(root, queue_path)
         except (FileNotFoundError, RuntimeError, ValueError) as exc:
@@ -635,7 +672,10 @@ def workspace_refresh_written_records(
     for refresh in result.refreshed:
         records.extend(source_refresh_written_records(root, refresh))
     if result.ingest is not None:
-        records.extend(_ingest_written_records(root, result.ingest))
+        if result.applied:
+            records.extend(_ingest_written_records(root, result.ingest))
+        else:
+            records.extend(pending_ingest_planned_records(root, result.ingest))
     if result.index is not None:
         records.append(mutation_record(action="write", path=result.index.path, kind="wiki_index"))
     if result.pruning is not None:

--- a/src/splendor/state/source_pointer.py
+++ b/src/splendor/state/source_pointer.py
@@ -15,6 +15,10 @@ def pointer_artifact_relpath(source_id: str) -> str:
     return f"raw/sources/{source_id}/pointer.json"
 
 
+def pointer_artifact_path(layout, source_id: str) -> Path:
+    return layout.raw_sources_dir / source_id / "pointer.json"
+
+
 def load_source_pointer(path: Path) -> SourcePointerArtifact:
     try:
         raw = path.read_text(encoding="utf-8")

--- a/src/splendor/state/source_registry.py
+++ b/src/splendor/state/source_registry.py
@@ -19,7 +19,7 @@ from splendor.state.source_compat import (
     is_legacy_copied_manifest,
     logical_source_id_for_ref,
 )
-from splendor.state.source_pointer import pointer_artifact_relpath, write_source_pointer
+from splendor.state.source_pointer import pointer_artifact_path, write_source_pointer
 from splendor.utils.fs import (
     copy_file_atomic,
     copy_file_if_missing,
@@ -206,7 +206,7 @@ def _materialized_path_for(
     if storage_mode in {"copy", "symlink"}:
         return _stored_path_for(layout, source_id, candidate)
     if storage_mode == "pointer":
-        return layout.root / pointer_artifact_relpath(source_id)
+        return pointer_artifact_path(layout, source_id)
     return None
 
 

--- a/tests/test_add_source.py
+++ b/tests/test_add_source.py
@@ -6,6 +6,7 @@ import pytest
 from splendor.commands.add_source import add_source, expand_source_paths
 from splendor.commands.init import initialize_workspace
 from splendor.commands.materialize_source import materialize_source
+from splendor.config import load_config, write_config
 from splendor.state.source_pointer import load_source_pointer
 from splendor.state.source_registry import (
     _effective_storage_mode,
@@ -236,6 +237,25 @@ def test_add_source_supports_pointer_for_workspace_sources(tmp_path: Path) -> No
     assert pointer.source_ref_kind == "workspace_path"
     assert pointer.checksum == manifest.checksum
     assert pointer.created_at == manifest.materialized_at
+
+
+def test_add_source_pointer_respects_custom_raw_sources_layout(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.layout.raw_sources_dir = "custom/source-artifacts"
+    write_config(tmp_path, config)
+    source = tmp_path / "note.md"
+    source.write_text("# note\n", encoding="utf-8")
+
+    result = add_source(tmp_path, source, storage_mode="pointer")
+
+    manifest = load_source_record(result.manifest_path)
+    expected_path = tmp_path / "custom" / "source-artifacts" / result.source_id / "pointer.json"
+    assert result.stored_path == expected_path
+    assert expected_path.exists()
+    assert manifest.path == f"custom/source-artifacts/{result.source_id}/pointer.json"
+    assert manifest.storage_path == manifest.path
+    assert not (tmp_path / "raw" / "sources" / result.source_id / "pointer.json").exists()
 
 
 def test_add_source_rejects_pointer_for_external_sources(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,9 +110,17 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     parser = build_parser()
 
     lookup = parser.parse_args(["source", "lookup", "brief", "--json"])
-    refresh = parser.parse_args(["source", "refresh", "docs/brief.md", "--json"])
+    refresh = parser.parse_args(["source", "refresh", "docs/brief.md", "--apply", "--json"])
     update_path = parser.parse_args(
-        ["source", "update-path", "docs/old.md", "docs/new.md", "--force", "--json"]
+        [
+            "source",
+            "update-path",
+            "docs/old.md",
+            "docs/new.md",
+            "--force",
+            "--apply",
+            "--json",
+        ]
     )
     reconcile = parser.parse_args(
         ["source", "reconcile", "docs/brief.md", "--current", "src-a", "--apply", "--json"]
@@ -130,11 +138,13 @@ def test_cli_source_parser_accepts_lookup_and_refresh_json_flags() -> None:
     assert lookup.json_output is True
     assert refresh.source_command == "refresh"
     assert refresh.query == "docs/brief.md"
+    assert refresh.apply is True
     assert refresh.json_output is True
     assert update_path.source_command == "update-path"
     assert update_path.query == "docs/old.md"
     assert update_path.new_path == Path("docs/new.md")
     assert update_path.force is True
+    assert update_path.apply is True
     assert update_path.json_output is True
     assert reconcile.source_command == "reconcile"
     assert reconcile.selector == "docs/brief.md"
@@ -375,7 +385,7 @@ def test_cli_source_forget_preview_is_non_mutating(tmp_path: Path, capsys) -> No
     source_path = tmp_path / "brief.md"
     source_path.write_text("# Brief\n\nKeep preview safe.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source_path)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
     manifest_path = tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
     summary_path = tmp_path / "wiki" / "sources" / f"{source_id}.md"
@@ -413,7 +423,7 @@ def test_cli_source_forget_apply_removes_source_owned_state(tmp_path: Path, caps
     source_path = tmp_path / "brief.md"
     source_path.write_text("# Brief\n\nRemove generated state.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source_path)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
     manifest_path = tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
     summary_path = tmp_path / "wiki" / "sources" / f"{source_id}.md"
@@ -827,7 +837,15 @@ def test_cli_workspace_refresh_parser_accepts_safe_refresh_flags() -> None:
     parser = build_parser()
 
     args = parser.parse_args(
-        ["workspace", "refresh", "--changed", "--ingest", "--rebuild-index", "--json"]
+        [
+            "workspace",
+            "refresh",
+            "--changed",
+            "--ingest",
+            "--rebuild-index",
+            "--apply",
+            "--json",
+        ]
     )
 
     assert args.command == "workspace"
@@ -835,6 +853,7 @@ def test_cli_workspace_refresh_parser_accepts_safe_refresh_flags() -> None:
     assert args.changed is True
     assert args.ingest is True
     assert args.rebuild_index is True
+    assert args.apply is True
     assert args.json_output is True
 
 
@@ -1332,7 +1351,7 @@ def test_cli_source_refresh_registers_changed_workspace_source_and_queues_it(
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
 
     assert exit_code == 0
     out = capsys.readouterr().out
@@ -1355,6 +1374,39 @@ def test_cli_source_refresh_registers_changed_workspace_source_and_queues_it(
     assert records_by_id[refreshed_id].superseded_by is None
 
 
+def test_cli_source_refresh_defaults_to_preview_without_mutating(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    original_manifests = {
+        path.name: path.read_text(encoding="utf-8")
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+    }
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mutation"]["mode"] == "preview"
+    assert payload["mutation"]["mutates"] is False
+    assert payload["mutation"]["written"] == []
+    assert {item["kind"] for item in payload["mutation"]["planned"]} == {
+        "queue_record",
+        "source_manifest",
+    }
+    assert {
+        path.name: path.read_text(encoding="utf-8")
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+    } == original_manifests
+    assert not any(
+        path.name == f"ingest-{payload['source_id']}.json"
+        for path in (tmp_path / "state" / "queue").glob("*.json")
+    )
+
+
 def test_cli_source_refresh_reports_existing_version_match(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     source = tmp_path / "brief.md"
@@ -1362,11 +1414,11 @@ def test_cli_source_refresh_reports_existing_version_match(tmp_path: Path, capsy
     main(["--root", str(tmp_path), "add-source", str(source)])
     original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
-    main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
     source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
 
     assert exit_code == 0
     out = capsys.readouterr().out
@@ -1409,7 +1461,9 @@ def test_cli_source_refresh_json_reports_materialized_artifact_write(
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--json"])
+    exit_code = main(
+        ["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply", "--json"]
+    )
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
@@ -1437,7 +1491,9 @@ def test_cli_source_refresh_json_reports_queue_handoff(tmp_path: Path, capsys) -
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--json"])
+    exit_code = main(
+        ["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply", "--json"]
+    )
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
@@ -1506,7 +1562,7 @@ def test_cli_source_refresh_preserves_no_commit_capture_intent(
     monkeypatch.setattr("splendor.state.source_registry.captured_source_commit", fail_if_called)
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
 
     assert exit_code == 0
     refreshed_records = [
@@ -1537,7 +1593,7 @@ def test_cli_source_refresh_preserves_positive_commit_capture_intent(
     )
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
 
     assert exit_code == 0
     refreshed_records = [
@@ -1571,7 +1627,7 @@ def test_cli_source_refresh_uses_config_default_for_legacy_commit_capture_intent
     )
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
 
     assert exit_code == 0
     refreshed_records = [
@@ -1608,7 +1664,7 @@ def test_cli_source_refresh_preserves_legacy_positive_commit_capture_intent(
     )
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
 
     assert exit_code == 0
     refreshed_records = [
@@ -1642,7 +1698,7 @@ def test_cli_source_refresh_supports_original_path_legacy_manifest(tmp_path: Pat
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
 
     assert exit_code == 0
     assert "Detected changed source content" in capsys.readouterr().out
@@ -1654,10 +1710,10 @@ def test_cli_source_refresh_by_path_uses_latest_matching_source_ref(tmp_path: Pa
     source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source)])
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
-    main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
 
     assert exit_code == 0
     out = capsys.readouterr().out
@@ -1682,7 +1738,15 @@ def test_cli_source_update_path_repairs_missing_workspace_source(tmp_path: Path,
     capsys.readouterr()
 
     exit_code = main(
-        ["--root", str(tmp_path), "source", "update-path", "docs/brief.md", "moved/brief.md"]
+        [
+            "--root",
+            str(tmp_path),
+            "source",
+            "update-path",
+            "docs/brief.md",
+            "moved/brief.md",
+            "--apply",
+        ]
     )
 
     assert exit_code == 0
@@ -1733,12 +1797,23 @@ def test_cli_source_update_path_json_reports_deterministic_payload(tmp_path: Pat
     capsys.readouterr()
 
     exit_code = main(
-        ["--root", str(tmp_path), "source", "update-path", manifest.source_id, "new.md", "--json"]
+        [
+            "--root",
+            str(tmp_path),
+            "source",
+            "update-path",
+            manifest.source_id,
+            "new.md",
+            "--apply",
+            "--json",
+        ]
     )
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
+    mutation = payload.pop("mutation")
     assert payload == {
+        "applied": True,
         "source_id": manifest.source_id,
         "logical_id": "source:old.md",
         "old_path": "old.md",
@@ -1757,6 +1832,60 @@ def test_cli_source_update_path_json_reports_deterministic_payload(tmp_path: Pat
             "splendor source freshness",
         ],
     }
+    assert mutation["mode"] == "apply"
+    assert mutation["mutates"] is True
+    assert mutation["planned"] == []
+    assert {
+        (item["action"], item["kind"], item["path"], item["source_id"])
+        for item in mutation["written"]
+    } == {
+        (
+            "write",
+            "source_manifest",
+            f"state/manifests/sources/{manifest.source_id}.json",
+            manifest.source_id,
+        ),
+        (
+            "write",
+            "queue_record",
+            f"state/queue/ingest-{manifest.source_id}.json",
+            manifest.source_id,
+        ),
+    }
+
+
+def test_cli_source_update_path_defaults_to_preview_without_mutating(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    old_source = tmp_path / "old.md"
+    new_source = tmp_path / "new.md"
+    old_source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "old.md"])
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    before_manifest = manifest_path.read_text(encoding="utf-8")
+    manifest = load_source_record(manifest_path)
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{manifest.source_id}.json"
+    queue_before = queue_path.read_text(encoding="utf-8")
+    old_source.rename(new_source)
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "source", "update-path", manifest.source_id, "new.md", "--json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["applied"] is False
+    assert payload["mutation"]["mode"] == "preview"
+    assert payload["mutation"]["mutates"] is False
+    assert payload["mutation"]["written"] == []
+    assert {(item["kind"], item["path"]) for item in payload["mutation"]["planned"]} == {
+        ("source_manifest", f"state/manifests/sources/{manifest.source_id}.json"),
+        ("queue_record", f"state/queue/ingest-{manifest.source_id}.json"),
+    }
+    assert manifest_path.read_text(encoding="utf-8") == before_manifest
+    assert queue_path.read_text(encoding="utf-8") == queue_before
 
 
 @pytest.mark.parametrize(
@@ -1842,7 +1971,9 @@ def test_cli_source_update_path_does_not_mutate_maintained_synthesis(
     topic_before = topic.read_text(encoding="utf-8")
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "update-path", "old.md", "new.md"])
+    exit_code = main(
+        ["--root", str(tmp_path), "source", "update-path", "old.md", "new.md", "--apply"]
+    )
 
     assert exit_code == 0
     assert topic.read_text(encoding="utf-8") == topic_before
@@ -1858,13 +1989,15 @@ def test_cli_source_update_path_reingests_same_byte_move_to_refresh_provenance(
     main(["--root", str(tmp_path), "add-source", "old.md"])
     manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
     source_id = manifest_path.stem
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     page_path = tmp_path / "wiki" / "sources" / f"{source_id}.md"
     assert "old.md" in page_path.read_text(encoding="utf-8")
     source.rename(replacement)
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "update-path", "old.md", "new.md"])
+    exit_code = main(
+        ["--root", str(tmp_path), "source", "update-path", "old.md", "new.md", "--apply"]
+    )
 
     assert exit_code == 0
     updated = load_source_record(manifest_path)
@@ -1872,7 +2005,7 @@ def test_cli_source_update_path_reingests_same_byte_move_to_refresh_provenance(
     assert updated.last_run_id is not None
     assert (tmp_path / "state" / "queue" / f"ingest-{source_id}.json").exists()
 
-    ingest_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+    ingest_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
 
     assert ingest_code == 0
     page_text = page_path.read_text(encoding="utf-8")
@@ -1893,7 +2026,16 @@ def test_cli_source_update_path_changed_bytes_reports_partial_repair(
     capsys.readouterr()
 
     exit_code = main(
-        ["--root", str(tmp_path), "source", "update-path", "old.md", "new.md", "--json"]
+        [
+            "--root",
+            str(tmp_path),
+            "source",
+            "update-path",
+            "old.md",
+            "new.md",
+            "--apply",
+            "--json",
+        ]
     )
 
     assert exit_code == 1
@@ -2021,7 +2163,7 @@ def test_cli_source_freshness_suggests_wiki_work_only_after_current_ingest(
     source.write_text("# Brief\n\nCurrent.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source)])
     source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     capsys.readouterr()
 
     exit_code = main(["--root", str(tmp_path), "source", "freshness", "--json"])
@@ -2042,7 +2184,7 @@ def test_cli_source_freshness_marks_old_versions_historical_when_current_manifes
     main(["--root", str(tmp_path), "add-source", str(source)])
     original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
-    main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
     refreshed_id = next(
         path.stem
         for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
@@ -2073,7 +2215,7 @@ def test_cli_source_freshness_targets_latest_manifest_when_file_reverts(
     main(["--root", str(tmp_path), "add-source", str(source)])
     original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
-    main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
     refreshed_id = next(
         path.stem
         for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
@@ -2208,7 +2350,9 @@ def test_cli_workspace_refresh_rebuilds_index_standalone(tmp_path: Path, capsys)
     main(["--root", str(tmp_path), "init"])
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--rebuild-index", "--json"])
+    exit_code = main(
+        ["--root", str(tmp_path), "workspace", "refresh", "--rebuild-index", "--apply", "--json"]
+    )
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
@@ -2232,7 +2376,7 @@ def test_cli_workspace_refresh_changed_ingests_and_rebuilds_index(tmp_path: Path
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
     capsys.readouterr()
@@ -2246,6 +2390,7 @@ def test_cli_workspace_refresh_changed_ingests_and_rebuilds_index(tmp_path: Path
             "--changed",
             "--ingest",
             "--rebuild-index",
+            "--apply",
             "--json",
         ]
     )
@@ -2306,6 +2451,58 @@ def test_cli_workspace_refresh_changed_ingests_and_rebuilds_index(tmp_path: Path
     assert main(["--root", str(tmp_path), "health"]) == 0
 
 
+def test_cli_workspace_refresh_defaults_to_preview_without_mutating(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    write_config(tmp_path, config)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    manifests_before = {
+        path.name: path.read_text(encoding="utf-8")
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+    }
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "workspace",
+            "refresh",
+            "--changed",
+            "--ingest",
+            "--rebuild-index",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    refreshed_id = payload["refreshed"][0]["source_id"]
+    assert payload["mutation"]["mode"] == "preview"
+    assert payload["mutation"]["mutates"] is False
+    assert payload["mutation"]["written"] == []
+    assert {
+        path.name: path.read_text(encoding="utf-8")
+        for path in (tmp_path / "state" / "manifests" / "sources").glob("*.json")
+    } == manifests_before
+    assert not (tmp_path / "wiki" / "sources" / f"{refreshed_id}.md").exists()
+    assert (tmp_path / "wiki" / "sources" / f"{original_id}.md").exists()
+    assert {item["kind"] for item in payload["mutation"]["planned"]} >= {
+        "queue_record",
+        "run_record",
+        "source_manifest",
+        "source_summary_page",
+        "wiki_index",
+        "wiki_log",
+    }
+
+
 def test_cli_workspace_refresh_prunes_superseded_summaries_standalone(
     tmp_path: Path, capsys
 ) -> None:
@@ -2316,7 +2513,7 @@ def test_cli_workspace_refresh_prunes_superseded_summaries_standalone(
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
     main(
@@ -2328,6 +2525,7 @@ def test_cli_workspace_refresh_prunes_superseded_summaries_standalone(
             "--changed",
             "--ingest",
             "--rebuild-index",
+            "--apply",
         ]
     )
     capsys.readouterr()
@@ -2339,6 +2537,7 @@ def test_cli_workspace_refresh_prunes_superseded_summaries_standalone(
             "workspace",
             "refresh",
             "--prune-superseded",
+            "--apply",
             "--json",
         ]
     )
@@ -2389,12 +2588,12 @@ def test_cli_workspace_refresh_changed_rebuilds_index_without_ingest(
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
     capsys.readouterr()
 
     exit_code = main(
-        ["--root", str(tmp_path), "workspace", "refresh", "--changed", "--rebuild-index"]
+        ["--root", str(tmp_path), "workspace", "refresh", "--changed", "--rebuild-index", "--apply"]
     )
 
     assert exit_code == 0
@@ -2414,7 +2613,7 @@ def test_cli_workspace_refresh_prunes_superseded_summaries_and_updates_topic_ref
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
     main(
         [
@@ -2452,6 +2651,7 @@ def test_cli_workspace_refresh_prunes_superseded_summaries_and_updates_topic_ref
             "--rebuild-index",
             "--prune-superseded",
             "--update-topic-refs",
+            "--apply",
             "--json",
         ]
     )
@@ -2517,7 +2717,7 @@ def test_cli_workspace_refresh_reports_skipped_superseded_prune_candidates(
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
     main(
@@ -2529,6 +2729,7 @@ def test_cli_workspace_refresh_reports_skipped_superseded_prune_candidates(
             "--changed",
             "--ingest",
             "--rebuild-index",
+            "--apply",
         ]
     )
     old_summary = tmp_path / "wiki" / "sources" / f"{original_id}.md"
@@ -2542,6 +2743,7 @@ def test_cli_workspace_refresh_reports_skipped_superseded_prune_candidates(
             "workspace",
             "refresh",
             "--prune-superseded",
+            "--apply",
             "--json",
         ]
     )
@@ -2563,7 +2765,7 @@ def test_cli_workspace_refresh_ingests_only_refreshed_sources(tmp_path: Path, ca
     changed_source.write_text("# Changed\n\nOriginal.\n", encoding="utf-8")
     pending_source.write_text("# Pending\n\nQueued separately.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(changed_source)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     main(["--root", str(tmp_path), "add-source", str(pending_source)])
     pending_id = next(
         load_source_record(path).source_id
@@ -2574,7 +2776,16 @@ def test_cli_workspace_refresh_ingests_only_refreshed_sources(tmp_path: Path, ca
     capsys.readouterr()
 
     exit_code = main(
-        ["--root", str(tmp_path), "workspace", "refresh", "--changed", "--ingest", "--json"]
+        [
+            "--root",
+            str(tmp_path),
+            "workspace",
+            "refresh",
+            "--changed",
+            "--ingest",
+            "--apply",
+            "--json",
+        ]
     )
 
     assert exit_code == 0
@@ -2595,7 +2806,7 @@ def test_cli_workspace_refresh_reports_missing_source_as_unresolved(tmp_path: Pa
     source.unlink()
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed"])
+    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed", "--apply"])
 
     assert exit_code == 1
     out = capsys.readouterr().out
@@ -2625,7 +2836,7 @@ def test_cli_workspace_refresh_continues_valid_changed_source_when_another_sourc
     missing_source.unlink()
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed"])
+    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed", "--apply"])
 
     assert exit_code == 1
     out = capsys.readouterr().out
@@ -2661,7 +2872,9 @@ def test_cli_workspace_refresh_json_reports_skipped_missing_and_final_freshness(
     missing_source.unlink()
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed", "--json"])
+    exit_code = main(
+        ["--root", str(tmp_path), "workspace", "refresh", "--changed", "--apply", "--json"]
+    )
 
     assert exit_code == 1
     payload = json.loads(capsys.readouterr().out)
@@ -2694,7 +2907,7 @@ def test_cli_workspace_refresh_ingests_refreshed_valid_sources_despite_missing_s
     pending_source.write_text("# Pending\n\nQueued separately.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(changed_source)])
     main(["--root", str(tmp_path), "add-source", str(missing_source)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     main(["--root", str(tmp_path), "add-source", str(pending_source)])
     pending_id = next(
         load_source_record(path).source_id
@@ -2706,7 +2919,16 @@ def test_cli_workspace_refresh_ingests_refreshed_valid_sources_despite_missing_s
     capsys.readouterr()
 
     exit_code = main(
-        ["--root", str(tmp_path), "workspace", "refresh", "--changed", "--ingest", "--json"]
+        [
+            "--root",
+            str(tmp_path),
+            "workspace",
+            "refresh",
+            "--changed",
+            "--ingest",
+            "--apply",
+            "--json",
+        ]
     )
 
     assert exit_code == 1
@@ -2748,7 +2970,7 @@ def test_cli_workspace_refresh_continues_after_changed_source_refresh_failure(
     monkeypatch.setattr(workspace_module, "refresh_source", fail_one_source)
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed"])
+    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed", "--apply"])
 
     assert exit_code == 1
     out = capsys.readouterr().out
@@ -2772,7 +2994,7 @@ def test_cli_workspace_refresh_json_reports_failed_refresh_and_ingests_successes
     pending_source.write_text("# Pending\n\nQueued separately.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(ok_source)])
     main(["--root", str(tmp_path), "add-source", str(broken_source)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     main(["--root", str(tmp_path), "add-source", str(pending_source)])
     pending_id = next(
         load_source_record(path).source_id
@@ -2791,7 +3013,16 @@ def test_cli_workspace_refresh_json_reports_failed_refresh_and_ingests_successes
     capsys.readouterr()
 
     exit_code = main(
-        ["--root", str(tmp_path), "workspace", "refresh", "--changed", "--ingest", "--json"]
+        [
+            "--root",
+            str(tmp_path),
+            "workspace",
+            "refresh",
+            "--changed",
+            "--ingest",
+            "--apply",
+            "--json",
+        ]
     )
 
     assert exit_code == 1
@@ -2832,7 +3063,7 @@ def test_cli_workspace_refresh_human_output_is_path_first(tmp_path: Path, capsys
     source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed"])
+    exit_code = main(["--root", str(tmp_path), "workspace", "refresh", "--changed", "--apply"])
 
     assert exit_code == 0
     out = capsys.readouterr().out
@@ -2852,7 +3083,7 @@ def test_cli_pr_summary_reports_generated_state_without_mutating(tmp_path: Path,
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     write_queryable_wiki_page(
         tmp_path / "wiki" / "topics" / "brief.md",
         title="Brief synthesis",
@@ -2993,7 +3224,7 @@ def test_cli_pr_summary_respects_custom_layout_paths(tmp_path: Path, capsys) -> 
     source = tmp_path / "brief.md"
     source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     main(["--root", str(tmp_path), "lint"])
     capsys.readouterr()
 
@@ -3136,7 +3367,7 @@ def test_cli_source_refresh_preserves_active_lease_protection(tmp_path: Path, ca
     queue_path.write_text(queue.model_dump_json(indent=2) + "\n", encoding="utf-8")
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
 
     assert exit_code == 1
     assert f"Error: Queue item is already leased: ingest-{source_id}" in capsys.readouterr().out
@@ -3155,7 +3386,7 @@ def test_cli_source_refresh_preserves_dead_letter_protection(tmp_path: Path, cap
     queue_path.write_text(queue.model_dump_json(indent=2) + "\n", encoding="utf-8")
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
 
     assert exit_code == 1
     out = capsys.readouterr().out
@@ -3620,7 +3851,7 @@ def test_cli_ingest_requires_exactly_one_target_mode() -> None:
 def test_cli_ingest_pending_reports_no_jobs(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
 
-    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
 
     assert exit_code == 0
     captured = capsys.readouterr()
@@ -3631,16 +3862,18 @@ def test_cli_ingest_pending_json_reports_no_jobs(tmp_path: Path, capsys) -> None
     main(["--root", str(tmp_path), "init"])
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--json"])
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply", "--json"])
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
+    mutation = payload.pop("mutation")
     assert payload == {
         "total": 0,
         "summary": {"processed": 0, "succeeded": 0, "failed": 0, "skipped": 0},
         "items": [],
         "next_actions": [],
     }
+    assert mutation == {"mode": "apply", "mutates": False, "planned": [], "written": []}
 
 
 def test_cli_ingest_pending_reports_skipped_items(tmp_path: Path, capsys) -> None:
@@ -3661,13 +3894,44 @@ def test_cli_ingest_pending_reports_skipped_items(tmp_path: Path, capsys) -> Non
     )
     queue_path.write_text(queue_record.model_dump_json(indent=2) + "\n", encoding="utf-8")
 
-    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
 
     assert exit_code == 0
     captured = capsys.readouterr()
     assert f"{source_id}: skipped (lease active until 2099-01-01T00:00:00+00:00)" in captured.out
     assert "Drain summary: processed=0 succeeded=0 failed=0 skipped=1" in captured.out
     assert "No pending ingest jobs" not in captured.out
+
+
+def test_cli_ingest_pending_defaults_to_preview_without_mutating(tmp_path: Path, capsys) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    queue_before = queue_path.read_text(encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["items"][0]["outcome"] == "planned"
+    assert payload["mutation"]["mode"] == "preview"
+    assert payload["mutation"]["mutates"] is False
+    assert payload["mutation"]["written"] == []
+    assert {item["kind"] for item in payload["mutation"]["planned"]} >= {
+        "queue_record",
+        "run_record",
+        "source_manifest",
+        "source_summary_page",
+        "wiki_index",
+        "wiki_log",
+    }
+    assert queue_path.read_text(encoding="utf-8") == queue_before
+    assert not (tmp_path / "wiki" / "sources" / f"{source_id}.md").exists()
+    assert not list((tmp_path / "state" / "runs").glob("*.json"))
 
 
 def test_cli_ingest_pending_prints_summary(tmp_path: Path, capsys) -> None:
@@ -3680,7 +3944,7 @@ def test_cli_ingest_pending_prints_summary(tmp_path: Path, capsys) -> None:
     source_id = manifest_paths[0].stem
     enqueue_ingest_job(tmp_path, source_id)
 
-    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
 
     assert exit_code == 0
     captured = capsys.readouterr()
@@ -3696,7 +3960,7 @@ def test_cli_ingest_pending_json_reports_single_success_next_action(tmp_path: Pa
     source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--json"])
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply", "--json"])
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
@@ -3721,7 +3985,7 @@ def test_cli_ingest_pending_json_reports_batch_success_next_action(tmp_path: Pat
     main(["--root", str(tmp_path), "add-source", str(second)])
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--json"])
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply", "--json"])
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
@@ -3747,7 +4011,7 @@ def test_cli_ingest_pending_continues_after_failure(tmp_path: Path, capsys) -> N
     bad_source_id = next(path.stem for path in manifest_paths if path.stem != ok_source_id)
     enqueue_ingest_job(tmp_path, bad_source_id)
 
-    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
 
     assert exit_code == 1
     captured = capsys.readouterr()
@@ -3775,7 +4039,7 @@ def test_cli_ingest_pending_json_reports_partial_failure(tmp_path: Path, capsys)
     )
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--json"])
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply", "--json"])
 
     assert exit_code == 1
     payload = json.loads(capsys.readouterr().out)
@@ -3805,7 +4069,7 @@ def test_cli_ingest_pending_reports_failed_and_skipped_mix(tmp_path: Path, capsy
     missing_source.unlink()
     enqueue_ingest_job(tmp_path, failing_source_id)
 
-    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
 
     assert exit_code == 1
     captured = capsys.readouterr()
@@ -3854,7 +4118,7 @@ def test_cli_ingest_pending_json_reports_skipped_queue_states(tmp_path: Path, ca
         write_queue_item(queue_path, load_queue_item(queue_path).model_copy(update=queue_update))
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--json"])
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply", "--json"])
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1758,7 +1758,7 @@ def test_cli_source_update_path_repairs_missing_workspace_source(tmp_path: Path,
     assert "Logical ID: source:docs/brief.md" in out
     assert "Checksum: matches manifest" in out
     assert f"Queued ingest: {tmp_path / 'state' / 'queue' / f'ingest-{source_id}.json'}" in out
-    assert "Next: splendor ingest --pending" in out
+    assert "Next: splendor ingest --pending --apply" in out
     updated = load_source_record(manifest_path)
     assert updated.source_id == source_id
     assert updated.source_ref == "moved/brief.md"
@@ -1828,7 +1828,7 @@ def test_cli_source_update_path_json_reports_deterministic_payload(tmp_path: Pat
         "updated": True,
         "queue_path": f"state/queue/ingest-{manifest.source_id}.json",
         "next_commands": [
-            "splendor ingest --pending",
+            "splendor ingest --pending --apply",
             "splendor source freshness",
         ],
     }
@@ -1886,6 +1886,42 @@ def test_cli_source_update_path_defaults_to_preview_without_mutating(
     }
     assert manifest_path.read_text(encoding="utf-8") == before_manifest
     assert queue_path.read_text(encoding="utf-8") == queue_before
+
+
+def test_cli_source_update_path_preview_preflights_active_queue_lease(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    old_source = tmp_path / "old.md"
+    new_source = tmp_path / "new.md"
+    old_source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "old.md"])
+    manifest_path = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
+    manifest_before = manifest_path.read_text(encoding="utf-8")
+    manifest = load_source_record(manifest_path)
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{manifest.source_id}.json"
+    queue_before = load_queue_item(queue_path).model_copy(
+        update={
+            "status": "leased",
+            "lease_owner": "local-cli:test",
+            "lease_expires_at": "2999-01-01T00:00:00+00:00",
+        }
+    )
+    queue_path.write_text(queue_before.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    old_source.rename(new_source)
+    capsys.readouterr()
+
+    exit_code = main(
+        ["--root", str(tmp_path), "source", "update-path", manifest.source_id, "new.md"]
+    )
+
+    assert exit_code == 1
+    assert (
+        f"Error: Queue item is already leased: ingest-{manifest.source_id}"
+        in capsys.readouterr().out
+    )
+    assert manifest_path.read_text(encoding="utf-8") == manifest_before
+    assert load_queue_item(queue_path).status == "leased"
 
 
 @pytest.mark.parametrize(
@@ -2045,7 +2081,7 @@ def test_cli_source_update_path_changed_bytes_reports_partial_repair(
     assert payload["queue_path"] is None
     assert payload["next_commands"] == [
         "splendor source refresh new.md",
-        "splendor ingest --pending",
+        "splendor ingest --pending --apply",
         "splendor source freshness",
     ]
     updated = load_source_record(manifest_path)
@@ -2078,7 +2114,8 @@ def test_cli_source_freshness_reports_changed_workspace_sources_without_mutating
     assert "Manifest checksum:" in out
     assert "Current checksum:" in out
     assert "Next: splendor source refresh brief.md" in out
-    assert "Next: splendor ingest --pending" in out
+    assert "Next: splendor source refresh brief.md --apply" in out
+    assert "Next: splendor ingest --pending --apply" in out
     assert "Next: splendor source refresh <path>" not in out
     assert manifest_path.read_text(encoding="utf-8") == before_manifest
     assert len(list((tmp_path / "state" / "manifests" / "sources").glob("*.json"))) == 1
@@ -2103,7 +2140,8 @@ def test_cli_source_freshness_quotes_changed_source_path_next_command(
     assert item["status"] == "changed"
     assert item["next_commands"] == [
         "splendor source refresh 'brief with spaces.md'",
-        "splendor ingest --pending",
+        "splendor source refresh 'brief with spaces.md' --apply",
+        "splendor ingest --pending --apply",
     ]
 
 
@@ -2236,7 +2274,8 @@ def test_cli_source_freshness_targets_latest_manifest_when_file_reverts(
     assert statuses[refreshed_id]["status"] == "changed"
     assert statuses[refreshed_id]["next_commands"] == [
         "splendor source refresh brief.md",
-        "splendor ingest --pending",
+        "splendor source refresh brief.md --apply",
+        "splendor ingest --pending --apply",
     ]
 
 
@@ -2493,13 +2532,10 @@ def test_cli_workspace_refresh_defaults_to_preview_without_mutating(tmp_path: Pa
     } == manifests_before
     assert not (tmp_path / "wiki" / "sources" / f"{refreshed_id}.md").exists()
     assert (tmp_path / "wiki" / "sources" / f"{original_id}.md").exists()
-    assert {item["kind"] for item in payload["mutation"]["planned"]} >= {
+    assert {item["kind"] for item in payload["mutation"]["planned"]} == {
         "queue_record",
-        "run_record",
         "source_manifest",
-        "source_summary_page",
         "wiki_index",
-        "wiki_log",
     }
 
 
@@ -2599,7 +2635,7 @@ def test_cli_workspace_refresh_changed_rebuilds_index_without_ingest(
     assert exit_code == 0
     out = capsys.readouterr().out
     assert "Rebuilt index: " in out
-    assert "Next: splendor ingest --pending, then splendor wiki rebuild-index" in out
+    assert "Next: splendor ingest --pending --apply, then splendor wiki rebuild-index" in out
     assert list((tmp_path / "state" / "queue").glob("ingest-*.json"))
 
 
@@ -3074,7 +3110,7 @@ def test_cli_workspace_refresh_human_output_is_path_first(tmp_path: Path, capsys
     assert "changed=0" in out
     assert re.search(r"- brief\.md: refreshed source_id=src-[a-f0-9]{16}", out)
     assert f"Previous source ID: {original_id}" in out
-    assert "Next: splendor ingest --pending" in out
+    assert "Next: splendor ingest --pending --apply" in out
 
 
 def test_cli_pr_summary_reports_generated_state_without_mutating(tmp_path: Path, capsys) -> None:
@@ -3373,6 +3409,31 @@ def test_cli_source_refresh_preserves_active_lease_protection(tmp_path: Path, ca
     assert f"Error: Queue item is already leased: ingest-{source_id}" in capsys.readouterr().out
 
 
+def test_cli_source_refresh_preview_preflights_active_lease_protection(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    queue = load_queue_item(queue_path).model_copy(
+        update={
+            "status": "leased",
+            "lease_owner": "local-cli:test",
+            "lease_expires_at": "2999-01-01T00:00:00+00:00",
+        }
+    )
+    queue_path.write_text(queue.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
+
+    assert exit_code == 1
+    assert f"Error: Queue item is already leased: ingest-{source_id}" in capsys.readouterr().out
+
+
 def test_cli_source_refresh_preserves_dead_letter_protection(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     source = tmp_path / "brief.md"
@@ -3387,6 +3448,29 @@ def test_cli_source_refresh_preserves_dead_letter_protection(tmp_path: Path, cap
     capsys.readouterr()
 
     exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply"])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "dead-lettered" in out
+    assert "splendor queue retry" in out
+
+
+def test_cli_source_refresh_preview_preflights_dead_letter_protection(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    queue = load_queue_item(queue_path).model_copy(
+        update={"status": "dead_letter", "last_error": "too many failures"}
+    )
+    queue_path.write_text(queue.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md"])
 
     assert exit_code == 1
     out = capsys.readouterr().out
@@ -3921,16 +4005,40 @@ def test_cli_ingest_pending_defaults_to_preview_without_mutating(tmp_path: Path,
     assert payload["mutation"]["mode"] == "preview"
     assert payload["mutation"]["mutates"] is False
     assert payload["mutation"]["written"] == []
-    assert {item["kind"] for item in payload["mutation"]["planned"]} >= {
-        "queue_record",
-        "run_record",
-        "source_manifest",
-        "source_summary_page",
-        "wiki_index",
-        "wiki_log",
-    }
+    assert {item["kind"] for item in payload["mutation"]["planned"]} == {"queue_record"}
     assert queue_path.read_text(encoding="utf-8") == queue_before
     assert not (tmp_path / "wiki" / "sources" / f"{source_id}.md").exists()
+    assert not list((tmp_path / "state" / "runs").glob("*.json"))
+
+
+def test_cli_ingest_pending_preview_reports_invalid_payload_without_mutating(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    source = tmp_path / "brief.md"
+    source.write_text("hello\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    source_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    manifest_path = tmp_path / "state" / "manifests" / "sources" / f"{source_id}.json"
+    queue_path = tmp_path / "state" / "queue" / f"ingest-{source_id}.json"
+    queue_before = queue_path.read_text(encoding="utf-8")
+    manifest_path.unlink()
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--json"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"] == {"processed": 1, "succeeded": 0, "failed": 1, "skipped": 0}
+    assert payload["items"][0]["outcome"] == "failed"
+    assert "Queue payload is missing source manifest" in payload["items"][0]["message"]
+    assert payload["mutation"] == {
+        "mode": "preview",
+        "mutates": False,
+        "planned": [],
+        "written": [],
+    }
+    assert queue_path.read_text(encoding="utf-8") == queue_before
     assert not list((tmp_path / "state" / "runs").glob("*.json"))
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1407,6 +1407,51 @@ def test_cli_source_refresh_defaults_to_preview_without_mutating(tmp_path: Path,
     )
 
 
+def test_cli_source_refresh_pointer_preview_respects_custom_raw_sources_layout(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    config = load_config(tmp_path)
+    config.layout.raw_sources_dir = "custom/source-artifacts"
+    write_config(tmp_path, config)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", "--storage-mode", "pointer", "brief.md"])
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    preview_code = main(["--root", str(tmp_path), "source", "refresh", "brief.md", "--json"])
+
+    assert preview_code == 0
+    preview = json.loads(capsys.readouterr().out)
+    refreshed_id = preview["source_id"]
+    expected_ref = f"custom/source-artifacts/{refreshed_id}/pointer.json"
+    assert {(item["kind"], item["path"]) for item in preview["mutation"]["planned"]} == {
+        ("queue_record", f"state/queue/ingest-{refreshed_id}.json"),
+        ("source_artifact", expected_ref),
+        ("source_manifest", f"state/manifests/sources/{refreshed_id}.json"),
+        ("source_manifest", f"state/manifests/sources/{preview['requested_source_id']}.json"),
+    }
+    assert not (tmp_path / expected_ref).exists()
+
+    apply_code = main(
+        ["--root", str(tmp_path), "source", "refresh", "brief.md", "--apply", "--json"]
+    )
+
+    assert apply_code == 0
+    applied = json.loads(capsys.readouterr().out)
+    manifest = load_source_record(
+        tmp_path / "state" / "manifests" / "sources" / f"{refreshed_id}.json"
+    )
+    assert manifest.storage_path == expected_ref
+    assert any(
+        item["kind"] == "source_artifact" and item["path"] == expected_ref
+        for item in applied["mutation"]["written"]
+    )
+    assert (tmp_path / expected_ref).exists()
+    assert not (tmp_path / "raw" / "sources" / refreshed_id / "pointer.json").exists()
+
+
 def test_cli_source_refresh_reports_existing_version_match(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     source = tmp_path / "brief.md"
@@ -2583,6 +2628,7 @@ def test_cli_workspace_refresh_prunes_superseded_summaries_standalone(
     refreshed_id = payload["pruning"]["pruned"][0]["superseded_by"]
     assert payload["refreshed"] == []
     assert payload["ingest"] is None
+    assert payload["pruning"]["applied"] is True
     assert payload["pruning"]["pruned"] == [
         {
             "path": f"wiki/sources/{original_id}.md",
@@ -2615,6 +2661,76 @@ def test_cli_workspace_refresh_prunes_superseded_summaries_standalone(
         tmp_path / "state" / "manifests" / "sources" / f"{original_id}.json"
     )
     assert f"wiki/sources/{original_id}.md" not in original_manifest.linked_pages
+
+
+def test_cli_workspace_refresh_preview_marks_prune_and_topic_ref_actions_unapplied(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    write_config(tmp_path, config)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nOriginal.\n", encoding="utf-8")
+    main(["--root", str(tmp_path), "add-source", str(source)])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
+    original_id = next((tmp_path / "state" / "manifests" / "sources").glob("*.json")).stem
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "add-topic",
+            "Brief Synthesis",
+            "--source-refs",
+            original_id,
+        ]
+    )
+    topic_path = tmp_path / "wiki" / "topics" / "brief-synthesis.md"
+    topic_before = topic_path.read_text(encoding="utf-8")
+    source.write_text("# Brief\n\nUpdated.\n", encoding="utf-8")
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            "workspace",
+            "refresh",
+            "--changed",
+            "--ingest",
+            "--rebuild-index",
+            "--apply",
+        ]
+    )
+    original_summary = tmp_path / "wiki" / "sources" / f"{original_id}.md"
+    original_summary_before = original_summary.read_text(encoding="utf-8")
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "workspace",
+            "refresh",
+            "--prune-superseded",
+            "--update-topic-refs",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    refreshed_id = payload["pruning"]["pruned"][0]["superseded_by"]
+    assert payload["mutation"]["mode"] == "preview"
+    assert payload["mutation"]["written"] == []
+    assert payload["pruning"]["applied"] is False
+    assert payload["topic_ref_migration"]["applied"] is False
+    assert payload["topic_ref_migration"]["updated"] == [
+        {
+            "path": "wiki/topics/brief-synthesis.md",
+            "replacements": {original_id: refreshed_id},
+        }
+    ]
+    assert original_summary.read_text(encoding="utf-8") == original_summary_before
+    assert topic_path.read_text(encoding="utf-8") == topic_before
 
 
 def test_cli_workspace_refresh_changed_rebuilds_index_without_ingest(
@@ -2695,6 +2811,8 @@ def test_cli_workspace_refresh_prunes_superseded_summaries_and_updates_topic_ref
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
     refreshed_id = payload["refreshed"][0]["source_id"]
+    assert payload["pruning"]["applied"] is True
+    assert payload["topic_ref_migration"]["applied"] is True
     assert payload["pruning"]["pruned"] == [
         {
             "path": f"wiki/sources/{original_id}.md",

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -94,8 +94,9 @@ def test_run_health_checks_hints_checksum_mismatch_active_workspace_source(
 
     assert [issue.code for issue in result.issues] == ["source-health-check-failed"]
     assert result.issues[0].remediation_hint == (
-        "Run splendor source refresh brief.md, then splendor ingest --pending; for all changed "
-        "curated workspace sources run splendor ingest --changed."
+        "Run splendor source refresh brief.md, then splendor source refresh brief.md --apply, "
+        "then splendor ingest --pending --apply; for all changed curated workspace sources run "
+        "splendor ingest --changed."
     )
 
 

--- a/tests/test_queue_commands.py
+++ b/tests/test_queue_commands.py
@@ -242,7 +242,7 @@ def test_queue_clean_selects_superseded_and_completed_records(tmp_path: Path) ->
     old_queue_path = enqueue_ingest_job(tmp_path, old.source_id)
     done_queue_path = enqueue_ingest_job(tmp_path, done.source_id)
     old_path.write_text("# Old\n\nUpdated.\n", encoding="utf-8")
-    main(["--root", str(tmp_path), "source", "refresh", old.source_id])
+    main(["--root", str(tmp_path), "source", "refresh", old.source_id, "--apply"])
     write_queue_item(
         done_queue_path,
         load_queue_item(done_queue_path).model_copy(update={"status": "done"}),
@@ -274,7 +274,7 @@ def test_queue_clean_completed_selector_matches_done_orphaned_and_superseded_rec
     superseded_queue_path = enqueue_ingest_job(tmp_path, superseded.source_id)
     orphan.manifest_path.unlink()
     superseded_path.write_text("# Superseded\n\nUpdated.\n", encoding="utf-8")
-    main(["--root", str(tmp_path), "source", "refresh", superseded.source_id])
+    main(["--root", str(tmp_path), "source", "refresh", superseded.source_id, "--apply"])
     for queue_path in [orphan_queue_path, superseded_queue_path]:
         write_queue_item(
             queue_path,

--- a/tests/test_source_forget.py
+++ b/tests/test_source_forget.py
@@ -23,7 +23,7 @@ def test_source_forget_keeps_run_record_referenced_by_remaining_source(
     forgotten_path = tmp_path / "forgotten.md"
     forgotten_path.write_text("# Forgotten\n\nHas a run.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(forgotten_path)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     forgotten_manifest = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
     forgotten = load_source_record(forgotten_manifest)
     assert forgotten.last_run_id is not None
@@ -101,7 +101,7 @@ def test_source_forget_reports_run_id_residuals_from_wiki_and_run_records(
     source_path = tmp_path / "brief.md"
     source_path.write_text("# Brief\n\nRun references.\n", encoding="utf-8")
     main(["--root", str(tmp_path), "add-source", str(source_path)])
-    main(["--root", str(tmp_path), "ingest", "--pending"])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     manifest = next((tmp_path / "state" / "manifests" / "sources").glob("*.json"))
     source = load_source_record(manifest)
     assert source.last_run_id is not None

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import yaml
 
+import splendor.commands.wiki as wiki_module
 from splendor.cli import main
 from splendor.commands import brief as brief_module
 from splendor.commands.add_source import add_source
@@ -284,6 +285,33 @@ def test_rebuild_wiki_index_includes_pages_in_deterministic_sections(tmp_path: P
     assert "[Alpha Architecture](architecture/alpha.md)" in first_index
     assert "[Zeta Topic](topics/zeta.md)" in first_index
     assert "[Source A](sources/src-a.md)" in first_index
+
+
+def test_rebuild_wiki_index_loads_pages_once(tmp_path: Path, monkeypatch) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "zeta.md",
+        kind="topic",
+        title="Zeta Topic",
+        page_id="topic-zeta",
+    )
+    load_calls = 0
+    original_load_wiki_pages = wiki_module.load_wiki_pages
+
+    def counted_load_wiki_pages(*args, **kwargs):
+        nonlocal load_calls
+        load_calls += 1
+        return original_load_wiki_pages(*args, **kwargs)
+
+    monkeypatch.setattr(wiki_module, "load_wiki_pages", counted_load_wiki_pages)
+
+    result = rebuild_wiki_index(tmp_path)
+
+    assert result.page_count == 1
+    assert load_calls == 1
+    assert "[Zeta Topic](topics/zeta.md)" in (tmp_path / "wiki" / "index.md").read_text(
+        encoding="utf-8"
+    )
 
 
 def test_wiki_rebuild_index_cli_reports_invalid_frontmatter(tmp_path: Path, capsys) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -315,7 +315,7 @@ def test_add_source_queues_pending_ingest_for_cli_handoff(tmp_path: Path, capsys
     assert "Queued ingest:" in out
     assert "Next: splendor ingest --pending" in out
 
-    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
 
     assert exit_code == 0
     out = capsys.readouterr().out
@@ -336,7 +336,7 @@ def test_pending_ingest_multiple_sources_points_back_to_status(tmp_path: Path, c
     main(["--root", str(tmp_path), "add-source", str(second)])
     capsys.readouterr()
 
-    exit_code = main(["--root", str(tmp_path), "ingest", "--pending"])
+    exit_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
 
     assert exit_code == 0
     out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Make legacy mutating maintenance/workflow commands preview-first where practical: `ingest --pending`, `source refresh`, `source update-path`, and `workspace refresh`.
- Add explicit `--apply` write/drain behavior with shared mutation contracts in JSON and unmistakable preview/apply human output.
- Update agent handoff guidance, quickstart/product/schema docs, and synchronized M19 planning state for `M19-P5.1`.

## Implementation Notes
- Reuses `src/splendor/commands/mutation.py` for `mutation.mode`, `mutation.mutates`, `mutation.planned`, and `mutation.written` output.
- Adds non-writing planning paths for pending ingest drains, source refresh/update-path, workspace refresh pruning/migration/pending drains, and wiki index rebuild planning.
- Keeps direct single-source `splendor ingest <source>` behavior out of scope while making `ingest --apply` valid only with `--pending`.

## Validation
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

Closes #153