### PR TITLE
M19-P8.1: Cold-start adoption and PATH-safe git lookup

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M19-P6.1`
-- Last action taken: `M19-P6.1` was merged to main via PR #168, making handoff
-  inference completion-aware when stale planning docs still name completed work.
-- Current planned slice: `M19 handoff breadth and policy-cited implementation surfacing`
-- Current PR sub-slice: `M19-P7.1`
+- Previous completed PR sub-slice: `M19-P7.1`
+- Last action taken: `M19-P7.1` was merged to main via PR #169, broadening handoff
+  context while keeping completion-aware current-state inference intact.
+- Current planned slice: `M19 cold-start adoption and PATH-safe git lookup`
+- Current PR sub-slice: `M19-P8.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 cold-start adoption and PATH-safe git lookup`
-- Next planned PR sub-slice: `M19-P8.1`
+- Next planned slice: `M20 advanced semantic search or vector index`
+- Next planned PR sub-slice: `M20-P1.1`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ The repo now contains:
 - `state/` with source manifests plus queue/run/query state
 - `reports/` with timestamped lint and health reports
 
+`splendor init` prints deterministic state review groups for the generated configuration, human
+workspace, source/derived state, and runtime state paths. In cold-start repositories, use those
+groups as the first review/commit checklist before seeding sources or opening generated-state PRs.
+
 For a fuller walkthrough, see [docs/guides/quickstart.md](docs/guides/quickstart.md).
 
 ## Example Workspace
@@ -323,12 +327,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M19-P6.1`
-- Current planned slice: `M19 handoff breadth and policy-cited implementation surfacing`
-- Current PR sub-slice: `M19-P7.1`
+- Previous completed PR sub-slice: `M19-P7.1`
+- Current planned slice: `M19 cold-start adoption and PATH-safe git lookup`
+- Current PR sub-slice: `M19-P8.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 cold-start adoption and PATH-safe git lookup`
-- Next planned PR sub-slice: `M19-P8.1`
+- Next planned slice: `M20 advanced semantic search or vector index`
+- Next planned PR sub-slice: `M20-P1.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -652,3 +656,5 @@ next ordered slice.
 parent/sibling issues, and read-first files get deterministic boosts from implementation/test paths
 cited by surfaced authority docs while keeping maintenance actions in the separate maintenance
 block.
+`M19-P8.1` is in progress: it focuses the final M19 durability slice on cold-start state review
+groups and PATH-safe git lookup without starting M20 vector search or mutating web workflow bets.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -343,6 +343,9 @@ Implemented fields:
   runtime-only command guidance and explanatory notes so review-needed wiki state, missing
   synthesis, queue drift, source freshness, and generated contradiction-review tasks stay
   discoverable without becoming default human planning records.
+- Git subprocess lookup is PATH-safe: Splendor resolves `git` before invoking it and treats a
+  missing executable or non-searchable PATH entries as unavailable git context rather than as a
+  workspace failure. Persisted schemas remain unchanged because this is runtime-only lookup state.
 - Suggested actions are derived from local git commits, best-effort read-only GitHub issue/PR
   context through `gh` when available, source freshness, queue operator state, invalid/stale/
   contested/review-needed wiki pages, ingested sources missing maintained synthesis follow-up,

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M19-P6.1`
-- Current planned slice: `M19 handoff breadth and policy-cited implementation surfacing`
-- Current PR sub-slice: `M19-P7.1`
+- Previous completed PR sub-slice: `M19-P7.1`
+- Current planned slice: `M19 cold-start adoption and PATH-safe git lookup`
+- Current PR sub-slice: `M19-P8.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M19 cold-start adoption and PATH-safe git lookup`
-- Next planned PR sub-slice: `M19-P8.1`
+- Next planned slice: `M20 advanced semantic search or vector index`
+- Next planned PR sub-slice: `M20-P1.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1326,9 +1326,13 @@ item instead of remaining the top work recommendation. Merged PR state can corro
 inference, but docs-only planning intake and arbitrary historical mentions do not advance current
 state by themselves.
 
-`M19-P7.1` is the active handoff-breadth slice. It broadens GitHub issue handoff from a single best
-open thread to a bounded set of related open parent/sibling issues and boosts implementation/test
-files explicitly named by surfaced authority docs in read-first file ranking.
+`M19-P7.1` is implemented on `main`. It broadens GitHub issue handoff from a single best open
+thread to a bounded set of related open parent/sibling issues and boosts implementation/test files
+explicitly named by surfaced authority docs in read-first file ranking.
+
+`M19-P8.1` is the active cold-start robustness slice. It keeps M19 focused on first-run state
+location/review clarity and PATH-safe git lookup regression coverage before any M20 vector-search
+or mutating-web bets begin.
 
 The remaining M19 sequence is therefore:
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1156,6 +1156,9 @@ Current implementation:
   visible even when git context is disabled or unavailable. JSON maintenance context also includes
   deterministic command guidance and notes for review-needed wiki pages, missing synthesis
   follow-up, source freshness, queue drift, and generated review tasks.
+- Git lookup for handoff and local provenance uses a PATH-safe resolver that ignores PATH entries
+  that are files or otherwise not searchable directories. A malformed cold-start shell PATH should
+  degrade git context to unavailable rather than crashing the CLI.
 - `splendor suggest-next [--since <ref>] [--no-git] [goal]` renders the ranked action subset
   directly. It is read-only and deterministic. For non-maintenance goals it ranks open work
   threads, recent git/PR context, task-relevant authority docs, active planning records, read-first

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -979,6 +979,10 @@ def handle_init(args: argparse.Namespace) -> int:
     print(f"Initialized Splendor workspace at {result.root}")
     print(f"Created directories: {len(result.created_directories)}")
     print(f"Created files: {len(result.created_files)}")
+    print("State review groups:")
+    for group in result.review_groups:
+        paths = ", ".join(group.paths)
+        print(f"- {group.label}: {paths} ({group.note})")
     return 0
 
 

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -21,7 +21,7 @@ from splendor.schemas import (
 from splendor.state.paths import resolve_workspace_path
 from splendor.state.query_snapshot import last_query_path_for
 from splendor.state.source_compat import canonical_source_ref
-from splendor.utils.git import run_git
+from splendor.utils.git import is_git_executable_missing, run_git
 from splendor.utils.planning import (
     iter_planning_paths,
     parse_planning_document,
@@ -1411,7 +1411,23 @@ def _build_git_context(
         )
 
     warnings: list[str] = []
-    inside = _git_output(root, ["rev-parse", "--is-inside-work-tree"], required=False)
+    inside_result = run_git(root, ["rev-parse", "--is-inside-work-tree"])
+    inside = inside_result.stdout.strip() if inside_result.returncode == 0 else None
+    if is_git_executable_missing(inside_result):
+        return GitContext(
+            enabled=True,
+            available=False,
+            since=since,
+            base_ref=None,
+            merge_base=None,
+            branch=None,
+            head=None,
+            repository=None,
+            commits=[],
+            threads=[],
+            read_first_paths=authority_read_first_paths,
+            warnings=["git executable not found; git context unavailable."],
+        )
     if inside != "true":
         return GitContext(
             enabled=True,

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -21,7 +21,7 @@ from splendor.schemas import (
 from splendor.state.paths import resolve_workspace_path
 from splendor.state.query_snapshot import last_query_path_for
 from splendor.state.source_compat import canonical_source_ref
-from splendor.utils.git import git_command
+from splendor.utils.git import run_git
 from splendor.utils.planning import (
     iter_planning_paths,
     parse_planning_document,
@@ -1688,18 +1688,7 @@ def _is_planning_only_path(path: str) -> bool:
 
 
 def _git_output(root: Path, args: list[str], *, required: bool = True) -> str | None:
-    command = git_command(*args)
-    if command is None:
-        if required:
-            raise ValueError("git executable not found")
-        return None
-    result = subprocess.run(
-        command,
-        cwd=root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = run_git(root, args)
     if result.returncode != 0:
         if required:
             message = result.stderr.strip() or result.stdout.strip() or "git command failed"

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -21,6 +21,7 @@ from splendor.schemas import (
 from splendor.state.paths import resolve_workspace_path
 from splendor.state.query_snapshot import last_query_path_for
 from splendor.state.source_compat import canonical_source_ref
+from splendor.utils.git import git_command
 from splendor.utils.planning import (
     iter_planning_paths,
     parse_planning_document,
@@ -1687,8 +1688,13 @@ def _is_planning_only_path(path: str) -> bool:
 
 
 def _git_output(root: Path, args: list[str], *, required: bool = True) -> str | None:
+    command = git_command(*args)
+    if command is None:
+        if required:
+            raise ValueError("git executable not found")
+        return None
     result = subprocess.run(
-        ["git", *args],
+        command,
         cwd=root,
         check=False,
         capture_output=True,

--- a/src/splendor/commands/init.py
+++ b/src/splendor/commands/init.py
@@ -17,35 +17,6 @@ from splendor.layout import (
 )
 from splendor.utils.fs import ensure_directory, write_if_missing
 
-KEEP_FILES = [
-    "raw/sources/.gitkeep",
-    "raw/assets/.gitkeep",
-    "raw/imports/.gitkeep",
-    "derived/ocr/.gitkeep",
-    "derived/parsed/.gitkeep",
-    "derived/metadata/.gitkeep",
-    "derived/summaries/.gitkeep",
-    "wiki/concepts/.gitkeep",
-    "wiki/entities/.gitkeep",
-    "wiki/topics/.gitkeep",
-    "wiki/sources/.gitkeep",
-    "wiki/glossary/.gitkeep",
-    "wiki/architecture/.gitkeep",
-    "planning/milestones/.gitkeep",
-    "planning/tasks/.gitkeep",
-    "planning/decisions/.gitkeep",
-    "planning/questions/.gitkeep",
-    "state/manifests/.gitkeep",
-    "state/manifests/sources/.gitkeep",
-    "state/queue/.gitkeep",
-    "state/runs/.gitkeep",
-    "state/queries/.gitkeep",
-    "state/locks/.gitkeep",
-    "reports/lint/.gitkeep",
-    "reports/health/.gitkeep",
-    "reports/ingest/.gitkeep",
-]
-
 
 @dataclass(frozen=True)
 class InitReviewGroup:
@@ -88,8 +59,7 @@ def initialize_workspace(root: Path) -> InitResult:
         created_files.append(layout.index_file)
     if write_if_missing(layout.log_file, LOG_TEMPLATE):
         created_files.append(layout.log_file)
-    for keep_file in KEEP_FILES:
-        keep_path = root / keep_file
+    for keep_path in _keep_files(layout):
         if write_if_missing(keep_path, ""):
             created_files.append(keep_path)
 
@@ -128,8 +98,41 @@ def _init_review_groups(layout: ResolvedLayout) -> list[InitReviewGroup]:
             label="runtime state",
             paths=[
                 layout.state_dir.relative_to(layout.root).as_posix(),
+                layout.source_records_dir.relative_to(layout.root).as_posix(),
                 layout.reports_dir.relative_to(layout.root).as_posix(),
             ],
             note="machine-readable manifests, queues, runs, and reports",
         ),
     ]
+
+
+def _keep_files(layout: ResolvedLayout) -> list[Path]:
+    directories = [
+        layout.raw_sources_dir,
+        layout.raw_assets_dir,
+        layout.raw_imports_dir,
+        layout.derived_ocr_dir,
+        layout.derived_parsed_dir,
+        layout.derived_metadata_dir,
+        layout.derived_summaries_dir,
+        layout.wiki_dir / "concepts",
+        layout.wiki_dir / "entities",
+        layout.wiki_dir / "topics",
+        layout.wiki_sources_dir,
+        layout.wiki_dir / "glossary",
+        layout.wiki_dir / "architecture",
+        layout.planning_dir / "milestones",
+        layout.planning_dir / "tasks",
+        layout.planning_dir / "decisions",
+        layout.planning_dir / "questions",
+        layout.state_dir / "manifests",
+        layout.source_records_dir,
+        layout.queue_dir,
+        layout.runs_dir,
+        layout.queries_dir,
+        layout.state_dir / "locks",
+        layout.reports_dir / "lint",
+        layout.reports_dir / "health",
+        layout.reports_dir / "ingest",
+    ]
+    return [directory / ".gitkeep" for directory in directories]

--- a/src/splendor/commands/init.py
+++ b/src/splendor/commands/init.py
@@ -8,7 +8,13 @@ from pathlib import Path
 import yaml
 
 from splendor.config import config_path_for, default_config, load_config, write_config
-from splendor.layout import INDEX_TEMPLATE, LOG_TEMPLATE, required_directories, resolve_layout
+from splendor.layout import (
+    INDEX_TEMPLATE,
+    LOG_TEMPLATE,
+    ResolvedLayout,
+    required_directories,
+    resolve_layout,
+)
 from splendor.utils.fs import ensure_directory, write_if_missing
 
 KEEP_FILES = [
@@ -42,10 +48,18 @@ KEEP_FILES = [
 
 
 @dataclass(frozen=True)
+class InitReviewGroup:
+    label: str
+    paths: list[str]
+    note: str
+
+
+@dataclass(frozen=True)
 class InitResult:
     root: Path
     created_directories: list[Path]
     created_files: list[Path]
+    review_groups: list[InitReviewGroup]
 
 
 def initialize_workspace(root: Path) -> InitResult:
@@ -80,5 +94,42 @@ def initialize_workspace(root: Path) -> InitResult:
             created_files.append(keep_path)
 
     return InitResult(
-        root=root, created_directories=created_directories, created_files=created_files
+        root=root,
+        created_directories=created_directories,
+        created_files=created_files,
+        review_groups=_init_review_groups(layout),
     )
+
+
+def _init_review_groups(layout: ResolvedLayout) -> list[InitReviewGroup]:
+    return [
+        InitReviewGroup(
+            label="configuration",
+            paths=["splendor.yaml"],
+            note="project defaults and configurable state locations",
+        ),
+        InitReviewGroup(
+            label="human workspace",
+            paths=[
+                layout.wiki_dir.relative_to(layout.root).as_posix(),
+                layout.planning_dir.relative_to(layout.root).as_posix(),
+            ],
+            note="reviewed wiki and planning markdown",
+        ),
+        InitReviewGroup(
+            label="source and derived state",
+            paths=[
+                layout.raw_dir.relative_to(layout.root).as_posix(),
+                layout.derived_dir.relative_to(layout.root).as_posix(),
+            ],
+            note="imported sources and generated parsed artifacts",
+        ),
+        InitReviewGroup(
+            label="runtime state",
+            paths=[
+                layout.state_dir.relative_to(layout.root).as_posix(),
+                layout.reports_dir.relative_to(layout.root).as_posix(),
+            ],
+            note="machine-readable manifests, queues, runs, and reports",
+        ),
+    ]

--- a/src/splendor/commands/init.py
+++ b/src/splendor/commands/init.py
@@ -75,7 +75,7 @@ def _init_review_groups(layout: ResolvedLayout) -> list[InitReviewGroup]:
     return [
         InitReviewGroup(
             label="configuration",
-            paths=["splendor.yaml"],
+            paths=[config_path_for(layout.root).relative_to(layout.root).as_posix()],
             note="project defaults and configurable state locations",
         ),
         InitReviewGroup(

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlsplit
@@ -23,7 +22,7 @@ from splendor.schemas import (
 from splendor.state.paths import resolve_workspace_path
 from splendor.state.source_compat import canonical_source_ref, logical_source_id_for_ref
 from splendor.state.source_registry import load_source_record
-from splendor.utils.git import git_command
+from splendor.utils.git import run_git
 from splendor.utils.planning import iter_planning_paths, parse_planning_document, planning_directory
 from splendor.utils.wiki import parse_wiki_markdown
 
@@ -853,19 +852,7 @@ def _current_main_head_slice(root: Path) -> str | None:
 
 
 def _git_output(root: Path, *args: str) -> str | None:
-    command = git_command(*args)
-    if command is None:
-        return None
-    try:
-        result = subprocess.run(
-            command,
-            cwd=root,
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-    except OSError:
-        return None
+    result = run_git(root, args)
     if result.returncode != 0:
         return None
     return result.stdout.strip()

--- a/src/splendor/commands/lint.py
+++ b/src/splendor/commands/lint.py
@@ -23,6 +23,7 @@ from splendor.schemas import (
 from splendor.state.paths import resolve_workspace_path
 from splendor.state.source_compat import canonical_source_ref, logical_source_id_for_ref
 from splendor.state.source_registry import load_source_record
+from splendor.utils.git import git_command
 from splendor.utils.planning import iter_planning_paths, parse_planning_document, planning_directory
 from splendor.utils.wiki import parse_wiki_markdown
 
@@ -852,9 +853,12 @@ def _current_main_head_slice(root: Path) -> str | None:
 
 
 def _git_output(root: Path, *args: str) -> str | None:
+    command = git_command(*args)
+    if command is None:
+        return None
     try:
         result = subprocess.run(
-            ["git", *args],
+            command,
             cwd=root,
             check=False,
             capture_output=True,

--- a/src/splendor/commands/pr_summary.py
+++ b/src/splendor/commands/pr_summary.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -14,7 +13,7 @@ from splendor.schemas import SourceRecord
 from splendor.schemas.maintenance import MaintenanceReport
 from splendor.state.source_compat import canonical_source_ref, effective_logical_id
 from splendor.state.source_registry import load_source_record
-from splendor.utils.git import git_command
+from splendor.utils.git import run_git
 
 
 @dataclass(frozen=True)
@@ -200,18 +199,7 @@ def _merge_base(root: Path, *, since: str) -> str:
 
 
 def _git_text(root: Path, args: list[str], *, required: bool = True) -> str | None:
-    command = git_command(*args)
-    if command is None:
-        if required:
-            raise ValueError("git executable not found")
-        return None
-    result = subprocess.run(
-        command,
-        cwd=root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = run_git(root, args)
     if result.returncode != 0:
         if required:
             message = result.stderr.strip() or result.stdout.strip() or "git command failed"

--- a/src/splendor/commands/pr_summary.py
+++ b/src/splendor/commands/pr_summary.py
@@ -14,6 +14,7 @@ from splendor.schemas import SourceRecord
 from splendor.schemas.maintenance import MaintenanceReport
 from splendor.state.source_compat import canonical_source_ref, effective_logical_id
 from splendor.state.source_registry import load_source_record
+from splendor.utils.git import git_command
 
 
 @dataclass(frozen=True)
@@ -199,8 +200,13 @@ def _merge_base(root: Path, *, since: str) -> str:
 
 
 def _git_text(root: Path, args: list[str], *, required: bool = True) -> str | None:
+    command = git_command(*args)
+    if command is None:
+        if required:
+            raise ValueError("git executable not found")
+        return None
     result = subprocess.run(
-        ["git", *args],
+        command,
         cwd=root,
         check=False,
         capture_output=True,

--- a/src/splendor/commands/repo_scan.py
+++ b/src/splendor/commands/repo_scan.py
@@ -18,6 +18,7 @@ from splendor.state.source_registry import (
     load_source_record,
     register_source,
 )
+from splendor.utils.git import git_command
 from splendor.utils.hashing import sha256_file
 
 _CONFIG_EXTENSIONS = {"json", "yaml", "yml"}
@@ -567,9 +568,12 @@ def _directory_has_entries(path: Path) -> bool:
 
 
 def _git_ignore_context(root: Path) -> GitIgnoreContext:
+    command = git_command("-C", root, "rev-parse", "--show-toplevel")
+    if command is None:
+        return GitIgnoreContext(repo_root=None, workspace_root=root.resolve())
     try:
         top_level = subprocess.run(
-            ["git", "-C", str(root), "rev-parse", "--show-toplevel"],
+            command,
             text=True,
             capture_output=True,
             check=False,
@@ -667,15 +671,12 @@ def _git_ignored_repo_paths(
 ) -> set[str]:
     if not repo_paths_by_value or gitignore.repo_root is None:
         return set()
+    command = git_command("-C", gitignore.repo_root, "check-ignore", "--stdin")
+    if command is None:
+        return set()
     try:
         result = subprocess.run(
-            [
-                "git",
-                "-C",
-                str(gitignore.repo_root),
-                "check-ignore",
-                "--stdin",
-            ],
+            command,
             input="\n".join(repo_paths_by_value) + "\n",
             text=True,
             capture_output=True,

--- a/src/splendor/commands/repo_scan.py
+++ b/src/splendor/commands/repo_scan.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 from dataclasses import dataclass, replace
 from fnmatch import fnmatchcase
 from pathlib import Path
@@ -18,7 +17,7 @@ from splendor.state.source_registry import (
     load_source_record,
     register_source,
 )
-from splendor.utils.git import git_command
+from splendor.utils.git import run_git
 from splendor.utils.hashing import sha256_file
 
 _CONFIG_EXTENSIONS = {"json", "yaml", "yml"}
@@ -568,18 +567,7 @@ def _directory_has_entries(path: Path) -> bool:
 
 
 def _git_ignore_context(root: Path) -> GitIgnoreContext:
-    command = git_command("-C", root, "rev-parse", "--show-toplevel")
-    if command is None:
-        return GitIgnoreContext(repo_root=None, workspace_root=root.resolve())
-    try:
-        top_level = subprocess.run(
-            command,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-    except OSError:
-        return GitIgnoreContext(repo_root=None, workspace_root=root.resolve())
+    top_level = run_git(root, ["-C", root, "rev-parse", "--show-toplevel"])
     if top_level.returncode != 0:
         return GitIgnoreContext(repo_root=None, workspace_root=root.resolve())
     return GitIgnoreContext(
@@ -671,19 +659,11 @@ def _git_ignored_repo_paths(
 ) -> set[str]:
     if not repo_paths_by_value or gitignore.repo_root is None:
         return set()
-    command = git_command("-C", gitignore.repo_root, "check-ignore", "--stdin")
-    if command is None:
-        return set()
-    try:
-        result = subprocess.run(
-            command,
-            input="\n".join(repo_paths_by_value) + "\n",
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-    except OSError:
-        return set()
+    result = run_git(
+        gitignore.repo_root,
+        ["-C", gitignore.repo_root, "check-ignore", "--stdin"],
+        input="\n".join(repo_paths_by_value) + "\n",
+    )
     if result.returncode not in {0, 1}:
         return set()
 

--- a/src/splendor/utils/git.py
+++ b/src/splendor/utils/git.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import subprocess
 from collections.abc import Iterable
-from os import PathLike
+from os import PathLike, fspath
 from pathlib import Path
 from shutil import which
+
+GIT_EXECUTABLE_NOT_FOUND = "git executable not found"
 
 
 def git_executable() -> str | None:
@@ -19,7 +21,7 @@ def git_command(*args: str | PathLike[str]) -> list[str] | None:
     executable = git_executable()
     if executable is None:
         return None
-    return [executable, *(str(arg) for arg in args)]
+    return [executable, *(fspath(arg) for arg in args)]
 
 
 def run_git(
@@ -29,14 +31,14 @@ def run_git(
     input: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     args_list = list(args)
-    fallback_command = ["git", *(str(arg) for arg in args_list)]
+    fallback_command = ["git", *(fspath(arg) for arg in args_list)]
     command = git_command(*args_list)
     if command is None:
         return subprocess.CompletedProcess(
             fallback_command,
             returncode=127,
             stdout="",
-            stderr="git executable not found",
+            stderr=GIT_EXECUTABLE_NOT_FOUND,
         )
     try:
         return subprocess.run(
@@ -54,6 +56,10 @@ def run_git(
             stdout="",
             stderr=str(exc),
         )
+
+
+def is_git_executable_missing(result: subprocess.CompletedProcess[str]) -> bool:
+    return result.returncode == 127 and result.stderr == GIT_EXECUTABLE_NOT_FOUND
 
 
 def _git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:

--- a/src/splendor/utils/git.py
+++ b/src/splendor/utils/git.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Iterable
 from os import PathLike
 from pathlib import Path
 from shutil import which
@@ -21,22 +22,42 @@ def git_command(*args: str | PathLike[str]) -> list[str] | None:
     return [executable, *(str(arg) for arg in args)]
 
 
-def _git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    command = git_command(*args)
+def run_git(
+    root: Path,
+    args: Iterable[str | PathLike[str]],
+    *,
+    input: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    args_list = list(args)
+    fallback_command = ["git", *(str(arg) for arg in args_list)]
+    command = git_command(*args_list)
     if command is None:
         return subprocess.CompletedProcess(
-            ["git", *args],
+            fallback_command,
             returncode=127,
             stdout="",
             stderr="git executable not found",
         )
-    return subprocess.run(
-        command,
-        cwd=root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        return subprocess.run(
+            command,
+            cwd=root,
+            input=input,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        return subprocess.CompletedProcess(
+            fallback_command,
+            returncode=127,
+            stdout="",
+            stderr=str(exc),
+        )
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return run_git(root, args)
 
 
 def captured_source_commit(root: Path, source_path: Path) -> str | None:

--- a/src/splendor/utils/git.py
+++ b/src/splendor/utils/git.py
@@ -3,12 +3,35 @@
 from __future__ import annotations
 
 import subprocess
+from os import PathLike
 from pathlib import Path
+from shutil import which
+
+
+def git_executable() -> str | None:
+    """Return a PATH-resolved git executable, ignoring unsafe PATH entries."""
+
+    return which("git")
+
+
+def git_command(*args: str | PathLike[str]) -> list[str] | None:
+    executable = git_executable()
+    if executable is None:
+        return None
+    return [executable, *(str(arg) for arg in args)]
 
 
 def _git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    command = git_command(*args)
+    if command is None:
+        return subprocess.CompletedProcess(
+            ["git", *args],
+            returncode=127,
+            stdout="",
+            stderr="git executable not found",
+        )
     return subprocess.run(
-        ["git", *args],
+        command,
         cwd=root,
         check=False,
         capture_output=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,7 +59,7 @@ def test_cli_init_command(tmp_path: Path, capsys) -> None:
     captured = capsys.readouterr()
     assert "Initialized Splendor workspace" in captured.out
     assert "State review groups:" in captured.out
-    assert "- runtime state: state, reports" in captured.out
+    assert "- runtime state: state, state/manifests/sources, reports" in captured.out
 
 
 def test_cli_version_flag_prints_package_version(capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,8 @@ def test_cli_init_command(tmp_path: Path, capsys) -> None:
     assert (tmp_path / "wiki" / "index.md").exists()
     captured = capsys.readouterr()
     assert "Initialized Splendor workspace" in captured.out
+    assert "State review groups:" in captured.out
+    assert "- runtime state: state, reports" in captured.out
 
 
 def test_cli_version_flag_prints_package_version(capsys) -> None:

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -1,0 +1,30 @@
+import splendor.utils.git as git_utils
+
+
+class CustomPath:
+    def __fspath__(self) -> str:
+        return "from-fspath"
+
+    def __str__(self) -> str:
+        return "from-str"
+
+
+def test_git_command_uses_fspath_for_pathlike_arguments(monkeypatch) -> None:
+    monkeypatch.setattr(git_utils, "git_executable", lambda: "/usr/bin/git")
+
+    assert git_utils.git_command("show", CustomPath()) == [
+        "/usr/bin/git",
+        "show",
+        "from-fspath",
+    ]
+
+
+def test_run_git_reports_missing_executable(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(git_utils, "git_executable", lambda: None)
+
+    result = git_utils.run_git(tmp_path, ["status"])
+
+    assert git_utils.is_git_executable_missing(result)
+    assert result.args == ["git", "status"]
+    assert result.stdout == ""
+    assert result.stderr == git_utils.GIT_EXECUTABLE_NOT_FOUND

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -24,7 +24,7 @@ def test_initialize_workspace_creates_layout(tmp_path: Path) -> None:
         "source and derived state",
         "runtime state",
     ]
-    assert result.review_groups[-1].paths == ["state", "reports"]
+    assert result.review_groups[-1].paths == ["state", "state/manifests/sources", "reports"]
 
 
 def test_initialize_workspace_is_idempotent(tmp_path: Path) -> None:
@@ -33,6 +33,47 @@ def test_initialize_workspace_is_idempotent(tmp_path: Path) -> None:
 
     assert second.created_directories == []
     assert second.created_files == []
+
+
+def test_initialize_workspace_uses_configured_layout_for_keep_files(tmp_path: Path) -> None:
+    (tmp_path / "splendor.yaml").write_text(
+        "\n".join(
+            [
+                "schema_version: '1'",
+                "project_name: custom",
+                "layout:",
+                "  raw_dir: .splendor/raw",
+                "  raw_sources_dir: .splendor/raw/sources",
+                "  raw_assets_dir: .splendor/raw/assets",
+                "  raw_imports_dir: .splendor/raw/imports",
+                "  derived_dir: .splendor/derived",
+                "  derived_ocr_dir: .splendor/derived/ocr",
+                "  derived_parsed_dir: .splendor/derived/parsed",
+                "  derived_metadata_dir: .splendor/derived/metadata",
+                "  derived_summaries_dir: .splendor/derived/summaries",
+                "  wiki_dir: .splendor/wiki",
+                "  planning_dir: .splendor/planning",
+                "  state_dir: .splendor/state",
+                "  reports_dir: .splendor/reports",
+                "  source_records_dir: .splendor/state/manifests/sources",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = initialize_workspace(tmp_path)
+
+    assert (tmp_path / ".splendor" / "state" / "manifests" / "sources" / ".gitkeep").exists()
+    assert (tmp_path / ".splendor" / "wiki" / "index.md").exists()
+    assert not (tmp_path / "state").exists()
+    assert not (tmp_path / "wiki").exists()
+    assert not (tmp_path / "reports").exists()
+    assert result.review_groups[-1].paths == [
+        ".splendor/state",
+        ".splendor/state/manifests/sources",
+        ".splendor/reports",
+    ]
 
 
 def test_initialize_workspace_repairs_blank_project_name(tmp_path: Path) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -18,6 +18,13 @@ def test_initialize_workspace_creates_layout(tmp_path: Path) -> None:
     assert config.sources.external_storage_mode == "copy"
     assert result.created_directories
     assert result.created_files
+    assert [group.label for group in result.review_groups] == [
+        "configuration",
+        "human workspace",
+        "source and derived state",
+        "runtime state",
+    ]
+    assert result.review_groups[-1].paths == ["state", "reports"]
 
 
 def test_initialize_workspace_is_idempotent(tmp_path: Path) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -3191,6 +3191,24 @@ def test_agent_context_git_lookup_ignores_path_file_entries(
     assert payload["git_context"]["repository"] == "example/project"
 
 
+def test_agent_context_reports_missing_git_executable(tmp_path: Path, capsys, monkeypatch) -> None:
+    initialize_workspace(tmp_path)
+    path_entry = tmp_path / "not-a-directory"
+    path_entry.write_text("not a search directory\n", encoding="utf-8")
+    monkeypatch.setenv("PATH", str(path_entry))
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "brief", "--agent-context", "handoff", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["git_context"]["enabled"] is True
+    assert payload["git_context"]["available"] is False
+    assert payload["git_context"]["warnings"] == [
+        "git executable not found; git context unavailable."
+    ]
+
+
 def test_agent_context_explicit_since_empty_range_does_not_fallback_to_head(
     tmp_path: Path, capsys, monkeypatch
 ) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -3167,6 +3167,24 @@ def test_agent_context_reports_gh_timeout_as_warning(tmp_path: Path, capsys, mon
     assert any("Timed out" in warning for warning in payload["git_context"]["warnings"])
 
 
+def test_agent_context_git_lookup_ignores_path_file_entries(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    path_entry = tmp_path / "not-a-directory"
+    path_entry.write_text("not a search directory\n", encoding="utf-8")
+    monkeypatch.setenv("PATH", str(path_entry))
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "brief", "--agent-context", "handoff", "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["git_context"]["enabled"] is True
+    assert payload["git_context"]["available"] is False
+    assert payload["git_context"]["warnings"] == ["Not inside a git worktree."]
+
+
 def test_agent_context_explicit_since_empty_range_does_not_fallback_to_head(
     tmp_path: Path, capsys, monkeypatch
 ) -> None:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -3171,9 +3172,13 @@ def test_agent_context_git_lookup_ignores_path_file_entries(
     tmp_path: Path, capsys, monkeypatch
 ) -> None:
     initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path, repo="example/project")
+    _commit_all(tmp_path, "Initial context")
+    git_path = shutil.which("git")
+    assert git_path is not None
     path_entry = tmp_path / "not-a-directory"
     path_entry.write_text("not a search directory\n", encoding="utf-8")
-    monkeypatch.setenv("PATH", str(path_entry))
+    monkeypatch.setenv("PATH", f"{path_entry}{os.pathsep}{Path(git_path).parent}")
     capsys.readouterr()
 
     exit_code = main(["--root", str(tmp_path), "brief", "--agent-context", "handoff", "--json"])
@@ -3181,8 +3186,9 @@ def test_agent_context_git_lookup_ignores_path_file_entries(
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["git_context"]["enabled"] is True
-    assert payload["git_context"]["available"] is False
-    assert payload["git_context"]["warnings"] == ["Not inside a git worktree."]
+    assert payload["git_context"]["available"] is True
+    assert payload["git_context"]["branch"] == "main"
+    assert payload["git_context"]["repository"] == "example/project"
 
 
 def test_agent_context_explicit_since_empty_range_does_not_fallback_to_head(


### PR DESCRIPTION
## Summary

- Adds a shared PATH-safe git command resolver and routes Splendor-owned git subprocess calls through it so file/non-directory PATH entries degrade git context instead of crashing cold-start CLI use.
- Adds deterministic first-run `splendor init` state review groups for configuration, human workspace, source/derived state, and runtime state.
- Updates M19 planning state from merged `M19-P7.1` to active `M19-P8.1`, with `M20-P1.1` recorded as the next planned slice without starting M20 work.

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

## Notes

- Preserves the `M19-P6.1` completion-aware current-state inference path by only hardening its git subprocess lookup.
- Preserves the `M19-P7.1` broader work-thread and policy-cited read-first behavior; no ranking or GitHub thread semantics are changed.
- Does not implement M20 vector search, background workers, databases, OCR changes, mutating web workflows, or broader P3 polish items.