### PR TITLE
M19-P7.1: Handoff breadth and policy-cited implementation surfacing

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M19-P5.2`
-- Last action taken: `M19-P5.2` was squash-merged into main as commit `b1128c8`,
-  fixing generated text integrity and manifest provenance drift.
-- Current planned slice: `M19 completion-aware current-state handoff inference`
-- Current PR sub-slice: `M19-P6.1`
+- Previous completed PR sub-slice: `M19-P6.1`
+- Last action taken: `M19-P6.1` was merged to main via PR #168, making handoff
+  inference completion-aware when stale planning docs still name completed work.
+- Current planned slice: `M19 handoff breadth and policy-cited implementation surfacing`
+- Current PR sub-slice: `M19-P7.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 handoff breadth and policy-cited implementation surfacing`
-- Next planned PR sub-slice: `M19-P7.1`
+- Next planned slice: `M19 cold-start adoption and PATH-safe git lookup`
+- Next planned PR sub-slice: `M19-P8.1`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -323,12 +323,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M19-P5.2`
-- Current planned slice: `M19 completion-aware current-state handoff inference`
-- Current PR sub-slice: `M19-P6.1`
+- Previous completed PR sub-slice: `M19-P6.1`
+- Current planned slice: `M19 handoff breadth and policy-cited implementation surfacing`
+- Current PR sub-slice: `M19-P7.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 handoff breadth and policy-cited implementation surfacing`
-- Next planned PR sub-slice: `M19-P7.1`
+- Next planned slice: `M19 cold-start adoption and PATH-safe git lookup`
+- Next planned PR sub-slice: `M19-P8.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -648,3 +648,7 @@ after path repair plus ingest. `M19-P6.1` resumes handoff-inference work by maki
 `brief --agent-context` and `suggest-next` completion-aware when stale planning docs still name a
 slice already present in recent mainline implementation history and the roadmap names the
 next ordered slice.
+`M19-P7.1` broadens handoff context: promoted open work threads now pull in referenced open
+parent/sibling issues, and read-first files get deterministic boosts from implementation/test paths
+cited by surfaced authority docs while keeping maintenance actions in the separate maintenance
+block.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -354,12 +354,13 @@ Implemented fields:
   and rank the successor as the next work item. Stale `.agent-plan.md` or roadmap "current" text is
   still useful evidence, but it should be reconciled against merge state and explicit roadmap order
   before becoming the top suggested action.
-- Work-thread surfacing should preserve breadth. The JSON and human handoff can lead with the best
-  open issue or PR, but should also include a bounded set of related open parent/sibling threads
-  when goal terms, labels, issue references, or recent merged PR bodies connect them.
-- Files-to-read ranking may use high-authority path and symbol references as deterministic hints.
-  Paths and tests named by authority docs should rank above broad historical docs when they are
-  directly tied to the goal.
+- Work-thread surfacing preserves breadth. JSON and human handoff lead with the best open issue or
+  PR, and promoted open issues can pull in a bounded set of referenced open parent/sibling issue
+  threads so related work remains visible.
+- Files-to-read ranking uses surfaced authority-doc path references as deterministic hints.
+  Existing repo-relative implementation and test paths named by current/reviewed/PR-linked
+  authority docs can rank alongside recent git and GitHub paths when they are directly tied to the
+  goal.
 - Text-bearing PDF sources are routed through source-type dispatch during ingest. The source
   manifest keeps the same `source_ref`, `source_ref_kind`, and `storage_mode` contract as
   text-native sources, while extracted text artifacts are recorded in `derived_artifacts`.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -338,9 +338,11 @@ Implemented fields:
   deterministic `relevance_score` when available. Runtime authority entries also expose `origin`,
   `curation_state`, and `curation_commands`; provisional uncurated authority is repeated under
   `provisional_context` so agents can use it without confusing it for configured or curated source
-  authority. Maintenance context also exposes runtime-only command guidance and explanatory notes
-  so review-needed wiki state, missing synthesis, queue drift, source freshness, and generated
-  contradiction-review tasks stay discoverable without becoming default human planning records.
+  authority. Handoff JSON also exposes top-level `read_first_paths` so authority-cited files remain
+  visible even when git context is disabled or unavailable. Maintenance context also exposes
+  runtime-only command guidance and explanatory notes so review-needed wiki state, missing
+  synthesis, queue drift, source freshness, and generated contradiction-review tasks stay
+  discoverable without becoming default human planning records.
 - Suggested actions are derived from local git commits, best-effort read-only GitHub issue/PR
   context through `gh` when available, source freshness, queue operator state, invalid/stale/
   contested/review-needed wiki pages, ingested sources missing maintained synthesis follow-up,
@@ -356,7 +358,8 @@ Implemented fields:
   before becoming the top suggested action.
 - Work-thread surfacing preserves breadth. JSON and human handoff lead with the best open issue or
   PR, and promoted open issues can pull in a bounded set of referenced open parent/sibling issue
-  threads so related work remains visible.
+  threads, including referenced open issues fetched by number when they were outside the initial
+  open-issue list, so related work remains visible.
 - Files-to-read ranking uses surfaced authority-doc path references as deterministic hints.
   Existing repo-relative implementation and test paths named by current/reviewed/PR-linked
   authority docs can rank alongside recent git and GitHub paths when they are directly tied to the

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M19-P5.2`
-- Current planned slice: `M19 completion-aware current-state handoff inference`
-- Current PR sub-slice: `M19-P6.1`
+- Previous completed PR sub-slice: `M19-P6.1`
+- Current planned slice: `M19 handoff breadth and policy-cited implementation surfacing`
+- Current PR sub-slice: `M19-P7.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 handoff breadth and policy-cited implementation surfacing`
-- Next planned PR sub-slice: `M19-P7.1`
+- Next planned slice: `M19 cold-start adoption and PATH-safe git lookup`
+- Next planned PR sub-slice: `M19-P8.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1317,14 +1317,18 @@ gaps that should land before broader handoff inference work resumes: generated
 Evidence/Contradictions excerpts can leak control bytes into markdown/YAML, and path-repaired
 source manifests can keep stale `pipeline_version` provenance after ingest rewrites `last_run_id`.
 These stay under the `M19-P5` family because they are immediate post-v0.4 safety follow-ups for
-generated state integrity, while `M19-P6.1` remains the next handoff-inference feature slice.
+generated state integrity.
 
-`M19-P5.2` is now implemented on `main`, so the next active M19 handoff feature slice is
-`M19-P6.1`. This slice makes `brief --agent-context` and `suggest-next` reconcile stale dynamic
-planning state with a bounded ordered roadmap sequence and recent mainline implementation
-evidence, so a recently completed current slice advances to the next open roadmap item instead of
-remaining the top work recommendation. Merged PR state can corroborate the inference, but docs-only
-planning intake and arbitrary historical mentions do not advance current state by themselves.
+`M19-P6.1` is now implemented on `main`. It makes `brief --agent-context` and `suggest-next`
+reconcile stale dynamic planning state with a bounded ordered roadmap sequence and recent mainline
+implementation evidence, so a recently completed current slice advances to the next open roadmap
+item instead of remaining the top work recommendation. Merged PR state can corroborate the
+inference, but docs-only planning intake and arbitrary historical mentions do not advance current
+state by themselves.
+
+`M19-P7.1` is the active handoff-breadth slice. It broadens GitHub issue handoff from a single best
+open thread to a bounded set of related open parent/sibling issues and boosts implementation/test
+files explicitly named by surfaced authority docs in read-first file ranking.
 
 The remaining M19 sequence is therefore:
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1152,9 +1152,10 @@ Current implementation:
   GitHub issue/PR context through `gh` when available, read-first file paths, relevant matches,
   source refs, active planning records, ranked authority docs, clearly labeled provisional
   uncurated docs, recent sources/runs, maintenance reports, warnings, and ranked suggested actions.
-  JSON maintenance context also includes deterministic command guidance and notes for review-needed
-  wiki pages, missing synthesis follow-up, source freshness, queue drift, and generated review
-  tasks.
+  JSON includes top-level `read_first_paths` so authority-cited implementation/test files remain
+  visible even when git context is disabled or unavailable. JSON maintenance context also includes
+  deterministic command guidance and notes for review-needed wiki pages, missing synthesis
+  follow-up, source freshness, queue drift, and generated review tasks.
 - `splendor suggest-next [--since <ref>] [--no-git] [goal]` renders the ranked action subset
   directly. It is read-only and deterministic. For non-maintenance goals it ranks open work
   threads, recent git/PR context, task-relevant authority docs, active planning records, read-first
@@ -1199,8 +1200,9 @@ Current implementation:
   `1` through optional fields only.
 - Open work-thread surfacing is broad enough for agent handoff to show the best issue or PR first
   while retaining a bounded set of related open parent/sibling issues when a promoted open issue
-  names them by issue reference. This keeps a SynthBanshee-style active issue plus sibling/parent
-  work visible without vector search.
+  names them by issue reference. Handoff can fetch a bounded set of referenced open issues by
+  number when they are outside the initial open-issue list. This keeps a SynthBanshee-style active
+  issue plus sibling/parent work visible without vector search.
 - Files-to-read ranking treats surfaced authority-doc path references as implementation-surface
   hints. Existing repo-relative implementation and test paths named by ranked current/reviewed/
   PR-linked authority docs receive a deterministic boost without needing vector search.

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1197,12 +1197,13 @@ Current implementation:
   records. Accepted decision records are included as goal-relevant reviewed authority; superseded
   decisions are retained below current decisions as historical context. This extends schema version
   `1` through optional fields only.
-- Open work-thread surfacing should be broad enough for agent handoff. The top-ranked issue or PR
-  can remain first, but related open parent/sibling issues and review threads should remain visible
-  when they match the goal, labels, linked references, or recent merged PR context.
-- Files-to-read ranking should treat high-authority path and symbol references as implementation
-  surface hints. If authority docs name a concrete file, test, command, or symbol involved in the
-  requested work, that surface should receive a deterministic boost without needing vector search.
+- Open work-thread surfacing is broad enough for agent handoff to show the best issue or PR first
+  while retaining a bounded set of related open parent/sibling issues when a promoted open issue
+  names them by issue reference. This keeps a SynthBanshee-style active issue plus sibling/parent
+  work visible without vector search.
+- Files-to-read ranking treats surfaced authority-doc path references as implementation-surface
+  hints. Existing repo-relative implementation and test paths named by ranked current/reviewed/
+  PR-linked authority docs receive a deterministic boost without needing vector search.
 - Briefing is read-only and does not replace `splendor query`; query finds records, while briefing
   packages the surrounding project state needed to resume work.
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -2567,10 +2567,10 @@ def _print_agent_context(result: ProjectBrief) -> None:
             print("Recent commits:")
             for commit in result.git_context.commits[:3]:
                 print(f"- {commit.short_sha} score={commit.relevance_score}: {commit.subject}")
-        if result.git_context.read_first_paths:
-            print("Files to read first:")
-            for path in result.git_context.read_first_paths[:5]:
-                print(f"- {path}")
+    if result.read_first_paths:
+        print("Files to read first:")
+        for path in result.read_first_paths[:5]:
+            print(f"- {path}")
     if result.matches:
         print("Relevant matches:")
         for match in result.matches:

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -2558,7 +2558,7 @@ def _print_agent_context(result: ProjectBrief) -> None:
         promoted_threads = [thread for thread in result.git_context.threads if thread.promoted]
         if promoted_threads:
             print("Recent issues and PRs:")
-            for thread in promoted_threads[:3]:
+            for thread in promoted_threads[:5]:
                 print(
                     f"- {thread.kind} #{thread.number} [{thread.state}] "
                     f"score={thread.relevance_score}: {thread.title} ({thread.url})"

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -18,6 +18,7 @@ from splendor.schemas import (
     QuerySnapshot,
     SourceRecord,
 )
+from splendor.state.paths import resolve_workspace_path
 from splendor.state.query_snapshot import last_query_path_for
 from splendor.state.source_compat import canonical_source_ref
 from splendor.utils.planning import (
@@ -1986,6 +1987,10 @@ def _fetch_referenced_open_issue_threads(
             warnings.append(f"Could not run gh issue view {number}: {exc}")
             continue
         if result.returncode != 0:
+            message = (
+                result.stderr.strip() or result.stdout.strip() or f"gh issue view {number} failed"
+            )
+            warnings.append(f"gh issue view {number} failed: {message}")
             continue
         try:
             payload = json.loads(result.stdout or "{}")
@@ -2168,13 +2173,13 @@ def _is_existing_read_first_path(root: Path, path: str) -> bool:
 
 
 def _safe_existing_repo_file(root: Path, path: str) -> Path | None:
-    candidate = Path(path)
-    if candidate.is_absolute() or ".." in candidate.parts:
+    try:
+        resolved = resolve_workspace_path(root, path, context="Authority document")
+    except ValueError:
         return None
-    absolute = root / candidate
-    if not absolute.is_file():
+    if not resolved.is_file():
         return None
-    return absolute
+    return resolved
 
 
 def _recent_sources(sources: list[SourceRecord]) -> list[BriefSourceItem]:

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -47,10 +47,12 @@ _BRIEF_MATCH_LIMIT = 5
 _BRIEF_PLANNING_LIMIT = 8
 _BRIEF_SOURCE_LIMIT = 5
 _BRIEF_REPORT_COMMANDS = ("lint", "health")
-_SUGGESTION_LIMIT = 10
+_SUGGESTION_LIMIT = 8
+_MAINTENANCE_ACTION_LIMIT = 8
 _GIT_CONTEXT_LIMIT = 5
 _GIT_FILE_LIMIT = 8
 _AUTHORITY_READ_FIRST_LIMIT = 5
+_RELATED_THREAD_FETCH_LIMIT = 5
 _GIT_COMMAND_TIMEOUT_SECONDS = 5
 _HANDOFF_COMPLETION_COMMIT_LIMIT = 12
 _PROMOTED_THREAD_RELEVANCE_FLOOR = 60
@@ -400,6 +402,7 @@ class GitThreadBrief:
     summary: str
     relevance_score: int
     promoted: bool
+    related_to: int | None = None
 
 
 @dataclass(frozen=True)
@@ -439,6 +442,7 @@ class SuggestNextResult:
     latest_reports: list[BriefReportSnapshot]
     warnings: list[BriefWarning]
     git_context: GitContext
+    read_first_paths: list[str]
     handoff_current_state: HandoffCurrentState | None
     work_actions: list[SuggestedAction]
     maintenance_actions: list[SuggestedAction]
@@ -469,6 +473,7 @@ class BriefStateSnapshot:
     invalid_wiki_pages: list[InvalidWikiPageSnapshot]
     generated_review_task_count: int
     git_context: GitContext
+    read_first_paths: list[str]
     handoff_current_state: HandoffCurrentState | None
     maintenance_goal: bool
 
@@ -493,6 +498,7 @@ class ProjectBrief:
     maintenance_notes: list[str]
     provisional_context: list[AuthorityBrief]
     git_context: GitContext
+    read_first_paths: list[str]
     next_actions: list[str]
     handoff_current_state: HandoffCurrentState | None
 
@@ -501,8 +507,14 @@ def build_project_brief(
     root: Path, goal: str | None, *, include_git: bool = True, since: str | None = None
 ) -> ProjectBrief:
     snapshot = _collect_brief_state(root, goal, include_git=include_git, since=since)
-    suggested_actions = _ranked_suggestions(snapshot)
+    candidate_actions = _suggestion_candidates(snapshot)
+    suggested_actions = _finalize_suggestions(
+        candidate_actions, maintenance_goal=snapshot.maintenance_goal
+    )
     work_actions, maintenance_actions = _split_actions(suggested_actions)
+    maintenance_actions = _finalize_maintenance_actions(
+        candidate_actions, maintenance_goal=snapshot.maintenance_goal
+    )
     maintenance_commands, maintenance_notes = _maintenance_guidance(snapshot, maintenance_actions)
     next_actions = _next_actions(
         status=snapshot.status,
@@ -531,6 +543,7 @@ def build_project_brief(
         maintenance_notes=maintenance_notes,
         provisional_context=_provisional_authority_briefs(snapshot.authority_briefs),
         git_context=snapshot.git_context,
+        read_first_paths=snapshot.read_first_paths,
         next_actions=next_actions,
         handoff_current_state=snapshot.handoff_current_state,
     )
@@ -540,8 +553,12 @@ def build_suggest_next(
     root: Path, goal: str | None = None, *, include_git: bool = True, since: str | None = None
 ) -> SuggestNextResult:
     snapshot = _collect_brief_state(root, goal, include_git=include_git, since=since)
-    actions = _ranked_suggestions(snapshot)
+    candidate_actions = _suggestion_candidates(snapshot)
+    actions = _finalize_suggestions(candidate_actions, maintenance_goal=snapshot.maintenance_goal)
     work_actions, maintenance_actions = _split_actions(actions)
+    maintenance_actions = _finalize_maintenance_actions(
+        candidate_actions, maintenance_goal=snapshot.maintenance_goal
+    )
     maintenance_commands, maintenance_notes = _maintenance_guidance(snapshot, maintenance_actions)
     return SuggestNextResult(
         goal=snapshot.goal,
@@ -555,6 +572,7 @@ def build_suggest_next(
         latest_reports=snapshot.latest_reports,
         warnings=snapshot.warnings,
         git_context=snapshot.git_context,
+        read_first_paths=snapshot.read_first_paths,
         handoff_current_state=snapshot.handoff_current_state,
         work_actions=work_actions,
         maintenance_actions=maintenance_actions,
@@ -615,13 +633,17 @@ def _collect_brief_state(
     recent_runs = status.recent_runs
     latest_reports = _latest_reports(root, layout)
     last_query = _last_query(layout)
+    authority_read_first_scores = _authority_cited_read_first_paths(
+        root, authority_briefs, normalized_goal or None
+    )
     git_context = _build_git_context(
         root,
         normalized_goal or None,
         include_git=include_git,
         since=since,
-        authority_briefs=authority_briefs,
+        authority_read_first_scores=authority_read_first_scores,
     )
+    read_first_paths = _combined_read_first_paths(git_context, authority_read_first_scores)
     handoff_current_state = _handoff_current_state(root, git_context)
     return BriefStateSnapshot(
         root=root,
@@ -644,6 +666,7 @@ def _collect_brief_state(
         invalid_wiki_pages=invalid_wiki_pages,
         generated_review_task_count=generated_review_task_count,
         git_context=git_context,
+        read_first_paths=read_first_paths,
         handoff_current_state=handoff_current_state,
         maintenance_goal=maintenance_goal,
     )
@@ -1366,8 +1389,9 @@ def _build_git_context(
     *,
     include_git: bool,
     since: str | None,
-    authority_briefs: list[AuthorityBrief],
+    authority_read_first_scores: dict[str, int],
 ) -> GitContext:
+    authority_read_first_paths = _rank_read_first_scores(authority_read_first_scores)
     if not include_git:
         return GitContext(
             enabled=False,
@@ -1380,7 +1404,7 @@ def _build_git_context(
             repository=None,
             commits=[],
             threads=[],
-            read_first_paths=[],
+            read_first_paths=authority_read_first_paths,
             warnings=[],
         )
 
@@ -1398,7 +1422,7 @@ def _build_git_context(
             repository=None,
             commits=[],
             threads=[],
-            read_first_paths=[],
+            read_first_paths=authority_read_first_paths,
             warnings=["Not inside a git worktree."],
         )
 
@@ -1423,7 +1447,7 @@ def _build_git_context(
         warnings.extend(thread_warnings)
     else:
         warnings.append("GitHub remote repository could not be inferred from origin.")
-    read_first_paths = _read_first_paths(commits, threads, goal, root, authority_briefs)
+    read_first_paths = _read_first_paths(commits, threads, goal, authority_read_first_scores)
     return GitContext(
         enabled=True,
         available=True,
@@ -1845,49 +1869,22 @@ def _github_threads(
     goal_phrase = _normalize_goal_phrase(goal or "")
     thread_texts: list[tuple[GitThreadBrief, str]] = []
     for item in raw_threads:
-        title = str(item.get("title") or "")
-        body = str(item.get("body") or "")
-        url = str(item.get("url") or "")
-        number = item.get("number")
-        if not isinstance(number, int) or not title or not url:
+        parsed_thread = _git_thread_from_item(item, goal_tokens, goal_phrase)
+        if parsed_thread is None:
             continue
-        state = str(item.get("state") or "unknown").lower()
-        kind = str(item.get("kind") or "thread")
-        relevance_score = _goal_relevance_score(
-            goal_tokens,
-            goal_phrase=goal_phrase,
-            high_text=title,
-            medium_text=body,
-        )
-        summary = _one_line(body) or title
-        promoted = _promote_git_thread(
-            goal_tokens=goal_tokens,
-            relevance_score=relevance_score,
-            kind=kind,
-            text=" ".join([title, body]),
-        )
-        thread = GitThreadBrief(
-            kind=kind,
-            number=number,
-            title=title,
-            url=url,
-            state=state,
-            summary=summary,
-            relevance_score=relevance_score,
-            promoted=promoted,
-        )
-        thread_texts.append(
-            (
-                thread,
-                " ".join([title, body]),
-            )
-        )
+        thread_texts.append(parsed_thread)
+    related_thread_texts, related_warnings = _fetch_referenced_open_issue_threads(
+        root, repository, thread_texts, goal_tokens, goal_phrase
+    )
+    thread_texts.extend(related_thread_texts)
+    warnings.extend(related_warnings)
     threads = _promote_related_open_issue_threads(thread_texts)
     if goal_tokens:
         threads.sort(
             key=lambda item: (
                 item.state != "open",
                 not item.promoted,
+                item.related_to is not None,
                 -item.relevance_score,
                 item.kind != "issue",
                 item.number,
@@ -1896,6 +1893,116 @@ def _github_threads(
     else:
         threads.sort(key=lambda item: (item.state != "open", item.kind != "issue", item.number))
     return threads[:_GIT_CONTEXT_LIMIT], warnings
+
+
+def _git_thread_from_item(
+    item: dict[str, object], goal_tokens: set[str], goal_phrase: str
+) -> tuple[GitThreadBrief, str] | None:
+    title = str(item.get("title") or "")
+    body = str(item.get("body") or "")
+    url = str(item.get("url") or "")
+    number = item.get("number")
+    if not isinstance(number, int) or not title or not url:
+        return None
+    state = str(item.get("state") or "unknown").lower()
+    kind = str(item.get("kind") or "thread")
+    relevance_score = _goal_relevance_score(
+        goal_tokens,
+        goal_phrase=goal_phrase,
+        high_text=title,
+        medium_text=body,
+    )
+    summary = _one_line(body) or title
+    promoted = _promote_git_thread(
+        goal_tokens=goal_tokens,
+        relevance_score=relevance_score,
+        kind=kind,
+        text=" ".join([title, body]),
+    )
+    thread = GitThreadBrief(
+        kind=kind,
+        number=number,
+        title=title,
+        url=url,
+        state=state,
+        summary=summary,
+        relevance_score=relevance_score,
+        promoted=promoted,
+    )
+    return thread, " ".join([title, body])
+
+
+def _fetch_referenced_open_issue_threads(
+    root: Path,
+    repository: str,
+    thread_texts: list[tuple[GitThreadBrief, str]],
+    goal_tokens: set[str],
+    goal_phrase: str,
+) -> tuple[list[tuple[GitThreadBrief, str]], list[str]]:
+    existing_issue_numbers = {
+        thread.number for thread, _text in thread_texts if thread.kind == "issue"
+    }
+    referenced_numbers: list[int] = []
+    for thread, text in thread_texts:
+        if thread.kind != "issue" or thread.state != "open" or not thread.promoted:
+            continue
+        for number in sorted(_issue_numbers_in_text(text)):
+            if number in existing_issue_numbers or number in referenced_numbers:
+                continue
+            referenced_numbers.append(number)
+            if len(referenced_numbers) >= _RELATED_THREAD_FETCH_LIMIT:
+                break
+        if len(referenced_numbers) >= _RELATED_THREAD_FETCH_LIMIT:
+            break
+
+    warnings: list[str] = []
+    fetched: list[tuple[GitThreadBrief, str]] = []
+    for number in referenced_numbers:
+        command = [
+            "gh",
+            "issue",
+            "view",
+            str(number),
+            "--repo",
+            repository,
+            "--json",
+            "number,title,url,body,state,labels",
+        ]
+        try:
+            result = subprocess.run(
+                command,
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=_GIT_COMMAND_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            warnings.append(
+                f"Timed out after {_GIT_COMMAND_TIMEOUT_SECONDS}s running gh issue view {number}."
+            )
+            continue
+        except OSError as exc:
+            warnings.append(f"Could not run gh issue view {number}: {exc}")
+            continue
+        if result.returncode != 0:
+            continue
+        try:
+            payload = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            warnings.append(f"Could not parse gh issue view {number} output: {exc}")
+            continue
+        if not isinstance(payload, dict):
+            continue
+        parsed_thread = _git_thread_from_item(
+            {"kind": "issue", **payload}, goal_tokens, goal_phrase
+        )
+        if parsed_thread is None:
+            continue
+        thread, text = parsed_thread
+        if thread.state == "open":
+            fetched.append((thread, text))
+    return fetched, warnings
 
 
 def _promote_related_open_issue_threads(
@@ -1911,7 +2018,7 @@ def _promote_related_open_issue_threads(
         for thread, _text in thread_texts
         if thread.kind == "issue" and thread.state == "open" and thread.promoted
     }
-    related_numbers: dict[int, int] = {}
+    related_numbers: dict[int, tuple[int, int]] = {}
     for thread, text in thread_texts:
         if thread.number not in promoted_issue_numbers:
             continue
@@ -1919,18 +2026,23 @@ def _promote_related_open_issue_threads(
             related = threads_by_issue_number.get(number)
             if related is None or related.number == thread.number:
                 continue
-            related_numbers[number] = max(
-                related_numbers.get(number, 0),
-                max(thread.relevance_score - 5, _PROMOTED_THREAD_RELEVANCE_FLOOR),
+            related_score = max(
+                thread.relevance_score - 5,
+                _PROMOTED_THREAD_RELEVANCE_FLOOR + related.relevance_score,
             )
+            existing = related_numbers.get(number)
+            if existing is None or related_score > existing[0]:
+                related_numbers[number] = (related_score, thread.number)
     promoted: list[GitThreadBrief] = []
     for thread, _text in thread_texts:
-        related_score = related_numbers.get(thread.number)
-        if related_score is not None:
+        related = related_numbers.get(thread.number)
+        if related is not None:
+            related_score, related_to = related
             thread = replace(
                 thread,
                 promoted=True,
                 relevance_score=max(thread.relevance_score, related_score),
+                related_to=related_to,
                 summary=(
                     thread.summary
                     if thread.summary.startswith("Related to promoted issue")
@@ -1972,8 +2084,7 @@ def _read_first_paths(
     commits: list[GitCommitBrief],
     threads: list[GitThreadBrief],
     goal: str | None,
-    root: Path,
-    authority_briefs: list[AuthorityBrief],
+    authority_read_first_scores: dict[str, int],
 ) -> list[str]:
     goal_tokens = _tokens(goal or "")
     goal_phrase = _normalize_goal_phrase(goal or "")
@@ -1995,15 +2106,33 @@ def _read_first_paths(
             continue
         for path in _repo_paths_in_text(" ".join([thread.title, thread.summary])):
             scored[path] = max(scored.get(path, 0), thread.relevance_score + 20)
-    for path, score in _authority_cited_read_first_paths(root, authority_briefs, goal).items():
+    for path, score in authority_read_first_scores.items():
         scored[path] = max(scored.get(path, 0), score)
+    return _rank_read_first_scores(scored)
+
+
+def _rank_read_first_scores(scored: dict[str, int]) -> list[str]:
     ranked = sorted(scored, key=lambda path: (-scored[path], path))
     return ranked[:_GIT_FILE_LIMIT]
 
 
+def _combined_read_first_paths(
+    git_context: GitContext, authority_read_first_scores: dict[str, int]
+) -> list[str]:
+    if git_context.read_first_paths:
+        return git_context.read_first_paths
+    return _rank_read_first_scores(authority_read_first_scores)
+
+
 def _repo_paths_in_text(text: str) -> list[str]:
-    candidates = re.findall(r"(?<![\w/.-])(?:[\w.-]+/)+[\w.-]+(?:\.[A-Za-z0-9]+)?", text)
-    return sorted(dict.fromkeys(candidate.strip("`.,)") for candidate in candidates))
+    candidates = re.findall(
+        r"(?<![\w/.-])(?:[\w.-]+/)+[\w.-]+(?:\.[A-Za-z0-9]+)?|"
+        r"(?<![\w/.-])[\w.-]+\.[A-Za-z0-9]{1,8}(?![\w/-])",
+        text,
+    )
+    return sorted(
+        dict.fromkeys(candidate.strip("`.,):;\"'") for candidate in candidates if candidate)
+    )
 
 
 def _authority_cited_read_first_paths(
@@ -2247,7 +2376,7 @@ def _has_pr_summary_reviewable_state(root: Path, base_ref: str) -> bool:
     return any(group.id != "uncategorized_changed_paths" for group in compact_review.attention)
 
 
-def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
+def _suggestion_candidates(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
     actions: list[SuggestedAction] = []
     goal_tokens = _tokens(snapshot.goal or "")
     goal_phrase = _normalize_goal_phrase(snapshot.goal or "")
@@ -2297,7 +2426,7 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
                 thread.summary,
                 None,
                 url=thread.url,
-                relevance_score=thread.relevance_score,
+                relevance_score=thread.relevance_score + (50 if thread.related_to is None else 0),
             )
         for commit in snapshot.git_context.commits:
             add(
@@ -2309,18 +2438,18 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
                 record_id=commit.short_sha,
                 relevance_score=commit.relevance_score,
             )
-        for path in snapshot.git_context.read_first_paths:
-            add(
-                "medium",
-                "git-context",
-                f"Read changed file {path}",
-                "Recent git or GitHub context points at this file for the work handoff.",
-                None,
-                path=path,
-                relevance_score=_goal_relevance_score(
-                    goal_tokens, goal_phrase=goal_phrase, high_text=path
-                ),
-            )
+    for path in snapshot.read_first_paths:
+        add(
+            "medium",
+            "git-context",
+            f"Read first file {path}",
+            "GitHub, git, or authority context points at this file for the work handoff.",
+            None,
+            path=path,
+            relevance_score=_goal_relevance_score(
+                goal_tokens, goal_phrase=goal_phrase, high_text=path
+            ),
+        )
     if snapshot.handoff_current_state is not None:
         state = snapshot.handoff_current_state
         evidence = "; ".join(state.evidence)
@@ -2565,7 +2694,7 @@ def _ranked_suggestions(snapshot: BriefStateSnapshot) -> list[SuggestedAction]:
             "splendor brief --agent-context",
         )
 
