### PR TITLE
M19-P6.1: Completion-aware current-state handoff inference

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M19-P5.1`
-- Last action taken: `M19-P5.1` was squash-merged into main as commit `94e5150`,
-  harmonizing legacy maintenance/workflow verbs behind preview/apply semantics.
-- Current planned slice: `M19 post-v0.4 generated-state safety follow-ups`
-- Current PR sub-slice: `M19-P5.2`
+- Previous completed PR sub-slice: `M19-P5.2`
+- Last action taken: `M19-P5.2` was squash-merged into main as commit `b1128c8`,
+  fixing generated text integrity and manifest provenance drift.
+- Current planned slice: `M19 completion-aware current-state handoff inference`
+- Current PR sub-slice: `M19-P6.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 completion-aware current-state handoff inference`
-- Next planned PR sub-slice: `M19-P6.1`
+- Next planned slice: `M19 handoff breadth and policy-cited implementation surfacing`
+- Next planned PR sub-slice: `M19-P7.1`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -646,4 +646,5 @@ records, index/log state, pruning changes, or topic-ref migrations.
 Evidence/Contradictions text corruption and stale source-manifest `pipeline_version` provenance
 after path repair plus ingest. `M19-P6.1` resumes handoff-inference work by making
 `brief --agent-context` and `suggest-next` completion-aware when stale planning docs still name a
-slice already present in mainline git or merged PR history.
+slice already present as the latest mainline implementation boundary and the roadmap names the
+next ordered slice.

--- a/README.md
+++ b/README.md
@@ -646,5 +646,5 @@ records, index/log state, pruning changes, or topic-ref migrations.
 Evidence/Contradictions text corruption and stale source-manifest `pipeline_version` provenance
 after path repair plus ingest. `M19-P6.1` resumes handoff-inference work by making
 `brief --agent-context` and `suggest-next` completion-aware when stale planning docs still name a
-slice already present as the latest mainline implementation boundary and the roadmap names the
+slice already present in recent mainline implementation history and the roadmap names the
 next ordered slice.

--- a/README.md
+++ b/README.md
@@ -323,12 +323,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M19-P5.1`
-- Current planned slice: `M19 post-v0.4 generated-state safety follow-ups`
-- Current PR sub-slice: `M19-P5.2`
+- Previous completed PR sub-slice: `M19-P5.2`
+- Current planned slice: `M19 completion-aware current-state handoff inference`
+- Current PR sub-slice: `M19-P6.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 completion-aware current-state handoff inference`
-- Next planned PR sub-slice: `M19-P6.1`
+- Next planned slice: `M19 handoff breadth and policy-cited implementation surfacing`
+- Next planned PR sub-slice: `M19-P7.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -642,6 +642,8 @@ preview by default, report planned writes through the shared mutation contract, 
 explicit `--apply` before draining queue jobs or writing manifests, source summaries, queue/run
 records, index/log state, pruning changes, or topic-ref migrations.
 
-`M19-P5.2` is the next focused bugfix slice before handoff-inference work resumes. It addresses
-the new SynthBanshee follow-up reports for generated Evidence/Contradictions text corruption and
-stale source-manifest `pipeline_version` provenance after path repair plus ingest.
+`M19-P5.2` is implemented: it addresses the SynthBanshee follow-up reports for generated
+Evidence/Contradictions text corruption and stale source-manifest `pipeline_version` provenance
+after path repair plus ingest. `M19-P6.1` resumes handoff-inference work by making
+`brief --agent-context` and `suggest-next` completion-aware when stale planning docs still name a
+slice already present in mainline git or merged PR history.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -323,12 +323,12 @@ Implemented fields:
   manifests, queue jobs, wiki pages, run records, reports, or GitHub state.
 - `brief --agent-context` and `suggest-next` include an optional JSON `handoff_current_state`
   object when planning state appears stale because the named current slice is the latest mainline
-  slice boundary with implementation/test/tooling changes and an ordered roadmap sequence names the
-  following slice. Merged PR context can corroborate the mainline evidence, but arbitrary
-  historical mentions and stale `Next planned PR sub-slice` lines do not advance state by
-  themselves. The object records `current_slice`, `inferred_slice`, completion `evidence`, and the
-  ordered roadmap `source_path`. Absence of the object means no completion-aware advancement was
-  inferred.
+  slice boundary found in a bounded recent mainline scan with implementation/test/tooling changes,
+  and a bounded ordered roadmap sequence names the following slice. Merged PR context can
+  corroborate the mainline evidence, but arbitrary historical mentions and stale
+  `Next planned PR sub-slice` lines do not advance state by themselves. The object records
+  `current_slice`, `inferred_slice`, completion `evidence`, and the ordered roadmap `source_path`.
+  Absence of the object means no completion-aware advancement was inferred.
 - `splendor brief --agent-context [--since <ref>] [--no-git] [goal]` and
   `splendor suggest-next [--since <ref>] [--no-git] [goal]` are read-only handoff views over
   existing deterministic state plus runtime-only git/GitHub signals. They do not create planning

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -321,6 +321,11 @@ Implemented fields:
   keep `paths` for quick scanning plus `path_actions` and `action_counts` for add/change/delete/
   rename review without falling back to the detailed groups. The command does not create
   manifests, queue jobs, wiki pages, run records, reports, or GitHub state.
+- `brief --agent-context` and `suggest-next` include an optional JSON `handoff_current_state`
+  object when planning state appears stale because the named current slice is already present in
+  mainline git history or merged PR context. The object records `current_slice`, `inferred_slice`,
+  completion `evidence`, and the ordered roadmap `source_path` when known. Absence of the object
+  means no completion-aware advancement was inferred.
 - `splendor brief --agent-context [--since <ref>] [--no-git] [goal]` and
   `splendor suggest-next [--since <ref>] [--no-git] [goal]` are read-only handoff views over
   existing deterministic state plus runtime-only git/GitHub signals. They do not create planning

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -322,10 +322,13 @@ Implemented fields:
   rename review without falling back to the detailed groups. The command does not create
   manifests, queue jobs, wiki pages, run records, reports, or GitHub state.
 - `brief --agent-context` and `suggest-next` include an optional JSON `handoff_current_state`
-  object when planning state appears stale because the named current slice is already present in
-  mainline git history or merged PR context. The object records `current_slice`, `inferred_slice`,
-  completion `evidence`, and the ordered roadmap `source_path` when known. Absence of the object
-  means no completion-aware advancement was inferred.
+  object when planning state appears stale because the named current slice is the latest mainline
+  slice boundary with implementation/test/tooling changes and an ordered roadmap sequence names the
+  following slice. Merged PR context can corroborate the mainline evidence, but arbitrary
+  historical mentions and stale `Next planned PR sub-slice` lines do not advance state by
+  themselves. The object records `current_slice`, `inferred_slice`, completion `evidence`, and the
+  ordered roadmap `source_path`. Absence of the object means no completion-aware advancement was
+  inferred.
 - `splendor brief --agent-context [--since <ref>] [--no-git] [goal]` and
   `splendor suggest-next [--since <ref>] [--no-git] [goal]` are read-only handoff views over
   existing deterministic state plus runtime-only git/GitHub signals. They do not create planning

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M19-P5.1`
-- Current planned slice: `M19 post-v0.4 generated-state safety follow-ups`
-- Current PR sub-slice: `M19-P5.2`
+- Previous completed PR sub-slice: `M19-P5.2`
+- Current planned slice: `M19 completion-aware current-state handoff inference`
+- Current PR sub-slice: `M19-P6.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 completion-aware current-state handoff inference`
-- Next planned PR sub-slice: `M19-P6.1`
+- Next planned slice: `M19 handoff breadth and policy-cited implementation surfacing`
+- Next planned PR sub-slice: `M19-P7.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1318,6 +1318,12 @@ Evidence/Contradictions excerpts can leak control bytes into markdown/YAML, and 
 source manifests can keep stale `pipeline_version` provenance after ingest rewrites `last_run_id`.
 These stay under the `M19-P5` family because they are immediate post-v0.4 safety follow-ups for
 generated state integrity, while `M19-P6.1` remains the next handoff-inference feature slice.
+
+`M19-P5.2` is now implemented on `main`, so the next active M19 handoff feature slice is
+`M19-P6.1`. This slice makes `brief --agent-context` and `suggest-next` reconcile stale dynamic
+planning state with mainline git or merged PR evidence plus the ordered roadmap sequence, so a
+recently completed current slice advances to the next open roadmap item instead of remaining the
+top work recommendation.
 
 The remaining M19 sequence is therefore:
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -1321,9 +1321,10 @@ generated state integrity, while `M19-P6.1` remains the next handoff-inference f
 
 `M19-P5.2` is now implemented on `main`, so the next active M19 handoff feature slice is
 `M19-P6.1`. This slice makes `brief --agent-context` and `suggest-next` reconcile stale dynamic
-planning state with mainline git or merged PR evidence plus the ordered roadmap sequence, so a
+planning state with a bounded ordered roadmap sequence and mainline implementation evidence, so a
 recently completed current slice advances to the next open roadmap item instead of remaining the
-top work recommendation.
+top work recommendation. Merged PR state can corroborate the inference, but docs-only planning
+intake and arbitrary historical mentions do not advance current state by themselves.
 
 The remaining M19 sequence is therefore:
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -1321,10 +1321,10 @@ generated state integrity, while `M19-P6.1` remains the next handoff-inference f
 
 `M19-P5.2` is now implemented on `main`, so the next active M19 handoff feature slice is
 `M19-P6.1`. This slice makes `brief --agent-context` and `suggest-next` reconcile stale dynamic
-planning state with a bounded ordered roadmap sequence and mainline implementation evidence, so a
-recently completed current slice advances to the next open roadmap item instead of remaining the
-top work recommendation. Merged PR state can corroborate the inference, but docs-only planning
-intake and arbitrary historical mentions do not advance current state by themselves.
+planning state with a bounded ordered roadmap sequence and recent mainline implementation
+evidence, so a recently completed current slice advances to the next open roadmap item instead of
+remaining the top work recommendation. Merged PR state can corroborate the inference, but docs-only
+planning intake and arbitrary historical mentions do not advance current state by themselves.
 
 The remaining M19 sequence is therefore:
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -922,9 +922,10 @@ Current implementation:
 - `splendor file-answer` prints the created page and a restrained review hint after filing.
 - `brief --agent-context` and `suggest-next` treat dynamic planning files as one input rather than
   the final word on current work. When `.agent-plan.md`, README, or roadmap state still names a
-  current slice that mainline git history or merged PR context shows as completed, handoff
-  inference can advance to the next ordered roadmap slice while keeping maintenance state in the
-  separate maintenance block.
+  current slice that the latest mainline slice boundary shows as implementation-complete, handoff
+  inference can advance to the next bounded ordered roadmap slice while keeping maintenance state
+  in the separate maintenance block. Merged PR state can corroborate that inference, but stale
+  dynamic `Next planned` lines and historical mentions are not enough on their own.
 - Multi-page, LLM-assisted, and automatic-page-selection compile/update behavior remains deferred
   to later reviewed compile-loop slices.
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -920,6 +920,11 @@ Current implementation:
   boilerplate when selecting snippets, supports tag/source filters, records those filters in JSON
   and saved snapshots, and text output points to `file-answer` when a saved query has matches.
 - `splendor file-answer` prints the created page and a restrained review hint after filing.
+- `brief --agent-context` and `suggest-next` treat dynamic planning files as one input rather than
+  the final word on current work. When `.agent-plan.md`, README, or roadmap state still names a
+  current slice that mainline git history or merged PR context shows as completed, handoff
+  inference can advance to the next ordered roadmap slice while keeping maintenance state in the
+  separate maintenance block.
 - Multi-page, LLM-assisted, and automatic-page-selection compile/update behavior remains deferred
   to later reviewed compile-loop slices.
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -922,7 +922,7 @@ Current implementation:
 - `splendor file-answer` prints the created page and a restrained review hint after filing.
 - `brief --agent-context` and `suggest-next` treat dynamic planning files as one input rather than
   the final word on current work. When `.agent-plan.md`, README, or roadmap state still names a
-  current slice that the latest mainline slice boundary shows as implementation-complete, handoff
+  current slice that a bounded recent mainline scan shows as implementation-complete, handoff
   inference can advance to the next bounded ordered roadmap slice while keeping maintenance state
   in the separate maintenance block. Merged PR state can corroborate that inference, but stale
   dynamic `Next planned` lines and historical mentions are not enough on their own.

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -54,6 +54,7 @@ _GIT_COMMAND_TIMEOUT_SECONDS = 5
 _PROMOTED_THREAD_RELEVANCE_FLOOR = 60
 _SUGGESTION_CATEGORY_LIMITS = {
     "work-thread": 4,
+    "current-state": 1,
     "git-context": 3,
     "source-freshness": 3,
     "queue": 3,
@@ -69,20 +70,21 @@ _SUGGESTION_CATEGORY_LIMITS = {
     "orientation": 1,
 }
 _WORK_FIRST_CATEGORY_ORDER = {
-    "work-thread": 0,
-    "git-context": 1,
-    "authority": 2,
-    "planning": 3,
-    "goal-match": 4,
-    "source-freshness": 5,
-    "queue": 6,
-    "wiki-validation": 7,
-    "contradiction-review": 8,
-    "synthesis": 9,
-    "wiki-review": 10,
-    "maintenance": 11,
-    "query": 12,
-    "orientation": 13,
+    "current-state": 0,
+    "work-thread": 1,
+    "git-context": 2,
+    "authority": 3,
+    "planning": 4,
+    "goal-match": 5,
+    "source-freshness": 6,
+    "queue": 7,
+    "wiki-validation": 8,
+    "contradiction-review": 9,
+    "synthesis": 10,
+    "wiki-review": 11,
+    "maintenance": 12,
+    "query": 13,
+    "orientation": 14,
 }
 _MAINTENANCE_FIRST_CATEGORY_ORDER = {
     "source-freshness": 0,
@@ -92,13 +94,14 @@ _MAINTENANCE_FIRST_CATEGORY_ORDER = {
     "synthesis": 4,
     "wiki-review": 5,
     "contradiction-review": 6,
-    "work-thread": 7,
-    "git-context": 8,
-    "authority": 9,
-    "planning": 10,
-    "goal-match": 11,
-    "query": 12,
-    "orientation": 13,
+    "current-state": 7,
+    "work-thread": 8,
+    "git-context": 9,
+    "authority": 10,
+    "planning": 11,
+    "goal-match": 12,
+    "query": 13,
+    "orientation": 14,
 }
 _MAINTENANCE_CATEGORIES = {
     "source-freshness",
@@ -125,6 +128,14 @@ _AUTHORITY_ORIGIN_ORDER = {
     "inferred-authority": 1,
 }
 _TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]{1,}")
+_ROADMAP_SLICE_PATTERN = re.compile(r"\b(?:[A-Z][A-Za-z0-9]*-P\d+(?:\.\d+)?|[A-Z]\d+[a-z])\b")
+_PLANNING_STATE_PATTERN = re.compile(
+    r"^\s*-\s+(?P<label>"
+    r"Previous completed PR sub-slice|Current planned slice|Current PR sub-slice|"
+    r"Current PR lifecycle|Next planned slice|Next planned PR sub-slice"
+    r"):\s*(?P<value>.+?)\s*$",
+    re.MULTILINE,
+)
 _AUTHORITY_ROLE_ORDER = {
     "current-authority": 0,
     "roadmap": 1,
@@ -406,6 +417,14 @@ class GitContext:
 
 
 @dataclass(frozen=True)
+class HandoffCurrentState:
+    current_slice: str
+    inferred_slice: str
+    evidence: list[str]
+    source_path: str | None
+
+
+@dataclass(frozen=True)
 class SuggestNextResult:
     goal: str | None
     actions: list[SuggestedAction]
@@ -418,6 +437,7 @@ class SuggestNextResult:
     latest_reports: list[BriefReportSnapshot]
     warnings: list[BriefWarning]
     git_context: GitContext
+    handoff_current_state: HandoffCurrentState | None
     work_actions: list[SuggestedAction]
     maintenance_actions: list[SuggestedAction]
     maintenance_commands: list[MaintenanceCommand]
@@ -447,6 +467,7 @@ class BriefStateSnapshot:
     invalid_wiki_pages: list[InvalidWikiPageSnapshot]
     generated_review_task_count: int
     git_context: GitContext
+    handoff_current_state: HandoffCurrentState | None
     maintenance_goal: bool
 
 
@@ -471,6 +492,7 @@ class ProjectBrief:
     provisional_context: list[AuthorityBrief]
     git_context: GitContext
     next_actions: list[str]
+    handoff_current_state: HandoffCurrentState | None
 
 
 def build_project_brief(
@@ -508,6 +530,7 @@ def build_project_brief(
         provisional_context=_provisional_authority_briefs(snapshot.authority_briefs),
         git_context=snapshot.git_context,
         next_actions=next_actions,
+        handoff_current_state=snapshot.handoff_current_state,
     )
 
 
@@ -530,6 +553,7 @@ def build_suggest_next(
         latest_reports=snapshot.latest_reports,
         warnings=snapshot.warnings,
         git_context=snapshot.git_context,
+        handoff_current_state=snapshot.handoff_current_state,
         work_actions=work_actions,
         maintenance_actions=maintenance_actions,
         maintenance_commands=maintenance_commands,
@@ -592,6 +616,7 @@ def _collect_brief_state(
     git_context = _build_git_context(
         root, normalized_goal or None, include_git=include_git, since=since
     )
+    handoff_current_state = _handoff_current_state(root, git_context)
     return BriefStateSnapshot(
         root=root,
         goal=normalized_goal or None,
@@ -613,6 +638,7 @@ def _collect_brief_state(
         invalid_wiki_pages=invalid_wiki_pages,
         generated_review_task_count=generated_review_task_count,
         git_context=git_context,
+        handoff_current_state=handoff_current_state,
         maintenance_goal=maintenance_goal,
     )
 
@@ -1403,6 +1429,131 @@ def _build_git_context(
     )
 
 
+def _handoff_current_state(root: Path, git_context: GitContext) -> HandoffCurrentState | None:
+    planning_state = _combined_planning_state(root)
+    current_slice = planning_state.get("Current PR sub-slice")
+    if current_slice is None:
+        return None
+    next_slice, source_path = _next_ordered_roadmap_slice(
+        root,
+        current_slice,
+        fallback=planning_state.get("Next planned PR sub-slice"),
+    )
+    if next_slice is None or next_slice == current_slice:
+        return None
+    evidence = _completed_slice_evidence(root, current_slice, git_context)
+    if not evidence:
+        return None
+    return HandoffCurrentState(
+        current_slice=current_slice,
+        inferred_slice=next_slice,
+        evidence=evidence,
+        source_path=source_path,
+    )
+
+
+def _combined_planning_state(root: Path) -> dict[str, str]:
+    combined: dict[str, str] = {}
+    for relpath in (
+        ".agent-plan.md",
+        "README.md",
+        "docs/splendor_mvp_to_v1_roadmap.md",
+    ):
+        path = root / relpath
+        if not path.is_file():
+            continue
+        values = _parse_planning_state_text(path.read_text(encoding="utf-8"))
+        for label, value in values.items():
+            combined.setdefault(label, value)
+    return combined
+
+
+def _parse_planning_state_text(text: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for match in _PLANNING_STATE_PATTERN.finditer(text):
+        value = match.group("value").strip()
+        if value.startswith("`") and value.endswith("`"):
+            value = value[1:-1]
+        values[match.group("label")] = value
+    return values
+
+
+def _next_ordered_roadmap_slice(
+    root: Path, current_slice: str, *, fallback: str | None
+) -> tuple[str | None, str | None]:
+    candidates: list[tuple[str, Path]] = []
+    roadmap = root / "docs" / "splendor_mvp_to_v1_roadmap.md"
+    if roadmap.is_file():
+        candidates.append(("docs/splendor_mvp_to_v1_roadmap.md", roadmap))
+    for relpath in (".agent-plan.md", "README.md"):
+        path = root / relpath
+        if path.is_file():
+            candidates.append((relpath, path))
+    for relpath, path in candidates:
+        ordered = _ordered_slice_tokens(path.read_text(encoding="utf-8"))
+        for index, token in enumerate(ordered[:-1]):
+            if token == current_slice:
+                return ordered[index + 1], relpath
+    return fallback, None
+
+
+def _ordered_slice_tokens(text: str) -> list[str]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for match in _ROADMAP_SLICE_PATTERN.finditer(text):
+        token = match.group(0)
+        if token in seen:
+            continue
+        seen.add(token)
+        ordered.append(token)
+    return ordered
+
+
+def _completed_slice_evidence(root: Path, current_slice: str, git_context: GitContext) -> list[str]:
+    evidence: list[str] = []
+    if git_context.enabled and git_context.available:
+        for ref in _mainline_refs_for_completion(root, git_context):
+            subject = _git_output(
+                root,
+                ["log", "--first-parent", "--max-count=60", "--pretty=format:%s%n%b", ref],
+                required=False,
+            )
+            if subject and _text_mentions_slice(subject, current_slice):
+                evidence.append(f"mainline git history at {ref} mentions {current_slice}")
+                break
+        for thread in git_context.threads:
+            if thread.kind != "pr" or thread.state not in {"merged", "closed"}:
+                continue
+            if _text_mentions_slice(thread.title, current_slice):
+                evidence.append(
+                    f"GitHub PR #{thread.number} is {thread.state} and mentions {current_slice}"
+                )
+                break
+    return evidence
+
+
+def _mainline_refs_for_completion(root: Path, git_context: GitContext) -> list[str]:
+    refs = [
+        git_context.base_ref,
+        "origin/main",
+        "main",
+        "HEAD" if git_context.branch == "main" else None,
+    ]
+    resolved: list[str] = []
+    for ref in refs:
+        if ref is None or ref in resolved:
+            continue
+        if _git_output(root, ["rev-parse", "--verify", f"{ref}^{{commit}}"], required=False):
+            resolved.append(ref)
+    return resolved
+
+
+def _text_mentions_slice(text: str, slice_id: str) -> bool:
+    return (
+        re.search(rf"(?<![A-Za-z0-9_.-]){re.escape(slice_id)}(?![A-Za-z0-9_.-])", text) is not None
+    )
+
+
 def _git_output(root: Path, args: list[str], *, required: bool = True) -> str | None:
     result = subprocess.run(
         ["git", *args],
@@ -1970,6 +2121,28 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
                     goal_tokens, goal_phrase=goal_phrase, high_text=path
                 ),
             )
+    if snapshot.handoff_current_state is not None:
+        state = snapshot.handoff_current_state
+        evidence = "; ".join(state.evidence)
+        source_note = f" Ordered roadmap source: {state.source_path}." if state.source_path else ""
+        add(
+            "high",
+            "current-state",
+            f"Continue {state.inferred_slice} after completed {state.current_slice}",
+            (
+                f"Planning state still names {state.current_slice}, but {evidence}; "
+                f"advance handoff to {state.inferred_slice}.{source_note}"
+            ),
+            None,
+            record_id=state.inferred_slice,
+            relevance_score=_goal_relevance_score(
+                goal_tokens,
+                goal_phrase=goal_phrase,
+                high_text=" ".join([state.inferred_slice, state.current_slice]),
+                medium_text=evidence,
+            )
+            + 120,
+        )
 
     for item in snapshot.freshness.sources:
         source = item.source
@@ -2356,6 +2529,9 @@ def render_suggest_next_json(result: SuggestNextResult) -> str:
                 },
             },
             "git_context": asdict(result.git_context),
+            "handoff_current_state": (
+                asdict(result.handoff_current_state) if result.handoff_current_state else None
+            ),
             "status": {
                 "source_total": result.status.source_total,
                 "page_total": result.status.page_total,
@@ -2408,6 +2584,9 @@ def render_project_brief_json(brief: ProjectBrief) -> str:
             "last_query": asdict(brief.last_query) if brief.last_query else None,
             "warnings": [asdict(warning) for warning in brief.warnings],
             "git_context": asdict(brief.git_context),
+            "handoff_current_state": (
+                asdict(brief.handoff_current_state) if brief.handoff_current_state else None
+            ),
             "suggested_actions": [asdict(action) for action in brief.suggested_actions],
             "work_context": {"actions": [asdict(action) for action in brief.work_actions]},
             "maintenance_context": {
@@ -2444,6 +2623,9 @@ def render_agent_context_json(brief: ProjectBrief) -> str:
             },
             "source_refs": _agent_context_source_refs(brief),
             "git_context": asdict(brief.git_context),
+            "handoff_current_state": (
+                asdict(brief.handoff_current_state) if brief.handoff_current_state else None
+            ),
             "suggested_actions": [asdict(action) for action in brief.suggested_actions],
             "work_context": {"actions": [asdict(action) for action in brief.work_actions]},
             "maintenance_context": {

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -51,6 +51,7 @@ _SUGGESTION_LIMIT = 8
 _GIT_CONTEXT_LIMIT = 5
 _GIT_FILE_LIMIT = 8
 _GIT_COMMAND_TIMEOUT_SECONDS = 5
+_HANDOFF_COMPLETION_COMMIT_LIMIT = 12
 _PROMOTED_THREAD_RELEVANCE_FLOOR = 60
 _SUGGESTION_CATEGORY_LIMITS = {
     "work-thread": 4,
@@ -1505,9 +1506,7 @@ def _roadmap_sequence_blocks(text: str) -> list[str]:
     while index < len(lines):
         line = lines[index]
         normalized = line.lower()
-        is_sequence_intro = (
-            "remaining" in normalized and "sequence" in normalized and line.rstrip().endswith(":")
-        )
+        is_sequence_intro = _is_roadmap_sequence_intro(normalized)
         is_slice_list_heading = line.startswith("### ") and any(
             phrase in normalized for phrase in ("planned pr slices", "current pr sub-slices")
         )
@@ -1516,22 +1515,25 @@ def _roadmap_sequence_blocks(text: str) -> list[str]:
             continue
 
         block_lines = [line]
+        if is_sequence_intro and _has_multiple_slice_tokens(line):
+            blocks.append(line)
+            index += 1
+            continue
         index += 1
+        list_started = False
         while index < len(lines):
             next_line = lines[index]
             if next_line.startswith("#") and block_lines:
                 break
             if not next_line.strip():
-                if any(_ROADMAP_SLICE_PATTERN.search(item) for item in block_lines):
-                    break
                 block_lines.append(next_line)
                 index += 1
                 continue
-            if (
-                block_lines
-                and any(_ROADMAP_SLICE_PATTERN.search(item) for item in block_lines)
-                and not next_line.lstrip().startswith(("-", "*", "1."))
-            ):
+            stripped = next_line.lstrip()
+            is_list_line = stripped.startswith(("-", "*")) or re.match(r"\d+\.", stripped)
+            if is_list_line:
+                list_started = True
+            elif list_started or any(_ROADMAP_SLICE_PATTERN.search(item) for item in block_lines):
                 break
             block_lines.append(next_line)
             index += 1
@@ -1539,30 +1541,30 @@ def _roadmap_sequence_blocks(text: str) -> list[str]:
     return blocks
 
 
+def _is_roadmap_sequence_intro(normalized_line: str) -> bool:
+    return (
+        "remaining" in normalized_line
+        and "sequence" in normalized_line
+        and "no ordered" not in normalized_line
+        and "no remaining" not in normalized_line
+    )
+
+
+def _has_multiple_slice_tokens(text: str) -> bool:
+    tokens = {match.group(0) for match in _ROADMAP_SLICE_PATTERN.finditer(text)}
+    return len(tokens) >= 2
+
+
 def _completed_slice_evidence(root: Path, current_slice: str, git_context: GitContext) -> list[str]:
     evidence: list[str] = []
     if git_context.enabled and git_context.available:
         for ref in _mainline_refs_for_completion(root, git_context):
-            subject = _git_output(root, ["log", "-1", "--pretty=format:%s", ref], required=False)
-            if not subject or not _text_starts_with_slice(subject, current_slice):
-                continue
-            path_output = (
-                _git_output(
-                    root,
-                    ["show", "--pretty=format:", "--name-only", ref, "--"],
-                    required=False,
-                )
-                or ""
-            )
-            implementation_paths = [
-                path
-                for path in path_output.splitlines()
-                if path.strip() and not _is_planning_only_path(path.strip())
-            ]
-            if implementation_paths:
+            boundary = _mainline_slice_boundary(root, ref, current_slice)
+            if boundary is not None:
+                _sha, subject, implementation_paths = boundary
                 sample = ", ".join(sorted(implementation_paths)[:3])
                 evidence.append(
-                    f"mainline head at {ref} is {current_slice} with implementation "
+                    f"mainline history at {ref} includes {subject!r} with implementation "
                     f"changes: {sample}"
                 )
                 break
@@ -1577,6 +1579,48 @@ def _completed_slice_evidence(root: Path, current_slice: str, git_context: GitCo
                 )
                 break
     return evidence
+
+
+def _mainline_slice_boundary(
+    root: Path, ref: str, current_slice: str
+) -> tuple[str, str, list[str]] | None:
+    output = _git_output(
+        root,
+        [
+            "log",
+            "--first-parent",
+            f"--max-count={_HANDOFF_COMPLETION_COMMIT_LIMIT}",
+            "--pretty=format:%H%x1f%s%x1e",
+            ref,
+        ],
+        required=False,
+    )
+    for entry in (output or "").split("\x1e"):
+        stripped = entry.strip()
+        if not stripped:
+            continue
+        parts = stripped.split("\x1f", 1)
+        if len(parts) != 2:
+            continue
+        sha, subject = parts
+        if not _text_starts_with_slice(subject, current_slice):
+            continue
+        paths = _commit_implementation_paths(root, sha)
+        if paths:
+            return sha, subject, paths
+    return None
+
+
+def _commit_implementation_paths(root: Path, sha: str) -> list[str]:
+    path_output = (
+        _git_output(root, ["show", "--pretty=format:", "--name-only", sha, "--"], required=False)
+        or ""
+    )
+    return [
+        path
+        for path in path_output.splitlines()
+        if path.strip() and not _is_planning_only_path(path.strip())
+    ]
 
 
 def _mainline_refs_for_completion(root: Path, git_context: GitContext) -> list[str]:

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -1434,11 +1434,7 @@ def _handoff_current_state(root: Path, git_context: GitContext) -> HandoffCurren
     current_slice = planning_state.get("Current PR sub-slice")
     if current_slice is None:
         return None
-    next_slice, source_path = _next_ordered_roadmap_slice(
-        root,
-        current_slice,
-        fallback=planning_state.get("Next planned PR sub-slice"),
-    )
+    next_slice, source_path = _next_ordered_roadmap_slice(root, current_slice)
     if next_slice is None or next_slice == current_slice:
         return None
     evidence = _completed_slice_evidence(root, current_slice, git_context)
@@ -1478,53 +1474,104 @@ def _parse_planning_state_text(text: str) -> dict[str, str]:
     return values
 
 
-def _next_ordered_roadmap_slice(
-    root: Path, current_slice: str, *, fallback: str | None
-) -> tuple[str | None, str | None]:
-    candidates: list[tuple[str, Path]] = []
+def _next_ordered_roadmap_slice(root: Path, current_slice: str) -> tuple[str | None, str | None]:
     roadmap = root / "docs" / "splendor_mvp_to_v1_roadmap.md"
     if roadmap.is_file():
-        candidates.append(("docs/splendor_mvp_to_v1_roadmap.md", roadmap))
-    for relpath in (".agent-plan.md", "README.md"):
-        path = root / relpath
-        if path.is_file():
-            candidates.append((relpath, path))
-    for relpath, path in candidates:
-        ordered = _ordered_slice_tokens(path.read_text(encoding="utf-8"))
+        relpath = "docs/splendor_mvp_to_v1_roadmap.md"
+        ordered = _ordered_roadmap_sequence_tokens(roadmap.read_text(encoding="utf-8"))
         for index, token in enumerate(ordered[:-1]):
             if token == current_slice:
                 return ordered[index + 1], relpath
-    return fallback, None
+    return None, None
 
 
-def _ordered_slice_tokens(text: str) -> list[str]:
+def _ordered_roadmap_sequence_tokens(text: str) -> list[str]:
     ordered: list[str] = []
     seen: set[str] = set()
-    for match in _ROADMAP_SLICE_PATTERN.finditer(text):
-        token = match.group(0)
-        if token in seen:
-            continue
-        seen.add(token)
-        ordered.append(token)
+    for block in _roadmap_sequence_blocks(text):
+        for match in _ROADMAP_SLICE_PATTERN.finditer(block):
+            token = match.group(0)
+            if token in seen:
+                continue
+            seen.add(token)
+            ordered.append(token)
     return ordered
+
+
+def _roadmap_sequence_blocks(text: str) -> list[str]:
+    lines = text.splitlines()
+    blocks: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        normalized = line.lower()
+        is_sequence_intro = (
+            "remaining" in normalized and "sequence" in normalized and line.rstrip().endswith(":")
+        )
+        is_slice_list_heading = line.startswith("### ") and any(
+            phrase in normalized for phrase in ("planned pr slices", "current pr sub-slices")
+        )
+        if not is_sequence_intro and not is_slice_list_heading:
+            index += 1
+            continue
+
+        block_lines = [line]
+        index += 1
+        while index < len(lines):
+            next_line = lines[index]
+            if next_line.startswith("#") and block_lines:
+                break
+            if not next_line.strip():
+                if any(_ROADMAP_SLICE_PATTERN.search(item) for item in block_lines):
+                    break
+                block_lines.append(next_line)
+                index += 1
+                continue
+            if (
+                block_lines
+                and any(_ROADMAP_SLICE_PATTERN.search(item) for item in block_lines)
+                and not next_line.lstrip().startswith(("-", "*", "1."))
+            ):
+                break
+            block_lines.append(next_line)
+            index += 1
+        blocks.append("\n".join(block_lines))
+    return blocks
 
 
 def _completed_slice_evidence(root: Path, current_slice: str, git_context: GitContext) -> list[str]:
     evidence: list[str] = []
     if git_context.enabled and git_context.available:
         for ref in _mainline_refs_for_completion(root, git_context):
-            subject = _git_output(
-                root,
-                ["log", "--first-parent", "--max-count=60", "--pretty=format:%s%n%b", ref],
-                required=False,
+            subject = _git_output(root, ["log", "-1", "--pretty=format:%s", ref], required=False)
+            if not subject or not _text_starts_with_slice(subject, current_slice):
+                continue
+            path_output = (
+                _git_output(
+                    root,
+                    ["show", "--pretty=format:", "--name-only", ref, "--"],
+                    required=False,
+                )
+                or ""
             )
-            if subject and _text_mentions_slice(subject, current_slice):
-                evidence.append(f"mainline git history at {ref} mentions {current_slice}")
+            implementation_paths = [
+                path
+                for path in path_output.splitlines()
+                if path.strip() and not _is_planning_only_path(path.strip())
+            ]
+            if implementation_paths:
+                sample = ", ".join(sorted(implementation_paths)[:3])
+                evidence.append(
+                    f"mainline head at {ref} is {current_slice} with implementation "
+                    f"changes: {sample}"
+                )
                 break
+        if not evidence:
+            return evidence
         for thread in git_context.threads:
             if thread.kind != "pr" or thread.state not in {"merged", "closed"}:
                 continue
-            if _text_mentions_slice(thread.title, current_slice):
+            if _text_starts_with_slice(thread.title, current_slice):
                 evidence.append(
                     f"GitHub PR #{thread.number} is {thread.state} and mentions {current_slice}"
                 )
@@ -1548,9 +1595,15 @@ def _mainline_refs_for_completion(root: Path, git_context: GitContext) -> list[s
     return resolved
 
 
-def _text_mentions_slice(text: str, slice_id: str) -> bool:
+def _text_starts_with_slice(text: str, slice_id: str) -> bool:
+    return re.match(rf"^\s*{re.escape(slice_id)}(?![A-Za-z0-9_.-])", text) is not None
+
+
+def _is_planning_only_path(path: str) -> bool:
     return (
-        re.search(rf"(?<![A-Za-z0-9_.-]){re.escape(slice_id)}(?![A-Za-z0-9_.-])", text) is not None
+        path in {".agent-plan.md", "AGENTS.md", "README.md"}
+        or path.startswith("docs/")
+        or path.startswith("planning/")
     )
 
 

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2246,6 +2246,8 @@ def test_agent_context_advances_stale_current_slice_after_main_merge(
     tmp_path: Path, capsys, monkeypatch
 ) -> None:
     initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path, repo="HeOCR/hocrgen")
+    _commit_all(tmp_path, "Initial hocrgen workspace")
     (tmp_path / ".agent-plan.md").write_text(
         "# Agent Plan\n\n- Current PR sub-slice: `F3b`\n- Next planned PR sub-slice: `F4c`\n",
         encoding="utf-8",
@@ -2260,10 +2262,17 @@ def test_agent_context_advances_stale_current_slice_after_main_merge(
     docs = tmp_path / "docs"
     docs.mkdir(exist_ok=True)
     (docs / "splendor_mvp_to_v1_roadmap.md").write_text(
-        "# Roadmap\n\nRemaining sequence: `F3b`, `F4c`, `F5a`.\n",
+        "# Roadmap\n\n"
+        "Historical note: `F3b` once followed `F3a`.\n\n"
+        "The remaining hocrgen sequence is therefore:\n\n"
+        "- `F3b` completed operator intake manifests.\n"
+        "- `F4c` is the next adoption slice.\n"
+        "- `F5a` follows later.\n",
         encoding="utf-8",
     )
-    _init_git_repo(tmp_path, repo="HeOCR/hocrgen")
+    implementation = tmp_path / "src" / "hocrgen" / "intake.py"
+    implementation.parent.mkdir(parents=True)
+    implementation.write_text("INTAKE_READY = True\n", encoding="utf-8")
     _commit_all(tmp_path, "F3b: Typed repo-tracked operator intake manifests")
     _install_fake_gh(
         tmp_path,
@@ -2336,6 +2345,137 @@ def test_agent_context_advances_stale_current_slice_after_main_merge(
         assert payload["work_context"]["actions"][0]["category"] == "current-state"
         assert "F4c" in payload["work_context"]["actions"][0]["title"]
     assert "Continue F4c after completed F3b" in out
+
+
+def test_agent_context_does_not_advance_for_docs_only_planning_intake(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path, repo="HeOCR/hocrgen")
+    _commit_all(tmp_path, "Initial hocrgen workspace")
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n- Current PR sub-slice: `F3b`\n- Next planned PR sub-slice: `F4c`\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "splendor_mvp_to_v1_roadmap.md").write_text(
+        "# Roadmap\n\n"
+        "The remaining hocrgen sequence is therefore:\n\n"
+        "- `F3b` implementation.\n"
+        "- `F4c` adoption follow-up.\n",
+        encoding="utf-8",
+    )
+    _commit_all(tmp_path, "F3b: Planning intake for operator manifests")
+    _install_fake_gh(
+        tmp_path,
+        monkeypatch,
+        issues=[],
+        prs=[
+            {
+                "number": 61,
+                "title": "F3b: Planning intake for operator manifests",
+                "url": "https://github.com/HeOCR/hocrgen/pull/61",
+                "body": "Records the F3b implementation plan.",
+                "state": "merged",
+                "isDraft": False,
+                "mergedAt": "2026-05-06T07:14:00Z",
+                "labels": [{"name": "area/docs"}],
+            }
+        ],
+    )
+    capsys.readouterr()
+
+    brief_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "Resume",
+            "hocrgen",
+            "after",
+            "F3b",
+            "--json",
+        ]
+    )
+    brief_payload = json.loads(capsys.readouterr().out)
+    suggest_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "Resume",
+            "hocrgen",
+            "after",
+            "F3b",
+            "--json",
+        ]
+    )
+    suggest_payload = json.loads(capsys.readouterr().out)
+
+    assert brief_exit == 0
+    assert suggest_exit == 0
+    assert brief_payload["handoff_current_state"] is None
+    assert suggest_payload["handoff_current_state"] is None
+
+
+def test_agent_context_does_not_use_stale_next_slice_without_ordered_roadmap(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path, repo="HeOCR/hocrgen")
+    _commit_all(tmp_path, "Initial hocrgen workspace")
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n- Current PR sub-slice: `F3b`\n- Next planned PR sub-slice: `F4c`\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "splendor_mvp_to_v1_roadmap.md").write_text(
+        "# Roadmap\n\n`F3b` and `F4c` are mentioned here, but no ordered remaining sequence.\n",
+        encoding="utf-8",
+    )
+    implementation = tmp_path / "src" / "hocrgen" / "intake.py"
+    implementation.parent.mkdir(parents=True)
+    implementation.write_text("INTAKE_READY = True\n", encoding="utf-8")
+    _commit_all(tmp_path, "F3b: Typed repo-tracked operator intake manifests")
+    _install_fake_gh(
+        tmp_path,
+        monkeypatch,
+        issues=[],
+        prs=[
+            {
+                "number": 63,
+                "title": "F3b: Typed repo-tracked operator intake manifests",
+                "url": "https://github.com/HeOCR/hocrgen/pull/63",
+                "body": "Merged F3b.",
+                "state": "merged",
+                "isDraft": False,
+                "mergedAt": "2026-05-06T07:14:00Z",
+                "labels": [],
+            }
+        ],
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "Resume",
+            "hocrgen",
+            "after",
+            "F3b",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["handoff_current_state"] is None
 
 
 def test_agent_context_preserves_non_stale_current_slice(

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2342,9 +2342,162 @@ def test_agent_context_advances_stale_current_slice_after_main_merge(
         assert state["current_slice"] == "F3b"
         assert state["inferred_slice"] == "F4c"
         assert any("F3b" in item for item in state["evidence"])
-        assert payload["work_context"]["actions"][0]["category"] == "current-state"
-        assert "F4c" in payload["work_context"]["actions"][0]["title"]
+        current_state_actions = [
+            action
+            for action in payload["work_context"]["actions"]
+            if action["category"] == "current-state"
+        ]
+        assert len(current_state_actions) == 1
+        assert current_state_actions[0]["rank"] == 1
+        assert "F4c" in current_state_actions[0]["title"]
     assert "Continue F4c after completed F3b" in out
+
+
+def test_agent_context_accepts_single_line_remaining_sequence(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path, repo="HeOCR/hocrgen")
+    _commit_all(tmp_path, "Initial hocrgen workspace")
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n- Current PR sub-slice: `F3b`\n- Next planned PR sub-slice: `F4c`\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "splendor_mvp_to_v1_roadmap.md").write_text(
+        "# Roadmap\n\nThe remaining hocrgen sequence is therefore: `F3b`, `F4c`, `F5a`.\n",
+        encoding="utf-8",
+    )
+    implementation = tmp_path / "src" / "hocrgen" / "intake.py"
+    implementation.parent.mkdir(parents=True)
+    implementation.write_text("INTAKE_READY = True\n", encoding="utf-8")
+    _commit_all(tmp_path, "F3b: Typed repo-tracked operator intake manifests")
+    _install_fake_gh(tmp_path, monkeypatch, issues=[], prs=[])
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "Resume",
+            "hocrgen",
+            "after",
+            "F3b",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["handoff_current_state"]["inferred_slice"] == "F4c"
+
+
+def test_agent_context_accepts_sequence_lists_with_blank_lines(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path, repo="HeOCR/hocrgen")
+    _commit_all(tmp_path, "Initial hocrgen workspace")
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n- Current PR sub-slice: `F3b`\n- Next planned PR sub-slice: `F4c`\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "splendor_mvp_to_v1_roadmap.md").write_text(
+        "# Roadmap\n\n"
+        "The remaining hocrgen sequence is therefore:\n\n"
+        "- `F3b` completed operator intake manifests.\n\n"
+        "- `F4c` is the next adoption slice.\n\n"
+        "- `F5a` follows later.\n",
+        encoding="utf-8",
+    )
+    implementation = tmp_path / "src" / "hocrgen" / "intake.py"
+    implementation.parent.mkdir(parents=True)
+    implementation.write_text("INTAKE_READY = True\n", encoding="utf-8")
+    _commit_all(tmp_path, "F3b: Typed repo-tracked operator intake manifests")
+    _install_fake_gh(tmp_path, monkeypatch, issues=[], prs=[])
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "Resume",
+            "hocrgen",
+            "after",
+            "F3b",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["handoff_current_state"]["inferred_slice"] == "F4c"
+
+
+def test_agent_context_scans_recent_mainline_for_slice_boundary(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path, repo="HeOCR/hocrgen")
+    _commit_all(tmp_path, "Initial hocrgen workspace")
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n- Current PR sub-slice: `F3b`\n- Next planned PR sub-slice: `F4c`\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "splendor_mvp_to_v1_roadmap.md").write_text(
+        "# Roadmap\n\nThe remaining hocrgen sequence is therefore: `F3b`, `F4c`.\n",
+        encoding="utf-8",
+    )
+    implementation = tmp_path / "src" / "hocrgen" / "intake.py"
+    implementation.parent.mkdir(parents=True)
+    implementation.write_text("INTAKE_READY = True\n", encoding="utf-8")
+    _commit_all(tmp_path, "F3b: Typed repo-tracked operator intake manifests")
+    (tmp_path / "notes.txt").write_text("follow-up note\n", encoding="utf-8")
+    _commit_all(tmp_path, "Merge pull request #63 from feature/f3b")
+    _install_fake_gh(
+        tmp_path,
+        monkeypatch,
+        issues=[],
+        prs=[
+            {
+                "number": 63,
+                "title": "F3b: Typed repo-tracked operator intake manifests",
+                "url": "https://github.com/HeOCR/hocrgen/pull/63",
+                "body": "Merged F3b.",
+                "state": "merged",
+                "isDraft": False,
+                "mergedAt": "2026-05-06T07:14:00Z",
+                "labels": [],
+            }
+        ],
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "Resume",
+            "hocrgen",
+            "after",
+            "F3b",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["handoff_current_state"]["inferred_slice"] == "F4c"
 
 
 def test_agent_context_does_not_advance_for_docs_only_planning_intake(

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2242,6 +2242,173 @@ def test_agent_context_hocrgen_retry_bar_ranks_current_planning_before_history(
     assert out.index("Active planning:") < out.index("Splendor maintenance:")
 
 
+def test_agent_context_advances_stale_current_slice_after_main_merge(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n- Current PR sub-slice: `F3b`\n- Next planned PR sub-slice: `F4c`\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "# hocrgen\n\n"
+        "What Comes Next\n\n"
+        "- Current PR sub-slice: `F3b`\n"
+        "- Next planned PR sub-slice: `F4c`\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "splendor_mvp_to_v1_roadmap.md").write_text(
+        "# Roadmap\n\nRemaining sequence: `F3b`, `F4c`, `F5a`.\n",
+        encoding="utf-8",
+    )
+    _init_git_repo(tmp_path, repo="HeOCR/hocrgen")
+    _commit_all(tmp_path, "F3b: Typed repo-tracked operator intake manifests")
+    _install_fake_gh(
+        tmp_path,
+        monkeypatch,
+        issues=[],
+        prs=[
+            {
+                "number": 63,
+                "title": "F3b: Typed repo-tracked operator intake manifests",
+                "url": "https://github.com/HeOCR/hocrgen/pull/63",
+                "body": "Merged F3b. Next roadmap work is F4c.",
+                "state": "merged",
+                "isDraft": False,
+                "mergedAt": "2026-05-06T07:14:00Z",
+                "labels": [],
+            }
+        ],
+    )
+    capsys.readouterr()
+
+    brief_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "Resume",
+            "hocrgen",
+            "after",
+            "F3b",
+            "--json",
+        ]
+    )
+    brief_payload = json.loads(capsys.readouterr().out)
+    suggest_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "Resume",
+            "hocrgen",
+            "after",
+            "F3b",
+            "--json",
+        ]
+    )
+    suggest_payload = json.loads(capsys.readouterr().out)
+    text_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "Resume",
+            "hocrgen",
+            "after",
+            "F3b",
+        ]
+    )
+    out = capsys.readouterr().out
+
+    assert brief_exit == 0
+    assert suggest_exit == 0
+    assert text_exit == 0
+    for payload in (brief_payload, suggest_payload):
+        state = payload["handoff_current_state"]
+        assert state["current_slice"] == "F3b"
+        assert state["inferred_slice"] == "F4c"
+        assert any("F3b" in item for item in state["evidence"])
+        assert payload["work_context"]["actions"][0]["category"] == "current-state"
+        assert "F4c" in payload["work_context"]["actions"][0]["title"]
+    assert "Continue F4c after completed F3b" in out
+
+
+def test_agent_context_preserves_non_stale_current_slice(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n- Current PR sub-slice: `S4d`\n- Next planned PR sub-slice: `S5a`\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "splendor_mvp_to_v1_roadmap.md").write_text(
+        "# Roadmap\n\nRemaining sequence: `S4c`, `S4d`, `S5a`.\n",
+        encoding="utf-8",
+    )
+    _init_git_repo(tmp_path, repo="DataHackIL/hocrsyngen")
+    _commit_all(tmp_path, "S4c: Previous merged synth handoff")
+    _install_fake_gh(
+        tmp_path,
+        monkeypatch,
+        issues=[],
+        prs=[
+            {
+                "number": 42,
+                "title": "S4c: Previous merged synth handoff",
+                "url": "https://github.com/DataHackIL/hocrsyngen/pull/42",
+                "body": "Merged S4c. S4d remains next.",
+                "state": "merged",
+                "isDraft": False,
+                "mergedAt": "2026-05-06T07:14:00Z",
+                "labels": [],
+            }
+        ],
+    )
+    capsys.readouterr()
+
+    brief_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "Resume",
+            "hocrsyngen",
+            "S4d",
+            "--json",
+        ]
+    )
+    brief_payload = json.loads(capsys.readouterr().out)
+    suggest_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "Resume",
+            "hocrsyngen",
+            "S4d",
+            "--json",
+        ]
+    )
+    suggest_payload = json.loads(capsys.readouterr().out)
+
+    assert brief_exit == 0
+    assert suggest_exit == 0
+    assert brief_payload["handoff_current_state"] is None
+    assert suggest_payload["handoff_current_state"] is None
+    assert "current-state" not in {
+        action["category"] for action in brief_payload["suggested_actions"]
+    }
+    assert "current-state" not in {action["category"] for action in suggest_payload["actions"]}
+
+
 def test_agent_context_hocrgen_retry_bar_uses_provisional_uncurated_authority(
     tmp_path: Path, capsys
 ) -> None:


### PR DESCRIPTION
## Summary

- Add completion-aware handoff current-state inference shared by `brief --agent-context` and `suggest-next`.
- Reconcile structured planning-state files with ordered roadmap slices, mainline git history, and merged PR title evidence so stale current slices advance to the next open slice.
- Expose inferred state in JSON via `handoff_current_state` and promote the inferred next slice as work context while keeping maintenance state in its separate maintenance block.
- Synchronize M19 planning state from completed `M19-P5.2` to current `M19-P6.1`, with `M19-P7.1` next.

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

## Notes

- Preserves the M18 work-first handoff separation: completion-aware current-state inference is a work action, while source freshness, queue cleanup, wiki review, and PR-summary guidance remain in maintenance context.
- Does not implement the M19-P7.1 breadth/policy-citation expansion or the M19-P8.1 cold-start/PATH-safe git lookup work.