### PR TITLE
M19-P5.2: Generated text integrity and manifest provenance fixes

### DIFF
--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -277,6 +277,11 @@ Implemented fields:
   shared mutation object. Without `--apply`, actionable jobs are reported as planned and no queue,
   source-summary, run, index, or log state is written. `--apply` drains eligible jobs and reports
   actual written records in `mutation.written`.
+- Successful ingest rewrites the touched source manifest's run provenance as a current
+  materialization: when `last_run_id`, generated run IDs, linked generated pages, derived
+  artifacts, or provenance links are refreshed, `pipeline_version` is refreshed to the current
+  Splendor pipeline version. Generated markdown and YAML frontmatter preserve readable UTF-8
+  punctuation and must not emit ASCII control bytes other than tab/newline/carriage return.
 - `splendor wiki compile <source-id|title|path>` remains non-mutating unless a maintained target
   page is selected and `--apply --proposal-hash <hash>` is supplied. Without `--page`, it reports
   the review-gated contract plus ranked maintained-page suggestions and ready-to-run

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -395,7 +395,10 @@ Used for:
 - source summary pages
 - architecture pages
 
-These remain markdown-first, but include standardized frontmatter for discoverability and provenance.
+These remain markdown-first, but include standardized frontmatter for discoverability and
+provenance. Generated page bodies and YAML frontmatter should preserve readable UTF-8 punctuation
+from source material and generated review evidence; control bytes are not valid generated text
+except for normal whitespace.
 
 ## 11. Core Object Schemas
 
@@ -428,6 +431,10 @@ Suggested fields:
 
 Field meanings:
 
+- `pipeline_version`
+  - The Splendor pipeline version that last materialized or refreshed the source manifest's
+    generated-state provenance. Ingest refreshes this field whenever it writes a new `last_run_id`
+    or generated-page/run provenance for an existing source record.
 - `source_ref`
   - Canonical identifier for the source the user registered.
   - For in-repo files this should usually be a repo-relative path.

--- a/src/splendor/commands/ingest.py
+++ b/src/splendor/commands/ingest.py
@@ -786,7 +786,13 @@ def _mark_attempt_failed(
         next_attempt_at=next_attempt_at,
     )
     if manifest_path is not None and source is not None and run_id is not None:
-        failed_source = source.model_copy(update={"status": "failed", "last_run_id": run_id})
+        failed_source = source.model_copy(
+            update={
+                "status": "failed",
+                "last_run_id": run_id,
+                "pipeline_version": __version__,
+            }
+        )
         write_source_record(manifest_path, failed_source)
 
 