-    return _finalize_suggestions(actions, maintenance_goal=snapshot.maintenance_goal)
+    return actions
 
 
 def _first_command(commands: list[str]) -> str | None:
@@ -2574,6 +2703,32 @@ def _first_command(commands: list[str]) -> str | None:
 
 def _finalize_suggestions(
     actions: list[SuggestedAction], *, maintenance_goal: bool
+) -> list[SuggestedAction]:
+    return _rank_and_cap_actions(
+        actions,
+        maintenance_goal=maintenance_goal,
+        category_limits=_SUGGESTION_CATEGORY_LIMITS,
+        total_limit=_SUGGESTION_LIMIT,
+    )
+
+
+def _finalize_maintenance_actions(
+    actions: list[SuggestedAction], *, maintenance_goal: bool
+) -> list[SuggestedAction]:
+    return _rank_and_cap_actions(
+        [action for action in actions if action.category in _MAINTENANCE_CATEGORIES],
+        maintenance_goal=maintenance_goal,
+        category_limits=_SUGGESTION_CATEGORY_LIMITS,
+        total_limit=_MAINTENANCE_ACTION_LIMIT,
+    )
+
+
+def _rank_and_cap_actions(
+    actions: list[SuggestedAction],
+    *,
+    maintenance_goal: bool,
+    category_limits: dict[str, int],
+    total_limit: int,
 ) -> list[SuggestedAction]:
     by_category: dict[str, int] = {}
     capped: list[tuple[int, SuggestedAction]] = []
