### PR TITLE
Ingest v0.5 SynthBanshee review

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M19-P7.1`
-- Last action taken: `M19-P7.1` was merged to main via PR #169, broadening handoff
-  context while keeping completion-aware current-state inference intact.
-- Current planned slice: `M19 cold-start adoption and PATH-safe git lookup`
-- Current PR sub-slice: `M19-P8.1`
+- Previous completed PR sub-slice: `M19-P8.1`
+- Last action taken: `M19-P8.1` and the v0.5.0 release were merged to main via PRs #170 and
+  #171; the v0.5 SynthBanshee integrated-use review accepted the M19 blocker loop as closed.
+- Current planned slice: `M20 advanced semantic search or vector index`
+- Current PR sub-slice: `M20-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 advanced semantic search or vector index`
-- Next planned PR sub-slice: `M20-P1.1`
+- Next planned slice: `M20 mutating web review workflows`
+- Next planned PR sub-slice: `M20-P2.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -393,7 +393,7 @@
 - [x] Implement `v0.4.0-release-prep`: release v0.4.0 after M19-P3.1
   - [x] Prepare release notes and version bump
   - [x] Tag `v0.4.0` and publish the GitHub release
-- [ ] Implement `M19-P4.1`: post-v0.4 external review intake and sequencing
+- [x] Implement `M19-P4.1`: post-v0.4 external review intake and sequencing
   - [x] Record hocrgen, SynthBanshee, and hocrsyngen v0.4 trial materials
   - [x] Add external review summary and findings register
   - [x] Realign M19 before M20 around legacy mutation safety and current-state handoff inference

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,11 +6,11 @@
 - Previous completed PR sub-slice: `M19-P8.1`
 - Last action taken: `M19-P8.1` and the v0.5.0 release were merged to main via PRs #170 and
   #171; the v0.5 SynthBanshee integrated-use review accepted the M19 blocker loop as closed.
-- Current planned slice: `M20 advanced semantic search or vector index`
-- Current PR sub-slice: `M20-P1.1`
+- Current planned slice: `M20 review intake and planning handoff`
+- Current PR sub-slice: `M20-P0.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 mutating web review workflows`
-- Next planned PR sub-slice: `M20-P2.1`
+- Next planned slice: `M20 advanced semantic search or vector index`
+- Next planned PR sub-slice: `M20-P1.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -516,5 +516,6 @@
 - `M19-P6.1` Completion-aware current-state handoff inference
 - `M19-P7.1` Multi-issue and policy-cited handoff breadth
 - `M19-P8.1` Cold-start adoption and PATH-safe git lookup
+- `M20-P0.1` v0.5 SynthBanshee integrated-use review intake
 - `M20-P1.1` Advanced semantic search or vector index
 - `M20-P2.1` Mutating web review workflows

--- a/README.md
+++ b/README.md
@@ -330,11 +330,11 @@ the source manifest, and kept separate from parsed PDF artifacts.
 ## What Comes Next
 
 - Previous completed PR sub-slice: `M19-P8.1`
-- Current planned slice: `M20 advanced semantic search or vector index`
-- Current PR sub-slice: `M20-P1.1`
+- Current planned slice: `M20 review intake and planning handoff`
+- Current PR sub-slice: `M20-P0.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 mutating web review workflows`
-- Next planned PR sub-slice: `M20-P2.1`
+- Next planned slice: `M20 advanced semantic search or vector index`
+- Next planned PR sub-slice: `M20-P1.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -659,6 +659,7 @@ parent/sibling issues, and read-first files get deterministic boosts from implem
 cited by surfaced authority docs while keeping maintenance actions in the separate maintenance
 block.
 `M19-P8.1` is implemented on `main`, and v0.5.0 has shipped with cold-start state review groups
-and PATH-safe git lookup hardening. The v0.5 SynthBanshee integrated-use review accepts the M19
-blocker loop as closed. Remaining polish for #160, #161, #162, and #163 stays tracked as follow-up
-issue work and should not block the first M20 product slice.
+and PATH-safe git lookup hardening. The v0.5 SynthBanshee integrated-use review exercised the
+PATH-safe git lookup fix and accepted the M19 blocker loop as closed; it did not independently rerun
+the cold-start layout path in a fresh repository. Remaining polish for #160, #161, #162, and #163
+stays tracked as follow-up issue work and should not block the first M20 product slice.

--- a/README.md
+++ b/README.md
@@ -323,16 +323,18 @@ the source manifest, and kept separate from parsed PDF artifacts.
 - [v0.4 external retry bar](docs/evaluations/v0_4_external_retry_bar.md)
 - [v0.4 external review summary](docs/evaluations/v0_4_external_review_round_summary.md)
 - [v0.4 external findings register](docs/evaluations/v0_4_external_findings_register.md)
+- [v0.5 SynthBanshee integrated-use review](docs/evaluations/v0_5_synthbanshee_integrated_use/summary.md)
 - [v0.4.0 release notes](docs/releases/v0_4_0_release_notes.md)
