### PR TITLE
M20-P1.1: Advanced semantic search or vector index

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M19-P8.1`
-- Last action taken: `M19-P8.1` and the v0.5.0 release were merged to main via PRs #170 and
-  #171; the v0.5 SynthBanshee integrated-use review accepted the M19 blocker loop as closed.
-- Current planned slice: `M20 review intake and planning handoff`
-- Current PR sub-slice: `M20-P0.1`
+- Previous completed PR sub-slice: `M20-P0.1`
+- Last action taken: `M20-P0.1` review intake merged to main via PR #172 after the v0.5.0
+  release; this branch implements the first M20 retrieval product slice.
+- Current planned slice: `M20 advanced semantic search or vector index`
+- Current PR sub-slice: `M20-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 advanced semantic search or vector index`
-- Next planned PR sub-slice: `M20-P1.1`
+- Next planned slice: `M20 mutating web review workflows`
+- Next planned PR sub-slice: `M20-P2.1`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -289,6 +289,12 @@ signals. Title/path/scope matches carry more weight than loose body overlap, and
 review noise from burying current specs, rollout plans, accepted decisions, and key contradicting
 research.
 
+`M20-P1.1` begins the advanced retrieval track conservatively. `splendor query` now adds
+runtime-only semantic expansion to deterministic local scoring with a small built-in acronym phrase
+map for common code/research workflow terms. This improves query and agent-context handoff matches
+such as `ASR` to `automatic speech recognition` without
+adding a persisted vector store, external service, database, or background worker.
+
 `M17-P4.1` reduces issue #117 contradiction-review task noise without weakening contradiction
 evidence. Ingest-created contradiction-review tasks are classified as generated planning records,
 hidden from default active planning handoff, and managed intentionally through task-list, resolve,
@@ -329,12 +335,12 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M19-P8.1`
-- Current planned slice: `M20 review intake and planning handoff`
-- Current PR sub-slice: `M20-P0.1`
+- Previous completed PR sub-slice: `M20-P0.1`
+- Current planned slice: `M20 advanced semantic search or vector index`
+- Current PR sub-slice: `M20-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 advanced semantic search or vector index`
-- Next planned PR sub-slice: `M20-P1.1`
+- Next planned slice: `M20 mutating web review workflows`
+- Next planned PR sub-slice: `M20-P2.1`
 
 `M5-P2` is implemented: the repository now pairs the MVP docs/example slice with
 hardening work for operational edge cases, consistent one-line CLI error output, and source/wheel

--- a/README.md
+++ b/README.md
@@ -289,11 +289,12 @@ signals. Title/path/scope matches carry more weight than loose body overlap, and
 review noise from burying current specs, rollout plans, accepted decisions, and key contradicting
 research.
 
-`M20-P1.1` begins the advanced retrieval track conservatively. `splendor query` now adds
-runtime-only semantic expansion to deterministic local scoring with a small built-in acronym phrase
-map for common code/research workflow terms. This improves query and agent-context handoff matches
-such as `ASR` to `automatic speech recognition` without
-adding a persisted vector store, external service, database, or background worker.
+`M20-P1.1` begins the retrieval track conservatively. `splendor query` now adds a bounded,
+runtime-only acronym phrase expansion to deterministic local scoring for common code/research
+workflow terms. This improves query and agent-context handoff recall for cases such as `ASR` to
+`automatic speech recognition` while keeping exact lexical evidence ranked ahead of expansion-only
+matches and without adding a persisted vector store, external service, database, or background
+worker.
 
 `M17-P4.1` reduces issue #117 contradiction-review task noise without weakening contradiction
 evidence. Ingest-created contradiction-review tasks are classified as generated planning records,

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -599,10 +599,10 @@ Current implementation fields:
 
 Query matches preserve rank, score, class/kind, record identity, path, status/review state, snippet,
 source refs, generated run IDs, provenance links, contradiction counts, review task IDs, and tags.
