### PR TITLE
M20-P4.1: Implement human-first page detail and project identity

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P1.4`
-- Last action taken: `M20-P1.4` merged to main via PR #178 with the runtime-only
-  current-work handoff ranking fix from planning authority.
+- Previous completed PR sub-slice: `M20-P4.0`
+- Last action taken: `M20-P4.0` merged to main via PR #183 with the human operator cockpit and
+  wiki navigation design/specification contract.
 - Current planned slice: `M20 human operator cockpit and wiki navigation`
-- Current PR sub-slice: `M20-P4.0`
+- Current PR sub-slice: `M20-P4.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M20 human operator cockpit and wiki navigation`
-- Next planned PR sub-slice: `M20-P4.1`
+- Next planned PR sub-slice: `M20-P4.2`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ non-draft GitHub PR with labels, milestone, and a clear description.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P1.4`
+- Previous completed PR sub-slice: `M20-P4.0`
 - Current planned slice: `M20 human operator cockpit and wiki navigation`
-- Current PR sub-slice: `M20-P4.0`
+- Current PR sub-slice: `M20-P4.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M20 human operator cockpit and wiki navigation`
-- Next planned PR sub-slice: `M20-P4.1`
+- Next planned PR sub-slice: `M20-P4.2`
 
 These planning-state lines are for contributors and agents. The detailed roadmap lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md).

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -514,16 +514,16 @@ Current runtime behavior:
 
 Human operator web rendering:
 
-- page frontmatter remains the machine-readable/audit contract, but human web detail pages should
-  not render full raw metadata before readable markdown content
-- fields such as `kind`, `status`, `review_state`, `authority_role`, `authority_freshness`,
-  `authority_lifecycle`, and source counts are suitable for compact human badges when present
+- page frontmatter remains the machine-readable/audit contract, but human web detail pages render
+  readable markdown before the full raw metadata block
+- fields such as document class, `kind`, `status`, `review_state`, `authority_role`,
+  `authority_freshness`, and source/run counts render as compact human badges when present
 - `related_pages`, `tags`, `source_refs`, `generated_by_run_ids`, `provenance_links`, `issue_refs`,
   `pr_refs`, `supersedes`, `superseded_by`, and `contradictions` are web navigation inputs for
   related-context sections, provenance trails, backlinks, supersession chains, and contradiction
   links
-- full parsed metadata should remain available through a collapsed or visually demoted technical
-  section so humans can audit the same fields without having to read them before the page body
+- full parsed metadata remains available through a collapsed technical section so humans can audit
+  the same fields without having to read them before the page body
 - future operator-cockpit read models should derive attention and relationship items from these
   local fields first, before adding new schema or durable derived indexes
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P1.4`
+- Previous completed PR sub-slice: `M20-P4.0`
 - Current planned slice: `M20 human operator cockpit and wiki navigation`
-- Current PR sub-slice: `M20-P4.0`
+- Current PR sub-slice: `M20-P4.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
 - Next planned slice: `M20 human operator cockpit and wiki navigation`
-- Next planned PR sub-slice: `M20-P4.1`
+- Next planned PR sub-slice: `M20-P4.2`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1428,6 +1428,7 @@ workflows stay out of scope for this slice. The ordered M20 sequence is therefor
 - `M20-P2.1` mutating web review workflows after the adoption-trust handoff follow-up.
 - `M20-P3.1` richer GitHub issue, PR, review-thread, and CI integrations.
 - `M20-P4.0` human operator cockpit and wiki navigation design/spec contract.
+- `M20-P4.1` human-first page detail layout and deterministic project identity.
 
 `M20-P2.1` is a proposal-first slice for issue #119. It keeps the current local web UI read-only
 while defining the narrow first mutation paths worth implementing later: accept one reviewed
@@ -1449,6 +1450,13 @@ keeps the web UI read-only first, and treats operator views as pure read models 
 The first implementation follow-up should be `M20-P4.1`: human-first page detail metadata demotion
 plus deterministic project identity. Broader cockpit home, planning roadmap, attention/health,
 knowledge-map, and recent-insight surfaces remain staged behind that contract.
+
+`M20-P4.1` implements that first narrow runtime follow-up. It resolves deterministic local web
+project identity from `wiki/index.md`, README, workspace basename, or a quiet Splendor fallback;
+makes the target project primary in page chrome; renders compact human page badges above readable
+markdown; and moves full parsed metadata into a collapsed technical section. The cockpit home read
+model, planning roadmap lanes, attention and recent routes, backlinks, browser mutation, config
+schema expansion, databases, background workers, hosted services, and external APIs remain deferred.
 
 ---
 

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -624,7 +624,8 @@ project display name through a deterministic cascade:
 5. quiet fallback such as `Splendor workspace`.
 
 Explicit project config is useful as a future precision mechanism, but it should not be required
