### PR TITLE
M20-P1.2: Retrieval evaluation and handoff retry fixtures

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,11 +3,11 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P0.1`
-- Last action taken: `M20-P0.1` review intake merged to main via PR #172 after the v0.5.0
-  release; this branch implements the first M20 retrieval product slice.
+- Previous completed PR sub-slice: `M20-P1.1`
+- Last action taken: `M20-P1.1` merged to main via PR #173 with conservative runtime acronym
+  phrase expansion for query and query-backed handoff recall.
 - Current planned slice: `M20 advanced semantic search or vector index`
-- Current PR sub-slice: `M20-P1.1`
+- Current PR sub-slice: `M20-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M20 mutating web review workflows`
 - Next planned PR sub-slice: `M20-P2.1`
@@ -518,4 +518,5 @@
 - `M19-P8.1` Cold-start adoption and PATH-safe git lookup
 - `M20-P0.1` v0.5 SynthBanshee integrated-use review intake
 - `M20-P1.1` Advanced semantic search or vector index
+- `M20-P1.2` Retrieval evaluation and handoff retry fixtures
 - `M20-P2.1` Mutating web review workflows

--- a/README.md
+++ b/README.md
@@ -296,9 +296,10 @@ workflow terms. This improves query and agent-context handoff recall for cases s
 matches and without adding a persisted vector store, external service, database, or background
 worker.
 
-`M20-P1.2` closes the first retrieval acceptance gap with deterministic fixture-backed coverage
-rather than new infrastructure. The fixtures assert that richer full-phrase evidence beats
-acronym-only evidence, shorthand queries still recover full-phrase records, current planning
+`M20-P1.2` closes the first retrieval acceptance gap with deterministic fixture-backed regression
+coverage rather than new infrastructure. The fixtures use competing records to assert that richer
+full-phrase evidence beats acronym-only evidence, shorthand queries still recover full-phrase
+records in non-empty corpora, query-backed agent handoff exposes that recovery, current planning
 authority outranks stale review material, and completed slices advance handoff to the next planned
 slice before mutating web workflows begin.
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,12 @@ workflow terms. This improves query and agent-context handoff recall for cases s
 matches and without adding a persisted vector store, external service, database, or background
 worker.
 
+`M20-P1.2` closes the first retrieval acceptance gap with deterministic fixture-backed coverage
+rather than new infrastructure. The fixtures assert that richer full-phrase evidence beats
+acronym-only evidence, shorthand queries still recover full-phrase records, current planning
+authority outranks stale review material, and completed slices advance handoff to the next planned
+slice before mutating web workflows begin.
+
 `M17-P4.1` reduces issue #117 contradiction-review task noise without weakening contradiction
 evidence. Ingest-created contradiction-review tasks are classified as generated planning records,
 hidden from default active planning handoff, and managed intentionally through task-list, resolve,
@@ -336,9 +342,9 @@ the source manifest, and kept separate from parsed PDF artifacts.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P0.1`
+- Previous completed PR sub-slice: `M20-P1.1`
 - Current planned slice: `M20 advanced semantic search or vector index`
-- Current PR sub-slice: `M20-P1.1`
+- Current PR sub-slice: `M20-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M20 mutating web review workflows`
 - Next planned PR sub-slice: `M20-P2.1`

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -1379,10 +1379,11 @@ improvement, not a full vector-search implementation: exact lexical evidence sti
 expansion-only matches, and broader retrieval evaluation remains part of the M20 search track.
 Mutating web review workflows stay deferred to `M20-P2.1`.
 
