### PR TITLE
M19-P5.2: Planning intake for generated integrity fixes

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,7 +6,7 @@
 - Previous completed PR sub-slice: `M19-P5.1`
 - Last action taken: `M19-P5.1` was squash-merged into main as commit `94e5150`,
   harmonizing legacy maintenance/workflow verbs behind preview/apply semantics.
-- Current planned slice: `M19 generated artifact integrity and provenance hygiene`
+- Current planned slice: `M19 post-v0.4 generated-state safety follow-ups`
 - Current PR sub-slice: `M19-P5.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M19 completion-aware current-state handoff inference`

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,11 +3,11 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M19-P4.1`
-- Last action taken: `M19-P4.1` was squash-merged into main as commit `80b2de0`,
-  adding the v0.4 external review intake and response plan.
-- Current planned slice: `M19 legacy mutation safety`
-- Current PR sub-slice: `M19-P5.1`
+- Previous completed PR sub-slice: `M19-P5.1`
+- Last action taken: `M19-P5.1` was squash-merged into main as commit `94e5150`,
+  harmonizing legacy maintenance/workflow verbs behind preview/apply semantics.
+- Current planned slice: `M19 generated artifact integrity and provenance hygiene`
+- Current PR sub-slice: `M19-P5.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M19 completion-aware current-state handoff inference`
 - Next planned PR sub-slice: `M19-P6.1`
@@ -512,6 +512,7 @@
 - `M19-P3.1` Registry and queue cleanup closure paths
 - `M19-P4.1` Post-v0.4 external review intake and sequencing
 - `M19-P5.1` Legacy preview/apply harmonization
+- `M19-P5.2` Generated text integrity and manifest provenance fixes
 - `M19-P6.1` Completion-aware current-state handoff inference
 - `M19-P7.1` Multi-issue and policy-cited handoff breadth
 - `M19-P8.1` Cold-start adoption and PATH-safe git lookup

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ the source manifest, and kept separate from parsed PDF artifacts.
 ## What Comes Next
 
 - Previous completed PR sub-slice: `M19-P5.1`
-- Current planned slice: `M19 generated artifact integrity and provenance hygiene`
+- Current planned slice: `M19 post-v0.4 generated-state safety follow-ups`
 - Current PR sub-slice: `M19-P5.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M19 completion-aware current-state handoff inference`

--- a/README.md
+++ b/README.md
@@ -323,9 +323,9 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M19-P4.1`
-- Current planned slice: `M19 legacy mutation safety`
-- Current PR sub-slice: `M19-P5.1`
+- Previous completed PR sub-slice: `M19-P5.1`
+- Current planned slice: `M19 generated artifact integrity and provenance hygiene`
+- Current PR sub-slice: `M19-P5.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M19 completion-aware current-state handoff inference`
 - Next planned PR sub-slice: `M19-P6.1`