-before the web UI can present a useful project identity.
+before the web UI can present a useful project identity. The local web runtime currently implements
+the file-based portion of this cascade without adding a config schema.
 
 ## 13. Execution Model
 
@@ -1515,7 +1516,9 @@ the CLI wiki status/suggest contracts. They expose source/page/queue/run/review 
 manifests, linked source-summary pages, latest ingest run state, and deterministic affected
 synthesis-page suggestions without adding mutating web actions. It also includes read-only
 `/planning`, `/planning/{kind}`, `/runs`, and `/queue` pages that list durable planning and runtime
-records and link planning rows back to their markdown detail pages.
+records and link planning rows back to their markdown detail pages. Page chrome now derives the
+target project identity from local files, and document detail pages lead with compact human badges
+plus readable markdown before collapsed technical metadata.
 
 ### Human operator contract
 

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -66,6 +66,8 @@ _LISTING_FRONTMATTER_LINE_LIMIT = 200
 _LISTING_FRONTMATTER_CHAR_LIMIT = 64 * 1024
 _LISTING_HEADING_LINE_LIMIT = 40
 _LISTING_HEADING_CHAR_LIMIT = 16 * 1024
+_IDENTITY_LINE_LIMIT = 80
+_IDENTITY_CHAR_LIMIT = 32 * 1024
 _GENERIC_INDEX_TITLE = "Splendor Wiki Index"
 _GENERIC_INDEX_SUMMARY = "This wiki is maintained by Splendor."
 
@@ -154,6 +156,7 @@ def create_app(root: Path) -> FastAPI:
             title,
             f'<p class="empty">{detail}</p>',
             root=workspace_root,
+            layout=_identity_layout_for(workspace_root),
             status_code=exc.status_code,
         )
 
@@ -164,6 +167,7 @@ def create_app(root: Path) -> FastAPI:
             "Workspace Error",
             '<p class="empty">Workspace configuration is invalid.</p>',
             root=workspace_root,
+            layout=_identity_layout_for(workspace_root),
             status_code=500,
         )
 
@@ -542,6 +546,13 @@ def _layout_for(root: Path) -> ResolvedLayout:
     return resolve_layout(root, config)
 
 
+def _identity_layout_for(root: Path) -> ResolvedLayout | None:
+    try:
+        return _layout_for(root)
+    except WebLayoutError:
+        return None
+
+
 def _validate_layout_root(root: Path, value: str, *, label: str) -> None:
     path = Path(value)
     if "\\" in value or path.is_absolute() or not path.parts or ".." in path.parts:
@@ -617,9 +628,8 @@ def _is_generic_index_identity(identity: _ProjectIdentity) -> bool:
 def _project_identity_from_markdown(path: Path) -> _ProjectIdentity | None:
     if not path.is_file():
         return None
-    try:
-        raw = path.read_text(encoding="utf-8")
-    except OSError:
+    raw = _read_identity_markdown(path)
+    if raw is None:
         return None
 
     lines = _strip_frontmatter(raw).splitlines()
@@ -637,6 +647,24 @@ def _project_identity_from_markdown(path: Path) -> _ProjectIdentity | None:
         name=heading,
         summary=_leading_paragraph(lines[heading_index + 1 :]),
     )
+
+
+def _read_identity_markdown(path: Path) -> str | None:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            lines: list[str] = []
+            char_count = 0
+            for _ in range(_IDENTITY_LINE_LIMIT):
+                line = handle.readline()
+                if not line:
+                    break
+                char_count += len(line)
+                if char_count > _IDENTITY_CHAR_LIMIT:
+                    break
+                lines.append(line)
+    except OSError:
+        return None
+    return "".join(lines)
 
 
 def _strip_frontmatter(markdown_text: str) -> str:
@@ -1267,7 +1295,7 @@ def _page(
         "header{border-bottom:1px solid var(--border);padding:18px 28px;background:var(--surface)}"
         ".brand{max-width:1060px;margin:0 auto}.brand p{margin:4px 0 0;color:var(--muted)}"
         ".brand .product{font-size:13px;text-transform:uppercase;letter-spacing:.08em}"
-        ".brand .page-title{color:var(--text);font-weight:600}"
+        ".brand .page-title{font-size:18px;margin:4px 0 0;color:var(--text)}"
         "main{max-width:1060px;margin:0 auto;padding:28px}"
         "h1{font-size:28px;margin:0}h2{font-size:18px;margin:0 0 6px}"
         "a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}"
@@ -1305,7 +1333,7 @@ def _page(
         "<body>"
         '<header><div class="brand">'
         f"<h1>{escaped_project}</h1>"
-        f'<p class="page-title">{escaped_title}</p>'
+        f'<h2 class="page-title">{escaped_title}</h2>'
         f'<p>{header_summary} <span class="product">Splendor</span></p>'
         "</div></header>"
         f"<main>{body}</main>"

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -66,6 +66,8 @@ _LISTING_FRONTMATTER_LINE_LIMIT = 200
 _LISTING_FRONTMATTER_CHAR_LIMIT = 64 * 1024
 _LISTING_HEADING_LINE_LIMIT = 40
 _LISTING_HEADING_CHAR_LIMIT = 16 * 1024
+_GENERIC_INDEX_TITLE = "Splendor Wiki Index"
+_GENERIC_INDEX_SUMMARY = "This wiki is maintained by Splendor."
 
 
 @dataclass(frozen=True)
@@ -493,9 +495,9 @@ def create_app(root: Path) -> FastAPI:
             "</form>"
             "</section>"
         )
-        if not query:
-            return _page("Search", form, root=workspace_root)
         layout = _layout_for(workspace_root)
+        if not query:
+            return _page("Search", form, root=workspace_root, layout=layout)
         try:
             result = run_query(workspace_root, query)
         except QueryValidationError as exc:
@@ -594,15 +596,22 @@ def _workspace_counts(
 
 def _build_project_identity(root: Path, layout: ResolvedLayout | None = None) -> _ProjectIdentity:
     index_path = layout.index_file if layout is not None else root / "wiki" / "index.md"
-    for path in (index_path, root / "README.md"):
-        identity = _project_identity_from_markdown(path)
-        if identity is not None:
-            return identity
+    index_identity = _project_identity_from_markdown(index_path)
+    if index_identity is not None and not _is_generic_index_identity(index_identity):
+        return index_identity
+
+    readme_identity = _project_identity_from_markdown(root / "README.md")
+    if readme_identity is not None:
+        return readme_identity
 
     basename = root.name.strip()
     if basename:
         return _ProjectIdentity(name=basename, summary=None)
     return _ProjectIdentity(name="Splendor workspace", summary=None)
+
+
+def _is_generic_index_identity(identity: _ProjectIdentity) -> bool:
+    return identity.name == _GENERIC_INDEX_TITLE and identity.summary == _GENERIC_INDEX_SUMMARY
 
 
 def _project_identity_from_markdown(path: Path) -> _ProjectIdentity | None:
@@ -1258,6 +1267,7 @@ def _page(
         "header{border-bottom:1px solid var(--border);padding:18px 28px;background:var(--surface)}"
         ".brand{max-width:1060px;margin:0 auto}.brand p{margin:4px 0 0;color:var(--muted)}"
         ".brand .product{font-size:13px;text-transform:uppercase;letter-spacing:.08em}"
+        ".brand .page-title{color:var(--text);font-weight:600}"
         "main{max-width:1060px;margin:0 auto;padding:28px}"
         "h1{font-size:28px;margin:0}h2{font-size:18px;margin:0 0 6px}"
         "a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}"
@@ -1295,6 +1305,7 @@ def _page(
         "<body>"
         '<header><div class="brand">'
         f"<h1>{escaped_project}</h1>"
+        f'<p class="page-title">{escaped_title}</p>'
         f'<p>{header_summary} <span class="product">Splendor</span></p>'
         "</div></header>"
         f"<main>{body}</main>"

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -95,6 +95,12 @@ class _WorkspaceCounts:
 
 
 @dataclass(frozen=True)
+class _ProjectIdentity:
+    name: str
+    summary: str | None
+
+
+@dataclass(frozen=True)
 class _DocumentDetail:
     path: str
     title: str
@@ -142,7 +148,12 @@ def create_app(root: Path) -> FastAPI:
         if exc.status_code >= 500:
             title = "Workspace Error"
         detail = html.escape(str(exc.detail))
-        return _page(title, f'<p class="empty">{detail}</p>', status_code=exc.status_code)
+        return _page(
+            title,
+            f'<p class="empty">{detail}</p>',
+            root=workspace_root,
+            status_code=exc.status_code,
+        )
 
     @app.exception_handler(WebLayoutError)
     def workspace_layout_error(_, __: WebLayoutError) -> HTMLResponse:
@@ -150,6 +161,7 @@ def create_app(root: Path) -> FastAPI:
         return _page(
             "Workspace Error",
             '<p class="empty">Workspace configuration is invalid.</p>',
+            root=workspace_root,
             status_code=500,
         )
 
@@ -180,7 +192,7 @@ def create_app(root: Path) -> FastAPI:
             f"<div><strong>{counts.runs}</strong><span>Runs</span></div>"
             "</section>"
         )
-        return _page("Splendor", body)
+        return _page("Home", body, root=workspace_root, layout=layout)
 
     @app.get("/status", response_class=HTMLResponse)
     def status() -> HTMLResponse:
@@ -195,6 +207,8 @@ def create_app(root: Path) -> FastAPI:
                 '<p class="empty">'
                 "Status failed because the workspace contains invalid records."
                 "</p>",
+                root=workspace_root,
+                layout=layout,
                 status_code=500,
             )
         if not source_rows:
@@ -239,7 +253,7 @@ def create_app(root: Path) -> FastAPI:
             "<th>Summary page</th><th>Source ref</th></tr></thead>"
             f"<tbody>{source_rows}</tbody></table>"
         )
-        return _page("Status", body)
+        return _page("Status", body, root=workspace_root, layout=layout)
 
     @app.get("/planning", response_class=HTMLResponse)
     def planning() -> HTMLResponse:
@@ -256,6 +270,8 @@ def create_app(root: Path) -> FastAPI:
                 '<p class="empty">'
                 "Planning view failed because the workspace contains invalid planning records."
                 "</p>",
+                root=workspace_root,
+                layout=layout,
                 status_code=500,
             )
         stats = "".join(
@@ -269,7 +285,7 @@ def create_app(root: Path) -> FastAPI:
             f'<section class="stats">{stats}</section>'
             f"{sections}"
         )