+- [v0.5.0 release notes](docs/releases/v0_5_0_release_notes.md)
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M19-P7.1`
-- Current planned slice: `M19 cold-start adoption and PATH-safe git lookup`
-- Current PR sub-slice: `M19-P8.1`
+- Previous completed PR sub-slice: `M19-P8.1`
+- Current planned slice: `M20 advanced semantic search or vector index`
+- Current PR sub-slice: `M20-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 advanced semantic search or vector index`
-- Next planned PR sub-slice: `M20-P1.1`
+- Next planned slice: `M20 mutating web review workflows`
+- Next planned PR sub-slice: `M20-P2.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel
@@ -656,5 +658,7 @@ next ordered slice.
 parent/sibling issues, and read-first files get deterministic boosts from implementation/test paths
 cited by surfaced authority docs while keeping maintenance actions in the separate maintenance
 block.
-`M19-P8.1` is in progress: it focuses the final M19 durability slice on cold-start state review
-groups and PATH-safe git lookup without starting M20 vector search or mutating web workflow bets.
+`M19-P8.1` is implemented on `main`, and v0.5.0 has shipped with cold-start state review groups
+and PATH-safe git lookup hardening. The v0.5 SynthBanshee integrated-use review accepts the M19
+blocker loop as closed. Remaining polish for #160, #161, #162, and #163 stays tracked as follow-up
+issue work and should not block the first M20 product slice.

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ workflow.
 - [v0.4 external retry bar](evaluations/v0_4_external_retry_bar.md)
 - [v0.4 external review round summary](evaluations/v0_4_external_review_round_summary.md)
 - [v0.4 external findings register](evaluations/v0_4_external_findings_register.md)
+- [v0.5 SynthBanshee integrated-use review](evaluations/v0_5_synthbanshee_integrated_use/summary.md)
 - [Public mock client acceptance](evaluations/public_mock_client_acceptance.md)
 
 ## Releases
@@ -42,4 +43,5 @@ workflow.
 - [v0.2.0 release notes](releases/v0_2_0_release_notes.md)
 - [v0.3.0 release notes](releases/v0_3_0_release_notes.md)
 - [v0.4.0 release notes](releases/v0_4_0_release_notes.md)
+- [v0.5.0 release notes](releases/v0_5_0_release_notes.md)
 - [v1 release handoff](releases/v1_release_handoff.md)

--- a/docs/evaluations/v0_4_external_findings_register.md
+++ b/docs/evaluations/v0_4_external_findings_register.md
@@ -37,6 +37,29 @@ now affect the accepted M19 sequence because they expose generated-state correct
 | V04-F13 | Generated Evidence/Contradictions text can leak control bytes. | SynthBanshee follow-up issue #165 reports UTF-8 punctuation from clean source docs becoming BEL, partial UTF-8 bytes, digit substitutions, and YAML `\xNN` escapes in generated wiki pages and review tasks. | Ingest generation, evidence extraction, wiki/task markdown, YAML frontmatter | P1 | Fix the encoding/sanitization path and add regression coverage proving generated markdown/YAML contains no control bytes. Treat as an immediate bugfix before broader handoff work. |
 | V04-F14 | Manifest `pipeline_version` provenance can stay stale after path repair plus ingest. | SynthBanshee follow-up issue #164 reports manifests retaining old `pipeline_version` values after `source update-path` and ingest rewrite `last_run_id`, while run records and wiki pages reflect the newer Splendor version. | Source manifests, ingest provenance, source path repair | P1 | Refresh manifest `pipeline_version` whenever ingest/source refresh rewrites manifest provenance, or document immutable semantics with a migration path. Include this in `M19-P5.2` with V04-F13. |
 