-`M20-P1.2` closes the first retrieval acceptance gap with deterministic public-evaluator-style
-fixtures instead of new index infrastructure. The fixtures cover hocrgen/hocrsyngen-style retry
-bars where exact full-phrase evidence must beat acronym-only evidence, shorthand queries must still
-recover full-phrase records, current planning authority must outrank stale historical review
+`M20-P1.2` closes the first retrieval acceptance gap with deterministic fixture-backed regression
+coverage instead of new index infrastructure. The fixtures cover hocrgen/hocrsyngen-style retry
+bars where exact full-phrase evidence must beat acronym-only evidence under competition, shorthand
+queries must still recover full-phrase records in non-empty corpora, query-backed agent handoff
+must expose that recovery, current planning authority must outrank stale historical review
 material, and completed-slice evidence must advance handoff to the next planned slice. The ordered
 M20 retrieval sequence is therefore:
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,9 +334,9 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P0.1`
+- Previous completed PR sub-slice: `M20-P1.1`
 - Current planned slice: `M20 advanced semantic search or vector index`
-- Current PR sub-slice: `M20-P1.1`
+- Current PR sub-slice: `M20-P1.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M20 mutating web review workflows`
 - Next planned PR sub-slice: `M20-P2.1`
@@ -1367,6 +1367,7 @@ relevant to the selected M20 implementation.
 ### Candidate PR slices
 - `M20-P0.1` Record v0.5 SynthBanshee integrated-use review intake and M20 issue disposition.
 - `M20-P1.1` Add advanced semantic search or a vector index (#118).
+- `M20-P1.2` Retrieval evaluation and handoff retry fixtures (#118).
 - `M20-P2.1` Explore mutating web review workflows (#119).
 - Add richer GitHub issue, PR, review-thread, and CI integrations on top of the v0.4 handoff model.
 
@@ -1377,6 +1378,17 @@ services, background workers, databases, or persisted vector-index state. This i
 improvement, not a full vector-search implementation: exact lexical evidence still ranks ahead of
 expansion-only matches, and broader retrieval evaluation remains part of the M20 search track.
 Mutating web review workflows stay deferred to `M20-P2.1`.
+
+`M20-P1.2` closes the first retrieval acceptance gap with deterministic public-evaluator-style
+fixtures instead of new index infrastructure. The fixtures cover hocrgen/hocrsyngen-style retry
+bars where exact full-phrase evidence must beat acronym-only evidence, shorthand queries must still
+recover full-phrase records, current planning authority must outrank stale historical review
+material, and completed-slice evidence must advance handoff to the next planned slice. The ordered
+M20 retrieval sequence is therefore:
+
+- `M20-P1.1` runtime semantic expansion for deterministic query and query-backed handoff recall.
+- `M20-P1.2` retrieval evaluation and handoff retry fixture closeout.
+- `M20-P2.1` mutating web review workflows after the retrieval closeout.
 
 ---
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -277,15 +277,26 @@ def test_run_query_m20_retrieval_fixture_prefers_exact_phrase_over_alias_only(
         page_id="topic-asr-alias-only",
         body=(
             "# ASR shorthand memo\n\n"
-            "ASR is mentioned here as an acronym-only alias without the richer retry evidence.\n"
+            "ASR retry gates mention hocrsyngen, renderer paths, test coverage, and agent retry "
+            "bars, but only through the shorthand acronym.\n"
+        ),
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "asr-stale-review.md",
+        title="Historical ASR review",
+        page_id="topic-asr-stale-review",
+        body=(
+            "# Historical ASR review\n\n"
+            "Older ASR review notes discuss retry bars but do not carry the full phrase evidence.\n"
         ),
     )
 
     result = run_query(tmp_path, "automatic speech recognition")
 
-    assert [match.path for match in result.matches[:2]] == [
+    assert [match.path for match in result.matches[:3]] == [
         "wiki/topics/asr-rich-evidence.md",
         "wiki/topics/asr-alias-only.md",
+        "wiki/topics/asr-stale-review.md",
     ]
     assert result.matches[0].score > result.matches[1].score
 
@@ -304,11 +315,32 @@ def test_run_query_m20_retrieval_fixture_recovers_full_phrase_from_shorthand(
             "shorthand acronym in its body.\n"
         ),
     )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "asr-shorthand-competitor.md",
+        title="ASR shorthand competitor",
+        page_id="topic-asr-shorthand-competitor",
+        body=(
+            "# ASR shorthand competitor\n\n"
+            "ASR appears here as a direct acronym match and competes for the shorthand query.\n"
+        ),
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "speech-recognition-history.md",
+        title="Speech recognition historical note",
+        page_id="topic-speech-recognition-history",
+        body=(
+            "# Speech recognition historical note\n\n"
+            "Historical speech recognition notes mention the domain without naming the complete "
+            "three-word phrase.\n"
+        ),
+    )
 
     result = run_query(tmp_path, "ASR")
 
-    assert result.match_count == 1
-    assert result.matches[0].path == "wiki/topics/full-phrase-only.md"
+    paths = [match.path for match in result.matches]
+    assert "wiki/topics/asr-shorthand-competitor.md" in paths
+    assert "wiki/topics/full-phrase-only.md" in paths
+    assert "wiki/topics/speech-recognition-history.md" not in paths
 
 
 def test_run_query_rejects_unknown_source_filter(tmp_path: Path) -> None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -257,6 +257,60 @@ def test_run_query_finds_extracted_ocr_source_summary_text(tmp_path: Path) -> No
     assert "Extracted OCR diagram evidence" in result.matches[0].snippet
 
 
+def test_run_query_m20_retrieval_fixture_prefers_exact_phrase_over_alias_only(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "asr-rich-evidence.md",
+        title="Automatic speech recognition retry gates",
+        page_id="topic-asr-rich-evidence",
+        body=(
+            "# Automatic speech recognition retry gates\n\n"
+            "The hocrsyngen handoff fixture requires automatic speech recognition evidence, "
+            "WER retry bars, renderer paths, and test coverage before the next agent retry.\n"
+        ),
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "asr-alias-only.md",
+        title="ASR shorthand memo",
+        page_id="topic-asr-alias-only",
+        body=(
+            "# ASR shorthand memo\n\n"
+            "ASR is mentioned here as an acronym-only alias without the richer retry evidence.\n"
+        ),
+    )
+
+    result = run_query(tmp_path, "automatic speech recognition")
+
+    assert [match.path for match in result.matches[:2]] == [
+        "wiki/topics/asr-rich-evidence.md",
+        "wiki/topics/asr-alias-only.md",
+    ]
+    assert result.matches[0].score > result.matches[1].score
+
+
+def test_run_query_m20_retrieval_fixture_recovers_full_phrase_from_shorthand(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "full-phrase-only.md",
+        title="Automatic speech recognition policy",
+        page_id="topic-full-phrase-only",
+        body=(
+            "# Automatic speech recognition policy\n\n"
+            "The policy names automatic speech recognition validation and never uses the "
+            "shorthand acronym in its body.\n"
+        ),
+    )
+
+    result = run_query(tmp_path, "ASR")
+
+    assert result.match_count == 1
+    assert result.matches[0].path == "wiki/topics/full-phrase-only.md"
+
+
 def test_run_query_rejects_unknown_source_filter(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
 

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2643,6 +2643,39 @@ def test_agent_context_m20_fixture_advances_retrieval_closeout_after_merged_slic
         kind="topic",
         body="M20-P1.1 advanced semantic search appears in stale review material.",
     )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "automatic-speech-recognition-closeout.md",
+        title="Automatic speech recognition closeout fixture",
+        page_id="topic-automatic-speech-recognition-closeout",
+        kind="topic",
+        body=(
+            "# Automatic speech recognition closeout fixture\n\n"
+            "The retrieval handoff should recover this full-phrase record for shorthand agent "
+            "goals even though the acronym itself is absent from this page.\n"
+        ),
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "asr-shorthand-competitor.md",
+        title="ASR shorthand competitor",
+        page_id="topic-asr-shorthand-competitor",
+        kind="topic",
+        body=(
+            "# ASR shorthand competitor\n\n"
+            "ASR appears here as a direct acronym match and competes with richer full-phrase "
+            "retrieval evidence.\n"
+        ),
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "speech-recognition-background.md",
+        title="Speech recognition background",
+        page_id="topic-speech-recognition-background",
+        kind="topic",
+        body=(
+            "# Speech recognition background\n\n"
+            "General speech recognition background should not satisfy the shorthand fixture by "
+            "itself.\n"
+        ),
+    )
     implementation = tmp_path / "src" / "splendor" / "commands" / "query.py"
     implementation.parent.mkdir(parents=True, exist_ok=True)
     implementation.write_text("SEMANTIC_EXPANSION_READY = True\n", encoding="utf-8")
@@ -2714,6 +2747,25 @@ def test_agent_context_m20_fixture_advances_retrieval_closeout_after_merged_slic
     assert authority_paths.index("docs/stale_external_review.md") > authority_paths.index(
         "docs/splendor_mvp_to_v1_roadmap.md"
     )
+
+    query_backed_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "--no-git",
+            "ASR",
+            "--json",
+        ]
+    )
+    query_backed_payload = json.loads(capsys.readouterr().out)
+    query_match_paths = [match["path"] for match in query_backed_payload["matches"]]
+
+    assert query_backed_exit == 0
+    assert "wiki/topics/asr-shorthand-competitor.md" in query_match_paths
+    assert "wiki/topics/automatic-speech-recognition-closeout.md" in query_match_paths
+    assert "wiki/topics/speech-recognition-background.md" not in query_match_paths
 
 
 def test_agent_context_accepts_single_line_remaining_sequence(

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2581,6 +2581,141 @@ def test_agent_context_advances_stale_current_slice_after_main_merge(
     assert "Continue F4c after completed F3b" in out
 
 
+def test_agent_context_m20_fixture_advances_retrieval_closeout_after_merged_slice(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path=".agent-plan.md",
+            role="current-authority",
+            purpose="Current M20 retrieval planning state.",
+            applies_to=["M20 retrieval handoff"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/splendor_mvp_to_v1_roadmap.md",
+            role="roadmap",
+            purpose="Ordered M20 retrieval and mutating-web sequence.",
+            applies_to=["M20 retrieval handoff"],
+        ),
+        AuthorityDocumentConfig(
+            path="docs/stale_external_review.md",
+            role="historical-review",
+            freshness="historical",
+            applies_to=["M20 retrieval M20-P1.1"],
+        ),
+    ]
+    write_config(tmp_path, config)
+    _init_git_repo(tmp_path, repo="splendor-dev/splendor")
+    _commit_all(tmp_path, "Initial Splendor workspace")
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n"
+        "- Previous completed PR sub-slice: `M20-P0.1`\n"
+        "- Current planned slice: `M20 advanced semantic search or vector index`\n"
+        "- Current PR sub-slice: `M20-P1.1`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `M20 mutating web review workflows`\n"
+        "- Next planned PR sub-slice: `M20-P2.1`\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "splendor_mvp_to_v1_roadmap.md").write_text(
+        "# Roadmap\n\n"
+        "The remaining M20 sequence is therefore:\n\n"
+        "- `M20-P1.1` adds conservative runtime acronym phrase expansion.\n"
+        "- `M20-P1.2` closes the retrieval evaluation and handoff retry fixture gap.\n"
+        "- `M20-P2.1` explores mutating web review workflows later.\n",
+        encoding="utf-8",
+    )
+    (docs / "stale_external_review.md").write_text(
+        "# Historical retrieval review\n\n"
+        "Historical notes still mention M20-P1.1 and advanced semantic search, but they are "
+        "background context after the runtime expansion slice merges.\n",
+        encoding="utf-8",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "topics" / "historical-m20-p1-1.md",
+        title="M20-P1.1 historical retrieval note",
+        page_id="topic-historical-m20-p1-1",
+        kind="topic",
+        body="M20-P1.1 advanced semantic search appears in stale review material.",
+    )
+    implementation = tmp_path / "src" / "splendor" / "commands" / "query.py"
+    implementation.parent.mkdir(parents=True, exist_ok=True)
+    implementation.write_text("SEMANTIC_EXPANSION_READY = True\n", encoding="utf-8")
+    _commit_all(tmp_path, "M20-P1.1: Advanced semantic search or vector index")
+    _install_fake_gh(
+        tmp_path,
+        monkeypatch,
+        issues=[
+            {
+                "number": 118,
+                "title": "M20-P1.1 Add advanced semantic search or vector index",
+                "url": "https://github.com/splendor-dev/splendor/issues/118",
+                "body": "Keep open until retrieval evaluation fixtures close the handoff gap.",
+                "state": "open",
+                "labels": [],
+            }
+        ],
+        prs=[
+            {
+                "number": 173,
+                "title": "M20-P1.1: Advanced semantic search or vector index",
+                "url": "https://github.com/splendor-dev/splendor/pull/173",
+                "body": "Merged runtime acronym phrase expansion. Follow with M20-P1.2 fixtures.",
+                "state": "merged",
+                "isDraft": False,
+                "mergedAt": "2026-05-07T22:37:25Z",
+                "labels": [],
+            }
+        ],
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "close",
+            "out",
+            "M20",
+            "retrieval",
+            "handoff",
+            "after",
+            "M20-P1.1",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    state = payload["handoff_current_state"]
+    assert state["current_slice"] == "M20-P1.1"
+    assert state["inferred_slice"] == "M20-P1.2"
+    assert any("M20-P1.1" in item for item in state["evidence"])
+    current_state_actions = [
+        action
+        for action in payload["work_context"]["actions"]
+        if action["category"] == "current-state"
+    ]
+    assert len(current_state_actions) == 1
+    assert current_state_actions[0]["rank"] == 1
+    assert "M20-P1.2" in current_state_actions[0]["title"]
+    authority_paths = [item["path"] for item in payload["authority_briefs"]]
+    assert authority_paths[:2] == [
+        ".agent-plan.md",
+        "docs/splendor_mvp_to_v1_roadmap.md",
+    ]
+    assert authority_paths.index("docs/stale_external_review.md") > authority_paths.index(
+        "docs/splendor_mvp_to_v1_roadmap.md"
+    )
+
+
 def test_agent_context_accepts_single_line_remaining_sequence(
     tmp_path: Path, capsys, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Adds deterministic M20 retrieval fixtures with real competition: full-phrase evidence must beat acronym-only/stale acronym records for full-phrase queries.
- Adds shorthand recovery coverage in a non-empty corpus: `ASR` must recover full-phrase `automatic speech recognition` records while unrelated partial phrase material stays out.
- Extends the handoff retry fixture so it now proves both sides of the closeout: merged `M20-P1.1` evidence advances current-state handoff to `M20-P1.2`, and query-backed `brief --agent-context` surfaces full-phrase evidence for shorthand agent goals under competition.
- Synchronizes `.agent-plan.md`, the README "What Comes Next" block, and the roadmap for `M20-P1.2`, keeping `M20-P2.1` as the next planned PR sub-slice.

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

## Scope notes

- Closes #118 with deterministic fixture-backed retrieval and handoff regression coverage for the M20 retrieval acceptance gap.
- Keeps the slice local-first and inspectable: no external services, background workers, hosted databases, persisted vector index, or new index state.
- Does not start #119 / `M20-P2.1` mutating web review workflows.
- Touches #160 only indirectly through a regression-style authority-ranking fixture; it does not redesign policy-cited read-first ranking or absorb the broader polish issue.