-        return _page("Planning", body)
+        return _page("Planning", body, root=workspace_root, layout=layout)
 
     @app.get("/planning/{kind}", response_class=HTMLResponse)
     def planning_kind(kind: str) -> HTMLResponse:
@@ -284,6 +300,8 @@ def create_app(root: Path) -> FastAPI:
                 '<p class="empty">'
                 "Planning view failed because the workspace contains invalid planning records."
                 "</p>",
+                root=workspace_root,
+                layout=layout,
                 status_code=500,
             )
         body = (
@@ -291,7 +309,7 @@ def create_app(root: Path) -> FastAPI:
             f"{html.escape(_planning_label(normalized_kind))}</p>"
             f"{_planning_table(normalized_kind, records)}"
         )
-        return _page(_planning_label(normalized_kind), body)
+        return _page(_planning_label(normalized_kind), body, root=workspace_root, layout=layout)
 
     @app.get("/runs", response_class=HTMLResponse)
     def runs() -> HTMLResponse:
@@ -305,6 +323,8 @@ def create_app(root: Path) -> FastAPI:
                 '<p class="empty">'
                 "Runs view failed because the workspace contains invalid run records."
                 "</p>",
+                root=workspace_root,
+                layout=layout,
                 status_code=500,
             )
         rows = "\n".join(_run_row(run) for run in run_records[:25])
@@ -319,7 +339,7 @@ def create_app(root: Path) -> FastAPI:
             "<th>Record</th></tr></thead>"
             f"<tbody>{rows}</tbody></table>"
         )
-        return _page("Runs", body)
+        return _page("Runs", body, root=workspace_root, layout=layout)
 
     @app.get("/queue", response_class=HTMLResponse)
     def queue() -> HTMLResponse:
@@ -333,6 +353,8 @@ def create_app(root: Path) -> FastAPI:
                 '<p class="empty">'
                 "Queue view failed because the workspace contains invalid queue records."
                 "</p>",
+                root=workspace_root,
+                layout=layout,
                 status_code=500,
             )
         status_counts: dict[str, int] = {}
@@ -355,7 +377,7 @@ def create_app(root: Path) -> FastAPI:
             "<th>Next attempt</th><th>Error</th><th>Record</th></tr></thead>"
             f"<tbody>{rows}</tbody></table>"
         )
-        return _page("Queue", body)
+        return _page("Queue", body, root=workspace_root, layout=layout)
 
     @app.get("/sources/{source_id}", response_class=HTMLResponse)
     def source_detail(source_id: str) -> HTMLResponse:
@@ -400,7 +422,7 @@ def create_app(root: Path) -> FastAPI:
             "<table><thead><tr><th>Page</th><th>Kind</th><th>Score</th><th>Reasons</th></tr></thead>"
             f"<tbody>{suggestion_rows}</tbody></table>"
         )
-        return _page(source.title, body)
+        return _page(source.title, body, root=workspace_root, layout=layout)
 
     @app.get("/browse", response_class=HTMLResponse)
     def browse() -> HTMLResponse:
@@ -437,7 +459,7 @@ def create_app(root: Path) -> FastAPI:
             f"<tbody>{content_rows}</tbody></table>"
             f"{special_section}"
         )
-        return _page("Browse", body)
+        return _page("Browse", body, root=workspace_root, layout=layout)
 
     @app.get("/documents/{document_path:path}", response_class=HTMLResponse)
     def document(document_path: str) -> HTMLResponse:
@@ -446,18 +468,18 @@ def create_app(root: Path) -> FastAPI:
         detail = _document_detail(workspace_root, layout, path)
         metadata = html.escape(json.dumps(detail.metadata, indent=2, sort_keys=True))
         body_html = _render_markdown(detail.body)
