### PR TITLE
M20-P2.1: Explore mutating web review workflows

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P1.3`
-- Last action taken: `M20-P1.3` merged to main via PR #176 with the v0.5.1
-  hocrgen/hocrsyngen retry findings and current-work handoff plan.
-- Current planned slice: `M20 current-work handoff ranking`
-- Current PR sub-slice: `M20-P1.4`
+- Previous completed PR sub-slice: `M20-P1.4`
+- Last action taken: `M20-P1.4` merged to main via PR #178 with the runtime-only
+  current-work handoff ranking fix from planning authority.
+- Current planned slice: `M20 mutating web review workflows`
+- Current PR sub-slice: `M20-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 mutating web review workflows`
-- Next planned PR sub-slice: `M20-P2.1`
+- Next planned slice: `M20 richer GitHub integrations`
+- Next planned PR sub-slice: `M20-P3.1`
 - Current blockers: none
 
 ## Planning Notation
@@ -522,3 +522,4 @@
 - `M20-P1.3` v0.5.1 retry findings and current-work handoff plan
 - `M20-P1.4` Current-work handoff ranking from planning authority
 - `M20-P2.1` Mutating web review workflows
+- `M20-P3.1` Richer GitHub issue, PR, review-thread, and CI integrations

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ non-draft GitHub PR with labels, milestone, and a clear description.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P1.3`
-- Current planned slice: `M20 current-work handoff ranking`
-- Current PR sub-slice: `M20-P1.4`
+- Previous completed PR sub-slice: `M20-P1.4`
+- Current planned slice: `M20 mutating web review workflows`
+- Current PR sub-slice: `M20-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 mutating web review workflows`
-- Next planned PR sub-slice: `M20-P2.1`
+- Next planned slice: `M20 richer GitHub integrations`
+- Next planned PR sub-slice: `M20-P3.1`
 
 These planning-state lines are for contributors and agents. The detailed roadmap lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ workflow.
 - [Schema contracts](schema_contracts.md)
 - [Source-resolution refactor plan](source_resolution_refactor_plan.md)
 - [Issue #70 design response](issue_70_design_response.md)
+- [Mutating web review workflows proposal](mutating_web_review_workflows.md)
 
 ## Guides
 

--- a/docs/mutating_web_review_workflows.md
+++ b/docs/mutating_web_review_workflows.md
@@ -13,7 +13,7 @@ authoritative runtime. The CLI remains the primary contract. Browser-side action
 same deterministic filesystem writes that already appear in CLI preview/apply output, so users can
 review the resulting git diff exactly as if they had run the command by hand.
 
-The first mutating web scope should be limited to three workflows:
+The first mutating web scope should be limited to two workflow families:
 
 1. Accept one maintained wiki compile proposal.
    - The browser displays the same target page, source-summary page, unified diff, source hash,
@@ -30,17 +30,40 @@ The first mutating web scope should be limited to three workflows:
    - The action writes only the selected task record and does not rewrite linked wiki pages,
      source summaries, or historical run records.
 
-3. Accept a previewed source or queue maintenance operation.
-   - The browser may render the existing `mutation.planned` records from commands such as
-     `source refresh`, `source update-path`, `source forget`, `source reconcile`, `queue clean`, or
-     `workspace refresh`.
-   - Apply maps to the same command with explicit apply flags.
-   - Bulk or destructive operations must keep the same selectors, large-apply guards, skipped
-     records, and residual-reference reporting as the CLI.
+Source and queue maintenance may become a later workflow family only after the single-page compile
+acceptance path proves the browser can preserve CLI-equivalent safety. Those later source/queue
+actions would have to render the existing `mutation.planned` records from commands such as
+`source refresh`, `source update-path`, `source forget`, `source reconcile`, `queue clean`, or
+`workspace refresh`; map apply to the same command with explicit apply flags; and keep the same
+selectors, large-apply guards, skipped records, and residual-reference reporting as the CLI.
 
 Everything else stays out of the first mutating web track: freeform page editing, multi-page
-synthesis rewrites, background ingestion, hosted collaboration, auth/roles, database-backed state,
-mandatory external providers, and automatic GitHub mutation.
+synthesis rewrites, source or queue maintenance apply buttons, background ingestion, hosted
+collaboration, auth/roles, database-backed state, mandatory external providers, and automatic
+GitHub mutation.
+
+## Browser Trust Boundary
+
+The local web server must treat browser mutations as local operator actions, not as ambient
+authority available to any page that can reach `localhost`.
+
+Before any mutating route exists, the implementation must define and test these controls:
+
+- Mutating routes use POST-only endpoints and never perform writes from GET, link prefetch, image,
+  script, or iframe loads.
+- The server does not enable permissive CORS, JSONP, or cross-origin embedding for mutating
+  endpoints.
+- Every mutation form carries a per-session or per-render local intent token that is checked on
+  apply, in addition to proposal hashes and input hashes.
+- The confirmation page shows affected paths, command-equivalent arguments, mutation mode, and
+  expected writes before the user can apply.
+- The token, proposal, and apply request are scoped to the current workspace root and cannot be
+  replayed across workspaces.
+- Browser apply failures disclose enough local diagnostic detail for repair, but do not expose
+  unrelated file contents or environment values.
+
+These controls are intentionally local and lightweight. They do not imply accounts, roles, hosted
+auth, remote collaboration, or a database-backed session store.
 
 ## Deterministic State Mapping
 
@@ -81,9 +104,12 @@ browser-side merge, collaborative editing session, hidden lock table, or asynchr
 
 ## First Implementation Shape
 
-The next implementation slice should start with one end-to-end path only: accepting a single
-`wiki compile` proposal for a maintained page. That path already has a narrow proposal hash,
-source/target inputs, schema validation, and a deterministic one-page write contract.
+The first implementation slice in this track should be a future `M20-P2.2`-style PR with one
+end-to-end path only: accepting a single `wiki compile` proposal for a maintained page. That path
+already has a narrow proposal hash, source/target inputs, schema validation, and a deterministic
+one-page write contract. This does not change the global planning state in `M20-P2.1`; the next
+planned PR remains `M20-P3.1` richer GitHub integrations unless the roadmap is deliberately
+reordered.
 
 A minimal implementation can add:
 
@@ -92,8 +118,8 @@ A minimal implementation can add:
 - a result page that lists written paths and next CLI/git review commands.
 
 It should not add a general mutation framework before that path proves useful. Source/queue
-maintenance and task review-state actions can follow after the compile path demonstrates that web
-acceptance stays local, deterministic, and git-reviewable.
+maintenance and broader task review-state actions can follow after the compile path demonstrates
+that web acceptance stays local, deterministic, and git-reviewable.
 
 ## Non-Goals
 

--- a/docs/mutating_web_review_workflows.md
+++ b/docs/mutating_web_review_workflows.md
@@ -1,0 +1,104 @@
+# M20-P2.1 Mutating Web Review Workflows Proposal
+
+Status: post-v1 design proposal for issue #119.
+
+Splendor's current local web UI remains read-only. This proposal defines the smallest mutating
+browser workflows worth supporting later, and the constraints they must satisfy before any runtime
+implementation starts.
+
+## Product Boundary
+
+The web UI may become a review and acceptance surface for existing local-first workflows, not a new
+authoritative runtime. The CLI remains the primary contract. Browser-side actions should map to the
+same deterministic filesystem writes that already appear in CLI preview/apply output, so users can
+review the resulting git diff exactly as if they had run the command by hand.
+
+The first mutating web scope should be limited to three workflows:
+
+1. Accept one maintained wiki compile proposal.
+   - The browser displays the same target page, source-summary page, unified diff, source hash,
+     target hash, and proposal hash produced by `splendor wiki compile <source> --page <page>`.
+   - Acceptance maps to the existing reviewed apply contract:
+     `splendor wiki compile <source> --page <page> --apply --proposal-hash <hash>`.
+   - Generated source-summary pages remain invalid compile targets.
+
+2. Resolve or mute generated review tasks.
+   - The browser may expose generated contradiction-review tasks already visible through
+     `splendor task list`.
+   - A resolve or mute action maps to the same planning-record update as the CLI task review-state
+     commands.
+   - The action writes only the selected task record and does not rewrite linked wiki pages,
+     source summaries, or historical run records.
+
+3. Accept a previewed source or queue maintenance operation.
+   - The browser may render the existing `mutation.planned` records from commands such as
+     `source refresh`, `source update-path`, `source forget`, `source reconcile`, `queue clean`, or
+     `workspace refresh`.
+   - Apply maps to the same command with explicit apply flags.
+   - Bulk or destructive operations must keep the same selectors, large-apply guards, skipped
+     records, and residual-reference reporting as the CLI.
+
+Everything else stays out of the first mutating web track: freeform page editing, multi-page
+synthesis rewrites, background ingestion, hosted collaboration, auth/roles, database-backed state,
+mandatory external providers, and automatic GitHub mutation.
+
+## Deterministic State Mapping
+
+Browser mutations should be thin wrappers over CLI-equivalent operations:
+
+- Preview computes a deterministic proposal from the current workspace bytes.
+- The proposal includes command-equivalent arguments, affected paths, expected input hashes, and a
+  proposal or mutation hash.
+- Apply reruns validation against current filesystem state before writing.
+- Writes go to normal Splendor files under the configured layout: wiki markdown, planning markdown,
+  source manifests, queue records, run records, reports, indexes, or derived artifacts only when
+  the underlying CLI command already owns those files.
+- The web server never hides writes in a service database or background worker.
+- The resulting working-tree diff is the review surface. Commit, push, and PR creation remain
+  outside the web UI.
+
+The web layer should reuse command modules directly or shell out through a stable CLI adapter only
+when needed. In both cases, the observable contract is the existing CLI mutation object and the
+same exit-code/error behavior.
+
+## Conflict Handling
+
+Conflict handling should prefer refusal over repair:
+
+- If the target file, source manifest, queue record, or generated source summary changed after
+  preview, apply must fail with a stale-proposal diagnostic and point back to a fresh preview.
+- If the proposal hash does not match the recomputed proposal, apply must fail without writes.
+- If git context is available and the affected paths contain uncommitted edits unrelated to the
+  proposal, the UI should warn before apply. The first implementation may refuse those applies
+  rather than attempt a merge.
+- If a CLI apply can partially succeed today, the web response must expose the same written,
+  skipped, residual, and failed records instead of summarizing them away.
+- If a workspace layout becomes unsafe or invalid, the web UI must return a non-mutating error and
+  leave repair to the CLI.
+
+This keeps browser acceptance equivalent to a reviewed local command. There is no optimistic
+browser-side merge, collaborative editing session, hidden lock table, or asynchronous worker queue.
+
+## First Implementation Shape
+
+The next implementation slice should start with one end-to-end path only: accepting a single
+`wiki compile` proposal for a maintained page. That path already has a narrow proposal hash,
+source/target inputs, schema validation, and a deterministic one-page write contract.
+
+A minimal implementation can add:
+
+- a read-only proposal detail page that renders the existing compile preview;
+- an explicit accept action guarded by the proposal hash and current input hashes;
+- a result page that lists written paths and next CLI/git review commands.
+
+It should not add a general mutation framework before that path proves useful. Source/queue
+maintenance and task review-state actions can follow after the compile path demonstrates that web
+acceptance stays local, deterministic, and git-reviewable.
+
+## Non-Goals
+
+- No runtime behavior changes in `M20-P2.1`.
+- No change to current read-only web routes.
+- No database, background worker, auth system, hosted service, or mandatory external API.
+- No automatic commits, branches, pushes, PRs, or GitHub issue mutation from the web UI.
+- No reopening of M19 durability work or hocrgen/hocrsyngen retry work.

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -1419,15 +1419,16 @@ workflows stay out of scope for this slice. The ordered M20 sequence is therefor
 - `M20-P3.1` richer GitHub issue, PR, review-thread, and CI integrations.
 
 `M20-P2.1` is a proposal-first slice for issue #119. It keeps the current local web UI read-only
-while defining the narrow mutation paths worth implementing later: accept one reviewed
-`wiki compile` proposal for a maintained page, resolve or mute generated review tasks, and accept
-previewed source/queue maintenance operations through the same CLI preview/apply contracts that
-already produce deterministic mutation records. Browser-side acceptance must rerun validation
+while defining the narrow first mutation paths worth implementing later: accept one reviewed
+`wiki compile` proposal for a maintained page and resolve or mute generated review tasks. Source
+and queue maintenance remains a later candidate after the single-page compile path proves browser
+acceptance can preserve CLI-equivalent safety. Browser-side acceptance must rerun validation
 against current workspace bytes, use proposal or mutation hashes plus expected input hashes, refuse
-stale proposals rather than merge them, and leave the resulting working-tree diff as the git-native
-review surface. The detailed proposal lives in `docs/mutating_web_review_workflows.md`. Runtime
-web mutation, background workers, databases, auth, hosted services, mandatory external APIs,
-automatic GitHub mutation, and broad multi-page editing stay out of scope for this slice.
+stale proposals rather than merge them, require same-origin POST-only local-intent protections, and
+leave the resulting working-tree diff as the git-native review surface. The detailed proposal lives
+in `docs/mutating_web_review_workflows.md`. Runtime web mutation, source or queue maintenance apply
+buttons, background workers, databases, auth, hosted services, mandatory external APIs, automatic
+GitHub mutation, and broad multi-page editing stay out of scope for this slice.
 
 ---
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P1.3`
-- Current planned slice: `M20 current-work handoff ranking`
-- Current PR sub-slice: `M20-P1.4`
+- Previous completed PR sub-slice: `M20-P1.4`
+- Current planned slice: `M20 mutating web review workflows`
+- Current PR sub-slice: `M20-P2.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 mutating web review workflows`
-- Next planned PR sub-slice: `M20-P2.1`
+- Next planned slice: `M20 richer GitHub integrations`
+- Next planned PR sub-slice: `M20-P3.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1371,7 +1371,8 @@ selected M20 implementation.
 - `M20-P1.3` Record v0.5.1 hocrgen/hocrsyngen retry findings and current-work handoff plan.
 - `M20-P1.4` Current-work handoff ranking from planning authority (#177).
 - `M20-P2.1` Explore mutating web review workflows (#119).
-- Add richer GitHub issue, PR, review-thread, and CI integrations on top of the v0.4 handoff model.
+- `M20-P3.1` Add richer GitHub issue, PR, review-thread, and CI integrations on top of the
+  v0.4 handoff model.
 
 `M20-P1.1` starts the retrieval product bet without crossing into heavyweight infrastructure. The
 first slice adds deterministic runtime acronym phrase expansion to `splendor query` and the
@@ -1415,6 +1416,18 @@ workflows stay out of scope for this slice. The ordered M20 sequence is therefor
 - `M20-P1.3` v0.5.1 retry evidence intake and current-work handoff planning.
 - `M20-P1.4` current-work handoff ranking from planning authority (#177).
 - `M20-P2.1` mutating web review workflows after the adoption-trust handoff follow-up.
+- `M20-P3.1` richer GitHub issue, PR, review-thread, and CI integrations.
+
+`M20-P2.1` is a proposal-first slice for issue #119. It keeps the current local web UI read-only
+while defining the narrow mutation paths worth implementing later: accept one reviewed
+`wiki compile` proposal for a maintained page, resolve or mute generated review tasks, and accept
+previewed source/queue maintenance operations through the same CLI preview/apply contracts that
+already produce deterministic mutation records. Browser-side acceptance must rerun validation
+against current workspace bytes, use proposal or mutation hashes plus expected input hashes, refuse
+stale proposals rather than merge them, and leave the resulting working-tree diff as the git-native
+review surface. The detailed proposal lives in `docs/mutating_web_review_workflows.md`. Runtime
+web mutation, background workers, databases, auth, hosted services, mandatory external APIs,
+automatic GitHub mutation, and broad multi-page editing stay out of scope for this slice.
 
 ---
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1476,6 +1476,16 @@ synthesis-page suggestions without adding mutating web actions. It also includes
 `/planning`, `/planning/{kind}`, `/runs`, and `/queue` pages that list durable planning and runtime
 records and link planning rows back to their markdown detail pages.
 
+Post-v1 mutating web review workflows should begin as thin browser acceptance surfaces over
+existing CLI preview/apply contracts, not as a separate runtime. The first eligible workflows are
+accepting one reviewed `wiki compile` proposal for a maintained page, resolving or muting generated
+review tasks, and accepting previewed source/queue maintenance operations. Each browser action must
+revalidate current workspace bytes, use the same proposal or mutation hashes and affected-path
+records as the CLI, write only deterministic local files owned by the underlying command, and leave
+git diff review outside the web UI. Stale proposals should fail closed and point users back to a
+fresh preview. The current implementation remains read-only until such a path is deliberately
+implemented.
+
 ### Avoid early
 - heavy collaborative editing
 - complex permissions

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -1478,13 +1478,15 @@ records and link planning rows back to their markdown detail pages.
 
 Post-v1 mutating web review workflows should begin as thin browser acceptance surfaces over
 existing CLI preview/apply contracts, not as a separate runtime. The first eligible workflows are
-accepting one reviewed `wiki compile` proposal for a maintained page, resolving or muting generated
-review tasks, and accepting previewed source/queue maintenance operations. Each browser action must
-revalidate current workspace bytes, use the same proposal or mutation hashes and affected-path
-records as the CLI, write only deterministic local files owned by the underlying command, and leave
-git diff review outside the web UI. Stale proposals should fail closed and point users back to a
-fresh preview. The current implementation remains read-only until such a path is deliberately
-implemented.
+accepting one reviewed `wiki compile` proposal for a maintained page and resolving or muting
+generated review tasks. Source and queue maintenance can be considered later after the single-page
+compile path proves safe. Each browser action must revalidate current workspace bytes, use the same
+proposal or mutation hashes and affected-path records as the CLI, write only deterministic local
+files owned by the underlying command, and leave git diff review outside the web UI. Mutating
+routes must also be POST-only, same-origin, non-CORS, and guarded by a local intent token or
+equivalent confirmation control so unrelated browser pages cannot exercise localhost write
+authority. Stale proposals should fail closed and point users back to a fresh preview. The current
+implementation remains read-only until such a path is deliberately implemented.
 
 ### Avoid early
 - heavy collaborative editing


### PR DESCRIPTION
## Planning notation

- PR sub-slice: `M20-P2.1`
- Parent milestone slice: `M20 mutating web review workflows`
- Plan source: `.agent-plan.md`, README `What Comes Next`, and `docs/splendor_mvp_to_v1_roadmap.md`
- Primary issue: Closes #119

## Summary

- Add a post-v1 mutating web review workflows proposal focused on the smallest future browser mutation paths worth supporting.
- Define how browser-side acceptance must map to deterministic CLI preview/apply state, proposal hashes, input hashes, local filesystem writes, and git-native review.
- Add explicit local browser trust-boundary requirements for future mutating routes: POST-only writes, no permissive CORS, local intent tokens, workspace scoping, and confirmation before apply.
- Advance synchronized planning state to make `M20-P2.1` current and define `M20-P3.1` as the next richer GitHub-integration follow-up.
- Update the product spec and docs index to point at the proposal while preserving the current read-only web UI surface.

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

## Scope Notes

- Design/proposal-only: no runtime code changes and no tests added because behavior is unchanged.
- Current local web routes remain read-only.
- The proposal preserves CLI-first semantics, deterministic file state, local-first operation, and git diff review.
- The first future web mutation path is narrowed to reviewed `wiki compile` acceptance, with generated review-task state updates as the only other first-track workflow family.
- Source/queue maintenance apply buttons are explicitly deferred until after the single-page compile acceptance path proves safe.
- The first implementation slice in this track is described as a future `M20-P2.2`-style PR; this PR keeps the global next planned slice as `M20-P3.1`.

## Non-goals

- No background workers, databases, auth system, hosted service, mandatory external API, broad mutating web infrastructure, or automatic GitHub mutation.
- No source/queue maintenance apply buttons in the first mutating web track.
- No reopening of M19 durability work or hocrgen/hocrsyngen retry work.
- No implementation of mutating web routes in this PR.