@@ -2591,7 +2746,7 @@ def _finalize_suggestions(
     )
     for sequence, action in ordered:
         current_count = by_category.get(action.category, 0)
-        category_limit = _SUGGESTION_CATEGORY_LIMITS.get(action.category, 1)
+        category_limit = category_limits.get(action.category, 1)
         if current_count >= category_limit:
             continue
         by_category[action.category] = current_count + 1
@@ -2607,7 +2762,7 @@ def _finalize_suggestions(
     )
     return [
         replace(action, rank=rank)
-        for rank, (_sequence, action) in enumerate(capped[:_SUGGESTION_LIMIT], start=1)
+        for rank, (_sequence, action) in enumerate(capped[:total_limit], start=1)
     ]
 
 
@@ -2729,6 +2884,7 @@ def render_suggest_next_json(result: SuggestNextResult) -> str:
                 },
             },
             "git_context": asdict(result.git_context),
+            "read_first_paths": result.read_first_paths,
             "handoff_current_state": (
                 asdict(result.handoff_current_state) if result.handoff_current_state else None
             ),
@@ -2784,6 +2940,7 @@ def render_project_brief_json(brief: ProjectBrief) -> str:
             "last_query": asdict(brief.last_query) if brief.last_query else None,
             "warnings": [asdict(warning) for warning in brief.warnings],
             "git_context": asdict(brief.git_context),