+        badges = _document_badges(detail)
         body = (
             '<p class="breadcrumbs"><a href="/browse">Browse</a> / '
             f"{html.escape(detail.path)}</p>"
-            '<section class="metadata">'
-            f"<div><strong>Class</strong><span>{html.escape(detail.document_class)}</span></div>"
-            f"<div><strong>Kind</strong><span>{html.escape(detail.kind or '-')}</span></div>"
-            f"<div><strong>Status</strong><span>{html.escape(detail.status or '-')}</span></div>"
-            f"<pre>{metadata}</pre>"
-            "</section>"
+            f"{badges}"
             f'<article class="markdown">{body_html}</article>'
+            '<details class="technical">'
+            "<summary>Technical metadata</summary>"
+            f"<pre>{metadata}</pre>"
+            "</details>"
         )
-        return _page(detail.title, body)
+        return _page(detail.title, body, root=workspace_root, layout=layout)
 
     @app.get("/search", response_class=HTMLResponse)
     def search(q: str = Query(default="")) -> HTMLResponse:
@@ -472,7 +494,7 @@ def create_app(root: Path) -> FastAPI:
             "</section>"
         )
         if not query:
-            return _page("Search", form)
+            return _page("Search", form, root=workspace_root)
         layout = _layout_for(workspace_root)
         try:
             result = run_query(workspace_root, query)
@@ -486,6 +508,8 @@ def create_app(root: Path) -> FastAPI:
                 '<p class="empty">'
                 "Search failed because the workspace contains invalid records."
                 "</p>",
+                root=workspace_root,
+                layout=layout,
                 status_code=500,
             )
 
@@ -504,7 +528,7 @@ def create_app(root: Path) -> FastAPI:
             else:
                 rows = '<p class="empty">No matches found.</p>'
         body = f"{form}<p>{html.escape(result.summary)}</p><section>{rows}</section>"
-        return _page("Search", body)
+        return _page("Search", body, root=workspace_root, layout=layout)
 
     return app
 
@@ -566,6 +590,75 @@ def _workspace_counts(
         ),
         runs=sum(1 for path in layout.runs_dir.glob("*.json") if path.is_file()),
     )
+
+
+def _build_project_identity(root: Path, layout: ResolvedLayout | None = None) -> _ProjectIdentity:
+    index_path = layout.index_file if layout is not None else root / "wiki" / "index.md"
+    for path in (index_path, root / "README.md"):
+        identity = _project_identity_from_markdown(path)
+        if identity is not None:
+            return identity
+
+    basename = root.name.strip()
+    if basename:
+        return _ProjectIdentity(name=basename, summary=None)
+    return _ProjectIdentity(name="Splendor workspace", summary=None)
+
+
+def _project_identity_from_markdown(path: Path) -> _ProjectIdentity | None:
+    if not path.is_file():
+        return None
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    lines = _strip_frontmatter(raw).splitlines()
+    heading: str | None = None
+    heading_index = -1
+    for index, line in enumerate(lines):
+        heading = _heading_from_line(line)
+        if heading:
+            heading_index = index
+            break
+    if heading is None:
+        return None
+
+    return _ProjectIdentity(
+        name=heading,
+        summary=_leading_paragraph(lines[heading_index + 1 :]),
+    )
+
+
+def _strip_frontmatter(markdown_text: str) -> str:
+    normalized = markdown_text.replace("\r\n", "\n").replace("\r", "\n")
+    if not normalized.startswith("---\n"):
+        return normalized
+    try:
+        _frontmatter_text, body = normalized.removeprefix("---\n").split("\n---\n", maxsplit=1)
+    except ValueError:
+        return normalized
+    return body
+
+
+def _leading_paragraph(lines: list[str]) -> str | None:
+    paragraph: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            if paragraph:
+                break
+            continue
+        if stripped.startswith("#") or stripped.startswith("```"):
+            if paragraph:
+                break
+            continue
+        if stripped.startswith(("> ", "- ", "* ", "+ ")) and not paragraph:
+            continue
+        paragraph.append(stripped)
+    if not paragraph:
+        return None
+    return " ".join(paragraph)
 
 
 def _normalize_planning_kind(kind: str) -> str:
@@ -873,6 +966,36 @@ def _document_detail(root: Path, layout: ResolvedLayout, path: Path) -> _Documen
     )
 
 