+## Post-v0.5 Disposition
+
+The v0.5 SynthBanshee integrated-use review closes the M19 blocker loop and turns this register into
+historical evidence plus follow-up triage. The original recommended actions below are no longer the
+active implementation queue unless the disposition says a follow-up issue remains open.
+
+| ID | v0.5 disposition | Current tracking |
+| --- | --- | --- |
+| V04-F1 | Implemented by `M19-P5.1`: legacy mutating maintenance/workflow verbs now preview by default and require explicit `--apply` for writes. | Closed M19 work. |
+| V04-F2 | Implemented by `M19-P6.1`: handoff inference reconciles stale dynamic planning docs with ordered roadmap and recent mainline evidence. | Closed M19 work. |
+| V04-F3 | Implemented by `M19-P7.1`: bounded related parent/sibling work threads now surface; issue #156 is closed. | Closed M19 work. |
+| V04-F4 | Implemented by `M19-P8.1` through first-run state location/review clarity. The v0.5 integrated-use reviewer accepted this from release notes and local coverage, but did not rerun a fresh cold-directory test. | Closed M19 blocker; no new issue unless fresh cold-start use reproduces churn. |
+| V04-F5 | Implemented by `M19-P8.1`: PATH-safe git lookup no longer crashes on empty or malformed PATH probes, and regression coverage exists. | Closed M19 work. |
+| V04-F6 | Materially improved by `M19-P7.1`, but goal phrasing can still displace authority-cited paths from the top read-first slots. | Follow-up #160 under Milestone 20. |
+| V04-F7 | Materially improved by `M19-P7.1`, but one `splendor wiki suggest <source-id>` maintenance action still leaks into the work footer. | Follow-up #161 under Milestone 20. |
+| V04-F8 | Partially improved for JSON, but human no-diff `pr-summary` output still needs a louder short-circuit. | Follow-up #162 under Milestone 20. |
+| V04-F9 | Partially improved: `mutation` is now present, but `queue clean --json` still emits redundant legacy aliases. | Follow-up #163 under Milestone 20. |
+| V04-F10 | Not addressed by M19; still acceptable polish. | Open only if first-run scan ranking becomes relevant to a later slice. |
+| V04-F11 | Not addressed by M19; still acceptable polish. | Open only if ingest progress becomes relevant to a later slice. |
+| V04-F12 | Not addressed by M19; still acceptable polish. | Open only if lint link resolution is reproduced. |
+| V04-F13 | Implemented by `M19-P5.2`: generated text integrity checks and sanitization cover control-byte leakage. | Closed M19 work. |
+| V04-F14 | Implemented by `M19-P5.2`: manifest `pipeline_version` provenance is refreshed when ingest rewrites manifest provenance. | Closed M19 work. |
+
 ## Validated Improvements
 
 | ID | Improvement | Evidence | Follow-up |
@@ -46,10 +69,11 @@ now affect the accepted M19 sequence because they expose generated-state correct
 | V04-S3 | Maintenance separation is materially better. | SynthBanshee and hocrgen saw maintenance state separated from primary work more clearly than v0.3. | Avoid regressing this when adding more issue/context signals. |
 | V04-S4 | Provisional uncurated context is useful. | Partners noticed relevant uncurated docs appearing with curation hints. | Keep provisional labels clear and avoid silently promoting unreviewed sources to authority. |
 
-## Suggested Sequencing
+## Historical M19 Sequencing
 
-The review round set the original M19 order. The post-round follow-up findings above insert one
-generated-state safety slice before completion-aware handoff inference resumes:
+The review round set the original M19 order. The post-round follow-up findings above inserted one
+generated-state safety slice before completion-aware handoff inference resumed. This sequence is now
+complete as of v0.5.0:
 
 1. **`M19-P5.1` safety first:** address V04-F1, because mixed mutation semantics can destroy
    exploratory handoff safety.
@@ -61,11 +85,13 @@ generated-state safety slice before completion-aware handoff inference resumes:
 4. **`M19-P7.1` handoff breadth third:** address V04-F3 and V04-F6 together if scope allows.
 5. **`M19-P8.1` cold-start adoption fourth:** address V04-F4 plus the narrower V04-F5 robustness
    bug.
-6. **Polish later:** address V04-F7 through V04-F12 as scoped follow-ups or opportunistic fixes.
+6. **Polish later:** V04-F7 through V04-F12 remain scoped follow-ups only where the post-v0.5
+   disposition table names an active issue.
 
 ## Non-Decisions
 
-- This register records the accepted M19 sequencing but does not implement any of those slices.
-- This register does not update product or roadmap commitments.
+- This register records the historical M19 sequencing and the post-v0.5 disposition; it is still not
+  itself a committed roadmap.
+- This register does not implement product behavior.
 - This register does not change the v0.4.0 release notes.
 - This register does not decide whether raw external notes should remain unedited long term.