@@ -1275,6 +1281,7 @@ def run_ingest_job(root: Path, queue_path: Path) -> IngestResult:
             update={
                 "status": "ingested",
                 "last_run_id": run_id,
+                "pipeline_version": __version__,
                 "generated_by_run_ids": sorted(set([*source.generated_by_run_ids, run_id])),
                 "linked_pages": sorted(set([*source.linked_pages, page_relpath])),
                 "derived_artifacts": sorted(set([*source.derived_artifacts, *derived_artifacts])),

--- a/src/splendor/utils/contradictions.py
+++ b/src/splendor/utils/contradictions.py
@@ -22,6 +22,7 @@ from splendor.schemas import (
 )
 from splendor.schemas.planning import status_for_review_task_state
 from splendor.utils.planning import parse_planning_document, planning_path, render_planning_document
+from splendor.utils.text_integrity import sanitize_generated_text
 from splendor.utils.time import utc_now_iso
 from splendor.utils.wiki import parse_wiki_markdown
 
@@ -702,11 +703,11 @@ def _is_metadata_only_contradiction(contradiction: DetectedContradiction) -> boo
 
 
 def _normalized_summary(value: str) -> str:
-    return _WHITESPACE_PATTERN.sub(" ", value.strip())
+    return _WHITESPACE_PATTERN.sub(" ", sanitize_generated_text(value).strip())
 
 
 def _normalized_excerpt(value: str) -> str:
-    return value.strip()
+    return sanitize_generated_text(value).strip()
 
 
 def _dedupe_detected_contradictions(

--- a/src/splendor/utils/contradictions.py
+++ b/src/splendor/utils/contradictions.py
@@ -561,15 +561,19 @@ def _render_review_task_body(
     evidence_lines = "\n".join(
         f"- `{item.page_id}`: {item.excerpt}" for item in annotation.evidence
     )
+    summary = sanitize_generated_text(annotation.summary)
+    evidence_lines = sanitize_generated_text(evidence_lines)
+    current_title = sanitize_generated_text(current.frontmatter.title)
+    candidate_title = sanitize_generated_text(candidate.frontmatter.title)
     return (
         "\n"
         "## Contradiction\n\n"
-        f"{annotation.summary}\n\n"
+        f"{summary}\n\n"
         "## Evidence\n\n"
         f"{evidence_lines}\n\n"
         "## Linked Pages\n\n"
-        f"- [{current.frontmatter.title}]({current_link}) (`{current.frontmatter.page_id}`)\n"
-        f"- [{candidate.frontmatter.title}]({candidate_link}) "
+        f"- [{current_title}]({current_link}) (`{current.frontmatter.page_id}`)\n"
+        f"- [{candidate_title}]({candidate_link}) "
         f"(`{candidate.frontmatter.page_id}`)\n\n"
         "## Notes\n\n"
     )

--- a/src/splendor/utils/planning.py
+++ b/src/splendor/utils/planning.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, ValidationError
 
 from splendor.layout import ResolvedLayout
 from splendor.utils.fs import write_text_atomic
-from splendor.utils.text_integrity import sanitize_generated_text, sanitize_generated_value
+from splendor.utils.text_integrity import sanitize_generated_value
 
 PlanningRecord = TypeVar("PlanningRecord", bound=BaseModel)
 
@@ -87,13 +87,11 @@ def render_frontmatter(record: BaseModel) -> str:
 
 
 def render_planning_markdown(record: BaseModel, *, title: str) -> str:
-    title = sanitize_generated_text(title)
     return f"---\n{render_frontmatter(record)}\n---\n\n# {title}\n\n## Notes\n\n"
 
 
 def render_planning_document(record: BaseModel, *, body: str) -> str:
     normalized_body = body.replace("\r\n", "\n").replace("\r", "\n")
-    normalized_body = sanitize_generated_text(normalized_body)
     return f"---\n{render_frontmatter(record)}\n---\n{normalized_body}"
 
 

--- a/src/splendor/utils/planning.py
+++ b/src/splendor/utils/planning.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, ValidationError
 
 from splendor.layout import ResolvedLayout
 from splendor.utils.fs import write_text_atomic
+from splendor.utils.text_integrity import sanitize_generated_text, sanitize_generated_value
 
 PlanningRecord = TypeVar("PlanningRecord", bound=BaseModel)
 
@@ -81,15 +82,18 @@ def validate_record_id(record_id: str) -> str:
 
 
 def render_frontmatter(record: BaseModel) -> str:
-    return yaml.safe_dump(record.model_dump(mode="json"), sort_keys=False).strip()
+    payload = sanitize_generated_value(record.model_dump(mode="json"))
+    return yaml.safe_dump(payload, sort_keys=False, allow_unicode=True).strip()
 
 
 def render_planning_markdown(record: BaseModel, *, title: str) -> str:
+    title = sanitize_generated_text(title)
     return f"---\n{render_frontmatter(record)}\n---\n\n# {title}\n\n## Notes\n\n"
 
 
 def render_planning_document(record: BaseModel, *, body: str) -> str:
     normalized_body = body.replace("\r\n", "\n").replace("\r", "\n")
+    normalized_body = sanitize_generated_text(normalized_body)
     return f"---\n{render_frontmatter(record)}\n---\n{normalized_body}"
 
 

--- a/src/splendor/utils/text_integrity.py
+++ b/src/splendor/utils/text_integrity.py
@@ -7,24 +7,8 @@ import unicodedata
 from collections.abc import Mapping
 from typing import Any
 
-_COMMON_MOJIBAKE_REPLACEMENTS = {
-    "â\x80\x94": "—",
-    "â€”": "—",
-    "â\x80\x93": "–",
-    "â€“": "–",
-    "â\x80\x98": "‘",
-    "â€˜": "‘",
-    "â\x80\x99": "’",
-    "â€™": "’",
-    "â\x80\x9c": "“",
-    "â€œ": "“",
-    "â\x80\x9d": "”",
-    "â€�": "”",
-    "â\x80¦": "…",
-    "â€¦": "…",
-}
-
 _CONTROL_CHARACTER_PATTERN = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+_LATIN1_DECODED_UTF8_SPAN_PATTERN = re.compile(r"[\x80-\xff]{2,}")
 _SPACES_PATTERN = re.compile(r" {2,}")
 
 
@@ -32,10 +16,23 @@ def sanitize_generated_text(value: str) -> str:
     """Preserve readable Unicode while removing controls from generated markdown/YAML."""
 
     text = unicodedata.normalize("NFC", value)
-    for broken, replacement in _COMMON_MOJIBAKE_REPLACEMENTS.items():
-        text = text.replace(broken, replacement)
+    if _CONTROL_CHARACTER_PATTERN.search(text):
+        text = _repair_latin1_decoded_utf8_spans(text)
     text = _CONTROL_CHARACTER_PATTERN.sub(" ", text)
     return "\n".join(_SPACES_PATTERN.sub(" ", line).rstrip() for line in text.split("\n"))
+
+
+def _repair_latin1_decoded_utf8_spans(value: str) -> str:
+    def repair(match: re.Match[str]) -> str:
+        span = match.group(0)
+        if not _CONTROL_CHARACTER_PATTERN.search(span):
+            return span
+        try:
+            return span.encode("latin-1").decode("utf-8")
+        except UnicodeError:
+            return span
+
+    return _LATIN1_DECODED_UTF8_SPAN_PATTERN.sub(repair, value)
 
 
 def sanitize_generated_value(value: Any) -> Any:

--- a/src/splendor/utils/text_integrity.py
+++ b/src/splendor/utils/text_integrity.py
@@ -1,0 +1,53 @@
+"""Generated text normalization helpers."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Mapping
+from typing import Any
+
+_COMMON_MOJIBAKE_REPLACEMENTS = {
+    "â\x80\x94": "—",
+    "â€”": "—",
+    "â\x80\x93": "–",
+    "â€“": "–",
+    "â\x80\x98": "‘",
+    "â€˜": "‘",
+    "â\x80\x99": "’",
+    "â€™": "’",
+    "â\x80\x9c": "“",
+    "â€œ": "“",
+    "â\x80\x9d": "”",
+    "â€�": "”",
+    "â\x80¦": "…",
+    "â€¦": "…",
+}
+
+_CONTROL_CHARACTER_PATTERN = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+_SPACES_PATTERN = re.compile(r" {2,}")
+
+
+def sanitize_generated_text(value: str) -> str:
+    """Preserve readable Unicode while removing controls from generated markdown/YAML."""
+
+    text = unicodedata.normalize("NFC", value)
+    for broken, replacement in _COMMON_MOJIBAKE_REPLACEMENTS.items():
+        text = text.replace(broken, replacement)
+    text = _CONTROL_CHARACTER_PATTERN.sub(" ", text)
+    return "\n".join(_SPACES_PATTERN.sub(" ", line).rstrip() for line in text.split("\n"))
+
+
+def sanitize_generated_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return sanitize_generated_text(value)
+    if isinstance(value, list):
+        return [sanitize_generated_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [sanitize_generated_value(item) for item in value]
+    if isinstance(value, Mapping):
+        return {
+            sanitize_generated_value(key): sanitize_generated_value(item)
+            for key, item in value.items()
+        }
+    return value

--- a/src/splendor/utils/wiki.py
+++ b/src/splendor/utils/wiki.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from splendor.layout import ResolvedLayout
 from splendor.schemas import KnowledgePageFrontmatter
 from splendor.utils.fs import write_text_atomic
+from splendor.utils.text_integrity import sanitize_generated_text, sanitize_generated_value
 
 
 @dataclass(frozen=True)
@@ -29,7 +30,8 @@ class ParsedWikiPage:
 
 
 def render_frontmatter(record: KnowledgePageFrontmatter) -> str:
-    return yaml.safe_dump(record.model_dump(mode="json"), sort_keys=False).strip()
+    payload = sanitize_generated_value(record.model_dump(mode="json"))
+    return yaml.safe_dump(payload, sort_keys=False, allow_unicode=True).strip()
 
 
 def parse_wiki_markdown(path: Path) -> ParsedWikiPage:
@@ -57,6 +59,7 @@ def parse_wiki_markdown(path: Path) -> ParsedWikiPage:
 
 
 def _fenced_extract_block(extract: str) -> str:
+    extract = sanitize_generated_text(extract)
     max_backtick_run = 0
     current_run = 0
     for char in extract:
@@ -80,12 +83,16 @@ def render_source_summary_page(
     contradictions: list[str] | None = None,
     provenance: list[str],
 ) -> str:
+    source_section = sanitize_generated_text(source_section)
+    summary = sanitize_generated_text(summary)
+    key_facts = [sanitize_generated_text(line) for line in key_facts]
     key_fact_lines = "\n".join(f"- {line}" for line in key_facts)
     contradiction_section = ""
     if contradictions:
+        contradictions = [sanitize_generated_text(line) for line in contradictions]
         contradiction_lines = "\n".join(f"- {line}" for line in contradictions)
         contradiction_section = f"## Contradictions\n\n{contradiction_lines}\n\n"
-    provenance_lines = "\n".join(f"- {line}" for line in provenance)
+    provenance_lines = "\n".join(f"- {sanitize_generated_text(line)}" for line in provenance)
     extract_section = ""
     if extract is not None:
         extract_section = f"## Extract\n\n{_fenced_extract_block(extract)}\n\n"

--- a/src/splendor/utils/wiki.py
+++ b/src/splendor/utils/wiki.py
@@ -93,12 +93,13 @@ def render_source_summary_page(
         contradiction_lines = "\n".join(f"- {line}" for line in contradictions)
         contradiction_section = f"## Contradictions\n\n{contradiction_lines}\n\n"
     provenance_lines = "\n".join(f"- {sanitize_generated_text(line)}" for line in provenance)
+    title = sanitize_generated_text(frontmatter.title)
     extract_section = ""
     if extract is not None:
         extract_section = f"## Extract\n\n{_fenced_extract_block(extract)}\n\n"
     return (
         f"---\n{render_frontmatter(frontmatter)}\n---\n\n"
-        f"# {frontmatter.title}\n\n"
+        f"# {title}\n\n"
         "## Source\n\n"
         f"{source_section}\n\n"
         "## Summary\n\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,12 @@ from splendor.schemas import (
     TaskRecord,
 )
 from splendor.state.query_snapshot import last_query_path_for, load_query_snapshot
-from splendor.state.runtime import load_queue_item, write_queue_item, write_run_record
+from splendor.state.runtime import (
+    load_queue_item,
+    load_run_record,
+    write_queue_item,
+    write_run_record,
+)
 from splendor.state.source_registry import load_source_record, write_source_record
 from splendor.utils.planning import render_planning_markdown
 
@@ -2073,6 +2078,10 @@ def test_cli_source_update_path_reingests_same_byte_move_to_refresh_provenance(
     main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
     page_path = tmp_path / "wiki" / "sources" / f"{source_id}.md"
     assert "old.md" in page_path.read_text(encoding="utf-8")
+    stale_manifest = load_source_record(manifest_path).model_copy(
+        update={"pipeline_version": "0.1.0a0"}
+    )
+    write_source_record(manifest_path, stale_manifest)
     source.rename(replacement)
     capsys.readouterr()
 
@@ -2089,8 +2098,14 @@ def test_cli_source_update_path_reingests_same_byte_move_to_refresh_provenance(
     ingest_code = main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
 
     assert ingest_code == 0
+    refreshed_manifest = load_source_record(manifest_path)
+    assert refreshed_manifest.pipeline_version == __version__
+    assert refreshed_manifest.last_run_id != stale_manifest.last_run_id
+    run_path = tmp_path / "state" / "runs" / f"{refreshed_manifest.last_run_id}.json"
+    assert load_run_record(run_path).pipeline_version == __version__
     page_text = page_path.read_text(encoding="utf-8")
     assert "new.md" in page_text
+    assert f"Pipeline version: `{__version__}`" in page_text
 
 
 def test_cli_source_update_path_changed_bytes_reports_partial_repair(

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -54,6 +54,17 @@ def extract_rendered_extract_section(body: str) -> str:
     return after_heading.split("\n\n## ", maxsplit=1)[0]
 
 
+def assert_no_forbidden_control_chars(text: str) -> None:
+    forbidden = [
+        f"0x{ord(char):02x}"
+        for char in text
+        if (
+            (ord(char) < 32 and char not in "\n\r\t") or ord(char) == 127 or 128 <= ord(char) <= 159
+        )
+    ]
+    assert forbidden == []
+
+
 def enable_sidecar_ocr(root: Path, *, suffix: str = ".ocr.txt") -> None:
     config = load_config(root)
     config.sources.ocr_enabled = True
@@ -140,6 +151,31 @@ def test_ingest_source_happy_path(tmp_path: Path) -> None:
     log_content = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
     assert added.source_id in log_content
     assert result.run_id in log_content
+
+
+def test_ingest_source_preserves_utf8_punctuation_in_generated_surfaces(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    update_summary_modes(tmp_path, external="excerpt")
+    source = tmp_path / "brief.md"
+    source.write_text(
+        "# Brief — Generated Text\n\n"
+        "## Core Claims\n\n"
+        "- Evidence keeps em dashes — smart quotes “naturalness” — ellipses … and café.\n",
+        encoding="utf-8",
+    )
+    added = add_source(tmp_path, source, storage_mode="copy")
+
+    result = ingest_source(tmp_path, added.source_id)
+
+    assert result.page_path is not None
+    page_text = result.page_path.read_text(encoding="utf-8")
+    frontmatter_text = page_text.removeprefix("---\n").split("\n---\n", maxsplit=1)[0]
+    assert "Brief — Generated Text" in page_text
+    assert "em dashes — smart quotes “naturalness” — ellipses … and café" in page_text
+    assert "\\x" not in frontmatter_text
+    assert_no_forbidden_control_chars(page_text)
 
 
 def test_ingest_source_records_distinct_start_and_finish_timestamps(
@@ -1925,6 +1961,57 @@ def test_ingest_source_marks_contradictions_and_creates_review_task(
     run_record = load_run_record(second_result.run_path)
     assert run_record.task_ids == [task_id]
     assert run_record.contradiction_ids == [second_page.contradictions[0].contradiction_id]
+
+
+def test_ingest_source_preserves_utf8_punctuation_in_contradiction_review_outputs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    initialize_workspace(tmp_path)
+
+    class FakeAnalyzer:
+        def detect(self, *, current, candidate):
+            return [
+                contradictions_module.DetectedContradiction(
+                    summary="Generated evidence differs — “alpha” vs “beta” …",
+                    current_excerpt="Current says naturalness — “alpha” — should stay readable.",
+                    candidate_excerpt="Candidate says naturalness — “beta” — should stay readable.",
+                )
+            ]
+
+    monkeypatch.setattr(
+        contradictions_module,
+        "build_contradiction_analyzer",
+        lambda config: FakeAnalyzer(),
+    )
+
+    first_source = tmp_path / "first.md"
+    first_source.write_text("# First\n\n## Core Claims\n\n- Claim one.\n", encoding="utf-8")
+    first_added = add_source(tmp_path, first_source, storage_mode="copy")
+    ingest_source(tmp_path, first_added.source_id)
+
+    second_source = tmp_path / "second.md"
+    second_source.write_text("# Second\n\n## Core Claims\n\n- Claim two.\n", encoding="utf-8")
+    second_added = add_source(tmp_path, second_source, storage_mode="copy")
+    second_result = ingest_source(tmp_path, second_added.source_id)
+
+    assert second_result.page_path is not None
+    second_text = second_result.page_path.read_text(encoding="utf-8")
+    second_frontmatter_text = second_text.removeprefix("---\n").split("\n---\n", maxsplit=1)[0]
+    assert "Generated evidence differs — “alpha” vs “beta” …" in second_text
+    assert "\\x" not in second_frontmatter_text
+    assert_no_forbidden_control_chars(second_text)
+
+    second_page = parse_frontmatter(second_result.page_path)[0]
+    task_path = (
+        tmp_path / "planning" / "tasks" / f"{second_page.contradictions[0].review_task_id}.md"
+    )
+    task_text = task_path.read_text(encoding="utf-8")
+    task_frontmatter_text = task_text.removeprefix("---\n").split("\n---\n", maxsplit=1)[0]
+    assert "Generated evidence differs — “alpha” vs “beta” …" in task_text
+    assert "Current says naturalness — “alpha” — should stay readable." in task_text
+    assert "Candidate says naturalness — “beta” — should stay readable." in task_text
+    assert "\\x" not in task_frontmatter_text
+    assert_no_forbidden_control_chars(task_text)
 
 
 def test_ingest_source_skips_boilerplate_only_contradiction_review(

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -9,6 +9,7 @@ from pypdf import PdfWriter
 import splendor.commands.ingest as ingest_module
 import splendor.utils.contradictions as contradictions_module
 from conftest import write_text_pdf
+from splendor import __version__
 from splendor.commands.add_source import add_source
 from splendor.commands.ingest import (
     drain_pending_ingest_jobs,
@@ -166,6 +167,10 @@ def test_ingest_source_preserves_utf8_punctuation_in_generated_surfaces(
         encoding="utf-8",
     )
     added = add_source(tmp_path, source, storage_mode="copy")
+    source_record = load_source_record(added.manifest_path).model_copy(
+        update={"title": "Brief — Generated Text\x07"}
+    )
+    write_source_record(added.manifest_path, source_record)
 
     result = ingest_source(tmp_path, added.source_id)
 
@@ -173,6 +178,7 @@ def test_ingest_source_preserves_utf8_punctuation_in_generated_surfaces(
     page_text = result.page_path.read_text(encoding="utf-8")
     frontmatter_text = page_text.removeprefix("---\n").split("\n---\n", maxsplit=1)[0]
     assert "Brief — Generated Text" in page_text
+    assert "# Brief — Generated Text" in page_text
     assert "em dashes — smart quotes “naturalness” — ellipses … and café" in page_text
     assert "\\x" not in frontmatter_text
     assert_no_forbidden_control_chars(page_text)
@@ -310,6 +316,10 @@ def test_ingest_source_rejects_unsupported_type(tmp_path: Path) -> None:
     source = tmp_path / "diagram.bin"
     source.write_bytes(b"\x00\x01\x02")
     added = add_source(tmp_path, source)
+    stale_source = load_source_record(added.manifest_path).model_copy(
+        update={"pipeline_version": "0.1.0a0"}
+    )
+    write_source_record(added.manifest_path, stale_source)
 
     with pytest.raises(ValueError, match="Unsupported source type"):
         ingest_source(tmp_path, added.source_id)
@@ -317,6 +327,7 @@ def test_ingest_source_rejects_unsupported_type(tmp_path: Path) -> None:
     source_record = load_source_record(added.manifest_path)
     assert source_record.status == "failed"
     assert source_record.last_run_id is not None
+    assert source_record.pipeline_version == __version__
     queue_path = tmp_path / "state" / "queue" / f"ingest-{added.source_id}.json"
     run_paths = list((tmp_path / "state" / "runs").glob("*.json"))
     assert load_queue_item(queue_path).status == "failed"
@@ -2010,6 +2021,62 @@ def test_ingest_source_preserves_utf8_punctuation_in_contradiction_review_output
     assert "Generated evidence differs — “alpha” vs “beta” …" in task_text
     assert "Current says naturalness — “alpha” — should stay readable." in task_text
     assert "Candidate says naturalness — “beta” — should stay readable." in task_text
+    assert "\\x" not in task_frontmatter_text
+    assert_no_forbidden_control_chars(task_text)
+
+
+def test_ingest_source_repairs_control_byte_mojibake_in_contradiction_outputs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    initialize_workspace(tmp_path)
+
+    class FakeAnalyzer:
+        def detect(self, *, current, candidate):
+            return [
+                contradictions_module.DetectedContradiction(
+                    summary=("Generated evidence differs â\x80\x94 \x1a raw SUB and \x7f raw DEL"),
+                    current_excerpt=(
+                        "Current says â\x80\x9cnaturalnessâ\x80\x9d â\x80\x94 alpha\x07."
+                    ),
+                    candidate_excerpt=(
+                        "Candidate says â\x80\x9cnaturalnessâ\x80\x9d â\x80\x94 beta\x1a."
+                    ),
+                )
+            ]
+
+    monkeypatch.setattr(
+        contradictions_module,
+        "build_contradiction_analyzer",
+        lambda config: FakeAnalyzer(),
+    )
+
+    first_source = tmp_path / "first.md"
+    first_source.write_text("# First\n\n## Core Claims\n\n- Claim one.\n", encoding="utf-8")
+    first_added = add_source(tmp_path, first_source, storage_mode="copy")
+    ingest_source(tmp_path, first_added.source_id)
+
+    second_source = tmp_path / "second.md"
+    second_source.write_text("# Second\n\n## Core Claims\n\n- Claim two.\n", encoding="utf-8")
+    second_added = add_source(tmp_path, second_source, storage_mode="copy")
+    second_result = ingest_source(tmp_path, second_added.source_id)
+
+    assert second_result.page_path is not None
+    second_text = second_result.page_path.read_text(encoding="utf-8")
+    second_frontmatter_text = second_text.removeprefix("---\n").split("\n---\n", maxsplit=1)[0]
+    assert "Generated evidence differs — raw SUB and raw DEL" in second_text
+    assert "Current says “naturalness” — alpha" in second_text
+    assert "\\x" not in second_frontmatter_text
+    assert_no_forbidden_control_chars(second_text)
+
+    second_page = parse_frontmatter(second_result.page_path)[0]
+    task_path = (
+        tmp_path / "planning" / "tasks" / f"{second_page.contradictions[0].review_task_id}.md"
+    )
+    task_text = task_path.read_text(encoding="utf-8")
+    task_frontmatter_text = task_text.removeprefix("---\n").split("\n---\n", maxsplit=1)[0]
+    assert "Generated evidence differs — raw SUB and raw DEL" in task_text
+    assert "Current says “naturalness” — alpha" in task_text
+    assert "Candidate says “naturalness” — beta" in task_text
     assert "\\x" not in task_frontmatter_text
     assert_no_forbidden_control_chars(task_text)
 

--- a/tests/test_text_integrity.py
+++ b/tests/test_text_integrity.py
@@ -1,0 +1,19 @@
+from splendor.utils.text_integrity import sanitize_generated_text
+
+
+def test_sanitize_generated_text_repairs_latin1_decoded_utf8_when_controls_present() -> None:
+    text = sanitize_generated_text("Evidence â\x80\x94 says â\x80\x9cnaturalnessâ\x80\x9d.")
+
+    assert text == "Evidence — says “naturalness”."
+
+
+def test_sanitize_generated_text_does_not_rewrite_literal_mojibake_examples() -> None:
+    text = sanitize_generated_text("The literal sequence â€” is documented here.")
+
+    assert text == "The literal sequence â€” is documented here."
+
+
+def test_sanitize_generated_text_removes_controls_that_are_not_repairable_mojibake() -> None:
+    text = sanitize_generated_text("alpha\x07 beta\x1a\x7f gamma")
+
+    assert text == "alpha beta gamma"


### PR DESCRIPTION
## Summary
- Add a generated-text integrity pass for wiki and planning markdown/frontmatter so readable UTF-8 punctuation is preserved while control bytes are stripped from generated output.
- Normalize contradiction review summaries/excerpts before they are persisted into source-summary YAML, contradiction sections, and generated review-task markdown.
- Refresh source manifest `pipeline_version` whenever ingest writes new run provenance such as `last_run_id`, and cover path-repair reingest with a stale manifest regression.

## Validation
- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

## Notes
- PR #166 (`codex/m19-p5-2-planning-docs`) is still open, so this PR keeps planning-intake overlap minimal and only updates schema/product semantics needed for the implementation.

Closes #165
Closes #164
