### PR TITLE
v0.5.2-release-prep: Current-work handoff retry release

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ For a fuller command overview, see [docs/guides/cli_overview.md](docs/guides/cli
 - [Roadmap](docs/splendor_mvp_to_v1_roadmap.md)
 - [CI and repo automation](docs/operations/ci_and_repo_automation.md)
 - [Release artifact operations](docs/operations/release_artifacts.md)
-- [v0.5.1 release notes](docs/releases/v0_5_1_release_notes.md)
+- [v0.5.2 release notes](docs/releases/v0_5_2_release_notes.md)
 
 Evaluation reports, design responses, and historical planning notes are kept under `docs/` for
 contributors who need them, but they are not the primary path for learning the tool.

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,4 +47,5 @@ workflow.
 - [v0.4.0 release notes](releases/v0_4_0_release_notes.md)
 - [v0.5.0 release notes](releases/v0_5_0_release_notes.md)
 - [v0.5.1 release notes](releases/v0_5_1_release_notes.md)
+- [v0.5.2 release notes](releases/v0_5_2_release_notes.md)
 - [v1 release handoff](releases/v1_release_handoff.md)

--- a/docs/releases/v0_5_2_release_notes.md
+++ b/docs/releases/v0_5_2_release_notes.md
@@ -1,0 +1,61 @@
+# v0.5.2 Current-Work Handoff Retry Release Notes
+
+`v0.5.2` is a tiny post-`v0.5.1` evaluation release for sending Splendor back through the
+`hocrgen` and `hocrsyngen` agent-handoff retry loops. It is still not the public v1 tag.
+
+The release exists because the `v0.5.1` retry showed that retrieval had improved, but
+`brief --agent-context` and `suggest-next` still promoted merged PR history above the current
+planned slice. `v0.5.2` packages the post-`v0.5.1` current-work handoff fix so reviewers can
+evaluate the corrected behavior from a release wheel instead of an editable checkout.
+
+## Release Purpose
+
+This release packages the M20 current-work handoff ranking fix on top of `v0.5.1`:
+
+- `brief --agent-context` and `suggest-next` now extract current planned work from `.agent-plan.md`,
+  README, and roadmap authority when the user asks for current or next roadmap work.
+- Completed PRs, recent commits, and historical/generated review evidence are demoted to
+  predecessor context for current-work goals instead of becoming the default next action.
+- Open issue and PR work-thread behavior remains intact when a live thread is the real current
+  work.
+- The implementation remains runtime-only and local-first. It adds no hosted service, background
+  worker, mandatory external API, web workflow, database, or persisted index state.
+- The M20 mutating web review workflow work remains proposal-only and read-only in this release.
+
+## Trial Focus
+
+The intended retry question is narrow:
+
+> Does Splendor now identify the current next `hocrgen` / `hocrsyngen` slice instead of leading
+> with merged PR review history?
+
+Recommended reviewer checks:
+
+- In `hocrgen`, retry the current planning handoff after refreshing or ingesting current project
+  state and judge whether Splendor names the active next slice before historical PR review work.
+- In `hocrsyngen`, retry both cold-start and applied-ingest handoff flows and judge whether current
+  planning authority is promoted into the work action instead of remaining buried in relevant
+  matches.
+- Compare against the `v0.5.1` retry findings in
+  `docs/evaluations/v0_5_1_retry_findings.md`; this release targets the handoff-ranking blocker
+  recorded there, not broader web mutation, vector search, or first-run state relocation.
+
+Reviewers should install from the `v0.5.2` GitHub Release wheel rather than an editable checkout.
+
+## Validation Expectations
+
+Before tagging `v0.5.2` after this preparation PR merges, run the full local validation suite from
+the repository root and confirm green `main` CI:
+
+```bash
+uv run ruff format --check .
+uv run ruff check .
+uv run pytest
+uv run splendor lint
+uv run splendor health
+uv build
+```
+
+The package metadata for this preparation PR is `0.5.2` in `pyproject.toml`,
+`src/splendor/__init__.py`, and `uv.lock`. Create the `v0.5.2` tag only after the release-prep PR
+merges and `main` is green.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "splendor"
-version = "0.5.1"
+version = "0.5.2"
 description = "Local-first, git-native, schema-driven knowledge compiler for code-and-research repositories."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/splendor/__init__.py
+++ b/src/splendor/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "splendor"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "bleach" },


### PR DESCRIPTION
## Summary

- Bump package metadata from `0.5.1` to `0.5.2` in `pyproject.toml`, `src/splendor/__init__.py`, and `uv.lock`.
- Add `v0.5.2` release notes for the post-`v0.5.1` current-work handoff ranking fix.
- Update README and docs index release-note links so reviewers land on the new retry release notes.

## Why

The hocrgen/hocrsyngen `v0.5.1` retry showed that retrieval improved, but `brief --agent-context` and `suggest-next` still promoted merged PR history above current planned work. `main` now contains the M20-P1.4 current-work handoff fix, so this PR prepares a tiny release wheel for a clean external retry.

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`
- `/Users/shaypalachy/.local/bin/uv run splendor health`
- `/Users/shaypalachy/.local/bin/uv build`
- `/Users/shaypalachy/.local/bin/uv run splendor --version`

## Scope Notes

- Release-prep only: no runtime behavior changes beyond package version metadata.
- The release notes position `v0.5.2` as a narrow hocrgen/hocrsyngen retry release for the post-`v0.5.1` handoff-ranking blocker.
- The M20 mutating web work remains proposal-only/read-only in this release.

## After merge

- Confirm `main` CI is green.
- Create GitHub Release `v0.5.2` with `docs/releases/v0_5_2_release_notes.md`.
- Ensure release artifacts are uploaded for the `v0.5.2` tag.