-Scores may include deterministic runtime semantic expansion from local document text, including
-a small built-in acronym phrase map. The semantic profile is recoverable from the document text and
-implementation constants; it is not persisted in `state/queries/last-query.json`, source manifests,
-wiki frontmatter, or any separate index file.
+Scores may include deterministic runtime acronym phrase expansion from local document text. The
+bounded expansion profile is recoverable from the document text and implementation constants,
+expansion-only matches are capped below direct lexical evidence, and no expansion state is persisted
+in `state/queries/last-query.json`, source manifests, wiki frontmatter, or any separate index file.
 When a source filter is provided by readable path and multiple content-addressed source versions
 share that path, `source_id` stores the primary resolved source ID and `source_ids` stores every
 matching source ID used for the filter.

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -599,6 +599,10 @@ Current implementation fields:
 
 Query matches preserve rank, score, class/kind, record identity, path, status/review state, snippet,
 source refs, generated run IDs, provenance links, contradiction counts, review task IDs, and tags.
+Scores may include deterministic runtime semantic expansion from local document text, including
+a small built-in acronym phrase map. The semantic profile is recoverable from the document text and
+implementation constants; it is not persisted in `state/queries/last-query.json`, source manifests,
+wiki frontmatter, or any separate index file.
 When a source filter is provided by readable path and multiple content-addressed source versions
 share that path, `source_id` stores the primary resolved source ID and `source_ids` stores every
 matching source ID used for the filter.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -1371,11 +1371,12 @@ relevant to the selected M20 implementation.
 - Add richer GitHub issue, PR, review-thread, and CI integrations on top of the v0.4 handoff model.
 
 `M20-P1.1` starts the retrieval product bet without crossing into heavyweight infrastructure. The
