### PR TITLE
v0.5.1-release-prep: release notes and package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ the source manifest, and kept separate from parsed PDF artifacts.
 - [v0.5 SynthBanshee integrated-use review](docs/evaluations/v0_5_synthbanshee_integrated_use/summary.md)
 - [v0.4.0 release notes](docs/releases/v0_4_0_release_notes.md)
 - [v0.5.0 release notes](docs/releases/v0_5_0_release_notes.md)
+- [v0.5.1 release notes](docs/releases/v0_5_1_release_notes.md)
 
 ## What Comes Next
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,4 +44,5 @@ workflow.
 - [v0.3.0 release notes](releases/v0_3_0_release_notes.md)
 - [v0.4.0 release notes](releases/v0_4_0_release_notes.md)
 - [v0.5.0 release notes](releases/v0_5_0_release_notes.md)
+- [v0.5.1 release notes](releases/v0_5_1_release_notes.md)
 - [v1 release handoff](releases/v1_release_handoff.md)

--- a/docs/releases/v0_5_1_release_notes.md
+++ b/docs/releases/v0_5_1_release_notes.md
@@ -1,0 +1,54 @@
+# v0.5.1 Retrieval and Handoff Retry Release Notes
+
+`v0.5.1` is a narrow post-v0.5.0 evaluation release for sending Splendor back through the
+`hocrgen` and `hocrsyngen` agent-handoff retry loops. It is still not the public v1 tag. The
+purpose is to validate whether the handoff and retrieval fixes that landed after `v0.5.0` are
+enough for those repos to reconsider Splendor as a day-to-day tool for coding-agent continuity.
+
+## Release Purpose
+
+This release packages the M20 retrieval closeout on top of the v0.5.0 durability baseline:
+
+- `splendor query` uses deterministic runtime acronym phrase expansion for common
+  code-and-research workflow terms, including shorthand such as `ASR` and the full phrase
+  `automatic speech recognition`.
+- Query-backed `brief --agent-context` paths benefit from the same local-first shorthand and
+  full-phrase recovery without adding a persisted vector store, hosted service, database, or
+  background worker.
+- Deterministic regression fixtures now cover the hocrgen/hocrsyngen retry pattern where richer
+  full-phrase evidence must beat acronym-only or stale acronym material under competition.
+- Shorthand query fixtures now run in non-empty corpora, so acronym recovery is tested against
+  direct acronym competitors and unrelated partial-phrase background material.
+- Agent handoff regression coverage now checks both completion-aware current-state inference and
+  query-backed full-phrase recovery for shorthand goals.
+- The M20 planning docs now keep mutating web review workflows deferred to `M20-P2.1` after this
+  retrieval/handoff retry release.
+
+## Trial Focus
+
+The next expected action after publishing `v0.5.1` is a fresh pair of external-style retry prompts:
+
+- `hocrgen`: retry the completed-`F3b` to next-`F4c` planning handoff and judge whether Splendor now
+  beats direct `rg`, `git`, and `gh` for starting the next implementation thread.
+- `hocrsyngen`: retry the merged-`S4c` to next-`S4d` handoff and re-check whether cold-start state
+  review plus current-state inference now feels safe enough for day-to-day agent use.
+
+Both trials should install from the `v0.5.1` GitHub Release wheel rather than an editable checkout,
+so the comparison is clean against the earlier `v0.5.0` and `v0.4.0` release-wheel evaluations.
+
+## Validation Expectations
+
+Before tagging `v0.5.1` after this preparation PR merges, run the full local validation suite from
+the repository root and confirm green `main` CI:
+
+```bash
+uv run ruff format --check .
+uv run ruff check .
+uv run pytest
+uv run splendor lint
+uv build
+```
+
+The package metadata for this preparation PR is `0.5.1` in `pyproject.toml`,
+`src/splendor/__init__.py`, and `uv.lock`. Create the `v0.5.1` tag only after the release-prep PR
+merges and `main` is green.

--- a/docs/releases/v0_5_1_release_notes.md
+++ b/docs/releases/v0_5_1_release_notes.md
@@ -46,6 +46,7 @@ uv run ruff format --check .
 uv run ruff check .
 uv run pytest
 uv run splendor lint
+uv run splendor health
 uv build
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "splendor"
-version = "0.5.0"
+version = "0.5.1"
 description = "Local-first, git-native, schema-driven knowledge compiler for code-and-research repositories."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/splendor/__init__.py
+++ b/src/splendor/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "splendor"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "bleach" },


### PR DESCRIPTION
## Summary

- Bumps package metadata from `0.5.0` to `0.5.1` in `pyproject.toml`, `src/splendor/__init__.py`, and `uv.lock`.
- Adds `docs/releases/v0_5_1_release_notes.md` for the hocrgen/hocrsyngen retry release.
- Links the v0.5.1 release notes from the README and docs index.

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv build`

## Scope notes

- Release-prep only: no runtime behavior changes.
- Keeps `M20-P2.1` mutating web review workflows deferred.
- Prepares the GitHub Release wheel comparison point for fresh hocrgen and hocrsyngen retry prompts after merge/tag/release publication.