--- a/docs/evaluations/v0_5_synthbanshee_integrated_use/claude_followup_reply.md
+++ b/docs/evaluations/v0_5_synthbanshee_integrated_use/claude_followup_reply.md
@@ -1,0 +1,164 @@
+# Repro Snippets
+
+## #160 — goal-phrasing sensitivity
+
+Missed-case command (`renderer.py` and `test_effective_prosody_cap.py` absent):
+
+```bash
+~/.local/bin/splendor brief --agent-context "pick up M17 ASR work"
+````
+
+Files to read first from that run:
+
+* `docs/audio_generation_v3_design.md`
+* `docs/implementation_plan.md`
+* `docs/spec.md`
+* `synthbanshee/data/taxonomy.yaml`
+* `synthbanshee/tts/mixer.py`
+
+Appeared-case command (`renderer.py` present, test file still absent — partial surface):
+
+```bash
+~/.local/bin/splendor brief --agent-context "what's the current state of the SynthBanshee active milestone"
+```
+
+Files to read first from that run:
+
+* `synthbanshee/data/taxonomy.yaml`
+* `synthbanshee/tts/mixer.py`
+* `synthbanshee/tts/renderer.py`
+* `synthbanshee/script/templates/she_proves/intimate_terror_coercive_control.j2`
+* `CLAUDE.md`
+
+Both files are named in `AGENTS.md` (which surfaces in both runs as current-authority/current/current/inferred-authority, top score). The boost is firing for `renderer.py` on the broader goal but suppressed on the narrower M17 goal — so this isn't "boost not implemented", it's a goal-token / score interaction that pushes authority-cited paths off the top-5 when a goal-specific token competes.
+
+Note also that `tests/unit/test_effective_prosody_cap.py` is missed in both outputs above despite being explicitly named in `AGENTS.md` alongside `renderer.py` — a separate signal that test-path boosting may be weaker than implementation-path boosting.
+
+For symmetry, the empty/broken-PATH probe (which strips git context entirely) did surface the test file:
+
+```bash
+PATH="/nonexistent:/tmp:/usr/local/bin" ~/.local/bin/splendor brief --agent-context "test"
+```
+
+Output:
+
+* Suggested next:
+  - `[medium/git-context] Read first file configs/scenes/test_scene_001.yaml`
+  - `[medium/git-context] Read first file tests/unit/test_effective_prosody_cap.py`
+  - `[medium/git-context] Read first file CLAUDE.md`
+
+This suggests the boost lands when there's nothing else competing for the slot — further pointing at "ranking interaction" rather than "boost wiring missing".
+
+## #163 — JSON schema coexistence
+
+Command:
+
+```bash
+~/.local/bin/splendor queue clean --orphaned --json
+```
+
+Top-level keys observed:
+
+* `actions`
+* `applied`
+* `mutation`
+* `selectors`
+* `skipped`
+* `summary`
+* `written`
+
+Trimmed body:
+
+```json
+{
+  "applied": false,
+  "selectors": ["orphaned"],
+  "summary": { "planned": 1, "written": 0, "skipped": 0 },
+  "actions": [
+    {
+      "job_id": "ingest-src-9d9759e5…",
+      "path": "state/queue/ingest-src-9d9759e5….json",
+      "source_id": "src-9d9759e5…",
+      "cleanup_state": "orphaned",
+      "status": "planned",
+      "reason": null
+    }
+  ],
+  "written": [],
+  "skipped": [],
+  "mutation": {
+    "mode": "preview",
+    "mutates": false,
+    "planned": [
+      {
+        "action": "delete",
+        "path": "state/queue/ingest-src-9d9759e5….json",
+        "kind": "queue_record",
+        "...": "..."
+      }
+    ]
+  }
+}
+```
+
+Redundancy map:
+
+* `applied` (bool) ≈ `mutation.mutates` (bool)
+* `summary.planned` ≈ `len(mutation.planned)`
+* `summary.written` ≈ `len(mutation.written)`
+* top-level `written` / `skipped` arrays overlap with `actions[].status` filtered views
+
+`actions` and `selectors` are verb-specific payloads (no equivalent in `mutation.*`) and should stay.
+
+Preferred canonical contract:
+
+* Keep `mutation.{mode,mutates,planned,written}` as the single cross-verb mutation contract.
+  - It is already used by:
+  - source refresh
+  - source update-path
+  - workspace refresh
+  - ingest --pending
+  - All mutating verbs already speak it.
+* Preserve verb-specific payloads (`actions`, `selectors` for queue clean).
+* Mark redundant top-level aliases as deprecated compatibility aliases in v0.5.x release notes:
+  - `applied`
+  - `summary`
+  - `written`
+  - `skipped`
+* Emit both for one minor release.
+* Drop deprecated aliases in v0.6.0.
+
+Rationale:
+
+* Documenting both indefinitely re-creates the v0.4 ambiguity that #163 was filed against.
+* Deprecating-then-dropping converges on one source of truth without breaking anything mid-cycle.
+
+## Optional — #161 trailing footer leak
+
+Tail of:
+
+```bash
+~/.local/bin/splendor brief --agent-context "pick up M17 ASR work"
+```
+
+Output:
+
+* Next actions:
+  - Review issue #97: TTS distress cue absent at I3–I5: rate + pitch are not sufficient signal
+  - Review issue #87: investigate(tts): #83 residual — Whisper WER regression on high-intensity (I3+) Tier A clips
+  - Review issue #92: tts: aggregate Hebrew TTS naturalness backlog from 2026-05-06 listening test
+  - Review commit `37c5f62`: `fix(tts): #87 partial — effective-prosody cap addresses Whisper backdoor + helium range (#90)`
+  - Review commit `94086a8`: `fix(preprocessing): #78 define loudness contract + metadata trail (does NOT recover Whisper — see #83) (#82)`
+  - Run `splendor wiki suggest <source-id>` for ingested sources missing synthesis follow-up.
+  - Open the top matching wiki or planning records for the stated goal.
+  - Read the top authority docs before changing planning-heavy behavior.
+
+The leaking line is:
+
+```text
+Run `splendor wiki suggest <source-id>` for ingested sources missing synthesis follow-up.
+```
+
+This is a maintenance verb in the middle of the work-context footer, between commit-review work items and the generic "open top matches" / "read top authority docs" tail.
+
+The other two tail lines are work-context-flavored (read-first guidance), which is fine; only the `wiki suggest` line is misplaced.