@@ -641,3 +641,7 @@ commands. `ingest --pending`, `source refresh`, `source update-path`, and `works
 preview by default, report planned writes through the shared mutation contract, and require
 explicit `--apply` before draining queue jobs or writing manifests, source summaries, queue/run
 records, index/log state, pruning changes, or topic-ref migrations.
+
+`M19-P5.2` is the next focused bugfix slice before handoff-inference work resumes. It addresses
+the new SynthBanshee follow-up reports for generated Evidence/Contradictions text corruption and
+stale source-manifest `pipeline_version` provenance after path repair plus ingest.

--- a/docs/evaluations/v0_4_external_findings_register.md
+++ b/docs/evaluations/v0_4_external_findings_register.md
@@ -25,8 +25,17 @@ Severity legend:
 | V04-F10 | Scan ranking can be too broad for first-run handoff. | hocrsyngen reported core handoff files competing with licenses, fixture corpora, and broad docs. | `repo scan`, first-use curation | P3 | Add stronger first-run ranking for `AGENTS.md`, `.agent-plan.md`, README, roadmap, and nearby tests/code. |
 | V04-F11 | Ingest needs progress feedback for long drains. | hocrsyngen observed `ingest --pending` remaining silent for roughly a minute. | Ingest command UX | P3 | Add deterministic progress/status output where it does not break JSON contracts. |
 | V04-F12 | Lint may report repo-relative README links as missing. | hocrsyngen reported false positives for links such as `docs/roadmap.md`. | `splendor lint` docs/link checks | P3 | Reproduce and fix link resolution, or narrow the diagnostic until it is reliable. |
+
+## Post-Round Follow-Up Findings
+
+These findings were filed as GitHub issues after the original v0.4 external review round. They are
+kept separate from the round findings above so the historical review record stays intact, but they
+now affect the accepted M19 sequence because they expose generated-state correctness risks.
+
+| ID | Finding | Evidence | Affected surface | Severity | Recommended next action |
+| --- | --- | --- | --- | --- | --- |
 | V04-F13 | Generated Evidence/Contradictions text can leak control bytes. | SynthBanshee follow-up issue #165 reports UTF-8 punctuation from clean source docs becoming BEL, partial UTF-8 bytes, digit substitutions, and YAML `\xNN` escapes in generated wiki pages and review tasks. | Ingest generation, evidence extraction, wiki/task markdown, YAML frontmatter | P1 | Fix the encoding/sanitization path and add regression coverage proving generated markdown/YAML contains no control bytes. Treat as an immediate bugfix before broader handoff work. |
-| V04-F14 | Manifest `pipeline_version` provenance can stay stale after path repair plus ingest. | SynthBanshee follow-up issue #164 reports manifests retaining old `pipeline_version` values after `source update-path` and ingest rewrite `last_run_id`, while run records and wiki pages reflect the newer Splendor version. | Source manifests, ingest provenance, source path repair | P1 | Refresh manifest `pipeline_version` whenever ingest/source refresh rewrites manifest provenance, or document immutable semantics with a migration path. |
+| V04-F14 | Manifest `pipeline_version` provenance can stay stale after path repair plus ingest. | SynthBanshee follow-up issue #164 reports manifests retaining old `pipeline_version` values after `source update-path` and ingest rewrite `last_run_id`, while run records and wiki pages reflect the newer Splendor version. | Source manifests, ingest provenance, source path repair | P1 | Refresh manifest `pipeline_version` whenever ingest/source refresh rewrites manifest provenance, or document immutable semantics with a migration path. Include this in `M19-P5.2` with V04-F13. |
 
 ## Validated Improvements
 
@@ -39,13 +48,14 @@ Severity legend:
 
 ## Suggested Sequencing
 
-The review round does not settle exact milestone names, but it does give a practical order:
+The review round set the original M19 order. The post-round follow-up findings above insert one
+generated-state safety slice before completion-aware handoff inference resumes:
 
 1. **`M19-P5.1` safety first:** address V04-F1, because mixed mutation semantics can destroy
    exploratory handoff safety.
-2. **`M19-P5.2` generated-state correctness before handoff inference:** address V04-F13 and, if
-   small, V04-F14, because corrupted generated artifacts and stale provenance undermine the state
-   later handoff commands depend on.
+2. **`M19-P5.2` generated-state correctness before handoff inference:** address both V04-F13 and
+   V04-F14, because corrupted generated artifacts and stale provenance undermine the state later
+   handoff commands depend on.
 3. **`M19-P6.1` handoff correctness second:** address V04-F2, because two partners failed the
    same completed-slice-to-next-slice inference test.
 4. **`M19-P7.1` handoff breadth third:** address V04-F3 and V04-F6 together if scope allows.

--- a/docs/evaluations/v0_4_external_findings_register.md
+++ b/docs/evaluations/v0_4_external_findings_register.md
@@ -25,6 +25,8 @@ Severity legend:
 | V04-F10 | Scan ranking can be too broad for first-run handoff. | hocrsyngen reported core handoff files competing with licenses, fixture corpora, and broad docs. | `repo scan`, first-use curation | P3 | Add stronger first-run ranking for `AGENTS.md`, `.agent-plan.md`, README, roadmap, and nearby tests/code. |
 | V04-F11 | Ingest needs progress feedback for long drains. | hocrsyngen observed `ingest --pending` remaining silent for roughly a minute. | Ingest command UX | P3 | Add deterministic progress/status output where it does not break JSON contracts. |
 | V04-F12 | Lint may report repo-relative README links as missing. | hocrsyngen reported false positives for links such as `docs/roadmap.md`. | `splendor lint` docs/link checks | P3 | Reproduce and fix link resolution, or narrow the diagnostic until it is reliable. |
+| V04-F13 | Generated Evidence/Contradictions text can leak control bytes. | SynthBanshee follow-up issue #165 reports UTF-8 punctuation from clean source docs becoming BEL, partial UTF-8 bytes, digit substitutions, and YAML `\xNN` escapes in generated wiki pages and review tasks. | Ingest generation, evidence extraction, wiki/task markdown, YAML frontmatter | P1 | Fix the encoding/sanitization path and add regression coverage proving generated markdown/YAML contains no control bytes. Treat as an immediate bugfix before broader handoff work. |
+| V04-F14 | Manifest `pipeline_version` provenance can stay stale after path repair plus ingest. | SynthBanshee follow-up issue #164 reports manifests retaining old `pipeline_version` values after `source update-path` and ingest rewrite `last_run_id`, while run records and wiki pages reflect the newer Splendor version. | Source manifests, ingest provenance, source path repair | P1 | Refresh manifest `pipeline_version` whenever ingest/source refresh rewrites manifest provenance, or document immutable semantics with a migration path. |
 
 ## Validated Improvements
 
@@ -41,12 +43,15 @@ The review round does not settle exact milestone names, but it does give a pract
 
 1. **`M19-P5.1` safety first:** address V04-F1, because mixed mutation semantics can destroy
    exploratory handoff safety.
-2. **`M19-P6.1` handoff correctness second:** address V04-F2, because two partners failed the
+2. **`M19-P5.2` generated-state correctness before handoff inference:** address V04-F13 and, if
+   small, V04-F14, because corrupted generated artifacts and stale provenance undermine the state
+   later handoff commands depend on.
+3. **`M19-P6.1` handoff correctness second:** address V04-F2, because two partners failed the
    same completed-slice-to-next-slice inference test.
-3. **`M19-P7.1` handoff breadth third:** address V04-F3 and V04-F6 together if scope allows.
-4. **`M19-P8.1` cold-start adoption fourth:** address V04-F4 plus the narrower V04-F5 robustness
+4. **`M19-P7.1` handoff breadth third:** address V04-F3 and V04-F6 together if scope allows.
+5. **`M19-P8.1` cold-start adoption fourth:** address V04-F4 plus the narrower V04-F5 robustness
    bug.
-5. **Polish later:** address V04-F7 through V04-F12 as scoped follow-ups or opportunistic fixes.
+6. **Polish later:** address V04-F7 through V04-F12 as scoped follow-ups or opportunistic fixes.
 
 ## Non-Decisions
 

--- a/docs/evaluations/v0_4_external_review_round_summary.md
+++ b/docs/evaluations/v0_4_external_review_round_summary.md
@@ -92,11 +92,13 @@ next work when the roadmap pointed to the following slice.
 The combined sequence accepted for the remaining M19 durability track is:
 
 1. `M19-P5.1`: legacy preview/apply harmonization for mutating maintenance/workflow verbs.
-2. `M19-P6.1`: completion-aware current-state planning inference.
-3. `M19-P7.1`: broader work-thread surfacing for related open issues and policy-cited
+2. `M19-P5.2`: generated text integrity and manifest provenance fixes from SynthBanshee follow-up
+   issues #165 and #164.
+3. `M19-P6.1`: completion-aware current-state planning inference.
+4. `M19-P7.1`: broader work-thread surfacing for related open issues and policy-cited
    implementation surfaces.
-4. `M19-P8.1`: cold-start/local-state ergonomics and PATH-safe git lookup.
-5. Later scoped polish: ingest progress, scan ranking, lint link cleanup, clearer no-diff
+5. `M19-P8.1`: cold-start/local-state ergonomics and PATH-safe git lookup.
+6. Later scoped polish: ingest progress, scan ranking, lint link cleanup, clearer no-diff
    PR summaries, and removal of trailing maintenance next-actions.
 
 ## Out Of Scope For This PR

--- a/docs/evaluations/v0_4_external_review_round_summary.md
+++ b/docs/evaluations/v0_4_external_review_round_summary.md
@@ -89,7 +89,10 @@ hocrgen and hocrsyngen both selected completion-aware current-state inference as
 their next trial. Both failures involved the same pattern: recently completed work remained ranked as
 next work when the roadmap pointed to the following slice.
 
-The combined sequence accepted for the remaining M19 durability track is:
+The original review-round sequence put completion-aware current-state inference next after legacy
+preview/apply harmonization. After that sequence was recorded, SynthBanshee follow-up issues #165
+and #164 exposed generated-state correctness risks, so the accepted remaining M19 durability track is
+now:
 
 1. `M19-P5.1`: legacy preview/apply harmonization for mutating maintenance/workflow verbs.
 2. `M19-P5.2`: generated text integrity and manifest provenance fixes from SynthBanshee follow-up

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,9 +334,9 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M19-P4.1`
-- Current planned slice: `M19 legacy mutation safety`
-- Current PR sub-slice: `M19-P5.1`
+- Previous completed PR sub-slice: `M19-P5.1`
+- Current planned slice: `M19 generated artifact integrity and provenance hygiene`
+- Current PR sub-slice: `M19-P5.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M19 completion-aware current-state handoff inference`
 - Next planned PR sub-slice: `M19-P6.1`