-first slice adds deterministic runtime semantic expansion to `splendor query` and the query-backed
-parts of `brief --agent-context`, using a small built-in acronym phrase map instead of external
-services, background workers, databases, or persisted vector-index state. This keeps retrieval
-improvements inspectable and recoverable from file-based workspace state while leaving mutating web
-review workflows for `M20-P2.1`.
+first slice adds deterministic runtime acronym phrase expansion to `splendor query` and the
+query-backed parts of `brief --agent-context`, using a small built-in map instead of external
+services, background workers, databases, or persisted vector-index state. This is a bounded recall
+improvement, not a full vector-search implementation: exact lexical evidence still ranks ahead of
+expansion-only matches, and broader retrieval evaluation remains part of the M20 search track.
+Mutating web review workflows stay deferred to `M20-P2.1`.
 
 ---
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M19-P8.1`
-- Current planned slice: `M20 review intake and planning handoff`
-- Current PR sub-slice: `M20-P0.1`
+- Previous completed PR sub-slice: `M20-P0.1`
+- Current planned slice: `M20 advanced semantic search or vector index`
+- Current PR sub-slice: `M20-P1.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 advanced semantic search or vector index`
-- Next planned PR sub-slice: `M20-P1.1`
+- Next planned slice: `M20 mutating web review workflows`
+- Next planned PR sub-slice: `M20-P2.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1369,6 +1369,13 @@ relevant to the selected M20 implementation.
 - `M20-P1.1` Add advanced semantic search or a vector index (#118).
 - `M20-P2.1` Explore mutating web review workflows (#119).
 - Add richer GitHub issue, PR, review-thread, and CI integrations on top of the v0.4 handoff model.
+
+`M20-P1.1` starts the retrieval product bet without crossing into heavyweight infrastructure. The
+first slice adds deterministic runtime semantic expansion to `splendor query` and the query-backed
+parts of `brief --agent-context`, using a small built-in acronym phrase map instead of external
+services, background workers, databases, or persisted vector-index state. This keeps retrieval
+improvements inspectable and recoverable from file-based workspace state while leaving mutating web
+review workflows for `M20-P2.1`.
 
 ---
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1118,12 +1118,12 @@ pages, sections such as `Core Claims`, `Design Implications`, `Product Experienc
 source extract should outrank frontmatter-derived facts, provenance boilerplate, and generic
 machine-generated labels.
 
-Current query ranking includes a deterministic local semantic expansion layer. It derives
-inspectable in-memory signals from document text through a small built-in acronym phrase map for
-common code/research workflow terms such as ASR, CLI, OCR, PR, and UI. These signals can match
-`ASR` against `automatic speech recognition` and flow into
-`brief --agent-context` query matches, but they do not write persisted index state, call external
-services, or change source/wiki schemas.
+Current query ranking includes a bounded deterministic acronym phrase expansion layer. It derives
+inspectable in-memory signals from document text through a small built-in map for common
+code/research workflow terms such as ASR, CLI, OCR, PR, and UI. These signals can match `ASR`
+against `automatic speech recognition` and flow into `brief --agent-context` query matches, but
+expansion-only matches are capped below direct lexical evidence. The feature does not write
+persisted index state, call external services, or change source/wiki schemas.
 
 Current query output includes any active deterministic filters. `splendor query --tag <tag>`
 restricts matches to wiki pages carrying all requested tags, and

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1118,6 +1118,13 @@ pages, sections such as `Core Claims`, `Design Implications`, `Product Experienc
 source extract should outrank frontmatter-derived facts, provenance boilerplate, and generic
 machine-generated labels.
 
+Current query ranking includes a deterministic local semantic expansion layer. It derives
+inspectable in-memory signals from document text through a small built-in acronym phrase map for
+common code/research workflow terms such as ASR, CLI, OCR, PR, and UI. These signals can match
+`ASR` against `automatic speech recognition` and flow into
+`brief --agent-context` query matches, but they do not write persisted index state, call external
+services, or change source/wiki schemas.
+
 Current query output includes any active deterministic filters. `splendor query --tag <tag>`
 restricts matches to wiki pages carrying all requested tags, and
 `splendor query --source <source-id|title|path>` resolves the source filter to canonical source
@@ -1249,7 +1256,9 @@ work-first default for implementation and planning goals.
 
 ### 18.1 Early search
 
-Early versions should use deterministic local search over markdown/filesystem metadata plus the wiki index.
+Early versions should use deterministic local search over markdown/filesystem metadata plus the wiki
+index. The first M20 retrieval improvement stays in that shape by adding runtime-only semantic
+expansion to the lexical scorer instead of introducing a mandatory vector database.
 
 ### 18.2 Future search
 

--- a/src/splendor/commands/query.py
+++ b/src/splendor/commands/query.py
@@ -446,14 +446,15 @@ def _contains_token_sequence(tokens: list[str], phrase: tuple[str, ...]) -> bool
 
 
 def _score_document(document: _QueryDocument, query_tokens: list[str]) -> int:
-    score = 0
+    lexical_score = 0
     for token in query_tokens:
-        score += 5 * document.title_tokens.count(token)
-        score += 4 * document.record_id_tokens.count(token)
-        score += 3 * document.keyword_tokens.count(token)
-        score += document.body_tokens.count(token)
-        score += 2 * document.semantic_tokens.count(token)
-    return score
+        lexical_score += 5 * document.title_tokens.count(token)
+        lexical_score += 4 * document.record_id_tokens.count(token)
+        lexical_score += 3 * document.keyword_tokens.count(token)
+        lexical_score += document.body_tokens.count(token)
+    semantic_score = sum(document.semantic_tokens.count(token) for token in query_tokens)
+    semantic_boost = min(1, semantic_score)
+    return lexical_score + semantic_boost if lexical_score > 0 else semantic_boost
 
 
 def _best_snippet(text: str, query_tokens: list[str]) -> str:
@@ -506,7 +507,10 @@ def _candidate_score(candidate: str, query_tokens: list[str]) -> int:
     if heading in _CLAIM_SECTION_HEADINGS:
         heading_bonus = 3
     boilerplate_penalty = _boilerplate_score(candidate)
-    return token_score + semantic_score + heading_bonus - boilerplate_penalty
+    semantic_boost = min(1, semantic_score)
+    if token_score == 0:
+        return semantic_boost - boilerplate_penalty
+    return token_score + semantic_boost + heading_bonus - boilerplate_penalty
 
 
 def _candidate_segments(text: str) -> list[str]:

--- a/src/splendor/commands/query.py
+++ b/src/splendor/commands/query.py
@@ -51,6 +51,14 @@ _BOILERPLATE_TERMS = {
     "source",
     "version",
 }
+_SEMANTIC_ALIASES = {
+    "asr": ("automatic", "speech", "recognition"),
+    "ci": ("continuous", "integration"),
+    "cli": ("command", "line", "interface"),
+    "ocr": ("optical", "character", "recognition"),
+    "pr": ("pull", "request"),
+    "ui": ("user", "interface"),
+}
 
 
 class QueryValidationError(ValueError):
@@ -127,6 +135,7 @@ class _QueryDocument:
     record_id_tokens: list[str]
     keyword_tokens: list[str]
     body_tokens: list[str]
+    semantic_tokens: list[str]
     snippet_source: str
 
 
@@ -318,6 +327,18 @@ def _iter_wiki_documents(root: Path, layout: ResolvedLayout) -> list[_QueryDocum
                     " ".join([frontmatter.kind, frontmatter.status, *frontmatter.tags])
                 ),
                 body_tokens=_content_tokens(parsed.body),
+                semantic_tokens=_semantic_tokens(
+                    " ".join(
+                        [
+                            frontmatter.title,
+                            frontmatter.page_id,
+                            frontmatter.kind,
+                            frontmatter.status,
+                            " ".join(frontmatter.tags),
+                            parsed.body,
+                        ]
+                    )
+                ),
                 snippet_source=parsed.body,
             )
         )