--- a/docs/evaluations/v0_5_synthbanshee_integrated_use/claude_followup_reply.md
+++ b/docs/evaluations/v0_5_synthbanshee_integrated_use/claude_followup_reply.md
@@ -6,7 +6,7 @@ Missed-case command (`renderer.py` and `test_effective_prosody_cap.py` absent):
 
 ```bash
 ~/.local/bin/splendor brief --agent-context "pick up M17 ASR work"
-````
+```
 
 Files to read first from that run:
 

--- a/docs/evaluations/v0_5_synthbanshee_integrated_use/claude_review.md
+++ b/docs/evaluations/v0_5_synthbanshee_integrated_use/claude_review.md
@@ -1,0 +1,84 @@
+# Splendor v0.5.0 — Review Report
+
+## Install & Version
+
+```bash
+uv tool install --reinstall \
+  https://github.com/splendor-dev/splendor/releases/download/v0.5.0/splendor-0.5.0-py3-none-any.whl
+~/.local/bin/splendor --version
+# → splendor 0.5.0
+````
+
+`.venv/bin/splendor` is unchanged at `0.2.0` — PATH precedence trap is unchanged. Always use `~/.local/bin/splendor`.
+
+## Review Commands Run
+
+```bash
+~/.local/bin/splendor brief --agent-context "pick up M17 ASR work"
+~/.local/bin/splendor brief --agent-context "what's the current state of the SynthBanshee active milestone"
+~/.local/bin/splendor suggest-next "what's the current SynthBanshee active work"
+~/.local/bin/splendor source refresh --help
+~/.local/bin/splendor ingest --help
+~/.local/bin/splendor workspace refresh --help
+~/.local/bin/splendor source update-path --help
+~/.local/bin/splendor source refresh AGENTS.md --json     # preview-mode contract probe
+~/.local/bin/splendor queue clean --orphaned --json       # JSON contract probe (#163)
+~/.local/bin/splendor ingest --pending --json             # preview-mode contract probe
+~/.local/bin/splendor pr-summary --since main             # degenerate head==merge_base (#162)
+~/.local/bin/splendor pr-summary --since main --json
+~/.local/bin/splendor health --json
+~/.local/bin/splendor lint --json
+PATH="" ~/.local/bin/splendor brief --agent-context "test"             # PATH-safe git
+PATH="/nonexistent:/tmp:/usr/local/bin" ~/.local/bin/splendor brief …
+PATH="/usr/bin:/bin" ~/.local/bin/splendor brief …
+# control-byte scan: find planning wiki state … | xargs grep -lP '[\x00-\x08\x0e-\x1f\x7f]'
+# trailing newline check: tail -c 30 planning/tasks/task-review-*.md | xxd
+ls -la CLAUDE.md AGENTS.md   # symlink confirmation (#157)
+```
+
+## Verdict: Mostly Closed with Caveats
+
+All blockers (A apply-gate, B multi-issue surfacing) are closed. All correctness/safety items in the codex framing are addressed. Four polish residuals remain — none of them block use, none of them require a v0.5.x patch loop.
+
+## Codex Framing — 8 Areas
+
+| # | Area                                                  | Status                                                                                                                                                                     |
+| - | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1 | Legacy mutating preview/apply harmonization           | Fixed — `--apply` uniformly required; `mutation.{mode,mutates,planned}` consistent                                                                                         |
+| 2 | Generated text control-byte sanitization (#165)       | Fixed — clean scan of `planning/`, `wiki/`, `state/`                                                                                                                       |
+| 3 | Manifest provenance after path repair + ingest (#164) | Fixed — issue closed via PR #167; not reproduced this trial                                                                                                                |
+| 4 | Completion-aware handoff (M19-P6.1)                   | Fixed — #91 / PR #95 demoted from suggestions, parent #87 + siblings remain                                                                                                |
+| 5 | Broader related work-thread surfacing (#156)          | Fixed — `[high/work-thread]` shows 3–4 issues with parents/siblings                                                                                                        |
+| 6 | Policy-cited file surfacing (#160)                    | Materially improved but still imperfect — `mixer.py` boosted; `renderer.py` + `test_effective_prosody_cap.py` missed on the M17-specific goal but present on broader goals |
+| 7 | Cold-start / custom-layout state review               | Trusting release notes — not exercised in cold dir; `splendor init --help` is bare; not in the 9                                                                           |
+| 8 | PATH-safe git lookup                                  | Fixed — `PATH=""` and `PATH="/nonexistent…"` both fall back gracefully without crash, no Git context: line                                                                 |
+
+## Codex Framing — 7 Earlier Recommendations
+
+| # | Recommendation                                     | Status                                                                                                                                                                                                                        |
+| - | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1 | Harmonize preview/apply for legacy verbs           | Fixed                                                                                                                                                                                                                         |
+| 2 | Surface 3–5 work-relevant open issues              | Fixed                                                                                                                                                                                                                         |
+| 3 | Boost files cited by authority/policy docs         | Materially improved but still imperfect                                                                                                                                                                                       |
+| 4 | Drop trailing maintenance next-action noise        | Materially improved but still imperfect — one `splendor wiki suggest` verb still leaks into the work footer                                                                                                                   |
+| 5 | Anchor specific authority sections, not just files | Not addressed, acceptable polish — boost is still file-level only                                                                                                                                                             |
+| 6 | Louder no-diff `pr-summary --since main`           | Materially improved but still imperfect — JSON gains a `compact_committed` mode tag, human output still says only `Changed paths: 0`                                                                                          |
+| 7 | Tighten JSON mutation vocabulary                   | Materially improved but still imperfect — `queue clean --json` ships both the v0.4 schema (`applied`/`summary.{planned,written,skipped}`/`actions`) and the documented mutation block side-by-side; pick one or document both |
+
+## Of the Original 9 Issues (#155–#163)
+
+* Fixed (4): #155, #156, #160 (mostly), #161 (mostly).
+* Materially improved but still imperfect (2): #162, #163.
+* Not addressed, acceptable polish (3): #157 (symlink dup), #158 (trailing newline — sampled v0.4-generated files all end in `\n`; unverified for fresh v0.5 generation), #159 (`splendor run prune`).
+* Blockers remaining: 0.
+
+## Recommendation: Move to M20
+
+v0.5.0 is strictly better than v0.4.0 for SynthBanshee day-to-day. M19 cleanup is done; the four polish residuals (#160 goal-sensitivity, #161 single leaky verb, #162 no-diff signal, #163 JSON contract coexistence) can ride on M20 work — they don't justify a dedicated v0.5.x patch cycle.
+
+Two of those residuals are interesting enough that splendor may want them as new tightly-scoped follow-up issues:
+
+* #160 goal-phrasing sensitivity: the read-first boost surfaces `renderer.py` for goal "current state of the milestone" but not for goal "pick up M17 ASR work" — looks like a score-weighting interaction with goal-token similarity that suppresses authority-cited paths when a more specific token is in the goal. Worth a focused regression issue against splendor.
+* #163 schema coexistence rather than harmonization: documented vocabulary now exists under `mutation`, but the legacy top-level `applied`/`summary` fields are still emitted alongside. Pick one as canonical or document both as supported.
+
+Memory updated: `project_splendor_eval_v050_2026_05_08.md` (new), `MEMORY.md` index, v0.4 memo flagged superseded.

--- a/docs/evaluations/v0_5_synthbanshee_integrated_use/claude_review.md
+++ b/docs/evaluations/v0_5_synthbanshee_integrated_use/claude_review.md
@@ -7,7 +7,7 @@ uv tool install --reinstall \
   https://github.com/splendor-dev/splendor/releases/download/v0.5.0/splendor-0.5.0-py3-none-any.whl
 ~/.local/bin/splendor --version
 # → splendor 0.5.0
-````
+```
 
 `.venv/bin/splendor` is unchanged at `0.2.0` — PATH precedence trap is unchanged. Always use `~/.local/bin/splendor`.
 