@@ -1312,8 +1312,16 @@ require explicit `--apply` before draining queue jobs or writing source manifest
 pages, run records, queue records, wiki index/log state, pruning changes, or maintained topic-ref
 migrations.
 
+After `M19-P5.1` merged, SynthBanshee follow-up issues identified two generated-state correctness
+gaps that should land before broader handoff inference work resumes: generated
+Evidence/Contradictions excerpts can leak control bytes into markdown/YAML, and path-repaired
+source manifests can keep stale `pipeline_version` provenance after ingest rewrites `last_run_id`.
+
 The remaining M19 sequence is therefore:
 
+- `M19-P5.2` Generated text integrity and manifest provenance fixes: eliminate control-byte
+  corruption from generated Evidence/Contradictions output and keep source-manifest
+  `pipeline_version` provenance coherent when ingest rewrites manifests.
 - `M19-P6.1` Completion-aware current-state handoff inference: reconcile stale dynamic planning
   docs against git/GitHub merge state and ordered roadmap items so completed slices lead to the
   next open slice.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -335,7 +335,7 @@ annotations plus linked review tasks for explicit conflicts, richer query metada
 deterministic lint/health validation for those cross-links.
 
 - Previous completed PR sub-slice: `M19-P5.1`
-- Current planned slice: `M19 generated artifact integrity and provenance hygiene`
+- Current planned slice: `M19 post-v0.4 generated-state safety follow-ups`
 - Current PR sub-slice: `M19-P5.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M19 completion-aware current-state handoff inference`
