### PR TITLE
M20-P1.6: Implement current-work authority classification

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,16 +3,15 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P4.1`
-- Last action taken: `M20-P4.1` merged to main via PR #185 with human-first page detail layout and
-  deterministic project identity, after `M20-P2.1`, v0.5.2 release prep, and the
-  hocrgen/hocrsyngen v0.5.2 retry replies identified a narrow current-work authority-model
-  correction.
-- Current planned slice: `M20 current-work authority model from v0.5.2 hocr retries`
-- Current PR sub-slice: `M20-P1.5`
+- Previous completed PR sub-slice: `M20-P1.5`
+- Last action taken: `M20-P1.5` merged to main via PR #181 with the v0.5.2 hocr retry findings and
+  current-work authority model recorded after `M20-P4.1` landed the first human operator cockpit
+  runtime follow-up.
+- Current planned slice: `M20 current-work authority classifier implementation (#182)`
+- Current PR sub-slice: `M20-P1.6`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 current-work authority classifier implementation (#182)`
-- Next planned PR sub-slice: `M20-P1.6`
+- Next planned slice: `M20 richer GitHub issue, PR, review-thread, and CI integrations`
+- Next planned PR sub-slice: `M20-P3.1`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ non-draft GitHub PR with labels, milestone, and a clear description.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P4.1`
-- Current planned slice: `M20 current-work authority model from v0.5.2 hocr retries`
-- Current PR sub-slice: `M20-P1.5`
+- Previous completed PR sub-slice: `M20-P1.5`
+- Current planned slice: `M20 current-work authority classifier implementation (#182)`
+- Current PR sub-slice: `M20-P1.6`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 current-work authority classifier implementation (#182)`
-- Next planned PR sub-slice: `M20-P1.6`
+- Next planned slice: `M20 richer GitHub issue, PR, review-thread, and CI integrations`
+- Next planned PR sub-slice: `M20-P3.1`
 
 These planning-state lines are for contributors and agents. The detailed roadmap lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md).

--- a/docs/current_work_authority_model.md
+++ b/docs/current_work_authority_model.md
@@ -100,8 +100,8 @@ and lint/health drift are maintenance context. They can lead only for maintenanc
 
 ## Extraction Contract
 
-M20-P1.6 should implement classification through deterministic extraction before relevance
-scoring. The extractor should not treat every matched slice token as an equally valid candidate.
+M20-P1.6 implements classification through deterministic extraction before relevance scoring. The
+extractor should not treat every matched slice token as an equally valid candidate.
 
 ### Source Priority
 

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -359,15 +359,15 @@ Implemented fields:
   and rank the successor as the next work item. Stale `.agent-plan.md` or roadmap "current" text is
   still useful evidence, but it should be reconciled against merge state and explicit roadmap order
   before becoming the top suggested action.
-- Planned current-work authority classification is additive and runtime-only. Existing
+- Current-work authority classification is additive and runtime-only. Existing
   `current_planned_work` JSON exposes `slice_id`, `planned_slice`, `authority_paths`,
-  `predecessor_slices`, and `reason`; M20-P1.6 may add optional classified-evidence fields but
-  must not remove or rename those fields. Additive fields should let agents distinguish the
-  selected current action from gated follow-ons, blocker/prerequisite context, completed
-  predecessor work, lower-priority conflicts, and historical or generated maintenance context. The
-  classification contract is defined in `docs/current_work_authority_model.md`; it must not require
-  persisted index state, schema-version bumps, databases, background workers, hosted services, or
-  mandatory external APIs.
+  `predecessor_slices`, and `reason`, and may also expose optional `evidence_class`,
+  `predecessor_evidence`, `gated_follow_ons`, `blocker_context`, `lower_priority_conflicts`, and
+  `selection_reconciled` fields. These fields let agents distinguish the selected current action
+  from gated follow-ons, blocker/prerequisite context, completed predecessor work, lower-priority
+  conflicts, and historical or generated maintenance context. The classification contract is
+  defined in `docs/current_work_authority_model.md`; it must not require persisted index state,
+  schema-version bumps, databases, background workers, hosted services, or mandatory external APIs.
 - Work-thread surfacing preserves breadth. JSON and human handoff lead with the best open issue or
   PR, and promoted open issues can pull in a bounded set of referenced open parent/sibling issue
   threads, including referenced open issues fetched by number when they were outside the initial

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P4.1`
-- Current planned slice: `M20 current-work authority model from v0.5.2 hocr retries`
-- Current PR sub-slice: `M20-P1.5`
+- Previous completed PR sub-slice: `M20-P1.5`
+- Current planned slice: `M20 current-work authority classifier implementation (#182)`
+- Current PR sub-slice: `M20-P1.6`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 current-work authority classifier implementation (#182)`
-- Next planned PR sub-slice: `M20-P1.6`
+- Next planned slice: `M20 richer GitHub issue, PR, review-thread, and CI integrations`
+- Next planned PR sub-slice: `M20-P3.1`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1463,11 +1463,13 @@ rather than a slice, gated follow-ons stay behind prerequisites, and merged PRs 
 context for current-work goals. `query` remains retrieval/search, not guaranteed handoff answer
 synthesis.
 
-`M20-P1.6` (#182) should be the next implementation slice. It should keep the runtime local-first
-and deterministic while adding the authority classification needed by the captured retry cases.
-The acceptance bar is narrow: hocrgen current-work handoff ranks `F6f2` first, keeps `F6g` gated
+`M20-P1.6` (#182) implements the narrow current-work authority classification layer needed by the
+captured retry cases. The runtime remains local-first and deterministic while `current_planned_work`
+adds classified evidence fields for selected work, predecessor evidence, gated follow-ons,
+blocker/prerequisite context, lower-priority conflicts, and reconciled selection state. The
+acceptance bar stays narrow: hocrgen current-work handoff ranks `F6f2` first, keeps `F6g` gated
 behind it, preserves `F1c` only as blocker/prerequisite context, suppresses merged PRs as top
-actions for current-work goals, and preserves the hocrsyngen `S8b` partial pass. This slice should
+actions for current-work goals, and preserves the hocrsyngen `S8b` partial pass. This slice does
 not broaden into query answer synthesis, mutating web workflows, background services, databases,
 mandatory external APIs, or a general agent-memory architecture.
 

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -135,7 +135,7 @@ _AUTHORITY_ORIGIN_ORDER = {
     "inferred-authority": 1,
 }
 _TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]{1,}")
-_ROADMAP_SLICE_INNER_PATTERN = r"(?:[A-Z][A-Za-z0-9]*-P\d+(?:\.\d+)?|[A-Z]\d+[a-z])"
+_ROADMAP_SLICE_INNER_PATTERN = r"(?:[A-Z][A-Za-z0-9]*-P\d+(?:\.\d+)?|[A-Z]\d+[a-z]\d*)"
 _ROADMAP_SLICE_PATTERN = re.compile(rf"\b{_ROADMAP_SLICE_INNER_PATTERN}\b")
 _PLANNING_STATE_PATTERN = re.compile(
     r"^\s*-\s+(?P<label>"
@@ -338,7 +338,6 @@ _GATED_FOLLOW_ON_TERMS = (
     "gated",
     "follow-on",
     "follow on",
-    "after",
     "behind",
     "depends",
     "blocked",
@@ -357,6 +356,7 @@ _COMPLETED_CONTEXT_TERMS = (
     "done",
     "merged",
     "closed",
+    "landed",
     "release note",
     "release notes",
 )
@@ -368,6 +368,33 @@ _HISTORICAL_CONTEXT_TERMS = (
     "old",
     "retrospective",
 )
+_CURRENT_STATUS_LINE_RE = re.compile(
+    r"^\s*-\s+Current PR sub-slice:\s+`?(?P<slice>[^`\s]+)`?", re.IGNORECASE
+)
+_NEXT_STATUS_LINE_RE = re.compile(
+    r"^\s*-\s+Next planned PR sub-slice:\s+`?(?P<slice>[^`\s]+)`?", re.IGNORECASE
+)
+_PREVIOUS_STATUS_LINE_RE = re.compile(
+    r"^\s*-\s+Previous completed PR sub-slice:\s+`?(?P<slice>[^`\s]+)`?", re.IGNORECASE
+)
+_LEADING_SLICE_RE = re.compile(
+    rf"^\s*(?:[-*]\s+(?:\[[ xX]\]\s+)?)?`?(?P<slice>{_ROADMAP_SLICE_INNER_PATTERN})`?"
+)
+_CURRENT_WORK_CANDIDATE_CLASSES = {
+    "active_task",
+    "current_status_row",
+    "unchecked_next_task",
+}
+_CURRENT_WORK_CLASS_ORDER = {
+    "active_task": 0,
+    "current_status_row": 1,
+    "unchecked_next_task": 2,
+}
+_CURRENT_WORK_SOURCE_ORDER = {
+    ".agent-plan.md": 0,
+    "README.md": 2,
+    "docs/splendor_mvp_to_v1_roadmap.md": 3,
+}
 
 
 @dataclass(frozen=True)
@@ -527,6 +554,8 @@ class ClassifiedPlanningEvidence:
     evidence_class: str
     path: str
     line: str
+    line_number: int
+    section: str | None = None
 
 
 @dataclass(frozen=True)
@@ -537,10 +566,10 @@ class CurrentPlannedWork:
     predecessor_slices: list[str]
     reason: str
     evidence_class: str | None = None
-    predecessor_evidence: list[dict[str, str]] | None = None
-    gated_follow_ons: list[dict[str, str]] | None = None
-    blocker_context: list[dict[str, str]] | None = None
-    lower_priority_conflicts: list[dict[str, str]] | None = None
+    predecessor_evidence: list[dict[str, object]] | None = None
+    gated_follow_ons: list[dict[str, object]] | None = None
+    blocker_context: list[dict[str, object]] | None = None
+    lower_priority_conflicts: list[dict[str, object]] | None = None
     selection_reconciled: bool = False
 
 
@@ -1658,7 +1687,7 @@ def _classified_planning_evidence(
         except OSError:
             continue
         heading_context = ""
-        for line in lines:
+        for line_number, line in enumerate(lines, start=1):
             stripped = line.strip()
             if stripped.startswith("#"):
                 heading_context = stripped.lstrip("#").strip().lower()
@@ -1666,12 +1695,10 @@ def _classified_planning_evidence(
             if not stripped:
                 continue
             line_context = " ".join([heading_context, stripped.lower()])
-            slice_ids = list(dict.fromkeys(_ROADMAP_SLICE_PATTERN.findall(stripped)))
-            if not slice_ids:
-                continue
             evidence_class = _classify_planning_line(line_context)
             if evidence_class is None:
                 continue
+            slice_ids = _classified_line_slice_ids(stripped, evidence_class)
             for slice_id in slice_ids:
                 evidence.append(
                     ClassifiedPlanningEvidence(
@@ -1679,12 +1706,20 @@ def _classified_planning_evidence(
                         evidence_class=evidence_class,
                         path=relpath,
                         line=stripped,
+                        line_number=line_number,
+                        section=heading_context or None,
                     )
                 )
     return evidence
 
 
 def _classify_planning_line(text: str) -> str | None:
+    if _CURRENT_STATUS_LINE_RE.search(text):
+        return "current_status_row"
+    if _NEXT_STATUS_LINE_RE.search(text):
+        return "unchecked_next_task"
+    if _PREVIOUS_STATUS_LINE_RE.search(text):
+        return "completed_work"
     if _contains_any(text, _COMPLETED_CONTEXT_TERMS):
         return "completed_work"
     if _contains_any(text, _GATED_FOLLOW_ON_TERMS):
@@ -1700,19 +1735,44 @@ def _classify_planning_line(text: str) -> str | None:
     return None
 
 
+def _classified_line_slice_ids(line: str, evidence_class: str) -> list[str]:
+    status_match = (
+        _CURRENT_STATUS_LINE_RE.search(line)
+        or _NEXT_STATUS_LINE_RE.search(line)
+        or _PREVIOUS_STATUS_LINE_RE.search(line)
+    )
+    if status_match is not None:
+        return [status_match.group("slice")]
+
+    slice_ids = list(dict.fromkeys(_ROADMAP_SLICE_PATTERN.findall(line)))
+    if not slice_ids:
+        return []
+    leading = _LEADING_SLICE_RE.search(line)
+    if leading is not None:
+        return [leading.group("slice")]
+    if evidence_class in {
+        "blocker_or_prerequisite_context",
+        "completed_work",
+        "gated_follow_on",
+        "historical_or_superseded_context",
+    }:
+        return slice_ids[:1]
+    return slice_ids
+
+
 def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
     return any(term in text for term in terms)
 
 
 def _classified_evidence_for_json(
     evidence: list[ClassifiedPlanningEvidence], *, exclude_slice: str | None = None
-) -> list[dict[str, str]]:
-    items: list[dict[str, str]] = []
-    seen: set[tuple[str, str, str, str]] = set()
+) -> list[dict[str, object]]:
+    items: list[dict[str, object]] = []
+    seen: set[tuple[str, str, str, str, int]] = set()
     for item in evidence:
         if exclude_slice is not None and item.slice_id == exclude_slice:
             continue
-        key = (item.slice_id, item.evidence_class, item.path, item.line)
+        key = (item.slice_id, item.evidence_class, item.path, item.line, item.line_number)
         if key in seen:
             continue
         seen.add(key)
@@ -1722,6 +1782,8 @@ def _classified_evidence_for_json(
                 "evidence_class": item.evidence_class,
                 "path": item.path,
                 "line": item.line,
+                "line_number": item.line_number,
+                "section": item.section,
             }
         )
     return items
@@ -1732,10 +1794,206 @@ def _classified_evidence_by_class(
     classes: set[str],
     *,
     exclude_slice: str | None = None,
-) -> list[dict[str, str]]:
+) -> list[dict[str, object]]:
     return _classified_evidence_for_json(
         [item for item in evidence if item.evidence_class in classes], exclude_slice=exclude_slice
     )
+
+
+def _classified_current_planned_work(
+    classified_evidence: list[ClassifiedPlanningEvidence],
+    states: list[tuple[str, dict[str, str]]],
+    git_context: GitContext,
+) -> CurrentPlannedWork | None:
+    combined, disagreements = _reconciled_planning_state(states)
+    candidates = [
+        item
+        for item in classified_evidence
+        if item.evidence_class in _CURRENT_WORK_CANDIDATE_CLASSES
+    ]
+    if not candidates:
+        return None
+    previous_slice = combined.get("Previous completed PR sub-slice")
+    current_slice = combined.get("Current PR sub-slice")
+    next_slice = combined.get("Next planned PR sub-slice")
+    current_lifecycle = (combined.get("Current PR lifecycle") or "").lower()
+    use_next = bool(
+        current_slice
+        and next_slice
+        and (
+            previous_slice == current_slice
+            or (git_context.branch == "main" and "main=merged" in current_lifecycle)
+        )
+    )
+    if use_next:
+        next_candidates = [item for item in candidates if item.slice_id == next_slice]
+        candidate = (
+            sorted(next_candidates, key=_classified_candidate_sort_key)[0]
+            if next_candidates
+            else _synthetic_classified_evidence(next_slice, "unchecked_next_task", states)
+        )
+    else:
+        candidate = sorted(candidates, key=_classified_candidate_sort_key)[0]
+    planned_slice = _planned_slice_for_candidate(candidate.slice_id, combined)
+    predecessor_slices = [
+        slice_id
+        for slice_id in [previous_slice, current_slice if use_next else None]
+        if slice_id and slice_id != candidate.slice_id
+    ]
+    reason_parts = [
+        "Classified planning evidence identifies the current handoff target.",
+        f"{candidate.evidence_class} from {candidate.path}:{candidate.line_number}.",
+    ]
+    if use_next and current_slice:
+        reason_parts.append(
+            f"{current_slice} is predecessor context; lead with {candidate.slice_id}."
+        )
+    if disagreements:
+        reason_parts.append("Reconciled disagreement: " + "; ".join(disagreements[:3]) + ".")
+    return CurrentPlannedWork(
+        slice_id=candidate.slice_id,
+        planned_slice=planned_slice,
+        authority_paths=[candidate.path],
+        predecessor_slices=predecessor_slices,
+        reason=" ".join(reason_parts),
+        evidence_class=candidate.evidence_class,
+        predecessor_evidence=_bounded_current_work_context(
+            classified_evidence,
+            candidate,
+            {"completed_work"},
+            predecessor_slices=set(predecessor_slices),
+        ),
+        gated_follow_ons=_bounded_current_work_context(
+            classified_evidence,
+            candidate,
+            {"gated_follow_on"},
+        ),
+        blocker_context=_bounded_current_work_context(
+            classified_evidence,
+            candidate,
+            {"blocker_or_prerequisite_context"},
+        ),
+        lower_priority_conflicts=_bounded_current_work_context(
+            classified_evidence,
+            candidate,
+            _CURRENT_WORK_CANDIDATE_CLASSES,
+            include_same_class=True,
+        ),
+        selection_reconciled=use_next or bool(disagreements),
+    )
+
+
+def _planned_slice_for_candidate(slice_id: str, combined: dict[str, str]) -> str | None:
+    if slice_id == combined.get("Current PR sub-slice"):
+        return combined.get("Current planned slice")
+    if slice_id == combined.get("Next planned PR sub-slice"):
+        return combined.get("Next planned slice")
+    return None
+
+
+def _synthetic_classified_evidence(
+    slice_id: str, evidence_class: str, states: list[tuple[str, dict[str, str]]]
+) -> ClassifiedPlanningEvidence:
+    path = states[0][0] if states else ""
+    return ClassifiedPlanningEvidence(
+        slice_id=slice_id,
+        evidence_class=evidence_class,
+        path=path,
+        line=f"Current work: {slice_id}",
+        line_number=0,
+        section=None,
+    )
+
+
+def _classified_candidate_sort_key(item: ClassifiedPlanningEvidence) -> tuple[int, int, int, int]:
+    return (
+        _current_work_source_priority(item.path),
+        _CURRENT_WORK_CLASS_ORDER.get(item.evidence_class, 99),
+        _current_work_section_priority(item.section),
+        item.line_number,
+    )
+
+
+def _current_work_source_priority(path: str) -> int:
+    return _CURRENT_WORK_SOURCE_ORDER.get(path, 5)
+
+
+def _current_work_section_priority(section: str | None) -> int:
+    normalized = section or ""
+    if any(term in normalized for term in ("current system state", "current work")):
+        return 0
+    if any(term in normalized for term in ("active task", "implementation checklist")):
+        return 1
+    if any(term in normalized for term in ("planned", "candidate", "roadmap")):
+        return 2
+    if any(
+        term in normalized for term in ("historical", "release", "review", "appendix", "archive")
+    ):
+        return 5
+    return 3
+
+
+def _bounded_current_work_context(
+    evidence: list[ClassifiedPlanningEvidence],
+    selected: ClassifiedPlanningEvidence,
+    classes: set[str],
+    *,
+    predecessor_slices: set[str] | None = None,
+    include_same_class: bool = False,
+    limit: int = 5,
+) -> list[dict[str, object]]:
+    predecessor_slices = predecessor_slices or set()
+    related: list[ClassifiedPlanningEvidence] = []
+    for item in evidence:
+        if item.slice_id == selected.slice_id:
+            continue
+        if item.evidence_class not in classes:
+            continue
+        if predecessor_slices and item.slice_id in predecessor_slices:
+            related.append(item)
+            continue
+        if include_same_class and not _candidate_can_conflict_with_selected(item, selected):
+            continue
+        if not include_same_class and not _context_item_is_near_selected(item, selected):
+            continue
+        related.append(item)
+    related = sorted(
+        related, key=lambda item: (_context_sort_key(item, selected), item.line_number)
+    )
+    return _classified_evidence_for_json(related[:limit])
+
+
+def _candidate_can_conflict_with_selected(
+    item: ClassifiedPlanningEvidence, selected: ClassifiedPlanningEvidence
+) -> bool:
+    if item.path == selected.path:
+        return item.section == selected.section or abs(item.line_number - selected.line_number) <= 6
+    return _current_work_source_priority(item.path) < _current_work_source_priority(
+        "docs/splendor_mvp_to_v1_roadmap.md"
+    )
+
+
+def _context_item_is_near_selected(
+    item: ClassifiedPlanningEvidence, selected: ClassifiedPlanningEvidence
+) -> bool:
+    if item.path != selected.path:
+        return False
+    if item.section == selected.section:
+        return True
+    if item.section and any(term in item.section for term in ("blocker", "prerequisite")):
+        return True
+    if _text_mentions_slice(item.line, selected.slice_id):
+        return True
+    return abs(item.line_number - selected.line_number) <= 6
+
+
+def _context_sort_key(
+    item: ClassifiedPlanningEvidence, selected: ClassifiedPlanningEvidence
+) -> tuple[int, int, int]:
+    same_path = 0 if item.path == selected.path else 1
+    same_section = 0 if item.section == selected.section else 1
+    distance = abs(item.line_number - selected.line_number)
+    return same_path, same_section, distance
 
 
 def _current_planned_work(
@@ -1751,8 +2009,12 @@ def _current_planned_work(
         return None
 
     classified_evidence = _classified_planning_evidence(root, authority_briefs)
+    states = _planning_state_by_path(root, authority_briefs)
+    classified = _classified_current_planned_work(classified_evidence, states, git_context)
+    if classified is not None:
+        return classified
     structured = _structured_current_planned_work(
-        root, git_context, authority_briefs, classified_evidence
+        root, git_context, authority_briefs, classified_evidence, states
     )
     if structured is not None:
         return structured
@@ -1764,8 +2026,9 @@ def _structured_current_planned_work(
     git_context: GitContext,
     authority_briefs: list[AuthorityBrief],
     classified_evidence: list[ClassifiedPlanningEvidence],
+    states: list[tuple[str, dict[str, str]]] | None = None,
 ) -> CurrentPlannedWork | None:
-    states = _planning_state_by_path(root, authority_briefs)
+    states = states if states is not None else _planning_state_by_path(root, authority_briefs)
     if not states:
         return None
     combined, disagreements = _reconciled_planning_state(states)
@@ -1812,6 +2075,18 @@ def _structured_current_planned_work(
         if use_next
         else "current_status_row"
     )
+    selected_anchor = (
+        selected_evidence[0]
+        if selected_evidence
+        else ClassifiedPlanningEvidence(
+            slice_id=slice_id,
+            evidence_class=evidence_class,
+            path=authority_paths[0] if authority_paths else "",
+            line=f"Current work: {slice_id}",
+            line_number=0,
+            section=None,
+        )
+    )
     return CurrentPlannedWork(
         slice_id=slice_id,
         planned_slice=next_planned_slice if use_next and next_planned_slice else planned_slice,
@@ -1820,24 +2095,32 @@ def _structured_current_planned_work(
         reason=" ".join(reason_parts),
         evidence_class=evidence_class,
         predecessor_evidence=_classified_evidence_by_class(
-            classified_evidence,
+            [item for item in classified_evidence if item.slice_id in set(predecessor_slices)],
             {"completed_work"},
-            exclude_slice=slice_id,
         ),
         gated_follow_ons=_classified_evidence_by_class(
-            classified_evidence,
+            [
+                item
+                for item in classified_evidence
+                if _context_item_is_near_selected(item, selected_anchor)
+            ],
             {"gated_follow_on"},
             exclude_slice=slice_id,
         ),
         blocker_context=_classified_evidence_by_class(
-            classified_evidence,
+            [
+                item
+                for item in classified_evidence
+                if _context_item_is_near_selected(item, selected_anchor)
+            ],
             {"blocker_or_prerequisite_context"},
             exclude_slice=slice_id,
         ),
-        lower_priority_conflicts=_classified_evidence_by_class(
+        lower_priority_conflicts=_bounded_current_work_context(
             classified_evidence,
+            selected_anchor,
             {"historical_or_superseded_context", "active_task", "unchecked_next_task"},
-            exclude_slice=slice_id,
+            include_same_class=True,
         ),
         selection_reconciled=use_next or bool(disagreements),
     )
@@ -1869,6 +2152,14 @@ def _line_inferred_current_planned_work(
                 if match is None:
                     continue
                 slice_id = match.group("slice")
+                selected_anchor = ClassifiedPlanningEvidence(
+                    slice_id=slice_id,
+                    evidence_class=line_class or "active_task",
+                    path=relpath,
+                    line=line.strip(),
+                    line_number=0,
+                    section=None,
+                )
                 return CurrentPlannedWork(
                     slice_id=slice_id,
                     planned_slice=None,
@@ -1885,19 +2176,28 @@ def _line_inferred_current_planned_work(
                         exclude_slice=slice_id,
                     ),
                     gated_follow_ons=_classified_evidence_by_class(
-                        classified_evidence,
+                        [
+                            item
+                            for item in classified_evidence
+                            if _context_item_is_near_selected(item, selected_anchor)
+                        ],
                         {"gated_follow_on"},
                         exclude_slice=slice_id,
                     ),
                     blocker_context=_classified_evidence_by_class(
-                        classified_evidence,
+                        [
+                            item
+                            for item in classified_evidence
+                            if _context_item_is_near_selected(item, selected_anchor)
+                        ],
                         {"blocker_or_prerequisite_context"},
                         exclude_slice=slice_id,
                     ),
-                    lower_priority_conflicts=_classified_evidence_by_class(
+                    lower_priority_conflicts=_bounded_current_work_context(
                         classified_evidence,
+                        selected_anchor,
                         {"historical_or_superseded_context", "active_task", "unchecked_next_task"},
-                        exclude_slice=slice_id,
+                        include_same_class=True,
                     ),
                 )
     return None

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -326,6 +326,48 @@ _CURRENT_WORK_LINE_PATTERNS = (
         re.IGNORECASE,
     ),
 )
+_ACTIVE_TASK_TERMS = (
+    "active",
+    "current",
+    "in progress",
+    "implementation",
+    "next implementation",
+)
+_UNCHECKED_NEXT_TERMS = ("next", "next planned", "real next", "follows", "follow with")
+_GATED_FOLLOW_ON_TERMS = (
+    "gated",
+    "follow-on",
+    "follow on",
+    "after",
+    "behind",
+    "depends",
+    "blocked",
+)
+_BLOCKER_CONTEXT_TERMS = (
+    "blocker",
+    "prerequisite",
+    "prereq",
+    "requires",
+    "needed before",
+    "missing",
+)
+_COMPLETED_CONTEXT_TERMS = (
+    "complete",
+    "completed",
+    "done",
+    "merged",
+    "closed",
+    "release note",
+    "release notes",
+)
+_HISTORICAL_CONTEXT_TERMS = (
+    "historical",
+    "history",
+    "superseded",
+    "archived",
+    "old",
+    "retrospective",
+)
 
 
 @dataclass(frozen=True)
@@ -480,12 +522,26 @@ class HandoffCurrentState:
 
 
 @dataclass(frozen=True)
+class ClassifiedPlanningEvidence:
+    slice_id: str
+    evidence_class: str
+    path: str
+    line: str
+
+
+@dataclass(frozen=True)
 class CurrentPlannedWork:
     slice_id: str
     planned_slice: str | None
     authority_paths: list[str]
     predecessor_slices: list[str]
     reason: str
+    evidence_class: str | None = None
+    predecessor_evidence: list[dict[str, str]] | None = None
+    gated_follow_ons: list[dict[str, str]] | None = None
+    blocker_context: list[dict[str, str]] | None = None
+    lower_priority_conflicts: list[dict[str, str]] | None = None
+    selection_reconciled: bool = False
 
 
 @dataclass(frozen=True)
@@ -1591,6 +1647,97 @@ def _handoff_current_state(root: Path, git_context: GitContext) -> HandoffCurren
     )
 
 
+def _classified_planning_evidence(
+    root: Path, authority_briefs: list[AuthorityBrief] | None = None
+) -> list[ClassifiedPlanningEvidence]:
+    evidence: list[ClassifiedPlanningEvidence] = []
+    for relpath in _current_work_fallback_paths(root, authority_briefs or []):
+        path = root / relpath
+        try:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            continue
+        heading_context = ""
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                heading_context = stripped.lstrip("#").strip().lower()
+                continue
+            if not stripped:
+                continue
+            line_context = " ".join([heading_context, stripped.lower()])
+            slice_ids = list(dict.fromkeys(_ROADMAP_SLICE_PATTERN.findall(stripped)))
+            if not slice_ids:
+                continue
+            evidence_class = _classify_planning_line(line_context)
+            if evidence_class is None:
+                continue
+            for slice_id in slice_ids:
+                evidence.append(
+                    ClassifiedPlanningEvidence(
+                        slice_id=slice_id,
+                        evidence_class=evidence_class,
+                        path=relpath,
+                        line=stripped,
+                    )
+                )
+    return evidence
+
+
+def _classify_planning_line(text: str) -> str | None:
+    if _contains_any(text, _COMPLETED_CONTEXT_TERMS):
+        return "completed_work"
+    if _contains_any(text, _GATED_FOLLOW_ON_TERMS):
+        return "gated_follow_on"
+    if _contains_any(text, _BLOCKER_CONTEXT_TERMS):
+        return "blocker_or_prerequisite_context"
+    if _contains_any(text, _HISTORICAL_CONTEXT_TERMS):
+        return "historical_or_superseded_context"
+    if "- [ ]" in text or _contains_any(text, _UNCHECKED_NEXT_TERMS):
+        return "unchecked_next_task"
+    if _contains_any(text, _ACTIVE_TASK_TERMS):
+        return "active_task"
+    return None
+
+
+def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    return any(term in text for term in terms)
+
+
+def _classified_evidence_for_json(
+    evidence: list[ClassifiedPlanningEvidence], *, exclude_slice: str | None = None
+) -> list[dict[str, str]]:
+    items: list[dict[str, str]] = []
+    seen: set[tuple[str, str, str, str]] = set()
+    for item in evidence:
+        if exclude_slice is not None and item.slice_id == exclude_slice:
+            continue
+        key = (item.slice_id, item.evidence_class, item.path, item.line)
+        if key in seen:
+            continue
+        seen.add(key)
+        items.append(
+            {
+                "slice_id": item.slice_id,
+                "evidence_class": item.evidence_class,
+                "path": item.path,
+                "line": item.line,
+            }
+        )
+    return items
+
+
+def _classified_evidence_by_class(
+    evidence: list[ClassifiedPlanningEvidence],
+    classes: set[str],
+    *,
+    exclude_slice: str | None = None,
+) -> list[dict[str, str]]:
+    return _classified_evidence_for_json(
+        [item for item in evidence if item.evidence_class in classes], exclude_slice=exclude_slice
+    )
+
+
 def _current_planned_work(
     root: Path,
     git_context: GitContext,
@@ -1603,14 +1750,20 @@ def _current_planned_work(
     if handoff_current_state is not None or not _is_current_work_goal(goal_tokens, goal):
         return None
 
-    structured = _structured_current_planned_work(root, git_context, authority_briefs)
+    classified_evidence = _classified_planning_evidence(root, authority_briefs)
+    structured = _structured_current_planned_work(
+        root, git_context, authority_briefs, classified_evidence
+    )
     if structured is not None:
         return structured
-    return _line_inferred_current_planned_work(root, authority_briefs)
+    return _line_inferred_current_planned_work(root, authority_briefs, classified_evidence)
 
 
 def _structured_current_planned_work(
-    root: Path, git_context: GitContext, authority_briefs: list[AuthorityBrief]
+    root: Path,
+    git_context: GitContext,
+    authority_briefs: list[AuthorityBrief],
+    classified_evidence: list[ClassifiedPlanningEvidence],
 ) -> CurrentPlannedWork | None:
     states = _planning_state_by_path(root, authority_briefs)
     if not states:
@@ -1649,17 +1802,51 @@ def _structured_current_planned_work(
         reason_parts.append("Reconciled disagreement: " + "; ".join(disagreements[:3]) + ".")
     if use_next and current_slice:
         reason_parts.append(f"{current_slice} is predecessor context; lead with {slice_id}.")
+    selected_evidence = [
+        item for item in classified_evidence if item.slice_id == slice_id and item.evidence_class
+    ]
+    evidence_class = (
+        selected_evidence[0].evidence_class
+        if selected_evidence
+        else "reconciled_current_status_row"
+        if use_next
+        else "current_status_row"
+    )
     return CurrentPlannedWork(
         slice_id=slice_id,
         planned_slice=next_planned_slice if use_next and next_planned_slice else planned_slice,
         authority_paths=sorted(dict.fromkeys(authority_paths)),
         predecessor_slices=predecessor_slices,
         reason=" ".join(reason_parts),
+        evidence_class=evidence_class,
+        predecessor_evidence=_classified_evidence_by_class(
+            classified_evidence,
+            {"completed_work"},
+            exclude_slice=slice_id,
+        ),
+        gated_follow_ons=_classified_evidence_by_class(
+            classified_evidence,
+            {"gated_follow_on"},
+            exclude_slice=slice_id,
+        ),
+        blocker_context=_classified_evidence_by_class(
+            classified_evidence,
+            {"blocker_or_prerequisite_context"},
+            exclude_slice=slice_id,
+        ),
+        lower_priority_conflicts=_classified_evidence_by_class(
+            classified_evidence,
+            {"historical_or_superseded_context", "active_task", "unchecked_next_task"},
+            exclude_slice=slice_id,
+        ),
+        selection_reconciled=use_next or bool(disagreements),
     )
 
 
 def _line_inferred_current_planned_work(
-    root: Path, authority_briefs: list[AuthorityBrief]
+    root: Path,
+    authority_briefs: list[AuthorityBrief],
+    classified_evidence: list[ClassifiedPlanningEvidence],
 ) -> CurrentPlannedWork | None:
     for relpath in _current_work_fallback_paths(root, authority_briefs):
         path = root / relpath
@@ -1669,7 +1856,13 @@ def _line_inferred_current_planned_work(
             continue
         for line in lines:
             normalized = line.lower()
-            if any(word in normalized for word in ("historical", "completed", "done", "merged")):
+            line_class = _classify_planning_line(normalized)
+            if line_class in {
+                "blocker_or_prerequisite_context",
+                "completed_work",
+                "gated_follow_on",
+                "historical_or_superseded_context",
+            }:
                 continue
             for pattern in _CURRENT_WORK_LINE_PATTERNS:
                 match = pattern.search(line)
@@ -1684,6 +1877,27 @@ def _line_inferred_current_planned_work(
                     reason=(
                         "Conventional authority text identifies the current handoff target: "
                         f"{line.strip()}"
+                    ),
+                    evidence_class="active_task",
+                    predecessor_evidence=_classified_evidence_by_class(
+                        classified_evidence,
+                        {"completed_work"},
+                        exclude_slice=slice_id,
+                    ),
+                    gated_follow_ons=_classified_evidence_by_class(
+                        classified_evidence,
+                        {"gated_follow_on"},
+                        exclude_slice=slice_id,
+                    ),
+                    blocker_context=_classified_evidence_by_class(
+                        classified_evidence,
+                        {"blocker_or_prerequisite_context"},
+                        exclude_slice=slice_id,
+                    ),
+                    lower_priority_conflicts=_classified_evidence_by_class(
+                        classified_evidence,
+                        {"historical_or_superseded_context", "active_task", "unchecked_next_task"},
+                        exclude_slice=slice_id,
                     ),
                 )
     return None
@@ -2723,12 +2937,29 @@ def _suggestion_candidates(snapshot: BriefStateSnapshot) -> list[SuggestedAction
         predecessor_note = (
             f" Predecessor context remains visible: {predecessors}." if predecessors else ""
         )
+        gated_note = (
+            " Gated follow-ons remain behind the selected work: "
+            + ", ".join(item["slice_id"] for item in (work.gated_follow_ons or [])[:3])
+            + "."
+            if work.gated_follow_ons
+            else ""
+        )
+        blocker_note = (
+            " Blocker/prerequisite context is not the selected slice: "
+            + ", ".join(item["slice_id"] for item in (work.blocker_context or [])[:3])
+            + "."
+            if work.blocker_context
+            else ""
+        )
         planned_note = f" ({work.planned_slice})" if work.planned_slice else ""
         add(
             "high",
             "current-state",
             f"Continue {work.slice_id}{planned_note} from current planning authority",
-            f"{work.reason} Authority: {authority_paths}.{predecessor_note}",
+            (
+                f"{work.reason} Authority: {authority_paths}."
+                f"{predecessor_note}{gated_note}{blocker_note}"
+            ),
             None,
             record_id=work.slice_id,
             path=work.authority_paths[0] if work.authority_paths else None,

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -3427,6 +3427,51 @@ def test_agent_context_hocrgen_retry_classifies_gated_and_blocker_context(
         assert "F1c" not in action["title"]
 
 
+def test_agent_context_hocrgen_retry_selects_active_checklist_without_state_block(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n"
+        "## Current Work\n\n"
+        "- [ ] F6f2: build the narrow synthetic target scale acceptance path.\n"
+        "- [ ] F6g: gated follow-on after F6f2 expands the larger batch.\n\n"
+        "## Blocker Context\n\n"
+        "- F1c is old blocker/prerequisite context for synthetic target scale, not current work.\n",
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "--no-git",
+            "continue",
+            "the",
+            "current",
+            "hocrgen",
+            "roadmap",
+            "work",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    current = payload["current_planned_work"]
+    assert current["slice_id"] == "F6f2"
+    assert current["evidence_class"] == "unchecked_next_task"
+    assert {item["slice_id"] for item in current["gated_follow_ons"]} == {"F6g"}
+    assert {item["slice_id"] for item in current["blocker_context"]} == {"F1c"}
+    lower_conflicts = {item["slice_id"] for item in current["lower_priority_conflicts"]}
+    assert "F6g" not in lower_conflicts
+    assert "F1c" not in lower_conflicts
+    assert payload["work_context"]["actions"][0]["category"] == "current-state"
+    assert "F6f2" in payload["work_context"]["actions"][0]["title"]
+
+
 def test_agent_context_hocrsyngen_retry_still_selects_s8b(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
     (tmp_path / ".agent-plan.md").write_text(

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -3346,6 +3346,124 @@ def test_agent_context_hocrgen_current_authority_beats_merged_pr_and_maintenance
         assert payload["maintenance_context"]["actions"][0]["category"] == "source-freshness"
 
 
+def test_agent_context_hocrgen_retry_classifies_gated_and_blocker_context(
+    tmp_path: Path, capsys
+) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n"
+        "- Previous completed PR sub-slice: `F6f1`\n"
+        "- Current planned slice: `F6 current public-beta closure`\n"
+        "- Current PR sub-slice: `F6f2`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `F6 follow-on scaleout`\n"
+        "- Next planned PR sub-slice: `F6g`\n\n"
+        "## Current Work\n\n"
+        "- [ ] F6f2: build the narrow synthetic target scale acceptance path.\n"
+        "- [ ] F6g: gated follow-on after F6f2 expands the larger batch.\n\n"
+        "## Blocker Context\n\n"
+        "- F1c is old blocker/prerequisite context for synthetic target scale, not current work.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "# hocrgen\n\n"
+        "- Previous completed PR sub-slice: `F6f1`\n"
+        "- Current planned slice: `F6 current public-beta closure`\n"
+        "- Current PR sub-slice: `F6f2`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `F6 follow-on scaleout`\n"
+        "- Next planned PR sub-slice: `F6g`\n",
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    brief_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "--no-git",
+            "continue",
+            "the",
+            "current",
+            "hocrgen",
+            "roadmap",
+            "work",
+            "--json",
+        ]
+    )
+    brief_payload = json.loads(capsys.readouterr().out)
+    suggest_exit = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "--no-git",
+            "continue",
+            "the",
+            "current",
+            "hocrgen",
+            "roadmap",
+            "work",
+            "--json",
+        ]
+    )
+    suggest_payload = json.loads(capsys.readouterr().out)
+
+    assert brief_exit == 0
+    assert suggest_exit == 0
+    for payload in (brief_payload, suggest_payload):
+        current = payload["current_planned_work"]
+        assert current["slice_id"] == "F6f2"
+        assert current["evidence_class"] in {"active_task", "current_status_row"}
+        assert {item["slice_id"] for item in current["gated_follow_ons"]} == {"F6g"}
+        assert {item["slice_id"] for item in current["blocker_context"]} == {"F1c"}
+        action = payload["work_context"]["actions"][0]
+        assert action["category"] == "current-state"
+        assert "F6f2" in action["title"]
+        assert "F6g" in action["reason"]
+        assert "F1c" in action["reason"]
+        assert "F1c" not in action["title"]
+
+
+def test_agent_context_hocrsyngen_retry_still_selects_s8b(tmp_path: Path, capsys) -> None:
+    initialize_workspace(tmp_path)
+    (tmp_path / ".agent-plan.md").write_text(
+        "# Agent Plan\n\n"
+        "- Previous completed PR sub-slice: `S8a`\n"
+        "- Current planned slice: `S8 production script abstraction`\n"
+        "- Current PR sub-slice: `S8b`\n"
+        "- Current PR lifecycle: `branch=in-progress; main=merged`\n"
+        "- Next planned slice: `S8 follow-on import polish`\n"
+        "- Next planned PR sub-slice: `S8c`\n\n"
+        "Current implementation work: `S8b` stabilizes the hocrsyngen handoff.\n",
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "suggest-next",
+            "--no-git",
+            "continue",
+            "current",
+            "hocrsyngen",
+            "roadmap",
+            "work",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["current_planned_work"]["slice_id"] == "S8b"
+    assert payload["work_context"]["actions"][0]["category"] == "current-state"
+    assert "S8b" in payload["work_context"]["actions"][0]["title"]
+
+
 def test_agent_context_keeps_matching_open_work_thread_ahead_of_current_authority(
     tmp_path: Path, capsys, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

- add deterministic current-work evidence classification to `current_planned_work`
- expose selected evidence class, predecessor evidence, gated follow-ons, blocker context, lower-priority conflicts, and reconciled selection state in handoff JSON
- keep F6g and F1c visible as context behind F6f2 while preserving S8b handoff selection
- update synchronized planning state and contracts for M20-P1.6

Closes #182.

## Validation

- `uv run pytest tests/test_wiki_commands.py -k "current_authority or current_work or hocrgen_retry or hocrsyngen_retry"`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run pytest`

## Notes

This stays runtime-only and local-first: no query answer synthesis, mutating web workflow, background service, database, mandatory external API, or persisted index state.