--- a/docs/evaluations/v0_5_synthbanshee_integrated_use/summary.md
+++ b/docs/evaluations/v0_5_synthbanshee_integrated_use/summary.md
@@ -16,8 +16,10 @@ Raw inputs:
 
 The v0.5.0 review accepts the M19 blocker loop as closed. Legacy mutating preview/apply safety,
 generated-text integrity, completion-aware handoff inference, broader related work-thread
-surfacing, cold-start/PATH hardening, and the main policy-cited read-first behavior are materially
-better than v0.4.0. No v0.5.x patch loop is justified by this review.
+surfacing, PATH-safe git lookup, and the main policy-cited read-first behavior are materially better
+than v0.4.0. The reviewer did not independently exercise cold-start/custom-layout behavior in a
+fresh directory; that part of M19-P8.1 is accepted here from release notes and local implementation
+coverage rather than external cold-dir validation. No v0.5.x patch loop is justified by this review.
 
 The remaining items are polish follow-ups that can ride with Milestone 20 work:
 
@@ -43,7 +45,7 @@ work threads instead of a single open issue.
 
 ## Planning Impact
 
-The review supports moving the active roadmap state from the final M19 durability slice to the first
-M20 product bet. M20 should start with `M20-P1.1` advanced semantic search or vector index work,
-while keeping #160-#163 visible as bounded polish follow-ups that should not reopen the M19 cleanup
-loop.
+The review supports closing the final M19 durability slice, recording this intake as `M20-P0.1`,
+and then moving to the first M20 product bet. After this intake, M20 should start with `M20-P1.1`
+advanced semantic search or vector index work while keeping #160-#163 visible as bounded polish
+follow-ups that should not reopen the M19 cleanup loop.

