### PR TITLE
M20-P4.2: Add cockpit home read model

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P3.1`
-- Last action taken: `M20-P3.1` merged to main via PR #189 with richer GitHub handoff status
-  signals for issue, PR, review-thread, and CI context.
-- Current planned slice: `M20 human operator cockpit and wiki navigation design/spec/architecture contract (#190)`
-- Current PR sub-slice: `M20-P4.0`
+- Previous completed PR sub-slice: `M20-P4.0`
+- Last action taken: `M20-P4.0` merged to main via PR #191 with the human operator cockpit
+  design/spec/architecture contract.
+- Current planned slice: `M20 first read-only cockpit home read model (#192)`
+- Current PR sub-slice: `M20-P4.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 first read-only cockpit home read model`
-- Next planned PR sub-slice: `M20-P4.2`
+- Next planned slice: `M20 planning roadmap view`
+- Next planned PR sub-slice: `M20-P4.3`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ non-draft GitHub PR with labels, milestone, and a clear description.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P3.1`
-- Current planned slice: `M20 human operator cockpit and wiki navigation design/spec/architecture contract (#190)`
-- Current PR sub-slice: `M20-P4.0`
+- Previous completed PR sub-slice: `M20-P4.0`
+- Current planned slice: `M20 first read-only cockpit home read model (#192)`
+- Current PR sub-slice: `M20-P4.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 first read-only cockpit home read model`
-- Next planned PR sub-slice: `M20-P4.2`
+- Next planned slice: `M20 planning roadmap view`
+- Next planned PR sub-slice: `M20-P4.3`
 
 These planning-state lines are for contributors and agents. The detailed roadmap lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md).

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P3.1`
-- Current planned slice: `M20 human operator cockpit and wiki navigation design/spec/architecture contract (#190)`
-- Current PR sub-slice: `M20-P4.0`
+- Previous completed PR sub-slice: `M20-P4.0`
+- Current planned slice: `M20 first read-only cockpit home read model (#192)`
+- Current PR sub-slice: `M20-P4.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 first read-only cockpit home read model`
-- Next planned PR sub-slice: `M20-P4.2`
+- Next planned slice: `M20 planning roadmap view`
+- Next planned PR sub-slice: `M20-P4.3`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1495,7 +1495,15 @@ makes the target project primary in page chrome; renders compact human page badg
 markdown; and moves full parsed metadata into a collapsed technical section. The cockpit home read
 model, planning roadmap lanes, attention and recent routes, backlinks, browser mutation, config
 schema expansion, databases, background workers, hosted services, and external APIs remain deferred.
-The next cockpit-track implementation follow-up remains `M20-P4.2`.
+
+`M20-P4.2` (#192) implements the first cockpit home read model for `/`. The root route is now
+driven by a pure request-time read model over local files and leads with project orientation,
+planning-status fallback panes, knowledge-map summary, recent durable activity, and deterministic
+inspect-next links before raw counts. It remains intentionally modest: no mutating web workflows,
+databases, background workers, hosted services, mandatory external APIs, broad GitHub integration,
+or query answer synthesis are introduced. Planning roadmap lanes, deeper attention and health
+interpretation, backlinks, and recent-insight/log rendering remain staged behind this first home
+read model. The next cockpit-track implementation follow-up is `M20-P4.3`.
 
 ---
 

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -137,6 +137,29 @@ class _RunSummary:
     record: RunRecord
 
 
+@dataclass(frozen=True)
+class _CockpitLink:
+    title: str
+    href: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class _CockpitSection:
+    title: str
+    items: list[_CockpitLink]
+    empty: str
+
+
+@dataclass(frozen=True)
+class _CockpitHomeReadModel:
+    counts: _WorkspaceCounts
+    roadmap: list[_CockpitSection]
+    knowledge: list[_CockpitLink]
+    recent_activity: list[_CockpitLink]
+    inspect_next: list[_CockpitLink]
+
+
 class WebLayoutError(ValueError):
     """Raised when configured web document roots are unsafe to serve."""
 
@@ -174,9 +197,8 @@ def create_app(root: Path) -> FastAPI:
     @app.get("/", response_class=HTMLResponse)
     def home() -> HTMLResponse:
         layout = _layout_for(workspace_root)
-        content_documents = _iter_content_documents(workspace_root, layout)
-        counts = _workspace_counts(layout, content_documents=content_documents)
-        empty_state = _empty_workspace_panel() if counts.is_sparse else ""
+        read_model = _build_cockpit_home_read_model(workspace_root, layout)
+        empty_state = _empty_workspace_panel() if read_model.counts.is_sparse else ""
         body = (
             '<section class="toolbar">'
             '<form action="/search" method="get">'
@@ -190,12 +212,24 @@ def create_app(root: Path) -> FastAPI:
             '<a class="button secondary" href="/status">Status</a>'
             "</section>"
             f"{empty_state}"
+            '<section class="cockpit-grid">'
+            f"{_cockpit_section(read_model.roadmap[0])}"
+            f"{_cockpit_section(read_model.roadmap[1])}"
+            f"{_cockpit_section(read_model.roadmap[2])}"
+            f"{_cockpit_section(read_model.roadmap[3])}"
+            "</section>"
+            '<section class="cockpit-grid">'
+            f"{_cockpit_secondary_sections(read_model)}"
+            "</section>"
+            "<h2>Raw workspace counts</h2>"
             '<section class="stats">'
-            f"<div><strong>{counts.wiki_content_pages}</strong>"
+            f"<div><strong>{read_model.counts.wiki_content_pages}</strong>"
             "<span>Wiki content pages</span></div>"
-            f"<div><strong>{counts.planning_records}</strong><span>Planning records</span></div>"
-            f"<div><strong>{counts.source_manifests}</strong><span>Source manifests</span></div>"
-            f"<div><strong>{counts.runs}</strong><span>Runs</span></div>"
+            f"<div><strong>{read_model.counts.planning_records}</strong>"
+            "<span>Planning records</span></div>"
+            f"<div><strong>{read_model.counts.source_manifests}</strong>"
+            "<span>Source manifests</span></div>"
+            f"<div><strong>{read_model.counts.runs}</strong><span>Runs</span></div>"
             "</section>"
         )
         return _page("Home", body, root=workspace_root, layout=layout)
@@ -602,6 +636,275 @@ def _workspace_counts(
             1 for path in layout.source_records_dir.glob("*.json") if path.is_file()
         ),
         runs=sum(1 for path in layout.runs_dir.glob("*.json") if path.is_file()),
+    )
+
+
+def _build_cockpit_home_read_model(root: Path, layout: ResolvedLayout) -> _CockpitHomeReadModel:
+    content_documents = _iter_content_documents(root, layout)
+    counts = _workspace_counts(layout, content_documents=content_documents)
+    planning_documents = [
+        document for document in content_documents if document.document_class == "planning"
+    ]
+    wiki_documents = [
+        document for document in content_documents if document.document_class == "wiki"
+    ]
+    return _CockpitHomeReadModel(
+        counts=counts,
+        roadmap=_cockpit_roadmap_sections(planning_documents),
+        knowledge=_cockpit_knowledge_summary(layout, wiki_documents),
+        recent_activity=_cockpit_recent_activity(root, layout),
+        inspect_next=_cockpit_inspect_next(counts, planning_documents, wiki_documents),
+    )
+
+
+def _cockpit_roadmap_sections(planning_documents: list[_DocumentSummary]) -> list[_CockpitSection]:
+    current = _planning_links(
+        planning_documents,
+        statuses={"in_progress", "active"},
+        limit=4,
+    )
+    next_work = _planning_links(
+        planning_documents,
+        statuses={"todo", "planned"},
+        limit=4,
+    )
+    attention = _planning_links(
+        planning_documents,
+        statuses={"blocked", "proposed", "open"},
+        limit=4,
+    )
+    completed = _planning_links(
+        planning_documents,
+        statuses={"done", "completed", "accepted", "answered"},
+        limit=3,
+    )
+    return [
+        _CockpitSection(
+            title="Current work",
+            items=current,
+            empty="No active task or milestone records found.",
+        ),
+        _CockpitSection(
+            title="Next planned work",
+            items=next_work,
+            empty="No todo or planned records found.",
+        ),
+        _CockpitSection(
+            title="Needs attention",
+            items=attention,
+            empty="No blocked tasks, proposed decisions, or open questions found.",
+        ),
+        _CockpitSection(
+            title="Recently completed",
+            items=completed,
+            empty="No completed planning records found.",
+        ),
+    ]
+
+
+def _planning_links(
+    planning_documents: list[_DocumentSummary], *, statuses: set[str], limit: int
+) -> list[_CockpitLink]:
+    links = [
+        _CockpitLink(
+            title=document.title,
+            href=f"/documents/{quote(document.path, safe='/')}",
+            detail=f"{document.kind or 'planning'} · {document.status or '-'}",
+        )
+        for document in planning_documents
+        if document.status in statuses
+    ]
+    return sorted(links, key=lambda item: (item.detail, item.title, item.href))[:limit]
+
+
+def _cockpit_knowledge_summary(
+    layout: ResolvedLayout, wiki_documents: list[_DocumentSummary]
+) -> list[_CockpitLink]:
+    maintained_pages = sum(
+        1 for document in wiki_documents if not document.path.startswith("wiki/sources/")
+    )
+    source_summary_pages = sum(
+        1 for document in wiki_documents if document.path.startswith("wiki/sources/")
+    )
+    review_needed = sum(1 for document in wiki_documents if document.status == "review_needed")
+    source_manifest_count = sum(
+        1 for path in layout.source_records_dir.glob("*.json") if path.is_file()
+    )
+    items = [
+        _CockpitLink(
+            title=f"{maintained_pages} maintained wiki pages",
+            href="/browse",
+            detail="Human-curated or synthesis pages outside generated source summaries.",
+        ),
+        _CockpitLink(
+            title=f"{source_summary_pages} generated source summaries",
+            href="/browse",
+            detail="Pages under the configured source-summary wiki root.",
+        ),
+        _CockpitLink(
+            title=f"{source_manifest_count} source manifests",
+            href="/status",
+            detail="Curated machine-readable source records.",
+        ),
+    ]
+    if review_needed:
+        items.append(
+            _CockpitLink(
+                title=f"{review_needed} wiki pages need review",
+                href="/browse",
+                detail="Review state is visible in document rows and page badges.",
+            )
+        )
+    return items
+
+
+def _cockpit_recent_activity(root: Path, layout: ResolvedLayout) -> list[_CockpitLink]:
+    items: list[_CockpitLink] = []
+    try:
+        for run in _run_records(root, layout)[:3]:
+            record = run.record
+            finished = record.finished_at or record.started_at
+            items.append(
+                _CockpitLink(
+                    title=f"{record.status} run {record.run_id}",
+                    href="/runs",
+                    detail=f"{finished} · {len(record.page_refs)} pages",
+                )
+            )
+    except (ValueError, ValidationError):
+        items.append(
+            _CockpitLink(
+                title="Run records need inspection",
+                href="/runs",
+                detail="At least one durable run record could not be parsed.",
+            )
+        )
+    items.extend(_cockpit_log_entries(layout, limit=max(0, 3 - len(items))))
+    return items[:3]
+
+
+def _cockpit_log_entries(layout: ResolvedLayout, *, limit: int) -> list[_CockpitLink]:
+    if limit <= 0 or not layout.log_file.is_file():
+        return []
+    entries: list[_CockpitLink] = []
+    try:
+        with layout.log_file.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if not stripped.startswith("- "):
+                    continue
+                entry = stripped.removeprefix("- ").strip()
+                if not entry:
+                    continue
+                log_path = layout.log_file.relative_to(layout.root).as_posix()
+                entries.append(
+                    _CockpitLink(
+                        title=entry,
+                        href=f"/documents/{quote(log_path, safe='/')}",
+                        detail="wiki/log.md",
+                    )
+                )
+                if len(entries) >= limit:
+                    break
+    except OSError:
+        return []
+    return entries
+
+
+def _cockpit_inspect_next(
+    counts: _WorkspaceCounts,
+    planning_documents: list[_DocumentSummary],
+    wiki_documents: list[_DocumentSummary],
+) -> list[_CockpitLink]:
+    links: list[_CockpitLink] = []
+    attention = _planning_links(
+        planning_documents,
+        statuses={"blocked", "proposed", "open"},
+        limit=1,
+    )
+    current = _planning_links(
+        planning_documents,
+        statuses={"in_progress", "active"},
+        limit=1,
+    )
+    if attention:
+        links.append(attention[0])
+    if current:
+        links.append(current[0])
+    if wiki_documents:
+        links.append(
+            _CockpitLink(
+                title="Browse knowledge records",
+                href="/browse",
+                detail=f"{counts.wiki_content_pages} wiki pages available.",
+            )
+        )
+    if counts.source_manifests or counts.runs:
+        links.append(
+            _CockpitLink(
+                title="Inspect workspace status",
+                href="/status",
+                detail="Sources, review state, queue, and recent runs.",
+            )
+        )
+    if not links:
+        links.append(
+            _CockpitLink(
+                title="Seed deterministic workspace knowledge",
+                href="/browse",
+                detail="Start with repo refresh or add-source, then return here.",
+            )
+        )
+    return _dedupe_cockpit_links(links)[:4]
+
+
+def _dedupe_cockpit_links(links: list[_CockpitLink]) -> list[_CockpitLink]:
+    seen: set[tuple[str, str]] = set()
+    result: list[_CockpitLink] = []
+    for link in links:
+        key = (link.title, link.href)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(link)
+    return result
+
+
+def _cockpit_section(section: _CockpitSection) -> str:
+    items = "".join(_cockpit_link_item(item) for item in section.items)
+    if not items:
+        items = f'<li class="empty">{html.escape(section.empty)}</li>'
+    return (
+        '<section class="cockpit-panel">'
+        f"<h2>{html.escape(section.title)}</h2>"
+        f"<ul>{items}</ul>"
+        "</section>"
+    )
+
+
+def _cockpit_secondary_sections(read_model: _CockpitHomeReadModel) -> str:
+    sections = [
+        _CockpitSection(
+            "Knowledge map summary",
+            read_model.knowledge,
+            "No knowledge records yet.",
+        ),
+        _CockpitSection(
+            "Recent durable activity",
+            read_model.recent_activity,
+            "No durable activity beyond workspace initialization yet.",
+        ),
+        _CockpitSection("Inspect next", read_model.inspect_next, "No inspection links yet."),
+    ]
+    return "".join(_cockpit_section(section) for section in sections)
+
+
+def _cockpit_link_item(item: _CockpitLink) -> str:
+    return (
+        "<li>"
+        f'<a href="{html.escape(item.href)}">{html.escape(item.title)}</a>'
+        f"<span>{html.escape(item.detail)}</span>"
+        "</li>"
     )
 
 
@@ -1306,6 +1609,13 @@ def _page(
         "button,.button{border:1px solid var(--accent);border-radius:6px;background:var(--accent);"
         "color:white;padding:9px 12px;font:inherit;cursor:pointer}"
         ".button.secondary{background:white;color:var(--accent)}"
+        ".cockpit-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));"
+        "gap:14px;margin:0 0 24px}"
+        ".cockpit-panel{border:1px solid var(--border);border-radius:8px;padding:14px}"
+        ".cockpit-panel ul{list-style:none;margin:10px 0 0;padding:0}"
+        ".cockpit-panel li{border-top:1px solid var(--border);padding:9px 0}"
+        ".cockpit-panel li:first-child{border-top:0;padding-top:0}"
+        ".cockpit-panel a{font-weight:600}.cockpit-panel span{display:block;color:var(--muted)}"
         ".stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px}"
         ".stats div,.metadata,.result,.empty-state{border:1px solid var(--border);"
         "border-radius:8px;"

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -70,6 +70,7 @@ _IDENTITY_LINE_LIMIT = 80
 _IDENTITY_CHAR_LIMIT = 32 * 1024
 _GENERIC_INDEX_TITLE = "Splendor Wiki Index"
 _GENERIC_INDEX_SUMMARY = "This wiki is maintained by Splendor."
+_REVIEW_NEEDED_STATES = {"draft", "machine-generated", "contested", "stale"}
 
 
 @dataclass(frozen=True)
@@ -79,6 +80,7 @@ class _DocumentSummary:
     document_class: str
     kind: str | None
     status: str | None
+    review_state: str | None
 
 
 @dataclass(frozen=True)
@@ -213,10 +215,7 @@ def create_app(root: Path) -> FastAPI:
             "</section>"
             f"{empty_state}"
             '<section class="cockpit-grid">'
-            f"{_cockpit_section(read_model.roadmap[0])}"
-            f"{_cockpit_section(read_model.roadmap[1])}"
-            f"{_cockpit_section(read_model.roadmap[2])}"
-            f"{_cockpit_section(read_model.roadmap[3])}"
+            f"{_cockpit_sections(read_model.roadmap)}"
             "</section>"
             '<section class="cockpit-grid">'
             f"{_cockpit_secondary_sections(read_model)}"
@@ -726,7 +725,9 @@ def _cockpit_knowledge_summary(
     source_summary_pages = sum(
         1 for document in wiki_documents if document.path.startswith("wiki/sources/")
     )
-    review_needed = sum(1 for document in wiki_documents if document.status == "review_needed")
+    review_needed = sum(
+        1 for document in wiki_documents if document.review_state in _REVIEW_NEEDED_STATES
+    )
     source_manifest_count = sum(
         1 for path in layout.source_records_dir.glob("*.json") if path.is_file()
     )
@@ -804,11 +805,9 @@ def _cockpit_log_entries(layout: ResolvedLayout, *, limit: int) -> list[_Cockpit
                         detail="wiki/log.md",
                     )
                 )
-                if len(entries) >= limit:
-                    break
     except OSError:
         return []
-    return entries
+    return list(reversed(entries[-limit:]))
 
 
 def _cockpit_inspect_next(
@@ -880,6 +879,10 @@ def _cockpit_section(section: _CockpitSection) -> str:
         f"<ul>{items}</ul>"
         "</section>"
     )
+
+
+def _cockpit_sections(sections: list[_CockpitSection]) -> str:
+    return "".join(_cockpit_section(section) for section in sections)
 
 
 def _cockpit_secondary_sections(read_model: _CockpitHomeReadModel) -> str:
@@ -1168,6 +1171,7 @@ def _document_summary(root: Path, layout: ResolvedLayout, path: Path) -> _Docume
         document_class=document_class,
         kind=metadata.get("kind") or default_kind,
         status=metadata.get("status"),
+        review_state=metadata.get("review_state"),
     )
 
 
@@ -1192,6 +1196,7 @@ def _read_listing_metadata(path: Path) -> dict[str, str | None]:
         "title": _frontmatter_string(frontmatter, "title") or heading,
         "kind": _frontmatter_string(frontmatter, "kind"),
         "status": _frontmatter_string(frontmatter, "status"),
+        "review_state": _frontmatter_string(frontmatter, "review_state"),
     }
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -150,6 +150,99 @@ def test_project_identity_reads_only_bounded_markdown(tmp_path: Path, monkeypatc
     assert identity == web._ProjectIdentity(name="Bounded Project", summary="Short summary.")
 
 
+def test_home_page_renders_cockpit_read_model(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    write_wiki_page(
+        tmp_path / "wiki" / "concepts" / "operator-cockpit.md",
+        title="Operator cockpit",
+        page_id="concept-operator-cockpit",
+        body="# Operator cockpit\n",
+    )
+    write_wiki_page(
+        tmp_path / "wiki" / "sources" / "src-web.md",
+        title="Source web",
+        page_id="source-src-web",
+        body="# Source web\n",
+    )
+    create_milestone(
+        tmp_path,
+        "Cockpit rollout",
+        record_id="milestone-cockpit",
+        status="active",
+        target_date=None,
+        task_refs=["task-home-read-model"],
+        decision_refs=["decision-home-scope"],
+        question_refs=["question-cockpit-cli"],
+    )
+    create_task(
+        tmp_path,
+        "Build home read model",
+        record_id="task-home-read-model",
+        status="in_progress",
+        priority="high",
+        owner="codex",
+        milestone_refs=["milestone-cockpit"],
+        decision_refs=["decision-home-scope"],
+        question_refs=["question-cockpit-cli"],
+        depends_on=[],
+        source_refs=[],
+    )
+    create_decision(
+        tmp_path,
+        "Keep home read only",
+        record_id="decision-home-scope",
+        status="proposed",
+        decided_at=None,
+        supersedes=[],
+        source_refs=[],
+        related_tasks=["task-home-read-model"],
+        related_questions=["question-cockpit-cli"],
+    )
+    create_question(
+        tmp_path,
+        "Should cockpit summary be a CLI command",
+        record_id="question-cockpit-cli",
+        status="open",
+        source_refs=[],
+        related_tasks=["task-home-read-model"],
+        related_decisions=["decision-home-scope"],
+    )
+    write_run_record(
+        layout.runs_dir / "run-home.json",
+        RunRecord(
+            run_id="run-home",
+            job_id="ingest-src-web",
+            job_type="ingest_source",
+            started_at="2026-05-01T10:01:00+00:00",
+            finished_at="2026-05-01T10:02:00+00:00",
+            status="succeeded",
+            input_refs=["state/manifests/sources/src-web.json"],
+            output_refs=["wiki/sources/src-web.md"],
+            pipeline_version="test",
+            source_ids=["src-web"],
+            page_refs=["wiki/sources/src-web.md"],
+        ),
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "Current work" in response.text
+    assert "Build home read model" in response.text
+    assert 'href="/documents/planning/tasks/task-home-read-model.md"' in response.text
+    assert "Needs attention" in response.text
+    assert "Keep home read only" in response.text
+    assert "Knowledge map summary" in response.text
+    assert "1 maintained wiki pages" in response.text
+    assert "1 generated source summaries" in response.text
+    assert "Recent durable activity" in response.text
+    assert "succeeded run run-home" in response.text
+    assert "Inspect next" in response.text
+    assert "Raw workspace counts" in response.text
+
+
 def test_browse_page_lists_wiki_and_planning_documents(tmp_path: Path) -> None:
     initialize_workspace(tmp_path)
     write_wiki_page(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -165,6 +165,13 @@ def test_home_page_renders_cockpit_read_model(tmp_path: Path) -> None:
         page_id="source-src-web",
         body="# Source web\n",
     )
+    (tmp_path / "wiki" / "log.md").write_text(
+        "# Splendor Wiki Log\n\n"
+        "## Timeline\n\n"
+        "- Initialized Splendor workspace.\n"
+        "- Added cockpit read model evidence.\n",
+        encoding="utf-8",
+    )
     create_milestone(
         tmp_path,
         "Cockpit rollout",
@@ -237,8 +244,10 @@ def test_home_page_renders_cockpit_read_model(tmp_path: Path) -> None:
     assert "Knowledge map summary" in response.text
     assert "1 maintained wiki pages" in response.text
     assert "1 generated source summaries" in response.text
+    assert "2 wiki pages need review" in response.text
     assert "Recent durable activity" in response.text
     assert "succeeded run run-home" in response.text
+    assert "Added cockpit read model evidence." in response.text
     assert "Inspect next" in response.text
     assert "Raw workspace counts" in response.text
 
@@ -341,6 +350,7 @@ def test_listing_metadata_stops_after_frontmatter_title(tmp_path: Path) -> None:
         "title": "Bounded listing",
         "kind": "concept",
         "status": "active",
+        "review_state": None,
     }
 
 


### PR DESCRIPTION
## Summary
- replaces the root web page count-first dashboard with a pure read-only cockpit home read model
- adds roadmap fallback panes, knowledge-map summary, recent durable activity, inspect-next links, and demoted raw counts
- advances synchronized planning state from M20-P4.0 to M20-P4.2 and records M20-P4.3 as the next cockpit slice

## Scope boundaries
- no mutating web workflows
- no databases, background workers, hosted auth, or external API requirements
- no broad GitHub integration or query answer synthesis

## Validation
- uv run ruff format --check .
- uv run ruff check .
- uv run splendor lint
- uv run pytest

Closes #192
