### PR TITLE
Prefer CLI over MCP in agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,8 @@
 - Published PRs should carry intentional GitHub metadata:
   apply the appropriate labels, assign the PR to a milestone, and avoid leaving review-ready work
   as draft unless the user explicitly asks for a draft.
-- Prefer repo-specific GitHub MCP tooling for PR metadata and fall back to `gh` only where the MCP
-  surface is missing, such as creating a missing label or milestone or opening the PR itself.
+- Use standard `git` and `gh` CLI first for repository and GitHub work; use git/GitHub MCP tools
+  only for CLI gaps, unavailable CLI, or explicit user request.
 - When finishing feature or PR work, explicitly verify that the published PR exists on GitHub and
   that its labels and milestone are set before treating the task as done.
 - When a PR implements work from a plan, update the versioned planning state in the same PR:

--- a/docs/operations/ci_and_repo_automation.md
+++ b/docs/operations/ci_and_repo_automation.md
@@ -407,9 +407,8 @@ should be treated as complete only after:
 - the pull request has intentional labels
 - the pull request is assigned to the appropriate milestone
 
-Prefer repo-specific GitHub MCP tooling for PR metadata updates and use `gh` only for operations
-the MCP surface does not support cleanly, such as creating a missing label or milestone or opening
-the PR itself.
+Use standard `git` and `gh` CLI first for repository and GitHub work. Use git/GitHub MCP tools
+only for CLI gaps, unavailable CLI, or explicit user request.
 
 If any of those publication steps are still missing, the work is still in progress even if the code
 changes are already committed locally.


### PR DESCRIPTION
## Summary
- Update agent instructions to prefer standard git and gh CLI for repository and GitHub work
- Limit git/GitHub MCP usage to CLI gaps, unavailable CLI, or explicit user request

## Testing
- Not run; documentation-only instruction cleanup.