+            "read_first_paths": brief.read_first_paths,
             "handoff_current_state": (
                 asdict(brief.handoff_current_state) if brief.handoff_current_state else None
             ),
@@ -2823,6 +2980,7 @@ def render_agent_context_json(brief: ProjectBrief) -> str:
             },
             "source_refs": _agent_context_source_refs(brief),
             "git_context": asdict(brief.git_context),
+            "read_first_paths": brief.read_first_paths,
             "handoff_current_state": (
                 asdict(brief.handoff_current_state) if brief.handoff_current_state else None
             ),

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -2144,7 +2144,9 @@ def _authority_cited_read_first_paths(
     for authority in authority_briefs[:_AUTHORITY_READ_FIRST_LIMIT]:
         if authority.lifecycle in {"historical", "superseded", "archived"}:
             continue
-        authority_path = root / authority.path
+        authority_path = _safe_existing_repo_file(root, authority.path)
+        if authority_path is None:
+            continue
         try:
             body = authority_path.read_text(encoding="utf-8", errors="replace")
         except OSError:
@@ -2162,11 +2164,17 @@ def _authority_cited_read_first_paths(
 
 
 def _is_existing_read_first_path(root: Path, path: str) -> bool:
+    return _safe_existing_repo_file(root, path) is not None
+
+
+def _safe_existing_repo_file(root: Path, path: str) -> Path | None:
     candidate = Path(path)
     if candidate.is_absolute() or ".." in candidate.parts:
-        return False
+        return None
     absolute = root / candidate
-    return absolute.is_file()
+    if not absolute.is_file():
+        return None
+    return absolute
 
 
 def _recent_sources(sources: list[SourceRecord]) -> list[BriefSourceItem]:

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -47,9 +47,10 @@ _BRIEF_MATCH_LIMIT = 5
 _BRIEF_PLANNING_LIMIT = 8
 _BRIEF_SOURCE_LIMIT = 5
 _BRIEF_REPORT_COMMANDS = ("lint", "health")
-_SUGGESTION_LIMIT = 8
+_SUGGESTION_LIMIT = 10
 _GIT_CONTEXT_LIMIT = 5
 _GIT_FILE_LIMIT = 8
+_AUTHORITY_READ_FIRST_LIMIT = 5
 _GIT_COMMAND_TIMEOUT_SECONDS = 5
 _HANDOFF_COMPLETION_COMMIT_LIMIT = 12
 _PROMOTED_THREAD_RELEVANCE_FLOOR = 60
@@ -615,7 +616,11 @@ def _collect_brief_state(
     latest_reports = _latest_reports(root, layout)
     last_query = _last_query(layout)
     git_context = _build_git_context(
-        root, normalized_goal or None, include_git=include_git, since=since
+        root,
+        normalized_goal or None,
+        include_git=include_git,
+        since=since,
+        authority_briefs=authority_briefs,
     )
     handoff_current_state = _handoff_current_state(root, git_context)
     return BriefStateSnapshot(
@@ -1356,7 +1361,12 @@ def _goal_relevance_score(
 
 
 def _build_git_context(
-    root: Path, goal: str | None, *, include_git: bool, since: str | None
+    root: Path,
+    goal: str | None,
+    *,
+    include_git: bool,
+    since: str | None,
+    authority_briefs: list[AuthorityBrief],
 ) -> GitContext:
     if not include_git:
         return GitContext(
@@ -1413,7 +1423,7 @@ def _build_git_context(
         warnings.extend(thread_warnings)
     else:
         warnings.append("GitHub remote repository could not be inferred from origin.")
-    read_first_paths = _read_first_paths(commits, threads, goal)
+    read_first_paths = _read_first_paths(commits, threads, goal, root, authority_briefs)
     return GitContext(
         enabled=True,
         available=True,
@@ -1833,7 +1843,7 @@ def _github_threads(
 
     goal_tokens = _tokens(goal or "")
     goal_phrase = _normalize_goal_phrase(goal or "")
-    threads: list[GitThreadBrief] = []
+    thread_texts: list[tuple[GitThreadBrief, str]] = []
     for item in raw_threads:
         title = str(item.get("title") or "")
         body = str(item.get("body") or "")
@@ -1856,22 +1866,28 @@ def _github_threads(
             kind=kind,
             text=" ".join([title, body]),
         )
-        threads.append(
-            GitThreadBrief(
-                kind=kind,
-                number=number,
-                title=title,
-                url=url,
-                state=state,
-                summary=summary,
-                relevance_score=relevance_score,
-                promoted=promoted,
+        thread = GitThreadBrief(
+            kind=kind,
+            number=number,
+            title=title,
+            url=url,
+            state=state,
+            summary=summary,
+            relevance_score=relevance_score,
+            promoted=promoted,
+        )
+        thread_texts.append(
+            (
+                thread,
+                " ".join([title, body]),
             )
         )
+    threads = _promote_related_open_issue_threads(thread_texts)
     if goal_tokens:
         threads.sort(
             key=lambda item: (
                 item.state != "open",
+                not item.promoted,
                 -item.relevance_score,
                 item.kind != "issue",
                 item.number,
@@ -1880,6 +1896,53 @@ def _github_threads(
     else:
         threads.sort(key=lambda item: (item.state != "open", item.kind != "issue", item.number))
     return threads[:_GIT_CONTEXT_LIMIT], warnings
+
+
+def _promote_related_open_issue_threads(
+    thread_texts: list[tuple[GitThreadBrief, str]],
+) -> list[GitThreadBrief]:
+    threads_by_issue_number = {
+        thread.number: thread
+        for thread, _text in thread_texts
+        if thread.kind == "issue" and thread.state == "open"
+    }
+    promoted_issue_numbers = {
+        thread.number
+        for thread, _text in thread_texts
+        if thread.kind == "issue" and thread.state == "open" and thread.promoted
+    }
+    related_numbers: dict[int, int] = {}
+    for thread, text in thread_texts:
+        if thread.number not in promoted_issue_numbers:
+            continue
+        for number in _issue_numbers_in_text(text):
+            related = threads_by_issue_number.get(number)
+            if related is None or related.number == thread.number:
+                continue
+            related_numbers[number] = max(
+                related_numbers.get(number, 0),
+                max(thread.relevance_score - 5, _PROMOTED_THREAD_RELEVANCE_FLOOR),
+            )
+    promoted: list[GitThreadBrief] = []
+    for thread, _text in thread_texts:
+        related_score = related_numbers.get(thread.number)
+        if related_score is not None:
+            thread = replace(
+                thread,
+                promoted=True,
+                relevance_score=max(thread.relevance_score, related_score),
+                summary=(
+                    thread.summary
+                    if thread.summary.startswith("Related to promoted issue")
+                    else f"Related to promoted issue context. {thread.summary}"
+                ),
+            )
+        promoted.append(thread)
+    return promoted
+
+
+def _issue_numbers_in_text(text: str) -> set[int]:
+    return {int(match.group(1)) for match in re.finditer(r"(?<![\w/])#(\d+)\b", text)}
 
 
 def _promote_git_thread(
@@ -1906,7 +1969,11 @@ def _one_line(text: str) -> str:
 
 
 def _read_first_paths(
-    commits: list[GitCommitBrief], threads: list[GitThreadBrief], goal: str | None
+    commits: list[GitCommitBrief],
+    threads: list[GitThreadBrief],
+    goal: str | None,
+    root: Path,
+    authority_briefs: list[AuthorityBrief],
 ) -> list[str]:
     goal_tokens = _tokens(goal or "")
     goal_phrase = _normalize_goal_phrase(goal or "")
@@ -1928,6 +1995,8 @@ def _read_first_paths(
             continue
         for path in _repo_paths_in_text(" ".join([thread.title, thread.summary])):
             scored[path] = max(scored.get(path, 0), thread.relevance_score + 20)
+    for path, score in _authority_cited_read_first_paths(root, authority_briefs, goal).items():
+        scored[path] = max(scored.get(path, 0), score)
     ranked = sorted(scored, key=lambda path: (-scored[path], path))
     return ranked[:_GIT_FILE_LIMIT]
 
@@ -1935,6 +2004,40 @@ def _read_first_paths(
 def _repo_paths_in_text(text: str) -> list[str]:
     candidates = re.findall(r"(?<![\w/.-])(?:[\w.-]+/)+[\w.-]+(?:\.[A-Za-z0-9]+)?", text)
     return sorted(dict.fromkeys(candidate.strip("`.,)") for candidate in candidates))
+
+
+def _authority_cited_read_first_paths(
+    root: Path, authority_briefs: list[AuthorityBrief], goal: str | None
+) -> dict[str, int]:
+    goal_tokens = _tokens(goal or "")
+    goal_phrase = _normalize_goal_phrase(goal or "")
+    scored: dict[str, int] = {}
+    for authority in authority_briefs[:_AUTHORITY_READ_FIRST_LIMIT]:
+        if authority.lifecycle in {"historical", "superseded", "archived"}:
+            continue
+        authority_path = root / authority.path
+        try:
+            body = authority_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for path in _repo_paths_in_text(body):
+            if not _is_existing_read_first_path(root, path):
+                continue
+            path_score = (
+                authority.score
+                + 35
+                + _goal_relevance_score(goal_tokens, goal_phrase=goal_phrase, high_text=path)
+            )
+            scored[path] = max(scored.get(path, 0), path_score)
+    return scored
+
+
+def _is_existing_read_first_path(root: Path, path: str) -> bool:
+    candidate = Path(path)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return False
+    absolute = root / candidate
+    return absolute.is_file()
 
 
 def _recent_sources(sources: list[SourceRecord]) -> list[BriefSourceItem]:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2232,11 +2232,59 @@ def test_agent_context_skips_non_repo_authority_paths_for_read_first(
         supersedes=[],
         superseded_by=None,
     )
+    symlink = tmp_path / "docs" / "outside-policy-link.md"
+    symlink.parent.mkdir(parents=True)
+    symlink.symlink_to(outside)
+    symlinked = brief_module.AuthorityBrief(
+        rank=3,
+        path="docs/outside-policy-link.md",
+        title="Symlinked outside policy",
+        role="current-authority",
+        freshness="current",
+        lifecycle="current",
+        score=500,
+        reason="Synthetic symlinked non-repo authority path.",
+        origin="configured-authority",
+        curation_state="configured",
+        curation_commands=[],
+        issue_refs=[],
+        pr_refs=[],
+        supersedes=[],
+        superseded_by=None,
+    )
 
     assert (
-        brief_module._authority_cited_read_first_paths(tmp_path, [traversal, absolute], "policy")
+        brief_module._authority_cited_read_first_paths(
+            tmp_path, [traversal, absolute, symlinked], "policy"
+        )
         == {}
     )
+
+
+def test_referenced_issue_fetch_warning_includes_failed_view(tmp_path: Path, monkeypatch) -> None:
+    _install_fake_gh(tmp_path, monkeypatch, issues=[], prs=[])
+    active_thread = brief_module.GitThreadBrief(
+        kind="issue",
+        number=91,
+        title="M17 ASR active thread",
+        url="https://github.com/SynthBanshee/SynthBanshee/issues/91",
+        state="open",
+        summary="Continue ASR work and keep #87 visible.",
+        relevance_score=90,
+        promoted=True,
+        related_to=None,
+    )
+
+    fetched, warnings = brief_module._fetch_referenced_open_issue_threads(
+        tmp_path,
+        "SynthBanshee/SynthBanshee",
+        [(active_thread, "Continue ASR work and keep #87 visible.")],
+        {"asr"},
+        "asr",
+    )
+
+    assert fetched == []
+    assert warnings == ["gh issue view 87 failed: issue not found"]
 
 
 def test_agent_context_hocrgen_retry_bar_ranks_current_planning_before_history(

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -1920,7 +1920,9 @@ def test_agent_context_synthbanshee_retry_bar_is_git_aware_and_work_first(
     ]
     write_config(tmp_path, config)
     (tmp_path / "CLAUDE.md").write_text(
-        "# CLAUDE\n\nASR sanity checks gate M17 effective prosody work.\n",
+        "# CLAUDE\n\n"
+        "ASR sanity checks gate M17 effective prosody work. The implementation surface is "
+        "synthbanshee/tts/renderer.py and tests/unit/test_effective_prosody_cap.py.\n",
         encoding="utf-8",
     )
     docs = tmp_path / "docs"
@@ -1953,11 +1955,35 @@ def test_agent_context_synthbanshee_retry_bar_is_git_aware_and_work_first(
         monkeypatch,
         issues=[
             {
-                "number": 89,
+                "number": 87,
+                "title": "Parent epic: microphone capture parity",
+                "url": "https://github.com/SynthBanshee/SynthBanshee/issues/87",
+                "body": "Parent work thread for the next speech safety follow-up.",
+                "state": "open",
+                "labels": [],
+            },
+            {
+                "number": 88,
+                "title": "Sibling task: renderer policy cleanup",
+                "url": "https://github.com/SynthBanshee/SynthBanshee/issues/88",
+                "body": "Sibling work thread for the same rollout.",
+                "state": "open",
+                "labels": [],
+            },
+            {
+                "number": 91,
                 "title": "fix(tts): M17 ASR follow-up after effective-prosody cap",
-                "url": "https://github.com/SynthBanshee/SynthBanshee/issues/89",
-                "body": "Next open ASR issue: close WER gap. Read synthbanshee/tts/renderer.py "
-                "and tests/unit/test_effective_prosody_cap.py.",
+                "url": "https://github.com/SynthBanshee/SynthBanshee/issues/91",
+                "body": "Next open ASR issue: close WER gap. Keep related parent/sibling "
+                "threads #87, #88, and #92 visible in handoff.",
+                "state": "open",
+                "labels": [],
+            },
+            {
+                "number": 92,
+                "title": "Sibling task: evaluation fixture follow-through",
+                "url": "https://github.com/SynthBanshee/SynthBanshee/issues/92",
+                "body": "Sibling work thread for the same rollout.",
                 "state": "open",
                 "labels": [],
             },
@@ -2005,12 +2031,25 @@ def test_agent_context_synthbanshee_retry_bar_is_git_aware_and_work_first(
     payload = json.loads(capsys.readouterr().out)
     actions = payload["suggested_actions"]
     assert actions[0]["category"] == "work-thread"
-    assert actions[0]["url"] == "https://github.com/SynthBanshee/SynthBanshee/issues/89"
+    assert actions[0]["url"] == "https://github.com/SynthBanshee/SynthBanshee/issues/91"
+    promoted_issue_urls = [
+        action["url"] for action in actions if action["category"] == "work-thread"
+    ]
+    assert promoted_issue_urls == [
+        "https://github.com/SynthBanshee/SynthBanshee/issues/91",
+        "https://github.com/SynthBanshee/SynthBanshee/issues/87",
+        "https://github.com/SynthBanshee/SynthBanshee/issues/88",
+        "https://github.com/SynthBanshee/SynthBanshee/issues/92",
+    ]
     assert all(
         action.get("url") != "https://github.com/SynthBanshee/SynthBanshee/issues/118"
         for action in actions
     )
-    assert payload["git_context"]["threads"][0]["number"] == 89
+    assert payload["git_context"]["threads"][0]["number"] == 91
+    promoted_thread_numbers = [
+        thread["number"] for thread in payload["git_context"]["threads"] if thread["promoted"]
+    ]
+    assert promoted_thread_numbers[:4] == [91, 87, 88, 92]
     irrelevant_threads = [
         thread for thread in payload["git_context"]["threads"] if thread["number"] == 118
     ]
@@ -2049,6 +2088,16 @@ def test_agent_context_synthbanshee_retry_bar_is_git_aware_and_work_first(
     suggest_payload = json.loads(capsys.readouterr().out)
     suggest_categories = [action["category"] for action in suggest_payload["actions"]]
     assert suggest_categories[0] == "work-thread"
+    assert [
+        action["url"]
+        for action in suggest_payload["work_context"]["actions"]
+        if action["category"] == "work-thread"
+    ] == [
+        "https://github.com/SynthBanshee/SynthBanshee/issues/91",
+        "https://github.com/SynthBanshee/SynthBanshee/issues/87",
+        "https://github.com/SynthBanshee/SynthBanshee/issues/88",
+        "https://github.com/SynthBanshee/SynthBanshee/issues/92",
+    ]
     assert all(
         action.get("url") != "https://github.com/SynthBanshee/SynthBanshee/issues/118"
         for action in suggest_payload["actions"]

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2183,6 +2183,62 @@ def test_agent_context_authority_cited_files_do_not_require_git(tmp_path: Path, 
     assert "- pyproject.toml" in out
 
 
+def test_agent_context_skips_non_repo_authority_paths_for_read_first(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    outside = tmp_path.parent / f"{tmp_path.name}-outside-policy.md"
+    outside.write_text(
+        "# Outside\n\nDo not surface pyproject.toml from this non-repo policy.\n",
+        encoding="utf-8",
+    )
+    config = load_config(tmp_path)
+    config.briefing.authority_documents = []
+    write_config(tmp_path, config)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'example'\n", encoding="utf-8")
+    capsys.readouterr()
+
+    traversal = brief_module.AuthorityBrief(
+        rank=1,
+        path=f"../{outside.name}",
+        title="Outside policy",
+        role="current-authority",
+        freshness="current",
+        lifecycle="current",
+        score=500,
+        reason="Synthetic non-repo authority path.",
+        origin="configured-authority",
+        curation_state="configured",
+        curation_commands=[],
+        issue_refs=[],
+        pr_refs=[],
+        supersedes=[],
+        superseded_by=None,
+    )
+    absolute = brief_module.AuthorityBrief(
+        rank=2,
+        path=str(outside),
+        title="Absolute outside policy",
+        role="current-authority",
+        freshness="current",
+        lifecycle="current",
+        score=500,
+        reason="Synthetic absolute authority path.",
+        origin="configured-authority",
+        curation_state="configured",
+        curation_commands=[],
+        issue_refs=[],
+        pr_refs=[],
+        supersedes=[],
+        superseded_by=None,
+    )
+
+    assert (
+        brief_module._authority_cited_read_first_paths(tmp_path, [traversal, absolute], "policy")
+        == {}
+    )
+
+
 def test_agent_context_hocrgen_retry_bar_ranks_current_planning_before_history(
     tmp_path: Path, capsys, monkeypatch
 ) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -53,7 +53,16 @@ def _install_fake_gh(
         f"issues = {issues!r}\n"
         f"prs = {prs!r}\n"
         "if sys.argv[1:3] == ['issue', 'list']:\n"
-        "    print(json.dumps(issues))\n"
+        "    print(json.dumps([issue for issue in issues if issue.get('_list', True)]))\n"
+        "elif sys.argv[1:3] == ['issue', 'view']:\n"
+        "    number = int(sys.argv[3])\n"
+        "    for issue in issues:\n"
+        "        if issue.get('number') == number:\n"
+        "            print(json.dumps(issue))\n"
+        "            break\n"
+        "    else:\n"
+        "        print('issue not found', file=sys.stderr)\n"
+        "        sys.exit(1)\n"
         "elif sys.argv[1:3] == ['pr', 'list']:\n"
         "    print(json.dumps(prs))\n"
         "else:\n"
@@ -1961,6 +1970,7 @@ def test_agent_context_synthbanshee_retry_bar_is_git_aware_and_work_first(
                 "body": "Parent work thread for the next speech safety follow-up.",
                 "state": "open",
                 "labels": [],
+                "_list": False,
             },
             {
                 "number": 88,
@@ -2064,11 +2074,9 @@ def test_agent_context_synthbanshee_retry_bar_is_git_aware_and_work_first(
         action["category"] for action in payload["maintenance_context"]["actions"]
     ]
     assert "queue" in maintenance_categories or "source-freshness" in maintenance_categories
-    flattened_categories = [action["category"] for action in actions]
-    assert flattened_categories.index("work-thread") < min(
-        flattened_categories.index(category)
-        for category in flattened_categories
-        if category in {"queue", "source-freshness"}
+    assert all(
+        action["category"] not in {"queue", "source-freshness"}
+        for action in payload["work_context"]["actions"]
     )
 
     suggest_exit = main(
@@ -2102,11 +2110,77 @@ def test_agent_context_synthbanshee_retry_bar_is_git_aware_and_work_first(
         action.get("url") != "https://github.com/SynthBanshee/SynthBanshee/issues/118"
         for action in suggest_payload["actions"]
     )
-    assert suggest_categories.index("work-thread") < min(
-        suggest_categories.index(category)
-        for category in suggest_categories
-        if category in {"queue", "source-freshness"}
+    assert all(
+        action["category"] not in {"queue", "source-freshness"}
+        for action in suggest_payload["work_context"]["actions"]
     )
+
+
+def test_agent_context_authority_cited_files_do_not_require_git(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path="docs/asr_policy.md",
+            role="current-authority",
+            purpose="ASR policy implementation surface.",
+            applies_to=["M17 ASR"],
+        )
+    ]
+    write_config(tmp_path, config)
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "asr_policy.md").write_text(
+        "# ASR Policy\n\n"
+        "Implement this through synthbanshee/tts/renderer.py, "
+        "tests/unit/test_effective_prosody_cap.py, and pyproject.toml.\n",
+        encoding="utf-8",
+    )
+    renderer = tmp_path / "synthbanshee" / "tts" / "renderer.py"
+    renderer.parent.mkdir(parents=True)
+    renderer.write_text("def render():\n    return 'asr'\n", encoding="utf-8")
+    renderer_test = tmp_path / "tests" / "unit" / "test_effective_prosody_cap.py"
+    renderer_test.parent.mkdir(parents=True, exist_ok=True)
+    renderer_test.write_text("def test_cap():\n    assert True\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'example'\n", encoding="utf-8")
+    capsys.readouterr()
+
+    json_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "--no-git",
+            "M17",
+            "ASR",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    text_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "--no-git",
+            "M17",
+            "ASR",
+        ]
+    )
+    out = capsys.readouterr().out
+
+    assert json_exit == 0
+    assert text_exit == 0
+    assert payload["git_context"]["enabled"] is False
+    assert {
+        "synthbanshee/tts/renderer.py",
+        "tests/unit/test_effective_prosody_cap.py",
+        "pyproject.toml",
+    } <= set(payload["read_first_paths"])
+    assert "Files to read first:" in out
+    assert "- pyproject.toml" in out
 
 
 def test_agent_context_hocrgen_retry_bar_ranks_current_planning_before_history(


### PR DESCRIPTION
## Summary

- Broadened GitHub handoff so a promoted open work issue can pull in referenced open parent/sibling issue threads, keeping the best thread first while surfacing related work breadth.
- Added deterministic read-first boosts for existing repo-relative implementation/test paths cited by surfaced current/reviewed/PR-linked authority docs.
- Updated M19 planning state and handoff docs for `M19-P7.1`, with `M19-P8.1` next.

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

## Notes

- Preserves the M18 work-first split: work-thread, authority, planning, and read-first context stay ahead of maintenance for implementation goals, while queue/source/wiki maintenance remains in `maintenance_context` and maintenance commands.
- Preserves the `M19-P6.1` completion-aware current-state inference path; this PR only broadens related work-thread surfacing and authority-cited read-first ranking.
- Does not implement vector search, background workers, databases, OCR flows, mutating web UI, or the `M19-P8.1` cold-start/PATH-safe git lookup follow-up.