@@ -375,6 +396,9 @@ def _iter_planning_documents(root: Path, layout: ResolvedLayout) -> list[_QueryD
                     record_id_tokens=_content_tokens(record_id),
                     keyword_tokens=_content_tokens(" ".join(keyword_values)),
                     body_tokens=_content_tokens(search_body),
+                    semantic_tokens=_semantic_tokens(
+                        " ".join([record.title, record_id, " ".join(keyword_values), search_body])
+                    ),
                     snippet_source=parsed.body,
                 )
             )
@@ -403,6 +427,24 @@ def _content_tokens(text: str) -> list[str]:
     return _TOKEN_PATTERN.findall(text.lower())
 
 
+def _semantic_tokens(text: str) -> list[str]:
+    tokens = _content_tokens(text)
+    semantic: list[str] = []
+    for token in tokens:
+        semantic.extend(_SEMANTIC_ALIASES.get(token, ()))
+
+    for alias, phrase in _SEMANTIC_ALIASES.items():
+        if _contains_token_sequence(tokens, phrase):
+            semantic.append(alias)
+    return semantic
+
+
+def _contains_token_sequence(tokens: list[str], phrase: tuple[str, ...]) -> bool:
+    if not phrase or len(phrase) > len(tokens):
+        return False
+    return any(tuple(tokens[index : index + len(phrase)]) == phrase for index in range(len(tokens)))
+
+
 def _score_document(document: _QueryDocument, query_tokens: list[str]) -> int:
     score = 0
     for token in query_tokens:
@@ -410,6 +452,7 @@ def _score_document(document: _QueryDocument, query_tokens: list[str]) -> int:
         score += 4 * document.record_id_tokens.count(token)
         score += 3 * document.keyword_tokens.count(token)
         score += document.body_tokens.count(token)
+        score += 2 * document.semantic_tokens.count(token)
     return score
 
 
@@ -455,14 +498,15 @@ def _default_snippet(text: str) -> str:
 def _candidate_score(candidate: str, query_tokens: list[str]) -> int:
     candidate_tokens = _content_tokens(candidate)
     token_score = sum(candidate_tokens.count(token) for token in query_tokens)
-    if token_score == 0:
+    semantic_score = sum(_semantic_tokens(candidate).count(token) for token in query_tokens)
+    if token_score == 0 and semantic_score == 0:
         return 0
     heading = _candidate_heading(candidate)
     heading_bonus = 0
     if heading in _CLAIM_SECTION_HEADINGS:
         heading_bonus = 3
     boilerplate_penalty = _boilerplate_score(candidate)
