### PR TITLE
M20-P3.1: Add GitHub handoff status signals

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,15 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P1.5`
-- Last action taken: `M20-P1.5` merged to main via PR #181 with the v0.5.2 hocr retry findings and
-  current-work authority model recorded after `M20-P4.1` landed the first human operator cockpit
-  runtime follow-up.
-- Current planned slice: `M20 current-work authority classifier implementation (#182)`
-- Current PR sub-slice: `M20-P1.6`
+- Previous completed PR sub-slice: `M20-P1.6`
+- Last action taken: `M20-P1.6` merged to main via PR #187 with the current-work authority
+  classification layer for hocr retry handoff acceptance.
+- Current planned slice: `M20 richer GitHub issue, PR, review-thread, and CI integrations (#188)`
+- Current PR sub-slice: `M20-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 richer GitHub issue, PR, review-thread, and CI integrations`
-- Next planned PR sub-slice: `M20-P3.1`
+- Next planned slice: `M20 human operator cockpit and wiki navigation design/spec/architecture contract`
+- Next planned PR sub-slice: `M20-P4.0`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ non-draft GitHub PR with labels, milestone, and a clear description.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P1.5`
-- Current planned slice: `M20 current-work authority classifier implementation (#182)`
-- Current PR sub-slice: `M20-P1.6`
+- Previous completed PR sub-slice: `M20-P1.6`
+- Current planned slice: `M20 richer GitHub issue, PR, review-thread, and CI integrations (#188)`
+- Current PR sub-slice: `M20-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 richer GitHub issue, PR, review-thread, and CI integrations`
-- Next planned PR sub-slice: `M20-P3.1`
+- Next planned slice: `M20 human operator cockpit and wiki navigation design/spec/architecture contract`
+- Next planned PR sub-slice: `M20-P4.0`
 
 These planning-state lines are for contributors and agents. The detailed roadmap lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md).

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P1.5`
-- Current planned slice: `M20 current-work authority classifier implementation (#182)`
-- Current PR sub-slice: `M20-P1.6`
+- Previous completed PR sub-slice: `M20-P1.6`
+- Current planned slice: `M20 richer GitHub issue, PR, review-thread, and CI integrations (#188)`
+- Current PR sub-slice: `M20-P3.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 richer GitHub issue, PR, review-thread, and CI integrations`
-- Next planned PR sub-slice: `M20-P3.1`
+- Next planned slice: `M20 human operator cockpit and wiki navigation design/spec/architecture contract`
+- Next planned PR sub-slice: `M20-P4.0`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1472,6 +1472,13 @@ behind it, preserves `F1c` only as blocker/prerequisite context, suppresses merg
 actions for current-work goals, and preserves the hocrsyngen `S8b` partial pass. This slice does
 not broaden into query answer synthesis, mutating web workflows, background services, databases,
 mandatory external APIs, or a general agent-memory architecture.
+
+`M20-P3.1` (#188) starts richer GitHub issue, PR, review-thread, and CI integrations with a narrow
+agent-handoff payload improvement. `brief --agent-context` and `suggest-next` keep using best-effort
+`gh` context only when available, but PR work-thread entries now include normalized review decision
+and status-check rollup fields plus a compact summary in the existing work-thread reason. The slice
+does not add hosted services, background workers, databases, auth complexity, mandatory external
+APIs, mutating web workflows, broad GitHub ingestion, or query answer synthesis.
 
 `M20-P4.0` is a docs/design-first slice for the human operator cockpit and wiki navigation track.
 It records the external review feedback that the local web UI currently exposes state without

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -2588,6 +2588,9 @@ def _github_threads(
 ) -> tuple[list[GitThreadBrief], list[str]]:
     warnings: list[str] = []
     raw_threads: list[dict[str, object]] = []
+    issue_fields = "number,title,url,body,state,labels"
+    pr_fields = "number,title,url,body,state,isDraft,mergedAt,labels"
+    pr_status_fields = f"{pr_fields},reviewDecision,statusCheckRollup"
     commands = [
         [
             "gh",
@@ -2600,7 +2603,7 @@ def _github_threads(
             "--limit",
             "30",
             "--json",
-            "number,title,url,body,state,labels",
+            issue_fields,
         ],
         [
             "gh",
@@ -2613,32 +2616,33 @@ def _github_threads(
             "--limit",
             "30",
             "--json",
-            "number,title,url,body,state,isDraft,mergedAt,labels,reviewDecision,statusCheckRollup",
+            pr_status_fields,
         ],
     ]
     kinds = ["issue", "pr"]
     for kind, command in zip(kinds, commands, strict=True):
-        try:
-            result = subprocess.run(
-                command,
-                cwd=root,
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=_GIT_COMMAND_TIMEOUT_SECONDS,
-            )
-        except subprocess.TimeoutExpired:
-            warnings.append(
-                f"Timed out after {_GIT_COMMAND_TIMEOUT_SECONDS}s running gh {kind} list."
-            )
-            continue
-        except OSError as exc:
-            warnings.append(f"Could not run gh {kind} list: {exc}")
+        result, command_warnings = _run_gh_list(root, command, kind)
+        warnings.extend(command_warnings)
+        if result is None:
             continue
         if result.returncode != 0:
-            message = result.stderr.strip() or result.stdout.strip() or f"gh {kind} list failed"
-            warnings.append(message)
-            continue
+            if kind == "pr" and _gh_json_field_failure(result):
+                fallback_command = [*command[:-1], pr_fields]
+                fallback_result, fallback_warnings = _run_gh_list(root, fallback_command, kind)
+                warnings.extend(fallback_warnings)
+                if fallback_result is not None and fallback_result.returncode == 0:
+                    warnings.append(
+                        "GitHub PR review/check status fields unavailable from gh; "
+                        "loaded PRs without review/check status."
+                    )
+                    result = fallback_result
+                else:
+                    message = _gh_failure_message(fallback_result or result, kind)
+                    warnings.append(message)
+                    continue
+            else:
+                warnings.append(_gh_failure_message(result, kind))
+                continue
         try:
             payload = json.loads(result.stdout or "[]")
         except json.JSONDecodeError as exc:
@@ -2677,6 +2681,39 @@ def _github_threads(
     else:
         threads.sort(key=lambda item: (item.state != "open", item.kind != "issue", item.number))
     return threads[:_GIT_CONTEXT_LIMIT], warnings
+
+
+def _run_gh_list(
+    root: Path, command: list[str], kind: str
+) -> tuple[subprocess.CompletedProcess[str] | None, list[str]]:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return None, [f"Timed out after {_GIT_COMMAND_TIMEOUT_SECONDS}s running gh {kind} list."]
+    except OSError as exc:
+        return None, [f"Could not run gh {kind} list: {exc}"]
+    return result, []
+
+
+def _gh_failure_message(result: subprocess.CompletedProcess[str], kind: str) -> str:
+    return result.stderr.strip() or result.stdout.strip() or f"gh {kind} list failed"
+
+
+def _gh_json_field_failure(result: subprocess.CompletedProcess[str]) -> bool:
+    message = " ".join([result.stderr, result.stdout]).lower()
+    return (
+        "unknown field" in message
+        or "available fields" in message
+        or "unknown json field" in message
+        or "unknown json" in message
+    )
 
 
 def _git_thread_from_item(
@@ -2755,10 +2792,12 @@ def _summarize_status_check_rollup(value: object) -> tuple[str | None, str | Non
         rollup_state = "pending"
     elif counts["success"]:
         rollup_state = "success"
+    elif counts["skipped"] or counts["neutral"]:
+        rollup_state = "skipped"
     else:
         rollup_state = "unknown"
     pieces = []
-    for state in ("failure", "pending", "success", "unknown"):
+    for state in ("failure", "pending", "success", "skipped", "neutral", "unknown"):
         count = counts[state]
         if count:
             pieces.append(f"{count} {state}")
@@ -2768,8 +2807,12 @@ def _summarize_status_check_rollup(value: object) -> tuple[str | None, str | Non
 def _status_check_state(item: dict[str, object]) -> str | None:
     conclusion = str(item.get("conclusion") or "").strip().lower()
     status = str(item.get("status") or item.get("state") or "").strip().lower()
-    if conclusion in {"success", "skipped", "neutral"}:
+    if conclusion == "success":
         return "success"
+    if conclusion == "skipped":
+        return "skipped"
+    if conclusion == "neutral":
+        return "neutral"
     if conclusion in {"failure", "cancelled", "timed_out", "action_required"}:
         return "failure"
     if status in {"completed", "success"}:

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -521,6 +521,9 @@ class GitThreadBrief:
     summary: str
     relevance_score: int
     promoted: bool
+    review_decision: str | None = None
+    check_state: str | None = None
+    check_summary: str | None = None
     related_to: int | None = None
 
 
@@ -2610,7 +2613,7 @@ def _github_threads(
             "--limit",
             "30",
             "--json",
-            "number,title,url,body,state,isDraft,mergedAt,labels",
+            "number,title,url,body,state,isDraft,mergedAt,labels,reviewDecision,statusCheckRollup",
         ],
     ]
     kinds = ["issue", "pr"]
@@ -2694,6 +2697,17 @@ def _git_thread_from_item(
         medium_text=body,
     )
     summary = _one_line(body) or title
+    review_decision = None
+    check_state = None
+    check_summary = None
+    if kind == "pr":
+        review_decision = _normalize_review_decision(item.get("reviewDecision"))
+        check_state, check_summary = _summarize_status_check_rollup(item.get("statusCheckRollup"))
+        github_status_context = _github_status_context(
+            review_decision=review_decision, check_summary=check_summary
+        )
+        if github_status_context:
+            summary = f"{summary} GitHub status: {github_status_context}."
     promoted = _promote_git_thread(
         goal_tokens=goal_tokens,
         relevance_score=relevance_score,
@@ -2707,10 +2721,73 @@ def _git_thread_from_item(
         url=url,
         state=state,
         summary=summary,
+        review_decision=review_decision,
+        check_state=check_state,
+        check_summary=check_summary,
         relevance_score=relevance_score,
         promoted=promoted,
     )
     return thread, " ".join([title, body])
+
+
+def _normalize_review_decision(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower().replace("_", "-")
+    return normalized or None
+
+
+def _summarize_status_check_rollup(value: object) -> tuple[str | None, str | None]:
+    if not isinstance(value, list):
+        return None, None
+    counts: Counter[str] = Counter()
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        state = _status_check_state(item)
+        if state is not None:
+            counts[state] += 1
+    if not counts:
+        return None, None
+    if counts["failure"]:
+        rollup_state = "failure"
+    elif counts["pending"]:
+        rollup_state = "pending"
+    elif counts["success"]:
+        rollup_state = "success"
+    else:
+        rollup_state = "unknown"
+    pieces = []
+    for state in ("failure", "pending", "success", "unknown"):
+        count = counts[state]
+        if count:
+            pieces.append(f"{count} {state}")
+    return rollup_state, ", ".join(pieces)
+
+
+def _status_check_state(item: dict[str, object]) -> str | None:
+    conclusion = str(item.get("conclusion") or "").strip().lower()
+    status = str(item.get("status") or item.get("state") or "").strip().lower()
+    if conclusion in {"success", "skipped", "neutral"}:
+        return "success"
+    if conclusion in {"failure", "cancelled", "timed_out", "action_required"}:
+        return "failure"
+    if status in {"completed", "success"}:
+        return "success"
+    if status in {"queued", "pending", "in_progress", "requested", "waiting", "expected"}:
+        return "pending"
+    if status in {"failure", "failed", "error"}:
+        return "failure"
+    return "unknown" if conclusion or status else None
+
+
+def _github_status_context(*, review_decision: str | None, check_summary: str | None) -> str | None:
+    parts = []
+    if review_decision:
+        parts.append(f"review={review_decision}")
+    if check_summary:
+        parts.append(f"checks={check_summary}")
+    return "; ".join(parts) if parts else None
 
 
 def _fetch_referenced_open_issue_threads(

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -75,6 +75,45 @@ def _install_fake_gh(
     monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ.get('PATH', '')}")
 
 
+def _install_status_field_fallback_gh(tmp_path: Path, monkeypatch) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    script = bin_dir / "gh"
+    prs = [
+        {
+            "number": 42,
+            "title": "M20-P3.1 fallback GitHub handoff context",
+            "url": "https://github.com/example/project/pull/42",
+            "body": "Agent handoff should keep PR context when status fields are unavailable.",
+            "state": "open",
+            "isDraft": False,
+            "mergedAt": None,
+            "labels": [],
+        }
+    ]
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json\n"
+        "import sys\n"
+        f"prs = {prs!r}\n"
+        "if sys.argv[1:3] == ['issue', 'list']:\n"
+        "    print('[]')\n"
+        "elif sys.argv[1:3] == ['pr', 'list']:\n"
+        "    fields = sys.argv[sys.argv.index('--json') + 1]\n"
+        "    if 'reviewDecision' in fields or 'statusCheckRollup' in fields:\n"
+        "        message = 'Unknown JSON field: reviewDecision\\nAvailable fields: number,title'\n"
+        "        print(message, file=sys.stderr)\n"
+        "        sys.exit(1)\n"
+        "    print(json.dumps(prs))\n"
+        "else:\n"
+        "    print('unsupported fake gh call', file=sys.stderr)\n"
+        "    sys.exit(2)\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ.get('PATH', '')}")
+
+
 def _install_marker_gh(tmp_path: Path, monkeypatch, *, sleep_seconds: float = 0) -> Path:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(exist_ok=True)
@@ -4170,6 +4209,8 @@ def test_agent_context_includes_pr_review_and_check_status(
                 "statusCheckRollup": [
                     {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
                     {"name": "tests", "status": "IN_PROGRESS", "conclusion": None},
+                    {"name": "health", "status": "COMPLETED", "conclusion": "SKIPPED"},
+                    {"name": "coverage", "status": "COMPLETED", "conclusion": "NEUTRAL"},
                 ],
             }
         ],
@@ -4195,12 +4236,48 @@ def test_agent_context_includes_pr_review_and_check_status(
     assert thread["kind"] == "pr"
     assert thread["review_decision"] == "changes-requested"
     assert thread["check_state"] == "pending"
-    assert thread["check_summary"] == "1 pending, 1 success"
+    assert thread["check_summary"] == "1 pending, 1 success, 1 skipped, 1 neutral"
     assert "review=changes-requested" in thread["summary"]
-    assert "checks=1 pending, 1 success" in thread["summary"]
+    assert "checks=1 pending, 1 success, 1 skipped, 1 neutral" in thread["summary"]
     action = payload["work_context"]["actions"][0]
     assert action["category"] == "work-thread"
-    assert "checks=1 pending, 1 success" in action["reason"]
+    assert "checks=1 pending, 1 success, 1 skipped, 1 neutral" in action["reason"]
+
+
+def test_agent_context_falls_back_when_pr_status_fields_are_unavailable(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path, repo="example/project")
+    _commit_all(tmp_path, "Initial context")
+    _install_status_field_fallback_gh(tmp_path, monkeypatch)
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "M20-P3.1",
+            "GitHub",
+            "handoff",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    thread = payload["git_context"]["threads"][0]
+    assert thread["kind"] == "pr"
+    assert thread["number"] == 42
+    assert thread["review_decision"] is None
+    assert thread["check_state"] is None
+    assert thread["check_summary"] is None
+    assert any(
+        "review/check status fields unavailable" in warning
+        for warning in payload["git_context"]["warnings"]
+    )
 
 
 def test_agent_context_git_lookup_ignores_path_file_entries(

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -4146,6 +4146,63 @@ def test_agent_context_reports_gh_timeout_as_warning(tmp_path: Path, capsys, mon
     assert any("Timed out" in warning for warning in payload["git_context"]["warnings"])
 
 
+def test_agent_context_includes_pr_review_and_check_status(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    _init_git_repo(tmp_path, repo="example/project")
+    _commit_all(tmp_path, "Initial context")
+    _install_fake_gh(
+        tmp_path,
+        monkeypatch,
+        issues=[],
+        prs=[
+            {
+                "number": 42,
+                "title": "M20-P3.1 improve GitHub handoff context",
+                "url": "https://github.com/example/project/pull/42",
+                "body": "Agent handoff should expose review and CI status.",
+                "state": "open",
+                "isDraft": False,
+                "mergedAt": None,
+                "labels": [],
+                "reviewDecision": "CHANGES_REQUESTED",
+                "statusCheckRollup": [
+                    {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                    {"name": "tests", "status": "IN_PROGRESS", "conclusion": None},
+                ],
+            }
+        ],
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "--root",
+            str(tmp_path),
+            "brief",
+            "--agent-context",
+            "M20-P3.1",
+            "GitHub",
+            "handoff",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    thread = payload["git_context"]["threads"][0]
+    assert thread["kind"] == "pr"
+    assert thread["review_decision"] == "changes-requested"
+    assert thread["check_state"] == "pending"
+    assert thread["check_summary"] == "1 pending, 1 success"
+    assert "review=changes-requested" in thread["summary"]
+    assert "checks=1 pending, 1 success" in thread["summary"]
+    action = payload["work_context"]["actions"][0]
+    assert action["category"] == "work-thread"
+    assert "checks=1 pending, 1 success" in action["reason"]
+
+
 def test_agent_context_git_lookup_ignores_path_file_entries(
     tmp_path: Path, capsys, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary
- closes #188
- extends best-effort GitHub PR handoff context with normalized review-decision and status-check rollup fields
- appends the compact review/check status to existing PR work-thread summaries so `brief --agent-context` and `suggest-next` surface it without a new platform layer
- advances synchronized planning state from `M20-P1.6` to `M20-P3.1` and points the next slice to `M20-P4.0`

## Why
`M20-P3.1` is the first narrow slice for richer GitHub issue, PR, review-thread, and CI integrations after the current-work authority correction. This keeps GitHub optional and local-first while making PR handoff status more useful when `gh` is available.

## Validation
- `uv run pytest tests/test_wiki_commands.py -k "agent_context_includes_pr_review_and_check_status or agent_context_reports_gh_timeout_as_warning or agent_context_explicit_since_empty_range_does_not_fallback_to_head"`
- `uv run pytest tests/test_wiki_commands.py -k "agent_context_includes_pr_review_and_check_status or referenced_issue_fetch_warning_includes_failed_view"`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run pytest`
- `uv run splendor brief --agent-context "M20-P3.1 GitHub handoff" --json`

## Boundaries
- no hosted services, databases, background workers, auth changes, or mandatory external APIs
- no mutating web workflow changes
- no query answer synthesis
- no broad GitHub ingestion or automation platform work