@@ -1316,6 +1316,8 @@ After `M19-P5.1` merged, SynthBanshee follow-up issues identified two generated-
 gaps that should land before broader handoff inference work resumes: generated
 Evidence/Contradictions excerpts can leak control bytes into markdown/YAML, and path-repaired
 source manifests can keep stale `pipeline_version` provenance after ingest rewrites `last_run_id`.
+These stay under the `M19-P5` family because they are immediate post-v0.4 safety follow-ups for
+generated state integrity, while `M19-P6.1` remains the next handoff-inference feature slice.
 
 The remaining M19 sequence is therefore:
 


### PR DESCRIPTION
## Summary

- insert `M19-P5.2` as the current Milestone 19 follow-up slice after merged `M19-P5.1`
- record SynthBanshee follow-up reports #165 and #164 as post-round follow-up findings, separate from the original v0.4 review-round findings
- make both generated text integrity and manifest `pipeline_version` provenance required scope for `M19-P5.2`
- keep `M19-P6.1` as the next planned handoff-inference slice after the generated-state safety follow-up

## Notes

This is a planning/docs-only PR. It does not close #164 or #165; the implementation PR should close those issues after runtime fixes and tests land.

References #164.
References #165.

## Validation

- `/Users/shaypalachy/.local/bin/uv run splendor lint`