+def _document_badges(detail: _DocumentDetail) -> str:
+    badges = [
+        ("Class", detail.document_class),
+        ("Kind", detail.kind),
+        ("Status", detail.status),
+        ("Review", _metadata_string(detail.metadata, "review_state")),
+        ("Authority", _metadata_string(detail.metadata, "authority_role")),
+        ("Freshness", _metadata_string(detail.metadata, "authority_freshness")),
+    ]
+    source_refs = detail.metadata.get("source_refs")
+    if isinstance(source_refs, list) and source_refs:
+        badges.append(("Sources", str(len(source_refs))))
+    run_refs = detail.metadata.get("generated_by_run_ids")
+    if isinstance(run_refs, list) and run_refs:
+        badges.append(("Runs", str(len(run_refs))))
+    badge_items = "".join(
+        f'<span class="badge"><strong>{html.escape(label)}</strong> {html.escape(value)}</span>'
+        for label, value in badges
+        if value
+    )
+    if not badge_items:
+        return ""
+    return f'<section class="badges">{badge_items}</section>'
+
+
+def _metadata_string(metadata: dict[str, object], key: str) -> str | None:
+    value = metadata.get(key)
+    return value if isinstance(value, str) and value else None
+
+
 def _planning_kind(layout: ResolvedLayout, path: Path) -> str | None:
     relative_parts = path.relative_to(layout.planning_dir).parts
     if not relative_parts:
@@ -1097,15 +1220,35 @@ def _search_row(match: QueryMatch) -> str:
     )
 
 
-def _page(title: str, body: str, *, status_code: int = 200) -> HTMLResponse:
+def _page(
+    title: str,
+    body: str,
+    *,
+    root: Path | None = None,
+    layout: ResolvedLayout | None = None,
+    status_code: int = 200,
+) -> HTMLResponse:
+    identity = (
+        _build_project_identity(root, layout)
+        if root is not None
+        else _ProjectIdentity(name="Splendor workspace", summary=None)
+    )
     escaped_title = html.escape(title)