-    return token_score + heading_bonus - boilerplate_penalty
+    return token_score + semantic_score + heading_bonus - boilerplate_penalty
 
 
 def _candidate_segments(text: str) -> list[str]:

--- a/src/splendor/commands/query.py
+++ b/src/splendor/commands/query.py
@@ -458,7 +458,9 @@ def _score_document(document: _QueryDocument, query_tokens: list[str]) -> int:
         lexical_score += document.body_tokens.count(token)
     semantic_score = sum(document.semantic_tokens.count(token) for token in query_tokens)
     semantic_boost = min(1, semantic_score)
-    return lexical_score + semantic_boost if lexical_score > 0 else semantic_boost
+    if lexical_score <= 0:
+        return semantic_boost
+    return lexical_score + semantic_boost + 1
 
 
 def _best_snippet(text: str, query_tokens: list[str]) -> str:

--- a/src/splendor/commands/query.py
+++ b/src/splendor/commands/query.py
@@ -442,7 +442,11 @@ def _semantic_tokens(text: str) -> list[str]:
 def _contains_token_sequence(tokens: list[str], phrase: tuple[str, ...]) -> bool:
     if not phrase or len(phrase) > len(tokens):
         return False
-    return any(tuple(tokens[index : index + len(phrase)]) == phrase for index in range(len(tokens)))
+    phrase_len = len(phrase)
+    return any(
+        tuple(tokens[index : index + phrase_len]) == phrase
+        for index in range(len(tokens) - phrase_len + 1)
+    )
 
 
 def _score_document(document: _QueryDocument, query_tokens: list[str]) -> int:
@@ -498,8 +502,9 @@ def _default_snippet(text: str) -> str:
 
 def _candidate_score(candidate: str, query_tokens: list[str]) -> int:
     candidate_tokens = _content_tokens(candidate)
+    semantic_tokens = _semantic_tokens(candidate)
     token_score = sum(candidate_tokens.count(token) for token in query_tokens)
-    semantic_score = sum(_semantic_tokens(candidate).count(token) for token in query_tokens)
+    semantic_score = sum(semantic_tokens.count(token) for token in query_tokens)
     if token_score == 0 and semantic_score == 0:
         return 0
     heading = _candidate_heading(candidate)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -424,7 +424,7 @@ def test_run_query_matches_acronym_phrase_expansion(tmp_path: Path) -> None:
 
     assert result.match_count == 1
     assert result.matches[0].path == "wiki/topics/asr-policy.md"
-    assert result.matches[0].score == 2
+    assert result.matches[0].score > 0
     assert result.matches[0].snippet == (
         "Automatic speech recognition validation must keep renderer and tests together."
     )
@@ -444,6 +444,30 @@ def test_run_query_expands_known_acronyms_back_to_full_phrases(tmp_path: Path) -
     assert result.match_count == 1
     assert result.matches[0].path == "wiki/topics/asr-gate.md"
     assert result.matches[0].snippet == "The ASR gate owns renderer validation."
+
+
+def test_run_query_keeps_exact_phrase_above_acronym_only_match(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "full-asr.md",
+        title="Full speech recognition notes",
+        page_id="topic-full-asr",
+        body="Automatic speech recognition is the exact retrieval target.",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "short-asr.md",
+        title="Short ASR note",
+        page_id="topic-short-asr",
+        body="ASR is mentioned here with less detail.",
+    )
+
+    result = run_query(tmp_path, "automatic speech recognition")
+
+    assert [match.path for match in result.matches] == [
+        "wiki/topics/full-asr.md",
+        "wiki/topics/short-asr.md",
+    ]
+    assert result.matches[0].score > result.matches[1].score
 
 
 def test_brief_agent_context_uses_semantic_query_matches_for_handoff(tmp_path: Path) -> None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -5,6 +5,7 @@ import yaml
 
 from conftest import write_text_pdf
 from splendor.commands.add_source import add_source
+from splendor.commands.brief import build_project_brief
 from splendor.commands.ingest import ingest_source
 from splendor.commands.init import initialize_workspace
 from splendor.commands.planning import create_question, create_task
