### PR TITLE
M20-P1.4: Current-work handoff ranking from planning authority

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P1.2`
-- Last action taken: `M20-P1.2` merged to main via PR #174 with deterministic retrieval and
-  handoff retry fixtures, followed by the v0.5.1 release prep PR #175.
+- Previous completed PR sub-slice: `M20-P1.3`
+- Last action taken: `M20-P1.3` merged to main via PR #176 with the v0.5.1
+  hocrgen/hocrsyngen retry findings and current-work handoff plan.
 - Current planned slice: `M20 current-work handoff ranking`
-- Current PR sub-slice: `M20-P1.3`
+- Current PR sub-slice: `M20-P1.4`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 current-work handoff ranking`
-- Next planned PR sub-slice: `M20-P1.4`
+- Next planned slice: `M20 mutating web review workflows`
+- Next planned PR sub-slice: `M20-P2.1`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ non-draft GitHub PR with labels, milestone, and a clear description.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P1.2`
+- Previous completed PR sub-slice: `M20-P1.3`
 - Current planned slice: `M20 current-work handoff ranking`
-- Current PR sub-slice: `M20-P1.3`
+- Current PR sub-slice: `M20-P1.4`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 current-work handoff ranking`
-- Next planned PR sub-slice: `M20-P1.4`
+- Next planned slice: `M20 mutating web review workflows`
+- Next planned PR sub-slice: `M20-P2.1`
 
 These planning-state lines are for contributors and agents. The detailed roadmap lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md).

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P1.2`
+- Previous completed PR sub-slice: `M20-P1.3`
 - Current planned slice: `M20 current-work handoff ranking`
-- Current PR sub-slice: `M20-P1.3`
+- Current PR sub-slice: `M20-P1.4`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 current-work handoff ranking`
-- Next planned PR sub-slice: `M20-P1.4`
+- Next planned slice: `M20 mutating web review workflows`
+- Next planned PR sub-slice: `M20-P2.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1400,14 +1400,15 @@ repairs stale curated sources, exact `F6f` retrieval still fails and handoff sti
 merged PR review or historical/generated summaries. This is now a current-work handoff-ranking and
 authority-priority problem, not a reason to broaden into mutating web workflows.
 
-`M20-P1.4` is the next implementation slice (#177). It should keep the first fix runtime-only and
-file-based: extract current planned work from `.agent-plan.md`, README, and roadmap authority for
-next-roadmap goals; make `brief --agent-context` and `suggest-next` lead with that work; demote
-merged PRs, recent commits, and completed-slice evidence to predecessor context unless the user
-asks to review history; and preserve open work-thread behavior when a live issue or PR is the real
-current work. Broad vector-search infrastructure, cold-start state relocation, general
-provider-gate ranking, and mutating web review workflows stay out of scope for this slice unless
-directly required by the current-work handoff fixtures. The ordered M20 sequence is therefore:
+`M20-P1.4` implements the runtime-only current-work handoff ranking fix (#177). It extracts current
+planned work from `.agent-plan.md`, README, and roadmap authority for current/next-roadmap goals;
+makes `brief --agent-context` and `suggest-next` lead with that work; demotes merged PRs, recent
+commits, and completed-slice evidence to predecessor context unless the user asks to review
+history; and preserves open work-thread behavior when a live issue or PR is the real current work.
+The implementation remains local-first and file-based: it adds no hosted service, background
+worker, mandatory external API, web workflow, or persisted index state. Broad vector-search
+infrastructure, cold-start state relocation, general provider-gate ranking, and mutating web review
+workflows stay out of scope for this slice. The ordered M20 sequence is therefore:
 
 - `M20-P1.1` runtime semantic expansion for deterministic query and query-backed handoff recall.
 - `M20-P1.2` retrieval evaluation and handoff retry fixture closeout.

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1255,6 +1255,11 @@ v0.4 direction from external trials:
   planning authority for those goals. If no indexed sources are available, cold-start handoff
   should either use clearly labeled provisional authority well enough to name the current slice or
   clearly say that applied ingest is required before indexed retrieval can answer.
+- Current-work handoff ranking is runtime-only. `brief --agent-context` and `suggest-next` may
+  extract a `current_planned_work` candidate from `.agent-plan.md`, README, and roadmap authority
+  conventions, then rank it ahead of merged PRs, commits, and maintenance actions for
+  current/next-roadmap goals. Open issues or PRs that directly match that current work remain the
+  leading work-thread signal.
 - First-run adoption should be explicit about state churn. `splendor init` may create a
   repository-local workspace, but the CLI and docs should make the state location, review burden,
   and local/throwaway-worktree strategy clear before a first-time agent creates many visible

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -6,6 +6,7 @@ import json
 import re
 import shlex
 import subprocess
+from collections import Counter
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 
@@ -278,9 +279,16 @@ _HISTORY_REVIEW_GOAL_TOKENS = {
     "historical",
     "merged",
     "past",
+}
+_PR_REVIEW_GOAL_TOKENS = {
     "pr",
     "prs",
     "pull",
+    "request",
+    "requests",
+}
+_REVIEW_ACTION_GOAL_TOKENS = {
+    "inspect",
     "review",
     "reviews",
 }
@@ -705,6 +713,7 @@ def _collect_brief_state(
         root,
         git_context,
         normalized_goal or None,
+        authority_briefs,
         handoff_current_state=handoff_current_state,
     )
     return BriefStateSnapshot(
@@ -1405,7 +1414,11 @@ def _is_maintenance_goal(goal_tokens: set[str]) -> bool:
 
 
 def _is_history_review_goal(goal_tokens: set[str]) -> bool:
-    return bool(goal_tokens & _HISTORY_REVIEW_GOAL_TOKENS)
+    if goal_tokens & _HISTORY_REVIEW_GOAL_TOKENS:
+        return True
+    return bool(
+        (goal_tokens & _REVIEW_ACTION_GOAL_TOKENS) and (goal_tokens & _PR_REVIEW_GOAL_TOKENS)
+    )
 
 
 def _is_current_work_goal(goal_tokens: set[str]) -> bool:
@@ -1578,6 +1591,7 @@ def _current_planned_work(
     root: Path,
     git_context: GitContext,
     goal: str | None,
+    authority_briefs: list[AuthorityBrief],
     *,
     handoff_current_state: HandoffCurrentState | None,
 ) -> CurrentPlannedWork | None:
@@ -1588,7 +1602,7 @@ def _current_planned_work(
     structured = _structured_current_planned_work(root, git_context)
     if structured is not None:
         return structured
-    return _line_inferred_current_planned_work(root)
+    return _line_inferred_current_planned_work(root, authority_briefs)
 
 
 def _structured_current_planned_work(
@@ -1597,11 +1611,9 @@ def _structured_current_planned_work(
     states = _planning_state_by_path(root)
     if not states:
         return None
-    combined: dict[str, str] = {}
+    combined, disagreements = _reconciled_planning_state(states)
     authority_paths: list[str] = []
     for relpath, values in states:
-        for label, value in values.items():
-            combined.setdefault(label, value)
         if values:
             authority_paths.append(relpath)
 
@@ -1629,6 +1641,8 @@ def _structured_current_planned_work(
             predecessor_slices.append(value)
 
     reason_parts = ["Structured planning-state lines identify the current handoff target."]
+    if disagreements:
+        reason_parts.append("Reconciled disagreement: " + "; ".join(disagreements[:3]) + ".")
     if use_next and current_slice:
         reason_parts.append(f"{current_slice} is predecessor context; lead with {slice_id}.")
     return CurrentPlannedWork(
@@ -1640,8 +1654,10 @@ def _structured_current_planned_work(
     )
 
 
-def _line_inferred_current_planned_work(root: Path) -> CurrentPlannedWork | None:
-    for relpath in _current_work_authority_paths(root):
+def _line_inferred_current_planned_work(
+    root: Path, authority_briefs: list[AuthorityBrief]
+) -> CurrentPlannedWork | None:
+    for relpath in _current_work_fallback_paths(root, authority_briefs):
         path = root / relpath
         try:
             lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
@@ -1669,6 +1685,33 @@ def _line_inferred_current_planned_work(root: Path) -> CurrentPlannedWork | None
     return None
 
 
+def _reconciled_planning_state(
+    states: list[tuple[str, dict[str, str]]],
+) -> tuple[dict[str, str], list[str]]:
+    combined: dict[str, str] = {}
+    disagreements: list[str] = []
+    labels = {label for _relpath, values in states for label in values}
+    for label in sorted(labels):
+        observations = [(relpath, values[label]) for relpath, values in states if label in values]
+        if not observations:
+            continue
+        counts = Counter(value for _relpath, value in observations)
+        if len(counts) == 1:
+            combined[label] = observations[0][1]
+            continue
+        top_value, top_count = counts.most_common(1)[0]
+        tied = [value for value, count in counts.items() if count == top_count]
+        if top_count > 1 and len(tied) == 1:
+            combined[label] = top_value
+            disagreements.append(
+                f"{label} uses majority value {top_value!r} "
+                f"from {top_count}/{len(observations)} docs"
+            )
+            continue
+        disagreements.append(f"{label} has no majority across {len(observations)} authority docs")
+    return combined, disagreements
+
+
 def _planning_state_by_path(root: Path) -> list[tuple[str, dict[str, str]]]:
     states: list[tuple[str, dict[str, str]]] = []
     for relpath in _current_work_authority_paths(root):
@@ -1679,6 +1722,23 @@ def _planning_state_by_path(root: Path) -> list[tuple[str, dict[str, str]]]:
         if values:
             states.append((relpath, values))
     return states
+
+
+def _current_work_fallback_paths(root: Path, authority_briefs: list[AuthorityBrief]) -> list[str]:
+    paths: list[str] = []
+    for authority in authority_briefs:
+        if authority.lifecycle in {"historical", "superseded", "archived"}:
+            continue
+        if authority.role not in {"current-authority", "roadmap"}:
+            continue
+        if _safe_existing_repo_file(root, authority.path) is None:
+            continue
+        if authority.path not in paths:
+            paths.append(authority.path)
+    for path in _current_work_authority_paths(root):
+        if path not in paths:
+            paths.append(path)
+    return paths
 
 
 def _current_work_authority_paths(root: Path) -> list[str]:
@@ -1696,10 +1756,7 @@ def _current_work_authority_paths(root: Path) -> list[str]:
 
 
 def _combined_planning_state(root: Path) -> dict[str, str]:
-    combined: dict[str, str] = {}
-    for _relpath, values in _planning_state_by_path(root):
-        for label, value in values.items():
-            combined.setdefault(label, value)
+    combined, _disagreements = _reconciled_planning_state(_planning_state_by_path(root))
     return combined
 
 
@@ -2954,7 +3011,7 @@ def _open_thread_covers_current_work(threads: list[GitThreadBrief], slice_id: st
     for thread in threads:
         if not thread.promoted or thread.state != "open":
             continue
-        if _text_starts_with_slice(thread.title, slice_id):
+        if _thread_mentions_slice(thread, slice_id):
             return True
     return False
 
@@ -2964,11 +3021,21 @@ def _thread_is_current_work_context(
 ) -> bool:
     if current_work is None:
         return False
-    if _text_starts_with_slice(thread.title, current_work.slice_id):
+    if _thread_mentions_slice(thread, current_work.slice_id):
         return True
     return any(
-        _text_starts_with_slice(thread.title, predecessor)
+        _thread_mentions_slice(thread, predecessor)
         for predecessor in current_work.predecessor_slices
+    )
+
+
+def _thread_mentions_slice(thread: GitThreadBrief, slice_id: str) -> bool:
+    return _text_mentions_slice(" ".join([thread.title, thread.summary]), slice_id)
+
+
+def _text_mentions_slice(text: str, slice_id: str) -> bool:
+    return (
+        re.search(rf"(?<![A-Za-z0-9_.-]){re.escape(slice_id)}(?![A-Za-z0-9_.-])", text) is not None
     )
 
 

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -1421,12 +1421,16 @@ def _is_history_review_goal(goal_tokens: set[str]) -> bool:
     )
 
 
-def _is_current_work_goal(goal_tokens: set[str]) -> bool:
+def _is_current_work_goal(goal_tokens: set[str], goal: str | None) -> bool:
     if not goal_tokens or _is_history_review_goal(goal_tokens):
         return False
     if goal_tokens & _CURRENT_WORK_GOAL_TOKENS:
         return True
-    return any(any(character.isdigit() for character in token) for token in goal_tokens)
+    return _goal_mentions_roadmap_slice(goal)
+
+
+def _goal_mentions_roadmap_slice(goal: str | None) -> bool:
+    return re.search(_ROADMAP_SLICE_INNER_PATTERN, goal or "", re.IGNORECASE) is not None
 
 
 def _flatten_handoff_values(value) -> list[str]:
@@ -1596,19 +1600,19 @@ def _current_planned_work(
     handoff_current_state: HandoffCurrentState | None,
 ) -> CurrentPlannedWork | None:
     goal_tokens = _tokens(goal or "")
-    if handoff_current_state is not None or not _is_current_work_goal(goal_tokens):
+    if handoff_current_state is not None or not _is_current_work_goal(goal_tokens, goal):
         return None
 
-    structured = _structured_current_planned_work(root, git_context)
+    structured = _structured_current_planned_work(root, git_context, authority_briefs)
     if structured is not None:
         return structured
     return _line_inferred_current_planned_work(root, authority_briefs)
 
 
 def _structured_current_planned_work(
-    root: Path, git_context: GitContext
+    root: Path, git_context: GitContext, authority_briefs: list[AuthorityBrief]
 ) -> CurrentPlannedWork | None:
-    states = _planning_state_by_path(root)
+    states = _planning_state_by_path(root, authority_briefs)
     if not states:
         return None
     combined, disagreements = _reconciled_planning_state(states)
@@ -1712,9 +1716,11 @@ def _reconciled_planning_state(
     return combined, disagreements
 
 
-def _planning_state_by_path(root: Path) -> list[tuple[str, dict[str, str]]]:
+def _planning_state_by_path(
+    root: Path, authority_briefs: list[AuthorityBrief] | None = None
+) -> list[tuple[str, dict[str, str]]]:
     states: list[tuple[str, dict[str, str]]] = []
-    for relpath in _current_work_authority_paths(root):
+    for relpath in _current_work_authority_paths(root, authority_briefs):
         path = root / relpath
         if not path.is_file():
             continue
@@ -1745,17 +1751,19 @@ def _current_work_fallback_paths(root: Path, authority_briefs: list[AuthorityBri
     return paths
 
 
-def _current_work_authority_paths(root: Path) -> list[str]:
+def _current_work_authority_paths(
+    root: Path, authority_briefs: list[AuthorityBrief] | None = None
+) -> list[str]:
     paths = [".agent-plan.md", "README.md", "docs/splendor_mvp_to_v1_roadmap.md"]
-    docs_dir = root / "docs"
-    if docs_dir.is_dir():
-        for path in sorted(docs_dir.rglob("*.md")):
-            relative = path.relative_to(root).as_posix()
-            name = path.name.lower()
-            if relative in paths:
-                continue
-            if "roadmap" in name or "plan" in name:
-                paths.append(relative)
+    for authority in authority_briefs or []:
+        if authority.lifecycle in {"historical", "superseded", "archived"}:
+            continue
+        if authority.role not in {"current-authority", "roadmap"}:
+            continue
+        if _safe_existing_repo_file(root, authority.path) is None:
+            continue
+        if authority.path not in paths:
+            paths.append(authority.path)
     return paths
 
 
@@ -2651,7 +2659,7 @@ def _suggestion_candidates(snapshot: BriefStateSnapshot) -> list[SuggestedAction
     actions: list[SuggestedAction] = []
     goal_tokens = _tokens(snapshot.goal or "")
     goal_phrase = _normalize_goal_phrase(snapshot.goal or "")
-    current_work_goal = _is_current_work_goal(goal_tokens)
+    current_work_goal = _is_current_work_goal(goal_tokens, snapshot.goal)
 
     def add(priority: str, category: str, title: str, reason: str, command: str | None, **kwargs):
         relevance_score = kwargs.pop(
@@ -3013,7 +3021,7 @@ def _first_command(commands: list[str]) -> str | None:
 
 def _open_thread_covers_current_work(threads: list[GitThreadBrief], slice_id: str) -> bool:
     for thread in threads:
-        if not thread.promoted or thread.state != "open":
+        if thread.state != "open":
             continue
         if _thread_mentions_slice(thread, slice_id):
             return True

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -3020,12 +3020,9 @@ def _first_command(commands: list[str]) -> str | None:
 
 
 def _open_thread_covers_current_work(threads: list[GitThreadBrief], slice_id: str) -> bool:
-    for thread in threads:
-        if thread.state != "open":
-            continue
-        if _thread_mentions_slice(thread, slice_id):
-            return True
-    return False
+    return any(
+        thread.state == "open" and _thread_mentions_slice(thread, slice_id) for thread in threads
+    )
 
 
 def _thread_is_current_work_context(

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -1718,7 +1718,11 @@ def _planning_state_by_path(root: Path) -> list[tuple[str, dict[str, str]]]:
         path = root / relpath
         if not path.is_file():
             continue
-        values = _parse_planning_state_text(path.read_text(encoding="utf-8", errors="replace"))
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        values = _parse_planning_state_text(text)
         if values:
             states.append((relpath, values))
     return states

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -134,7 +134,8 @@ _AUTHORITY_ORIGIN_ORDER = {
     "inferred-authority": 1,
 }
 _TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]{1,}")
-_ROADMAP_SLICE_PATTERN = re.compile(r"\b(?:[A-Z][A-Za-z0-9]*-P\d+(?:\.\d+)?|[A-Z]\d+[a-z])\b")
+_ROADMAP_SLICE_INNER_PATTERN = r"(?:[A-Z][A-Za-z0-9]*-P\d+(?:\.\d+)?|[A-Z]\d+[a-z])"
+_ROADMAP_SLICE_PATTERN = re.compile(rf"\b{_ROADMAP_SLICE_INNER_PATTERN}\b")
 _PLANNING_STATE_PATTERN = re.compile(
     r"^\s*-\s+(?P<label>"
     r"Previous completed PR sub-slice|Current planned slice|Current PR sub-slice|"
@@ -258,6 +259,31 @@ _MAINTENANCE_GOAL_FILLER_TOKENS = {
     "would",
     "you",
 }
+_CURRENT_WORK_GOAL_TOKENS = {
+    "continue",
+    "current",
+    "handoff",
+    "next",
+    "pick",
+    "plan",
+    "planned",
+    "planning",
+    "resume",
+    "roadmap",
+    "start",
+    "work",
+}
+_HISTORY_REVIEW_GOAL_TOKENS = {
+    "history",
+    "historical",
+    "merged",
+    "past",
+    "pr",
+    "prs",
+    "pull",
+    "review",
+    "reviews",
+}
 _INFERRED_CONTEXT_FILLER_TOKENS = _MAINTENANCE_GOAL_FILLER_TOKENS | {
     "agent",
     "critical",
@@ -278,6 +304,20 @@ _INFERRED_CONTEXT_FILLER_TOKENS = _MAINTENANCE_GOAL_FILLER_TOKENS | {
     "test",
     "tests",
 }
+_CURRENT_WORK_LINE_PATTERNS = (
+    re.compile(
+        r"\b(?:active|current)\b.{0,80}?\b(?:planning\s+)?"
+        r"(?:item|target|work|slice|step|implementation)\b.{0,80}?"
+        rf"`?(?P<slice>{_ROADMAP_SLICE_INNER_PATTERN})`?",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:next|real\s+next|next\s+planned)\b.{0,80}?"
+        r"\b(?:item|target|work|slice|step|implementation)\b.{0,80}?"
+        rf"`?(?P<slice>{_ROADMAP_SLICE_INNER_PATTERN})`?",
+        re.IGNORECASE,
+    ),
+)
 
 
 @dataclass(frozen=True)
@@ -432,6 +472,15 @@ class HandoffCurrentState:
 
 
 @dataclass(frozen=True)
+class CurrentPlannedWork:
+    slice_id: str
+    planned_slice: str | None
+    authority_paths: list[str]
+    predecessor_slices: list[str]
+    reason: str
+
+
+@dataclass(frozen=True)
 class SuggestNextResult:
     goal: str | None
     actions: list[SuggestedAction]
@@ -446,6 +495,7 @@ class SuggestNextResult:
     git_context: GitContext
     read_first_paths: list[str]
     handoff_current_state: HandoffCurrentState | None
+    current_planned_work: CurrentPlannedWork | None
     work_actions: list[SuggestedAction]
     maintenance_actions: list[SuggestedAction]
     maintenance_commands: list[MaintenanceCommand]
@@ -477,6 +527,7 @@ class BriefStateSnapshot:
     git_context: GitContext
     read_first_paths: list[str]
     handoff_current_state: HandoffCurrentState | None
+    current_planned_work: CurrentPlannedWork | None
     maintenance_goal: bool
 
 
@@ -503,6 +554,7 @@ class ProjectBrief:
     read_first_paths: list[str]
     next_actions: list[str]
     handoff_current_state: HandoffCurrentState | None
+    current_planned_work: CurrentPlannedWork | None
 
 
 def build_project_brief(
@@ -548,6 +600,7 @@ def build_project_brief(
         read_first_paths=snapshot.read_first_paths,
         next_actions=next_actions,
         handoff_current_state=snapshot.handoff_current_state,
+        current_planned_work=snapshot.current_planned_work,
     )
 
 
@@ -576,6 +629,7 @@ def build_suggest_next(
         git_context=snapshot.git_context,
         read_first_paths=snapshot.read_first_paths,
         handoff_current_state=snapshot.handoff_current_state,
+        current_planned_work=snapshot.current_planned_work,
         work_actions=work_actions,
         maintenance_actions=maintenance_actions,
         maintenance_commands=maintenance_commands,
@@ -647,6 +701,12 @@ def _collect_brief_state(
     )
     read_first_paths = _combined_read_first_paths(git_context, authority_read_first_scores)
     handoff_current_state = _handoff_current_state(root, git_context)
+    current_planned_work = _current_planned_work(
+        root,
+        git_context,
+        normalized_goal or None,
+        handoff_current_state=handoff_current_state,
+    )
     return BriefStateSnapshot(
         root=root,
         goal=normalized_goal or None,
@@ -670,6 +730,7 @@ def _collect_brief_state(
         git_context=git_context,
         read_first_paths=read_first_paths,
         handoff_current_state=handoff_current_state,
+        current_planned_work=current_planned_work,
         maintenance_goal=maintenance_goal,
     )
 
@@ -1343,6 +1404,18 @@ def _is_maintenance_goal(goal_tokens: set[str]) -> bool:
     return len(maintenance_matches) >= 2 and len(maintenance_matches) >= len(non_maintenance_tokens)
 
 
+def _is_history_review_goal(goal_tokens: set[str]) -> bool:
+    return bool(goal_tokens & _HISTORY_REVIEW_GOAL_TOKENS)
+
+
+def _is_current_work_goal(goal_tokens: set[str]) -> bool:
+    if not goal_tokens or _is_history_review_goal(goal_tokens):
+        return False
+    if goal_tokens & _CURRENT_WORK_GOAL_TOKENS:
+        return True
+    return any(any(character.isdigit() for character in token) for token in goal_tokens)
+
+
 def _flatten_handoff_values(value) -> list[str]:
     if value is None:
         return []
@@ -1501,17 +1574,130 @@ def _handoff_current_state(root: Path, git_context: GitContext) -> HandoffCurren
     )
 
 
-def _combined_planning_state(root: Path) -> dict[str, str]:
+def _current_planned_work(
+    root: Path,
+    git_context: GitContext,
+    goal: str | None,
+    *,
+    handoff_current_state: HandoffCurrentState | None,
+) -> CurrentPlannedWork | None:
+    goal_tokens = _tokens(goal or "")
+    if handoff_current_state is not None or not _is_current_work_goal(goal_tokens):
+        return None
+
+    structured = _structured_current_planned_work(root, git_context)
+    if structured is not None:
+        return structured
+    return _line_inferred_current_planned_work(root)
+
+
+def _structured_current_planned_work(
+    root: Path, git_context: GitContext
+) -> CurrentPlannedWork | None:
+    states = _planning_state_by_path(root)
+    if not states:
+        return None
     combined: dict[str, str] = {}
-    for relpath in (
-        ".agent-plan.md",
-        "README.md",
-        "docs/splendor_mvp_to_v1_roadmap.md",
-    ):
+    authority_paths: list[str] = []
+    for relpath, values in states:
+        for label, value in values.items():
+            combined.setdefault(label, value)
+        if values:
+            authority_paths.append(relpath)
+
+    previous_slice = combined.get("Previous completed PR sub-slice")
+    current_slice = combined.get("Current PR sub-slice")
+    next_slice = combined.get("Next planned PR sub-slice")
+    current_lifecycle = (combined.get("Current PR lifecycle") or "").lower()
+    planned_slice = combined.get("Current planned slice")
+    next_planned_slice = combined.get("Next planned slice")
+    branch = git_context.branch or ""
+
+    use_next = False
+    if current_slice and next_slice and previous_slice == current_slice:
+        use_next = True
+    elif current_slice and next_slice and branch == "main" and "main=merged" in current_lifecycle:
+        use_next = True
+
+    slice_id = next_slice if use_next and next_slice else current_slice or next_slice
+    if slice_id is None:
+        return None
+
+    predecessor_slices = []
+    for value in (previous_slice, current_slice if use_next else None):
+        if value and value != slice_id and value not in predecessor_slices:
+            predecessor_slices.append(value)
+
+    reason_parts = ["Structured planning-state lines identify the current handoff target."]
+    if use_next and current_slice:
+        reason_parts.append(f"{current_slice} is predecessor context; lead with {slice_id}.")
+    return CurrentPlannedWork(
+        slice_id=slice_id,
+        planned_slice=next_planned_slice if use_next and next_planned_slice else planned_slice,
+        authority_paths=sorted(dict.fromkeys(authority_paths)),
+        predecessor_slices=predecessor_slices,
+        reason=" ".join(reason_parts),
+    )
+
+
+def _line_inferred_current_planned_work(root: Path) -> CurrentPlannedWork | None:
+    for relpath in _current_work_authority_paths(root):
+        path = root / relpath
+        try:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            normalized = line.lower()
+            if any(word in normalized for word in ("historical", "completed", "done", "merged")):
+                continue
+            for pattern in _CURRENT_WORK_LINE_PATTERNS:
+                match = pattern.search(line)
+                if match is None:
+                    continue
+                slice_id = match.group("slice")
+                return CurrentPlannedWork(
+                    slice_id=slice_id,
+                    planned_slice=None,
+                    authority_paths=[relpath],
+                    predecessor_slices=[],
+                    reason=(
+                        "Conventional authority text identifies the current handoff target: "
+                        f"{line.strip()}"
+                    ),
+                )
+    return None
+
+
+def _planning_state_by_path(root: Path) -> list[tuple[str, dict[str, str]]]:
+    states: list[tuple[str, dict[str, str]]] = []
+    for relpath in _current_work_authority_paths(root):
         path = root / relpath
         if not path.is_file():
             continue
-        values = _parse_planning_state_text(path.read_text(encoding="utf-8"))
+        values = _parse_planning_state_text(path.read_text(encoding="utf-8", errors="replace"))
+        if values:
+            states.append((relpath, values))
+    return states
+
+
+def _current_work_authority_paths(root: Path) -> list[str]:
+    paths = [".agent-plan.md", "README.md", "docs/splendor_mvp_to_v1_roadmap.md"]
+    docs_dir = root / "docs"
+    if docs_dir.is_dir():
+        for path in sorted(docs_dir.rglob("*.md")):
+            relative = path.relative_to(root).as_posix()
+            name = path.name.lower()
+            if relative in paths:
+                continue
+            if "roadmap" in name or "plan" in name:
+                paths.append(relative)
+    return paths
+
+
+def _combined_planning_state(root: Path) -> dict[str, str]:
+    combined: dict[str, str] = {}
+    for _relpath, values in _planning_state_by_path(root):
         for label, value in values.items():
             combined.setdefault(label, value)
     return combined
@@ -2404,6 +2590,7 @@ def _suggestion_candidates(snapshot: BriefStateSnapshot) -> list[SuggestedAction
     actions: list[SuggestedAction] = []
     goal_tokens = _tokens(snapshot.goal or "")
     goal_phrase = _normalize_goal_phrase(snapshot.goal or "")
+    current_work_goal = _is_current_work_goal(goal_tokens)
 
     def add(priority: str, category: str, title: str, reason: str, command: str | None, **kwargs):
         relevance_score = kwargs.pop(
@@ -2440,9 +2627,15 @@ def _suggestion_candidates(snapshot: BriefStateSnapshot) -> list[SuggestedAction
 
     if snapshot.git_context.enabled and snapshot.git_context.available:
         for thread in snapshot.git_context.threads:
-            if not thread.promoted:
+            if not thread.promoted and not _thread_is_current_work_context(
+                thread, snapshot.current_planned_work
+            ):
                 continue
             priority = "high" if thread.state == "open" else "medium"
+            relevance_score = thread.relevance_score + (50 if thread.related_to is None else 0)
+            if current_work_goal and thread.state != "open" and snapshot.current_planned_work:
+                priority = "low"
+                relevance_score -= 80
             add(
                 priority,
                 "work-thread",
@@ -2450,17 +2643,49 @@ def _suggestion_candidates(snapshot: BriefStateSnapshot) -> list[SuggestedAction
                 thread.summary,
                 None,
                 url=thread.url,
-                relevance_score=thread.relevance_score + (50 if thread.related_to is None else 0),
+                relevance_score=relevance_score,
             )
+    if snapshot.current_planned_work is not None and not _open_thread_covers_current_work(
+        snapshot.git_context.threads, snapshot.current_planned_work.slice_id
+    ):
+        work = snapshot.current_planned_work
+        authority_paths = ", ".join(work.authority_paths[:3])
+        predecessors = ", ".join(work.predecessor_slices)
+        predecessor_note = (
+            f" Predecessor context remains visible: {predecessors}." if predecessors else ""
+        )
+        planned_note = f" ({work.planned_slice})" if work.planned_slice else ""
+        add(
+            "high",
+            "current-state",
+            f"Continue {work.slice_id}{planned_note} from current planning authority",
+            f"{work.reason} Authority: {authority_paths}.{predecessor_note}",
+            None,
+            record_id=work.slice_id,
+            path=work.authority_paths[0] if work.authority_paths else None,
+            relevance_score=_goal_relevance_score(
+                goal_tokens,
+                goal_phrase=goal_phrase,
+                high_text=" ".join([work.slice_id, work.planned_slice or ""]),
+                medium_text=" ".join(work.authority_paths + work.predecessor_slices),
+            )
+            + 150,
+        )
+    if snapshot.git_context.enabled and snapshot.git_context.available:
         for commit in snapshot.git_context.commits:
+            priority = "medium"
+            relevance_score = commit.relevance_score
+            if current_work_goal and snapshot.current_planned_work:
+                priority = "low"
+                relevance_score -= 80
             add(
-                "medium",
+                priority,
                 "git-context",
                 f"Review commit {commit.short_sha}: {commit.subject}",
                 "Recent git context relevant to the stated goal.",
                 None,
                 record_id=commit.short_sha,
-                relevance_score=commit.relevance_score,
+                relevance_score=relevance_score,
             )
     for path in snapshot.read_first_paths:
         add(
@@ -2725,6 +2950,28 @@ def _first_command(commands: list[str]) -> str | None:
     return commands[0] if commands else None
 
 
+def _open_thread_covers_current_work(threads: list[GitThreadBrief], slice_id: str) -> bool:
+    for thread in threads:
+        if not thread.promoted or thread.state != "open":
+            continue
+        if _text_starts_with_slice(thread.title, slice_id):
+            return True
+    return False
+
+
+def _thread_is_current_work_context(
+    thread: GitThreadBrief, current_work: CurrentPlannedWork | None
+) -> bool:
+    if current_work is None:
+        return False
+    if _text_starts_with_slice(thread.title, current_work.slice_id):
+        return True
+    return any(
+        _text_starts_with_slice(thread.title, predecessor)
+        for predecessor in current_work.predecessor_slices
+    )
+
+
 def _finalize_suggestions(
     actions: list[SuggestedAction], *, maintenance_goal: bool
 ) -> list[SuggestedAction]:
@@ -2912,6 +3159,9 @@ def render_suggest_next_json(result: SuggestNextResult) -> str:
             "handoff_current_state": (
                 asdict(result.handoff_current_state) if result.handoff_current_state else None
             ),
+            "current_planned_work": (
+                asdict(result.current_planned_work) if result.current_planned_work else None
+            ),
             "status": {
                 "source_total": result.status.source_total,
                 "page_total": result.status.page_total,
@@ -2968,6 +3218,9 @@ def render_project_brief_json(brief: ProjectBrief) -> str:
             "handoff_current_state": (
                 asdict(brief.handoff_current_state) if brief.handoff_current_state else None
             ),
+            "current_planned_work": (
+                asdict(brief.current_planned_work) if brief.current_planned_work else None
+            ),
             "suggested_actions": [asdict(action) for action in brief.suggested_actions],
             "work_context": {"actions": [asdict(action) for action in brief.work_actions]},
             "maintenance_context": {
@@ -3007,6 +3260,9 @@ def render_agent_context_json(brief: ProjectBrief) -> str:
             "read_first_paths": brief.read_first_paths,
             "handoff_current_state": (
                 asdict(brief.handoff_current_state) if brief.handoff_current_state else None
+            ),
+            "current_planned_work": (
+                asdict(brief.current_planned_work) if brief.current_planned_work else None
             ),
             "suggested_actions": [asdict(action) for action in brief.suggested_actions],
             "work_context": {"actions": [asdict(action) for action in brief.work_actions]},

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -3403,6 +3403,62 @@ def test_agent_context_keeps_matching_open_work_thread_ahead_of_current_authorit
     }
 
 
+def test_agent_context_keeps_unpromoted_matching_open_thread_ahead_of_current_authority(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n"
+        "- Previous completed PR sub-slice: `M20-P1.3`\n"
+        "- Current planned slice: `M20 current-work handoff ranking`\n"
+        "- Current PR sub-slice: `M20-P1.4`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `M20 mutating web review workflows`\n"
+        "- Next planned PR sub-slice: `M20-P2.1`\n",
+        encoding="utf-8",
+    )
+    _init_git_repo(tmp_path, repo="splendor-dev/splendor")
+    _commit_all(tmp_path, "M20-P1.3: Record retry findings")
+    _git(tmp_path, "switch", "-c", "codex/m20-p1-4-current-work-handoff-ranking")
+    _install_fake_gh(
+        tmp_path,
+        monkeypatch,
+        issues=[
+            {
+                "number": 177,
+                "title": "Implementation tracker",
+                "url": "https://github.com/splendor-dev/splendor/issues/177",
+                "body": "M20-P1.4 is the live implementation slice.",
+                "state": "open",
+                "labels": [],
+            }
+        ],
+        prs=[],
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "Start",
+            "current",
+            "work",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["current_planned_work"]["slice_id"] == "M20-P1.4"
+    assert payload["work_context"]["actions"][0]["category"] == "work-thread"
+    assert payload["work_context"]["actions"][0]["url"].endswith("/issues/177")
+    assert "current-state" not in {
+        action["category"] for action in payload["work_context"]["actions"]
+    }
+
+
 def test_agent_context_reconciles_structured_planning_state_majority(
     tmp_path: Path, capsys
 ) -> None:
@@ -3554,6 +3610,43 @@ def test_agent_context_review_current_work_goal_still_uses_current_authority(
     assert payload["work_context"]["actions"][0]["category"] == "current-state"
 
 
+def test_agent_context_issue_number_goal_does_not_trigger_current_authority(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n"
+        "- Previous completed PR sub-slice: `M20-P1.3`\n"
+        "- Current planned slice: `M20 current-work handoff ranking`\n"
+        "- Current PR sub-slice: `M20-P1.3`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `M20 current-work handoff ranking`\n"
+        "- Next planned PR sub-slice: `M20-P1.4`\n",
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "--no-git",
+            "review",
+            "issue",
+            "177",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["current_planned_work"] is None
+    assert "current-state" not in {
+        action["category"] for action in payload["work_context"]["actions"]
+    }
+
+
 def test_agent_context_fallback_current_work_follows_authority_ranking(
     tmp_path: Path, capsys
 ) -> None:
@@ -3577,6 +3670,57 @@ def test_agent_context_fallback_current_work_follows_authority_ranking(
     )
     (docs / "roadmap.md").write_text(
         "# hocrsyngen Roadmap\n\nCurrent roadmap work: `S7a`.\n",
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "--no-git",
+            "Continue",
+            "hocrsyngen",
+            "roadmap",
+            "work",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["current_planned_work"]["slice_id"] == "S7a"
+    assert payload["current_planned_work"]["authority_paths"] == ["docs/roadmap.md"]
+
+
+def test_agent_context_structured_current_work_ignores_unconfigured_plan_docs(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path="docs/roadmap.md",
+            role="roadmap",
+            purpose="Current hocrsyngen roadmap authority.",
+            applies_to=["hocrsyngen roadmap work"],
+        )
+    ]
+    write_config(tmp_path, config)
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "allograph_plan.md").write_text(
+        "# Allograph Plan\n\n"
+        "- Current planned slice: `S1 allograph work`\n"
+        "- Current PR sub-slice: `S1a`\n",
+        encoding="utf-8",
+    )
+    (docs / "roadmap.md").write_text(
+        "# hocrsyngen Roadmap\n\n"
+        "- Current planned slice: `S7 script abstraction`\n"
+        "- Current PR sub-slice: `S7a`\n",
         encoding="utf-8",
     )
     capsys.readouterr()

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2447,7 +2447,13 @@ def test_agent_context_hocrgen_retry_bar_ranks_current_planning_before_history(
     assert suggest_exit == 0
     suggest_payload = json.loads(capsys.readouterr().out)
     suggest_categories = [action["category"] for action in suggest_payload["actions"]]
-    assert suggest_categories[0] in {"work-thread", "git-context", "authority", "planning"}
+    assert suggest_categories[0] in {
+        "current-state",
+        "work-thread",
+        "git-context",
+        "authority",
+        "planning",
+    }
     if "goal-match" in suggest_categories:
         assert suggest_categories.index("authority") < suggest_categories.index("goal-match")
 
@@ -3111,10 +3117,290 @@ def test_agent_context_preserves_non_stale_current_slice(
     assert suggest_exit == 0
     assert brief_payload["handoff_current_state"] is None
     assert suggest_payload["handoff_current_state"] is None
+    for payload in (brief_payload, suggest_payload):
+        assert payload["current_planned_work"]["slice_id"] == "S4d"
+        current_state_actions = [
+            action
+            for action in payload["work_context"]["actions"]
+            if action["category"] == "current-state"
+        ]
+        assert len(current_state_actions) == 1
+        assert current_state_actions[0]["rank"] == 1
+        assert "S4d" in current_state_actions[0]["title"]
+
+
+def test_agent_context_hocrsyngen_current_authority_leads_after_applied_ingest(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n"
+        "- Previous completed PR sub-slice: `S6h`\n"
+        "- Current planned slice: `S7 script abstraction`\n"
+        "- Current PR sub-slice: `S6h`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `S7 script abstraction`\n"
+        "- Next planned PR sub-slice: `S7a`\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "# hocrsyngen\n\n"
+        "## What Comes Next\n\n"
+        "- Previous completed PR sub-slice: `S6h`\n"
+        "- Current planned slice: `S7 script abstraction`\n"
+        "- Current PR sub-slice: `S6h`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `S7 script abstraction`\n"
+        "- Next planned PR sub-slice: `S7a`\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "roadmap.md").write_text(
+        "# hocrsyngen Roadmap\n\n"
+        "S6h is complete in PR #55. The active current planning item is `S7a`.\n",
+        encoding="utf-8",
+    )
+    _init_git_repo(tmp_path, repo="HeOCR/hocrsyngen")
+    _commit_all(tmp_path, "S6h: Close S6 and activate S7 script abstraction")
+    _install_fake_gh(
+        tmp_path,
+        monkeypatch,
+        issues=[],
+        prs=[
+            {
+                "number": 55,
+                "title": "S6h: Close S6 and activate S7 script abstraction",
+                "url": "https://github.com/HeOCR/hocrsyngen/pull/55",
+                "body": "Merged S6h. Current roadmap authority points at S7a.",
+                "state": "merged",
+                "isDraft": False,
+                "mergedAt": "2026-05-08T10:00:00Z",
+                "labels": [],
+            },
+            {
+                "number": 39,
+                "title": "S0e: Align post-S4d production-readiness roadmap",
+                "url": "https://github.com/HeOCR/hocrsyngen/pull/39",
+                "body": "Historical S4d alignment.",
+                "state": "merged",
+                "isDraft": False,
+                "mergedAt": "2026-05-06T10:00:00Z",
+                "labels": [],
+            },
+        ],
+    )
+    for path in (".agent-plan.md", "README.md", "docs/roadmap.md"):
+        main(["--root", str(tmp_path), "add-source", path])
+    main(["--root", str(tmp_path), "ingest", "--pending", "--apply"])
+    capsys.readouterr()
+
+    brief_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "Continue",
+            "hocrsyngen",
+            "roadmap",
+            "work",
+            "after",
+            "S6h",
+            "--json",
+        ]
+    )
+    brief_payload = json.loads(capsys.readouterr().out)
+    suggest_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "Continue",
+            "hocrsyngen",
+            "roadmap",
+            "work",
+            "after",
+            "S6h",
+            "--json",
+        ]
+    )
+    suggest_payload = json.loads(capsys.readouterr().out)
+
+    assert brief_exit == 0
+    assert suggest_exit == 0
+    for payload in (brief_payload, suggest_payload):
+        assert payload["current_planned_work"]["slice_id"] == "S7a"
+        action = payload["work_context"]["actions"][0]
+        assert action["category"] == "current-state"
+        assert "S7a" in action["title"]
+        titles = [item["title"] for item in payload["work_context"]["actions"]]
+        assert any("S6h" in title for title in titles[1:])
+        assert all("S0e" not in title for title in titles[:1])
+
+
+def test_agent_context_hocrgen_current_authority_beats_merged_pr_and_maintenance(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n"
+        "- Previous completed PR sub-slice: `F6e`\n"
+        "- Current planned slice: `F6 current public-beta closure`\n"
+        "- Current PR sub-slice: `F6e`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `F6 current public-beta closure`\n"
+        "- Next planned PR sub-slice: `F6f`\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "# hocrgen\n\nThe real next item from current main is `F6f`, not F6a or F6e review.\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "HeOCR_hocrgen_long_term_roadmap.md").write_text(
+        "# Roadmap\n\n"
+        "Current roadmap work: `F6f` integrates the larger validated hocrsyngen batch.\n",
+        encoding="utf-8",
+    )
+    source = tmp_path / "docs" / "source_depth.md"
+    source.write_text("# Source depth\n\nOriginal readiness evidence.\n", encoding="utf-8")
+    _init_git_repo(tmp_path, repo="HeOCR/hocrgen")
+    _commit_all(tmp_path, "F6e: Close source-depth readiness evidence")
+    _install_fake_gh(
+        tmp_path,
+        monkeypatch,
+        issues=[],
+        prs=[
+            {
+                "number": 72,
+                "title": "F6a: Define post-F5 public beta closure roadmap",
+                "url": "https://github.com/HeOCR/hocrgen/pull/72",
+                "body": "Historical F6a roadmap context.",
+                "state": "merged",
+                "isDraft": False,
+                "mergedAt": "2026-05-07T10:00:00Z",
+                "labels": [],
+            },
+            {
+                "number": 76,
+                "title": "F6e: Close source-depth and composition readiness",
+                "url": "https://github.com/HeOCR/hocrgen/pull/76",
+                "body": "Merged F6e. F6f follows.",
+                "state": "merged",
+                "isDraft": False,
+                "mergedAt": "2026-05-08T10:00:00Z",
+                "labels": [],
+            },
+        ],
+    )
+    added = add_source(tmp_path, source)
+    main(["--root", str(tmp_path), "ingest", added.source_id])
+    source.write_text("# Source depth\n\nChanged readiness evidence.\n", encoding="utf-8")
+    capsys.readouterr()
+
+    brief_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "Continue",
+            "hocrgen",
+            "roadmap",
+            "work",
+            "from",
+            "current",
+            "main",
+            "--json",
+        ]
+    )
+    brief_payload = json.loads(capsys.readouterr().out)
+    suggest_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "Continue",
+            "hocrgen",
+            "roadmap",
+            "work",
+            "from",
+            "current",
+            "main",
+            "--json",
+        ]
+    )
+    suggest_payload = json.loads(capsys.readouterr().out)
+
+    assert brief_exit == 0
+    assert suggest_exit == 0
+    for payload in (brief_payload, suggest_payload):
+        assert payload["current_planned_work"]["slice_id"] == "F6f"
+        assert payload["work_context"]["actions"][0]["category"] == "current-state"
+        assert "F6f" in payload["work_context"]["actions"][0]["title"]
+        work_titles = [action["title"] for action in payload["work_context"]["actions"]]
+        assert work_titles.index(payload["work_context"]["actions"][0]["title"]) == 0
+        assert any("F6e" in title or "F6a" in title for title in work_titles[1:])
+        assert payload["maintenance_context"]["actions"][0]["category"] == "source-freshness"
+
+
+def test_agent_context_keeps_matching_open_work_thread_ahead_of_current_authority(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n"
+        "- Previous completed PR sub-slice: `M20-P1.3`\n"
+        "- Current planned slice: `M20 current-work handoff ranking`\n"
+        "- Current PR sub-slice: `M20-P1.4`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `M20 mutating web review workflows`\n"
+        "- Next planned PR sub-slice: `M20-P2.1`\n",
+        encoding="utf-8",
+    )
+    _init_git_repo(tmp_path, repo="splendor-dev/splendor")
+    _commit_all(tmp_path, "M20-P1.3: Record retry findings")
+    _git(tmp_path, "switch", "-c", "codex/m20-p1-4-current-work-handoff-ranking")
+    _install_fake_gh(
+        tmp_path,
+        monkeypatch,
+        issues=[
+            {
+                "number": 177,
+                "title": "M20-P1.4 Current-work handoff ranking from planning authority",
+                "url": "https://github.com/splendor-dev/splendor/issues/177",
+                "body": "Implement M20-P1.4 and keep M20-P2.1 out of scope.",
+                "state": "open",
+                "labels": [],
+            }
+        ],
+        prs=[],
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "Start",
+            "M20-P1.4",
+            "current",
+            "work",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["current_planned_work"]["slice_id"] == "M20-P1.4"
+    assert payload["work_context"]["actions"][0]["category"] == "work-thread"
+    assert payload["work_context"]["actions"][0]["url"].endswith("/issues/177")
     assert "current-state" not in {
-        action["category"] for action in brief_payload["suggested_actions"]
+        action["category"] for action in payload["work_context"]["actions"]
     }
-    assert "current-state" not in {action["category"] for action in suggest_payload["actions"]}
 
 
 def test_agent_context_hocrgen_retry_bar_uses_provisional_uncurated_authority(

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -3369,7 +3369,7 @@ def test_agent_context_keeps_matching_open_work_thread_ahead_of_current_authorit
         issues=[
             {
                 "number": 177,
-                "title": "M20-P1.4 Current-work handoff ranking from planning authority",
+                "title": "Current-work handoff ranking from planning authority",
                 "url": "https://github.com/splendor-dev/splendor/issues/177",
                 "body": "Implement M20-P1.4 and keep M20-P2.1 out of scope.",
                 "state": "open",
@@ -3401,6 +3401,148 @@ def test_agent_context_keeps_matching_open_work_thread_ahead_of_current_authorit
     assert "current-state" not in {
         action["category"] for action in payload["work_context"]["actions"]
     }
+
+
+def test_agent_context_reconciles_structured_planning_state_majority(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n"
+        "- Previous completed PR sub-slice: `S6h`\n"
+        "- Current planned slice: `S6 stale script boundary`\n"
+        "- Current PR sub-slice: `S6h`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `S6 stale script boundary`\n"
+        "- Next planned PR sub-slice: `S6i`\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "# hocrsyngen\n\n"
+        "## What Comes Next\n\n"
+        "- Previous completed PR sub-slice: `S6h`\n"
+        "- Current planned slice: `S7 script abstraction`\n"
+        "- Current PR sub-slice: `S6h`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `S7 script abstraction`\n"
+        "- Next planned PR sub-slice: `S7a`\n",
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "splendor_mvp_to_v1_roadmap.md").write_text(
+        "# Roadmap\n\n"
+        "- Previous completed PR sub-slice: `S6h`\n"
+        "- Current planned slice: `S7 script abstraction`\n"
+        "- Current PR sub-slice: `S6h`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `S7 script abstraction`\n"
+        "- Next planned PR sub-slice: `S7a`\n",
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "--no-git",
+            "Continue",
+            "hocrsyngen",
+            "roadmap",
+            "work",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["current_planned_work"]["slice_id"] == "S7a"
+    assert "majority value 'S7a'" in payload["current_planned_work"]["reason"]
+
+
+def test_agent_context_review_current_work_goal_still_uses_current_authority(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n"
+        "- Previous completed PR sub-slice: `M20-P1.3`\n"
+        "- Current planned slice: `M20 current-work handoff ranking`\n"
+        "- Current PR sub-slice: `M20-P1.3`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `M20 current-work handoff ranking`\n"
+        "- Next planned PR sub-slice: `M20-P1.4`\n",
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "--no-git",
+            "review",
+            "current",
+            "roadmap",
+            "work",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["current_planned_work"]["slice_id"] == "M20-P1.4"
+    assert payload["work_context"]["actions"][0]["category"] == "current-state"
+
+
+def test_agent_context_fallback_current_work_follows_authority_ranking(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path="docs/roadmap.md",
+            role="roadmap",
+            purpose="Current hocrsyngen roadmap authority.",
+            applies_to=["hocrsyngen roadmap work"],
+        )
+    ]
+    write_config(tmp_path, config)
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "allograph_plan.md").write_text(
+        "# Allograph Plan\n\nCurrent implementation work: `S1a`.\n",
+        encoding="utf-8",
+    )
+    (docs / "roadmap.md").write_text(
+        "# hocrsyngen Roadmap\n\nCurrent roadmap work: `S7a`.\n",
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "--no-git",
+            "Continue",
+            "hocrsyngen",
+            "roadmap",
+            "work",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["current_planned_work"]["slice_id"] == "S7a"
+    assert payload["current_planned_work"]["authority_paths"] == ["docs/roadmap.md"]
 
 
 def test_agent_context_hocrgen_retry_bar_uses_provisional_uncurated_authority(

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -3462,6 +3462,62 @@ def test_agent_context_reconciles_structured_planning_state_majority(
     assert "majority value 'S7a'" in payload["current_planned_work"]["reason"]
 
 
+def test_agent_context_skips_unreadable_structured_planning_file(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    agent_plan = tmp_path / ".agent-plan.md"
+    agent_plan.write_text(
+        "# Agent Plan\n\n"
+        "- Previous completed PR sub-slice: `S6h`\n"
+        "- Current planned slice: `S6 stale script boundary`\n"
+        "- Current PR sub-slice: `S6h`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `S6 stale script boundary`\n"
+        "- Next planned PR sub-slice: `S6i`\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "# hocrsyngen\n\n"
+        "## What Comes Next\n\n"
+        "- Previous completed PR sub-slice: `S6h`\n"
+        "- Current planned slice: `S7 script abstraction`\n"
+        "- Current PR sub-slice: `S6h`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `S7 script abstraction`\n"
+        "- Next planned PR sub-slice: `S7a`\n",
+        encoding="utf-8",
+    )
+    original_read_text = Path.read_text
+
+    def read_text_or_fail(path: Path, *args, **kwargs) -> str:
+        if path == agent_plan:
+            raise OSError("simulated transient read failure")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text_or_fail)
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "--no-git",
+            "Continue",
+            "hocrsyngen",
+            "roadmap",
+            "work",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["current_planned_work"]["slice_id"] == "S7a"
+    assert payload["current_planned_work"]["authority_paths"] == ["README.md"]
+
+
 def test_agent_context_review_current_work_goal_still_uses_current_authority(
     tmp_path: Path, capsys
 ) -> None:


### PR DESCRIPTION
## Summary

- Add runtime current-planned-work extraction from `.agent-plan.md`, README, and roadmap authority conventions for current/next roadmap handoff goals.
- Make `brief --agent-context` and `suggest-next` rank that current work above merged PRs, recent commits, and maintenance actions while preserving matching open issue/PR work-thread behavior.
- Add deterministic hocrsyngen-style S7a and hocrgen-style F6f regression fixtures, plus coverage for predecessor visibility, open-thread precedence, and planning-state synchronization.

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

## Scope Notes

- Runtime-only and local-first: no hosted service, background worker, mandatory external API, web workflow, or persisted index state.
- Current planning authority is exposed as `current_planned_work` in JSON handoff payloads.
- Completed PRs/commits remain visible as predecessor context below the current work answer.
- Matching open issue/PR threads still lead when they are the actual current work.

## Non-goals

- Does not start M20-P2.1 / #119 mutating web review workflows.
- Does not add vector search, broad provider-gate ranking, cold-start state relocation, or new persisted search/index state.

Closes #177.