--- a/docs/evaluations/v0_5_synthbanshee_integrated_use/summary.md
+++ b/docs/evaluations/v0_5_synthbanshee_integrated_use/summary.md
@@ -1,0 +1,49 @@
+# v0.5 SynthBanshee Integrated-Use Review Summary
+
+## Scope
+
+This folder preserves the SynthBanshee integrated-use review of Splendor v0.5.0. The reviewer had
+already judged v0.4.0 fit for day-to-day use and had been using Splendor inside SynthBanshee; this
+round checks the v0.5.0 release against the follow-up issues that emerged from real integrated
+usage rather than from a fresh adoption trial.
+
+Raw inputs:
+
+- `claude_review.md`
+- `claude_followup_reply.md`
+
+## Verdict
+
+The v0.5.0 review accepts the M19 blocker loop as closed. Legacy mutating preview/apply safety,
+generated-text integrity, completion-aware handoff inference, broader related work-thread
+surfacing, cold-start/PATH hardening, and the main policy-cited read-first behavior are materially
+better than v0.4.0. No v0.5.x patch loop is justified by this review.
+
+The remaining items are polish follow-ups that can ride with Milestone 20 work:
+
+- #160: goal phrasing can still displace policy-cited read-first files from the top slots.
+- #161: one maintenance-oriented `splendor wiki suggest` line still leaks into the work footer.
+- #162: no-diff `pr-summary --since <ref>` remains too quiet in human output.
+- #163: `queue clean --json` now emits the canonical `mutation` contract, but also keeps redundant
+  legacy top-level aliases.
+
+Issue #156 should be treated as closed by v0.5.0 because M19-P7.1 now surfaces parent and sibling
+work threads instead of a single open issue.
+
+## Follow-Up Disposition
+
+| Issue | Disposition | Recommended scope |
+| --- | --- | --- |
+| #156 | Close as completed. | No follow-up work; v0.5.0 now surfaces bounded related parent/sibling work threads. |
+| #160 | Keep open, retitle/reframe. | Add a focused regression for goal-sensitive ranking where surfaced authority docs name implementation/test paths but goal-token scoring pushes them out of the read-first list. |
+| #161 | Keep open, narrow. | Remove the remaining `splendor wiki suggest <source-id>` maintenance action from the `brief --agent-context` work footer or move it to the maintenance block only. |
+| #162 | Keep open, narrow. | Make no-diff human output short-circuit loudly when `head == merge_base` or `Changed paths == 0`; JSON improvements alone are not enough. |
+| #163 | Keep open, reframe as deprecation policy. | Treat `mutation.{mode,mutates,planned,written}` as canonical, keep verb-specific payloads, mark top-level aliases deprecated in v0.5.x docs, and plan alias removal in v0.6.0. |
+| #157, #158, #159 | Leave open as P2/P3 polish. | Not blockers for v0.5.0 and not part of the M20 handoff unless they become relevant to the selected slice. |
+
+## Planning Impact
+
+The review supports moving the active roadmap state from the final M19 durability slice to the first
+M20 product bet. M20 should start with `M20-P1.1` advanced semantic search or vector index work,
+while keeping #160-#163 visible as bounded polish follow-ups that should not reopen the M19 cleanup
+loop.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M19-P7.1`
-- Current planned slice: `M19 cold-start adoption and PATH-safe git lookup`
-- Current PR sub-slice: `M19-P8.1`
+- Previous completed PR sub-slice: `M19-P8.1`
+- Current planned slice: `M20 advanced semantic search or vector index`
+- Current PR sub-slice: `M20-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 advanced semantic search or vector index`
-- Next planned PR sub-slice: `M20-P1.1`
+- Next planned slice: `M20 mutating web review workflows`
+- Next planned PR sub-slice: `M20-P2.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1330,11 +1330,11 @@ state by themselves.
 thread to a bounded set of related open parent/sibling issues and boosts implementation/test files
 explicitly named by surfaced authority docs in read-first file ranking.
 
-`M19-P8.1` is the active cold-start robustness slice. It keeps M19 focused on first-run state
-location/review clarity and PATH-safe git lookup regression coverage before any M20 vector-search
-or mutating-web bets begin.
+`M19-P8.1` is implemented on `main`. It completed the final M19 durability pass by adding
+first-run state location/review clarity and PATH-safe git lookup regression coverage before any M20
+vector-search or mutating-web bets began.
 
-The remaining M19 sequence is therefore:
+The completed M19 sequence is therefore:
 
 - `M19-P5.2` Generated text integrity and manifest provenance fixes: eliminate control-byte
   corruption from generated Evidence/Contradictions output and keep source-manifest
@@ -1347,13 +1347,19 @@ The remaining M19 sequence is therefore:
 - `M19-P8.1` Cold-start adoption and focused robustness: make first-run state location/review
   explicit and fix the PATH-safe git lookup failure seen in the hocrsyngen trial.
 
+The v0.5 SynthBanshee integrated-use review in
+`docs/evaluations/v0_5_synthbanshee_integrated_use/summary.md` accepts the M19 blocker loop as
+closed. It leaves four bounded polish issues for later work: #160 goal-sensitive policy-cited
+read-first ranking, #161 one maintenance line leaking into the work footer, #162 too-quiet no-diff
+human `pr-summary`, and #163 mutation JSON compatibility aliases.
+
 ## Milestone 20 — post-v1 product bets
 
 ### Goal
