### PR TITLE
M20-P4.0: Define operator cockpit contract

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P1.6`
-- Last action taken: `M20-P1.6` merged to main via PR #187 with the current-work authority
-  classification layer for hocr retry handoff acceptance.
-- Current planned slice: `M20 richer GitHub issue, PR, review-thread, and CI integrations (#188)`
-- Current PR sub-slice: `M20-P3.1`
+- Previous completed PR sub-slice: `M20-P3.1`
+- Last action taken: `M20-P3.1` merged to main via PR #189 with richer GitHub handoff status
+  signals for issue, PR, review-thread, and CI context.
+- Current planned slice: `M20 human operator cockpit and wiki navigation design/spec/architecture contract (#190)`
+- Current PR sub-slice: `M20-P4.0`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 human operator cockpit and wiki navigation design/spec/architecture contract`
-- Next planned PR sub-slice: `M20-P4.0`
+- Next planned slice: `M20 first read-only cockpit home read model`
+- Next planned PR sub-slice: `M20-P4.2`
 - Current blockers: none
 
 ## Planning Notation
@@ -521,5 +521,9 @@
 - `M20-P1.2` Retrieval evaluation and handoff retry fixtures
 - `M20-P1.3` v0.5.1 retry findings and current-work handoff plan
 - `M20-P1.4` Current-work handoff ranking from planning authority
+- `M20-P1.5` v0.5.2 retry findings and current-work authority-model design
+- `M20-P1.6` Current-work authority classification and hocr retry acceptance coverage
 - `M20-P2.1` Mutating web review workflows
 - `M20-P3.1` Richer GitHub issue, PR, review-thread, and CI integrations
+- `M20-P4.0` Human operator cockpit and wiki navigation design/spec/architecture contract
+- `M20-P4.1` Human-first page detail layout and deterministic project identity

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ non-draft GitHub PR with labels, milestone, and a clear description.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P1.6`
-- Current planned slice: `M20 richer GitHub issue, PR, review-thread, and CI integrations (#188)`
-- Current PR sub-slice: `M20-P3.1`
+- Previous completed PR sub-slice: `M20-P3.1`
+- Current planned slice: `M20 human operator cockpit and wiki navigation design/spec/architecture contract (#190)`
+- Current PR sub-slice: `M20-P4.0`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 human operator cockpit and wiki navigation design/spec/architecture contract`
-- Next planned PR sub-slice: `M20-P4.0`
+- Next planned slice: `M20 first read-only cockpit home read model`
+- Next planned PR sub-slice: `M20-P4.2`
 
 These planning-state lines are for contributors and agents. The detailed roadmap lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md).

--- a/docs/human_operator_cockpit.md
+++ b/docs/human_operator_cockpit.md
@@ -1,6 +1,6 @@
 # Human Operator Cockpit And Wiki Navigation
 
-Status: design/specification contract for `M20-P4.0`.
+Status: design/specification contract for `M20-P4.0` / issue #190.
 
 This document defines the human-operator web/wiki product track derived from the May 2026
 SynthBanshee dogfood critique and the Gemini Pro, ChatGPT Pro, and Claude Opus review round
@@ -144,6 +144,29 @@ Required conceptual panes:
 
 Each pane needs a sparse-workspace empty state. A new workspace should look quiet and actionable,
 not broken.
+
+## Route-Level Contract
+
+The operator cockpit track should evolve existing read-only routes before adding new concepts. The
+first implementation of each route may be modest, but the information hierarchy should be clear.
+
+| Route | Primary operator question | Required contract |
+| --- | --- | --- |
+| `/` | What is this project and what should I inspect? | Render project identity, roadmap snapshot, attention summary, recent durable activity, knowledge-map summary, and deterministic inspect-next links before raw counts. |
+| `/documents/*` | What does this wiki page say and why should I trust it? | Render badges and readable markdown before full metadata; show relationship/provenance links when present; keep raw metadata accessible as technical detail. |
+| `/browse` | What knowledge exists here? | Group pages by human meaning such as maintained pages, generated source summaries, review state, tags, or related clusters before large flat inventories. |
+| `/search` | Which existing pages match this question? | Keep deterministic local search, but render result kinds, review states, source-backed context, and relationship hints where available instead of making title/path matches the whole experience. |
+| `/planning` | Where are we in the work? | Present active/current, next, blocked/gated, open decisions, open questions, recently completed, and historical lanes while preserving raw record access. |
+| `/status` | Is the knowledge workspace healthy? | Lead with healthy versus needs-attention interpretation, affected artifacts, and CLI hints; keep raw counts and diagnostics available. |
+| `/runs` | What happened recently in local execution? | Prioritize failed or relevant runs, affected sources/pages, and human explanations before run IDs and payload-like details. |
+| `/queue` | What work is pending, stuck, or failed? | Prioritize pending, retry-scheduled, failed, dead-letter, or stale-lease records with evidence and CLI hints; keep raw queue records visible. |
+| `/sources/*` | What source produced or changed this knowledge? | Show source title/path, source state, linked source-summary page, latest run, provenance, and affected synthesis suggestions before manifest internals. |
+| Future `/attention` | What needs inspection now? | Promote the shared attention read model once `/` and `/status` prove enough item types to justify a dedicated route. |
+| Future `/recent` | What changed or was learned recently? | Render `wiki/log.md` and durable run/page/planning timestamps without per-user last-seen state or filesystem mtime dependence. |
+
+Route implementations should share read models where the same judgment appears in more than one
+place. For example, "current work" should come from the current-work authority layer, and attention
+items should not be reclassified differently on `/`, `/status`, and a future `/attention` route.
 
 ## Page Detail Contract
 
@@ -326,6 +349,23 @@ Recommended test classes:
 - planning lane assignment tests;
 - attention item tests for contested, failed, blocked, and review-needed records;
 - relationship/backlink tests when those surfaces are implemented.
+
+## Acceptance Criteria For `M20-P4.0`
+
+This design slice is complete when:
+
+- the product contract names the human operator cockpit as a read-only comprehension layer;
+- the route-level contracts above cover the existing local web surfaces and likely future
+  `/attention` and `/recent` routes;
+- the architecture contract requires pure deterministic read models over local files;
+- project identity, page detail layout, planning lanes, attention items, recent activity,
+  relationship navigation, and raw audit access have explicit expectations;
+- non-goals reject runtime UI mutation, hidden caches, databases, background workers, hosted
+  services, and mandatory external APIs for this track;
+- the roadmap sequence points follow-up implementation at the next cockpit slice instead of
+  displacing remaining P3 polish work;
+- synchronized planning state in `.agent-plan.md`, `README.md`, and the roadmap identifies
+  `M20-P4.0` as the current PR sub-slice and `M20-P4.2` as the next cockpit implementation slice.
 
 ## Non-Goals
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P1.6`
-- Current planned slice: `M20 richer GitHub issue, PR, review-thread, and CI integrations (#188)`
-- Current PR sub-slice: `M20-P3.1`
+- Previous completed PR sub-slice: `M20-P3.1`
+- Current planned slice: `M20 human operator cockpit and wiki navigation design/spec/architecture contract (#190)`
+- Current PR sub-slice: `M20-P4.0`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 human operator cockpit and wiki navigation design/spec/architecture contract`
-- Next planned PR sub-slice: `M20-P4.0`
+- Next planned slice: `M20 first read-only cockpit home read model`
+- Next planned PR sub-slice: `M20-P4.2`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1480,7 +1480,7 @@ and status-check rollup fields plus a compact summary in the existing work-threa
 does not add hosted services, background workers, databases, auth complexity, mandatory external
 APIs, mutating web workflows, broad GitHub ingestion, or query answer synthesis.
 
-`M20-P4.0` is a docs/design-first slice for the human operator cockpit and wiki navigation track.
+`M20-P4.0` (#190) is a docs/design-first slice for the human operator cockpit and wiki navigation track.
 It records the external review feedback that the local web UI currently exposes state without
 constructing human meaning, then defines the additive design contract in
 `docs/human_operator_cockpit.md`. The track keeps the CLI as the deterministic operating surface,


### PR DESCRIPTION
## Summary
- closes #190
- formalizes the M20-P4.0 human operator cockpit and wiki navigation contract in docs/human_operator_cockpit.md
- adds route-level expectations and acceptance criteria for the read-only operator comprehension track
- advances synchronized planning state from M20-P3.1 to M20-P4.0 and points the next cockpit implementation slice at M20-P4.2

## Design boundaries
- docs/design-first only; no runtime web UI code changes
- preserves CLI-first and local-first semantics
- keeps operator views read-only and derived from deterministic local filesystem state
- explicitly rejects hidden caches, databases, background workers, hosted services, mandatory external APIs, and browser mutation for this track

## Validation
- uv run ruff format --check .
- uv run ruff check .
- uv run splendor lint
- uv run pytest

## Follow-up
- M20-P4.2 should implement the first read-only cockpit home read model.
- Remaining Milestone 20 P3 polish issues #160-#163 stay separate and should not displace the cockpit track.