@@ -405,6 +406,62 @@ def test_run_query_uses_best_matching_snippet_and_truncates(tmp_path: Path) -> N
     assert result.matches[0].snippet == (
         "The retrieval snippet should include the ranking evidence line exactly once."
     )
+
+
+def test_run_query_matches_acronym_phrase_expansion(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "asr-policy.md",
+        title="Speech milestone policy",
+        page_id="topic-speech-milestone-policy",
+        body=(
+            "# Speech milestone policy\n\n"
+            "Automatic speech recognition validation must keep renderer and tests together.\n"
+        ),
+    )
+
+    result = run_query(tmp_path, "ASR")
+
+    assert result.match_count == 1
+    assert result.matches[0].path == "wiki/topics/asr-policy.md"
+    assert result.matches[0].score == 2
+    assert result.matches[0].snippet == (
+        "Automatic speech recognition validation must keep renderer and tests together."
+    )
+
+
+def test_run_query_expands_known_acronyms_back_to_full_phrases(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "asr-gate.md",
+        title="ASR acceptance gate",
+        page_id="topic-asr-acceptance-gate",
+        body="# ASR acceptance gate\n\nThe ASR gate owns renderer validation.\n",
+    )
+
+    result = run_query(tmp_path, "automatic speech recognition")
+
+    assert result.match_count == 1
+    assert result.matches[0].path == "wiki/topics/asr-gate.md"
+    assert result.matches[0].snippet == "The ASR gate owns renderer validation."
+
+
+def test_brief_agent_context_uses_semantic_query_matches_for_handoff(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "asr-work.md",
+        title="Speech work handoff",
+        page_id="topic-speech-work-handoff",
+        body=(
+            "# Speech work handoff\n\n"
+            "Automatic speech recognition work should start from renderer tests and policy notes.\n"
+        ),
+    )
+
+    brief = build_project_brief(tmp_path, "pick up ASR work", include_git=False)
+
+    assert [match.path for match in brief.matches] == ["wiki/topics/asr-work.md"]
+    assert brief.matches[0].score > 0
 
 
 def test_run_query_prefers_claim_sections_over_source_summary_boilerplate(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -470,6 +470,32 @@ def test_run_query_keeps_exact_phrase_above_acronym_only_match(tmp_path: Path) -
     assert result.matches[0].score > result.matches[1].score
 
 
+def test_run_query_keeps_minimal_lexical_hit_above_semantic_only_match(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "lexical.md",
+        title="Lexical evidence",
+        page_id="topic-lexical-evidence",
+        body="recognition appears as direct lexical evidence.",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "semantic.md",
+        title="Semantic shorthand",
+        page_id="topic-semantic-shorthand",
+        body="ASR appears only as shorthand.",
+    )
+
+    result = run_query(tmp_path, "recognition")
+
+    assert [match.path for match in result.matches] == [
+        "wiki/topics/lexical.md",
+        "wiki/topics/semantic.md",
+    ]
+    assert result.matches[0].score > result.matches[1].score
+
+
 def test_brief_agent_context_uses_semantic_query_matches_for_handoff(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     write_wiki_page(


### PR DESCRIPTION
## Summary

- Adds bounded deterministic acronym phrase expansion to `splendor query`, using an explicit map for common code and research workflow terms.
- Threads the same improved query recall into `brief --agent-context` through existing query-backed match collection.
- Caps expansion-only matches below direct lexical evidence so semantic expansion improves recall without outranking exact query evidence.
- Synchronizes M20 planning state across `.agent-plan.md`, README, and the roadmap, and documents that this slice does not add persisted vector-index state.

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

## Scope notes

- Advances #118 as the first conservative retrieval sub-slice.
- Keeps the implementation local-first and deterministic: no external services, background workers, hosted databases, or mandatory vector store.
- Keeps exact lexical evidence ranked ahead of expansion-only acronym matches.
- Does not start #119 / `M20-P2.1` mutating web review workflows.
- Does not absorb unrelated M20 polish issues except for documenting the retrieval boundary where it affects this PR.