+    escaped_project = html.escape(identity.name)
+    escaped_summary = html.escape(identity.summary) if identity.summary else ""
+    browser_title = f"{escaped_title} · {escaped_project} · Splendor"
+    header_summary = (
+        f"<span>{escaped_summary}</span>"
+        if escaped_summary
+        else '<span class="empty">Local Splendor wiki</span>'
+    )
     return HTMLResponse(
         "<!doctype html>"
         '<html lang="en">'
         "<head>"
         '<meta charset="utf-8" />'
         '<meta name="viewport" content="width=device-width, initial-scale=1" />'
-        f"<title>{escaped_title} · Splendor</title>"
+        f"<title>{browser_title}</title>"
         "<style>"
         ":root{color-scheme:light;--border:#d8dee8;--text:#1f2937;--muted:#5f6b7a;"
         "--surface:#f8fafc;--accent:#0f766e}"
@@ -1113,6 +1256,8 @@ def _page(title: str, body: str, *, status_code: int = 200) -> HTMLResponse:
         "'Segoe UI',sans-serif;"
         "color:var(--text);background:white}"
         "header{border-bottom:1px solid var(--border);padding:18px 28px;background:var(--surface)}"
+        ".brand{max-width:1060px;margin:0 auto}.brand p{margin:4px 0 0;color:var(--muted)}"
+        ".brand .product{font-size:13px;text-transform:uppercase;letter-spacing:.08em}"
         "main{max-width:1060px;margin:0 auto;padding:28px}"
         "h1{font-size:28px;margin:0}h2{font-size:18px;margin:0 0 6px}"
         "a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}"
@@ -1137,12 +1282,21 @@ def _page(title: str, body: str, *, status_code: int = 200) -> HTMLResponse:
         "pre{overflow:auto;background:var(--surface);border-radius:6px;padding:12px}"
         ".metadata{display:grid;gap:10px;margin-bottom:24px;background:var(--surface)}"
         ".metadata div{display:flex;gap:10px}.metadata strong{width:70px}"
+        ".badges{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px}"
+        ".badge{border:1px solid var(--border);border-radius:999px;padding:4px 9px;"
+        "background:var(--surface);font-size:13px;color:var(--muted)}"
+        ".badge strong{color:var(--text);font-weight:600}"
+        ".technical{margin-top:24px;border-top:1px solid var(--border);padding-top:14px}"
+        ".technical summary{cursor:pointer;color:var(--muted)}"
         ".markdown{max-width:820px}.markdown img{max-width:100%}.result{margin:0 0 12px}"
         ".empty{color:var(--muted)}"
         "</style>"
         "</head>"
         "<body>"
-        f"<header><h1>{escaped_title}</h1></header>"
+        '<header><div class="brand">'
+        f"<h1>{escaped_project}</h1>"
+        f'<p>{header_summary} <span class="product">Splendor</span></p>'
+        "</div></header>"
         f"<main>{body}</main>"
         "</body></html>",
         status_code=status_code,

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -65,6 +65,49 @@ def test_home_page_shows_empty_state_for_initialized_workspace(tmp_path: Path) -
     assert "Source manifests" in response.text
 
 
+def test_project_identity_uses_wiki_index_heading_and_summary(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / "wiki" / "index.md").write_text(
+        "# SynthBanshee\n\nLocal code-and-research knowledge workspace.\n",
+        encoding="utf-8",
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "<h1>SynthBanshee</h1>" in response.text
+    assert "Local code-and-research knowledge workspace." in response.text
+    assert "<title>Home · SynthBanshee · Splendor</title>" in response.text
+
+
+def test_project_identity_falls_back_to_readme_when_index_is_missing(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / "wiki" / "index.md").unlink()
+    (tmp_path / "README.md").write_text(
+        "# README Project\n\nREADME summary becomes the local web identity.\n",
+        encoding="utf-8",
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/browse")
+
+    assert response.status_code == 200
+    assert "<h1>README Project</h1>" in response.text
+    assert "README summary becomes the local web identity." in response.text
+
+
+def test_project_identity_falls_back_to_workspace_basename(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / "wiki" / "index.md").unlink()
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert f"<h1>{tmp_path.name}</h1>" in response.text
+
+
 def test_browse_page_lists_wiki_and_planning_documents(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     write_wiki_page(
@@ -215,6 +258,47 @@ def test_document_detail_renders_markdown_and_metadata(tmp_path: Path) -> None:
     assert "This page describes local browsing." in response.text
     assert "concept-web-shell" in response.text
     assert "active" in response.text
+    assert response.text.index("<article") < response.text.index("Technical metadata")
+    assert '<details class="technical">' in response.text
+
+
+def test_document_detail_keeps_human_badges_before_body(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "concepts" / "reviewed.md",
+        title="Reviewed page",
+        page_id="concept-reviewed",
+        body="# Reviewed page\n\nReadable body comes after compact badges.\n",
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/documents/wiki/concepts/reviewed.md")
+
+    assert response.status_code == 200
+    assert '<section class="badges">' in response.text
+    assert "<strong>Class</strong> wiki" in response.text
+    assert "<strong>Kind</strong> concept" in response.text
+    assert "<strong>Status</strong> active" in response.text
+    assert response.text.index('<section class="badges">') < response.text.index("<article")
+    assert response.text.index("<article") < response.text.index("Technical metadata")
+
+
+def test_document_detail_preserves_full_metadata_access(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    write_wiki_page(
+        tmp_path / "wiki" / "concepts" / "metadata.md",
+        title="Metadata page",
+        page_id="concept-metadata",
+        body="# Metadata page\n\nReadable body stays primary.\n",
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/documents/wiki/concepts/metadata.md")
+
+    assert response.status_code == 200
+    assert "<summary>Technical metadata</summary>" in response.text
+    assert "&quot;page_id&quot;: &quot;concept-metadata&quot;" in response.text
+    assert "&quot;confidence&quot;: 0.8" in response.text
 
 
 def test_document_detail_renders_planning_task(tmp_path: Path) -> None:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -284,8 +284,8 @@ def test_document_detail_renders_markdown_and_metadata(tmp_path: Path) -> None:
     assert "This page describes local browsing." in response.text
     assert "concept-web-shell" in response.text
     assert "active" in response.text
-    assert response.text.index("<article") < response.text.index("Technical metadata")
     assert '<details class="technical">' in response.text
+    assert response.text.index("<article") < response.text.index('<details class="technical">')
 
 
 def test_document_detail_keeps_human_badges_before_body(tmp_path: Path) -> None:
@@ -306,7 +306,7 @@ def test_document_detail_keeps_human_badges_before_body(tmp_path: Path) -> None:
     assert "<strong>Kind</strong> concept" in response.text
     assert "<strong>Status</strong> active" in response.text
     assert response.text.index('<section class="badges">') < response.text.index("<article")
-    assert response.text.index("<article") < response.text.index("Technical metadata")
+    assert response.text.index("<article") < response.text.index('<details class="technical">')
 
 
 def test_document_detail_preserves_full_metadata_access(tmp_path: Path) -> None:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -131,7 +131,23 @@ def test_page_chrome_keeps_visible_route_title(tmp_path: Path) -> None:
 
     assert response.status_code == 200
     assert f"<h1>{tmp_path.name}</h1>" in response.text
-    assert '<p class="page-title">Browse</p>' in response.text
+    assert '<h2 class="page-title">Browse</h2>' in response.text
+
+
+def test_project_identity_reads_only_bounded_markdown(tmp_path: Path, monkeypatch) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "# Bounded Project\n\nShort summary.\n\n" + ("extra\n" * 200), encoding="utf-8"
+    )
+
+    def fail_read_text(*args, **kwargs):
+        raise AssertionError("identity parsing should not read the whole markdown file")
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+    identity = web._project_identity_from_markdown(readme)
+
+    assert identity == web._ProjectIdentity(name="Bounded Project", summary="Short summary.")
 
 
 def test_browse_page_lists_wiki_and_planning_documents(tmp_path: Path) -> None:
@@ -761,6 +777,7 @@ def test_document_links_respect_custom_layout_directories(tmp_path: Path) -> Non
     browse = client.get("/browse")
     detail = client.get("/documents/knowledge/concepts/web-shell.md")
     empty_search = client.get("/search")
+    missing_document = client.get("/documents/knowledge/missing.md")
 
     assert browse.status_code == 200
     assert 'href="/documents/knowledge/concepts/web-shell.md"' in browse.text
@@ -768,7 +785,10 @@ def test_document_links_respect_custom_layout_directories(tmp_path: Path) -> Non
     assert "<h1>Custom web shell</h1>" in detail.text
     assert empty_search.status_code == 200
     assert "<h1>Custom Knowledge</h1>" in empty_search.text
-    assert '<p class="page-title">Search</p>' in empty_search.text
+    assert '<h2 class="page-title">Search</h2>' in empty_search.text
+    assert missing_document.status_code == 404
+    assert "<h1>Custom Knowledge</h1>" in missing_document.text
+    assert '<h2 class="page-title">Not Found</h2>' in missing_document.text
 
 
 def test_web_routes_reject_layout_roots_that_escape_workspace(tmp_path: Path) -> None:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -97,15 +97,41 @@ def test_project_identity_falls_back_to_readme_when_index_is_missing(tmp_path: P
     assert "README summary becomes the local web identity." in response.text
 
 
+def test_project_identity_skips_generic_initialized_index_for_readme(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / "README.md").write_text(
+        "# Real Project\n\nREADME has the real project identity.\n",
+        encoding="utf-8",
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "<h1>Real Project</h1>" in response.text
+    assert "README has the real project identity." in response.text
+    assert "Splendor Wiki Index" not in response.text
+
+
 def test_project_identity_falls_back_to_workspace_basename(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
-    (tmp_path / "wiki" / "index.md").unlink()
     client = TestClient(create_app(tmp_path))
 
     response = client.get("/")
 
     assert response.status_code == 200
     assert f"<h1>{tmp_path.name}</h1>" in response.text
+
+
+def test_page_chrome_keeps_visible_route_title(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/browse")
+
+    assert response.status_code == 200
+    assert f"<h1>{tmp_path.name}</h1>" in response.text
+    assert '<p class="page-title">Browse</p>' in response.text
 
 
 def test_browse_page_lists_wiki_and_planning_documents(tmp_path: Path) -> None:
@@ -720,6 +746,10 @@ def test_document_links_respect_custom_layout_directories(tmp_path: Path) -> Non
         encoding="utf-8",
     )
     initialize_workspace(tmp_path)
+    (tmp_path / "knowledge" / "index.md").write_text(
+        "# Custom Knowledge\n\nCustom layout identity.\n",
+        encoding="utf-8",
+    )
     write_wiki_page(
         tmp_path / "knowledge" / "concepts" / "web-shell.md",
         title="Custom web shell",
@@ -730,11 +760,15 @@ def test_document_links_respect_custom_layout_directories(tmp_path: Path) -> Non
 
     browse = client.get("/browse")
     detail = client.get("/documents/knowledge/concepts/web-shell.md")
+    empty_search = client.get("/search")
 
     assert browse.status_code == 200
     assert 'href="/documents/knowledge/concepts/web-shell.md"' in browse.text
     assert detail.status_code == 200
     assert "<h1>Custom web shell</h1>" in detail.text
+    assert empty_search.status_code == 200
+    assert "<h1>Custom Knowledge</h1>" in empty_search.text
+    assert '<p class="page-title">Search</p>' in empty_search.text
 
 
 def test_web_routes_reject_layout_roots_that_escape_workspace(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Implement deterministic local web project identity derived from existing workspace files: `wiki/index.md`, README, workspace basename, then a quiet Splendor fallback.
- Make the target project primary in local web page chrome while keeping Splendor as the secondary product marker.
- Rework `/documents/{path}` so compact human badges and rendered markdown appear before full parsed metadata, with raw metadata preserved in a collapsed technical section.
- Synchronize M20 planning-state lines and document the runtime behavior in product/schema docs.

## Validation

- `/Users/shaypalachy/.local/bin/uv run ruff format --check .`
- `/Users/shaypalachy/.local/bin/uv run ruff check .`
- `/Users/shaypalachy/.local/bin/uv run pytest`
- `/Users/shaypalachy/.local/bin/uv run splendor lint`

## Scope Notes

- Read-only local web UI behavior only.
- Project identity stays in the web/read-model layer and does not expand `resolve_layout` or the config schema.
- Existing `serve`, `query`, `brief --agent-context`, `suggest-next`, lint, init, repo scan, and runtime behavior remain unchanged except for web rendering.

## Non-goals

- No cockpit home page implementation.
- No planning lanes, `/attention`, `/recent`, backlinks, browser mutation, config schema expansion, databases, background workers, hosted services, or external APIs.

Closes #184