-Keep larger product bets visible without treating them as the next blocker. Current external
-feedback points to handoff shape and workflow safety before search infrastructure. After the v0.4
-external review round, Milestone 20 remains deferred until the remaining M19 durability sequence is
-closed or explicitly reprioritized.
+Start larger product bets now that the v0.5 integrated-use review accepts the M19 durability loop
+as closed. The first M20 slice should focus on semantic retrieval or vector-index quality without
+absorbing mutating web workflows or reopening the closed M19 blocker sequence. Remaining M19 polish
+issues can ride along only when they are directly relevant to the selected M20 implementation.
 
 ### Candidate PR slices
 - `M20-P1.1` Add advanced semantic search or a vector index (#118).

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -335,11 +335,11 @@ annotations plus linked review tasks for explicit conflicts, richer query metada
 deterministic lint/health validation for those cross-links.
 
 - Previous completed PR sub-slice: `M19-P8.1`
-- Current planned slice: `M20 advanced semantic search or vector index`
-- Current PR sub-slice: `M20-P1.1`
+- Current planned slice: `M20 review intake and planning handoff`
+- Current PR sub-slice: `M20-P0.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 mutating web review workflows`
-- Next planned PR sub-slice: `M20-P2.1`
+- Next planned slice: `M20 advanced semantic search or vector index`
+- Next planned PR sub-slice: `M20-P1.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1349,19 +1349,23 @@ The completed M19 sequence is therefore:
 
 The v0.5 SynthBanshee integrated-use review in
 `docs/evaluations/v0_5_synthbanshee_integrated_use/summary.md` accepts the M19 blocker loop as
-closed. It leaves four bounded polish issues for later work: #160 goal-sensitive policy-cited
-read-first ranking, #161 one maintenance line leaking into the work footer, #162 too-quiet no-diff
-human `pr-summary`, and #163 mutation JSON compatibility aliases.
+closed. It exercised the PATH-safe git lookup fix directly, while treating the cold-start layout
+changes as accepted from release notes and local implementation coverage rather than from a fresh
+cold-directory retest. It leaves four bounded polish issues for later work: #160 goal-sensitive
+policy-cited read-first ranking, #161 one maintenance line leaking into the work footer, #162
+too-quiet no-diff human `pr-summary`, and #163 mutation JSON compatibility aliases.
 
 ## Milestone 20 — post-v1 product bets
 
 ### Goal
 Start larger product bets now that the v0.5 integrated-use review accepts the M19 durability loop
-as closed. The first M20 slice should focus on semantic retrieval or vector-index quality without
-absorbing mutating web workflows or reopening the closed M19 blocker sequence. Remaining M19 polish
-issues can ride along only when they are directly relevant to the selected M20 implementation.
+as closed. After the `M20-P0.1` intake handoff, the first M20 product slice should focus on semantic
+retrieval or vector-index quality without absorbing mutating web workflows or reopening the closed
+M19 blocker sequence. Remaining M19 polish issues can ride along only when they are directly
+relevant to the selected M20 implementation.
 
 ### Candidate PR slices
+- `M20-P0.1` Record v0.5 SynthBanshee integrated-use review intake and M20 issue disposition.
 - `M20-P1.1` Add advanced semantic search or a vector index (#118).
 - `M20-P2.1` Explore mutating web review workflows (#119).
 - Add richer GitHub issue, PR, review-thread, and CI integrations on top of the v0.4 handoff model.


### PR DESCRIPTION
## Summary

- preserve the raw v0.5 SynthBanshee integrated-use review and follow-up reply under `docs/evaluations/v0_5_synthbanshee_integrated_use/`
- add a synthesized intake summary that closes the M19 blocker loop while explicitly noting that cold-start/custom-layout behavior was not independently retested by the reviewer
- synchronize planning-state lines across `.agent-plan.md`, README "What Comes Next", and the roadmap so this review-intake PR is `M20-P0.1` and the next implementation slice is `M20-P1.1`
- update the v0.4 findings register with a post-v0.5 disposition table mapping original findings to completed M19 work or remaining follow-up issues
- update the documentation indexes to include the v0.5 review summary and v0.5.0 release notes

## GitHub issue updates

- closed #156 as completed by M19-P7.1 / v0.5.0
- updated #160 with the narrowed goal-sensitive authority-cited read-first ranking residual and assigned it to Milestone 20
- updated #161 with the single remaining `splendor wiki suggest` footer leak and assigned it to Milestone 20
- updated #162 with the remaining human no-diff short-circuit need and assigned it to Milestone 20
- updated #163 to canonicalize `mutation.{mode,mutates,planned,written}` and deprecate queue-clean aliases under Milestone 20

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run pytest` (`719 passed`)

## Notes

This PR does not implement M20 vector search, mutating web workflows, or the polish fixes themselves. It only ingests the v0.5 integrated-use review, updates planning truth, and narrows the follow-up issue backlog.
