### PR TITLE
M20-P4.3: Add planning roadmap view

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,14 +3,14 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P4.0`
-- Last action taken: `M20-P4.0` merged to main via PR #191 with the human operator cockpit
-  design/spec/architecture contract.
-- Current planned slice: `M20 first read-only cockpit home read model (#192)`
-- Current PR sub-slice: `M20-P4.2`
+- Previous completed PR sub-slice: `M20-P4.2`
+- Last action taken: `M20-P4.2` merged to main via PR #193 with the first read-only cockpit home
+  read model.
+- Current planned slice: `M20 planning roadmap view (#194)`
+- Current PR sub-slice: `M20-P4.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 planning roadmap view`
-- Next planned PR sub-slice: `M20-P4.3`
+- Next planned slice: `M20 attention and health interpretation`
+- Next planned PR sub-slice: `M20-P4.4`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ non-draft GitHub PR with labels, milestone, and a clear description.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P4.0`
-- Current planned slice: `M20 first read-only cockpit home read model (#192)`
-- Current PR sub-slice: `M20-P4.2`
+- Previous completed PR sub-slice: `M20-P4.2`
+- Current planned slice: `M20 planning roadmap view (#194)`
+- Current PR sub-slice: `M20-P4.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 planning roadmap view`
-- Next planned PR sub-slice: `M20-P4.3`
+- Next planned slice: `M20 attention and health interpretation`
+- Next planned PR sub-slice: `M20-P4.4`
 
 These planning-state lines are for contributors and agents. The detailed roadmap lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md).

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P4.0`
-- Current planned slice: `M20 first read-only cockpit home read model (#192)`
-- Current PR sub-slice: `M20-P4.2`
+- Previous completed PR sub-slice: `M20-P4.2`
+- Current planned slice: `M20 planning roadmap view (#194)`
+- Current PR sub-slice: `M20-P4.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 planning roadmap view`
-- Next planned PR sub-slice: `M20-P4.3`
+- Next planned slice: `M20 attention and health interpretation`
+- Next planned PR sub-slice: `M20-P4.4`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1504,6 +1504,14 @@ databases, background workers, hosted services, mandatory external APIs, broad G
 or query answer synthesis are introduced. Planning roadmap lanes, deeper attention and health
 interpretation, backlinks, and recent-insight/log rendering remain staged behind this first home
 read model. The next cockpit-track implementation follow-up is `M20-P4.3`.
+
+`M20-P4.3` (#194) implements the planning roadmap view for `/planning`. The route now leads with
+deterministic human-readable lanes for active/current, next, blocked or gated, open decisions, open
+questions, completed/answered, and historical/archived planning records while keeping raw
+kind-specific planning tables reachable for audit and debugging. The implementation stays
+read-only and request-time over local planning files; it does not add mutation flows, background
+jobs, databases, hosted services, broad search changes, or external APIs. Deeper attention and
+health interpretation remains the next cockpit-track follow-up in `M20-P4.4`.
 
 ---
 

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -128,6 +128,19 @@ class _PlanningSummary:
 
 
 @dataclass(frozen=True)
+class _PlanningRoadmapLane:
+    title: str
+    description: str
+    items: list[_PlanningSummary]
+    empty: str
+
+
+@dataclass(frozen=True)
+class _PlanningRoadmapReadModel:
+    lanes: list[_PlanningRoadmapLane]
+
+
+@dataclass(frozen=True)
 class _QueueSummary:
     path: str
     record: QueueItemRecord
@@ -318,11 +331,18 @@ def create_app(root: Path) -> FastAPI:
             f"<span>{html.escape(_planning_label(kind))}</span></div>"
             for kind in ("task", "milestone", "decision", "question")
         )
+        roadmap = _build_planning_roadmap(grouped)
         sections = "".join(_planning_section(kind, records) for kind, records in grouped.items())
         body = (
             '<p class="breadcrumbs"><a href="/">Home</a> / Planning</p>'
+            '<p class="empty">Planning records are grouped into deterministic roadmap lanes. '
+            "Raw kind-specific tables remain available below for audit and debugging.</p>"
+            f"{_planning_roadmap(roadmap)}"
+            '<details class="technical">'
+            "<summary>Raw planning records</summary>"
             f'<section class="stats">{stats}</section>'
             f"{sections}"
+            "</details>"
         )
         return _page("Planning", body, root=workspace_root, layout=layout)
 
@@ -1043,12 +1063,132 @@ def _planning_records(root: Path, layout: ResolvedLayout, kind: str) -> list[_Pl
     return sorted(records, key=lambda item: (item.status, item.record_id))
 
 
+def _build_planning_roadmap(
+    grouped: dict[str, list[_PlanningSummary]],
+) -> _PlanningRoadmapReadModel:
+    def matching(kind: str, statuses: set[str]) -> list[_PlanningSummary]:
+        return [record for record in grouped[kind] if record.status in statuses]
+
+    lanes = [
+        _PlanningRoadmapLane(
+            title="Active / current",
+            description="Tasks in progress and active milestones.",
+            items=[
+                *matching("task", {"in_progress"}),
+                *matching("milestone", {"active"}),
+            ],
+            empty="No task or milestone is marked active.",
+        ),
+        _PlanningRoadmapLane(
+            title="Next",
+            description="Todo tasks and planned milestones.",
+            items=[
+                *matching("task", {"todo"}),
+                *matching("milestone", {"planned"}),
+            ],
+            empty="No todo task or planned milestone found.",
+        ),
+        _PlanningRoadmapLane(
+            title="Blocked or gated",
+            description="Planning work that cannot proceed directly.",
+            items=matching("task", {"blocked"}),
+            empty="No blocked planning tasks found.",
+        ),
+        _PlanningRoadmapLane(
+            title="Open decisions",
+            description="Proposed decisions that still need a durable resolution.",
+            items=matching("decision", {"proposed"}),
+            empty="No proposed decisions found.",
+        ),
+        _PlanningRoadmapLane(
+            title="Open questions",
+            description="Questions that still need an answer or disposition.",
+            items=matching("question", {"open"}),
+            empty="No open questions found.",
+        ),
+        _PlanningRoadmapLane(
+            title="Completed / answered",
+            description="Status-based completed, accepted, or answered planning records.",
+            items=[
+                *matching("task", {"done"}),
+                *matching("milestone", {"completed"}),
+                *matching("decision", {"accepted"}),
+                *matching("question", {"answered"}),
+            ],
+            empty="No completed planning records found.",
+        ),
+        _PlanningRoadmapLane(
+            title="Historical / archived",
+            description="Superseded or deferred planning records kept for context.",
+            items=[
+                *matching("decision", {"superseded"}),
+                *matching("question", {"deferred"}),
+            ],
+            empty="No superseded decisions or deferred questions found.",
+        ),
+    ]
+    return _PlanningRoadmapReadModel(lanes=lanes)
+
+
+def _planning_roadmap(read_model: _PlanningRoadmapReadModel) -> str:
+    return (
+        '<section class="roadmap-grid">'
+        + "".join(_planning_roadmap_lane(lane) for lane in read_model.lanes)
+        + "</section>"
+    )
+
+
+def _planning_roadmap_lane(lane: _PlanningRoadmapLane) -> str:
+    items = "".join(_planning_roadmap_item(item) for item in _sort_roadmap_items(lane.items))
+    if not items:
+        items = f'<li class="empty">{html.escape(lane.empty)}</li>'
+    return (
+        '<section class="roadmap-lane">'
+        f"<h2>{html.escape(lane.title)}</h2>"
+        f"<p>{html.escape(lane.description)}</p>"
+        f"<ul>{items}</ul>"
+        "</section>"
+    )
+
+
+def _sort_roadmap_items(items: list[_PlanningSummary]) -> list[_PlanningSummary]:
+    return sorted(
+        items, key=lambda item: (_planning_kind_order(item.kind), item.status, item.title)
+    )
+
+
+def _planning_kind_order(kind: str) -> int:
+    return {
+        "milestone": 0,
+        "task": 1,
+        "decision": 2,
+        "question": 3,
+    }[kind]
+
+
+def _planning_roadmap_item(item: _PlanningSummary) -> str:
+    href = f"/documents/{quote(item.path, safe='/')}"
+    return (
+        "<li>"
+        f'<a href="{href}">{html.escape(item.title)}</a>'
+        "<span>"
+        f"{html.escape(item.kind)} · {html.escape(item.status)} · "
+        f"<code>{html.escape(item.record_id)}</code>"
+        "</span>"
+        f"<span>{html.escape(item.detail)}</span>"
+        "</li>"
+    )
+
+
 def _planning_detail(kind: str, metadata: dict[str, object]) -> str:
     if kind == "task":
         parts = [f"priority={metadata.get('priority', '-')}"]
         owner = metadata.get("owner")
         if owner:
             parts.append(f"owner={owner}")
+        depends_on = metadata.get("depends_on")
+        if isinstance(depends_on, list) and depends_on:
+            parts.append(f"blocked_by={len(depends_on)}")
         milestone_refs = metadata.get("milestone_refs")
         if isinstance(milestone_refs, list) and milestone_refs:
             parts.append(f"milestones={len(milestone_refs)}")
@@ -1621,6 +1761,15 @@ def _page(
         ".cockpit-panel li{border-top:1px solid var(--border);padding:9px 0}"
         ".cockpit-panel li:first-child{border-top:0;padding-top:0}"
         ".cockpit-panel a{font-weight:600}.cockpit-panel span{display:block;color:var(--muted)}"
+        ".roadmap-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));"
+        "gap:14px;margin:0 0 24px}"
+        ".roadmap-lane{border:1px solid var(--border);border-radius:8px;padding:14px;"
+        "background:var(--surface)}"
+        ".roadmap-lane p{margin:0;color:var(--muted)}"
+        ".roadmap-lane ul{list-style:none;margin:10px 0 0;padding:0}"
+        ".roadmap-lane li{border-top:1px solid var(--border);padding:9px 0}"
+        ".roadmap-lane li:first-child{border-top:0;padding-top:0}"
+        ".roadmap-lane a{font-weight:600}.roadmap-lane span{display:block;color:var(--muted)}"
         ".stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px}"
         ".stats div,.metadata,.result,.empty-state{border:1px solid var(--border);"
         "border-radius:8px;"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -520,6 +520,8 @@ def test_planning_page_lists_and_links_all_planning_kinds(tmp_path: Path) -> Non
     response = client.get("/planning")
 
     assert response.status_code == 200
+    assert "Active / current" in response.text
+    assert "Raw planning records" in response.text
     assert "Tasks" in response.text
     assert "Milestones" in response.text
     assert "Decisions" in response.text
@@ -530,6 +532,167 @@ def test_planning_page_lists_and_links_all_planning_kinds(tmp_path: Path) -> Non
     assert 'href="/documents/planning/questions/question-runtime-state.md"' in response.text
     assert "priority=high" in response.text
     assert "owner=codex" in response.text
+
+
+def test_planning_page_renders_human_roadmap_lanes_before_raw_tables(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    create_milestone(
+        tmp_path,
+        "Active milestone",
+        record_id="milestone-active",
+        status="active",
+        target_date=None,
+        task_refs=["task-current"],
+        decision_refs=[],
+        question_refs=[],
+    )
+    create_milestone(
+        tmp_path,
+        "Planned milestone",
+        record_id="milestone-planned",
+        status="planned",
+        target_date=None,
+        task_refs=["task-next"],
+        decision_refs=[],
+        question_refs=[],
+    )
+    create_task(
+        tmp_path,
+        "Current implementation",
+        record_id="task-current",
+        status="in_progress",
+        priority="high",
+        owner="codex",
+        milestone_refs=["milestone-active"],
+        decision_refs=[],
+        question_refs=[],
+        depends_on=[],
+        source_refs=[],
+    )
+    create_task(
+        tmp_path,
+        "Next implementation",
+        record_id="task-next",
+        status="todo",
+        priority="medium",
+        owner=None,
+        milestone_refs=["milestone-planned"],
+        decision_refs=[],
+        question_refs=[],
+        depends_on=[],
+        source_refs=[],
+    )
+    create_task(
+        tmp_path,
+        "Blocked implementation",
+        record_id="task-blocked",
+        status="blocked",
+        priority="high",
+        owner=None,
+        milestone_refs=[],
+        decision_refs=[],
+        question_refs=[],
+        depends_on=["task-current"],
+        source_refs=[],
+    )
+    create_task(
+        tmp_path,
+        "Completed implementation",
+        record_id="task-completed",
+        status="done",
+        priority="low",
+        owner=None,
+        milestone_refs=[],
+        decision_refs=[],
+        question_refs=[],
+        depends_on=[],
+        source_refs=[],
+    )
+    create_decision(
+        tmp_path,
+        "Choose roadmap grouping",
+        record_id="decision-roadmap-grouping",
+        status="proposed",
+        decided_at=None,
+        supersedes=[],
+        source_refs=[],
+        related_tasks=["task-current"],
+        related_questions=["question-roadmap-filter"],
+    )
+    create_decision(
+        tmp_path,
+        "Old grouping contract",
+        record_id="decision-old-grouping",
+        status="superseded",
+        decided_at="2026-05-01",
+        supersedes=[],
+        source_refs=[],
+        related_tasks=[],
+        related_questions=[],
+    )
+    create_question(
+        tmp_path,
+        "Should deferred questions be archived",
+        record_id="question-roadmap-filter",
+        status="open",
+        source_refs=[],
+        related_tasks=["task-current"],
+        related_decisions=["decision-roadmap-grouping"],
+    )
+    create_question(
+        tmp_path,
+        "Will archived questions stay visible",
+        record_id="question-archived-visible",
+        status="deferred",
+        source_refs=[],
+        related_tasks=[],
+        related_decisions=[],
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/planning")
+
+    assert response.status_code == 200
+    assert response.text.index("Active / current") < response.text.index("Raw planning records")
+    assert "Tasks in progress and active milestones." in response.text
+    assert "Next" in response.text
+    assert "Blocked or gated" in response.text
+    assert "Open decisions" in response.text
+    assert "Open questions" in response.text
+    assert "Completed / answered" in response.text
+    assert "Historical / archived" in response.text
+    assert 'href="/documents/planning/milestones/milestone-active.md"' in response.text
+    assert 'href="/documents/planning/tasks/task-current.md"' in response.text
+    assert 'href="/documents/planning/tasks/task-next.md"' in response.text
+    assert 'href="/documents/planning/tasks/task-blocked.md"' in response.text
+    assert 'href="/documents/planning/tasks/task-completed.md"' in response.text
+    assert 'href="/documents/planning/decisions/decision-roadmap-grouping.md"' in response.text
+    assert 'href="/documents/planning/decisions/decision-old-grouping.md"' in response.text
+    assert 'href="/documents/planning/questions/question-roadmap-filter.md"' in response.text
+    assert 'href="/documents/planning/questions/question-archived-visible.md"' in response.text
+    assert "milestone · active" in response.text
+    assert "task · blocked" in response.text
+    assert "blocked_by=1" in response.text
+    assert "decision · superseded" in response.text
+    assert "question · deferred" in response.text
+    assert 'href="/planning/tasks"' in response.text
+    assert 'href="/planning/decisions"' in response.text
+    assert "<summary>Raw planning records</summary>" in response.text
+
+
+def test_planning_page_renders_quiet_empty_roadmap_lanes(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/planning")
+
+    assert response.status_code == 200
+    assert "No task or milestone is marked active." in response.text
+    assert "No todo task or planned milestone found." in response.text
+    assert "No proposed decisions found." in response.text
+    assert "No open questions found." in response.text
+    assert "No completed planning records found." in response.text
+    assert "<summary>Raw planning records</summary>" in response.text
 
 
 def test_planning_kind_page_lists_one_kind_and_rejects_unknown_kind(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- closes #194
- adds a deterministic human-readable roadmap read model to the read-only /planning web route
- groups planning records into active/current, next, blocked or gated, open decisions, open questions, recently completed, and historical/archived lanes
- keeps raw kind-specific planning tables and document links available for audit/debugging
- updates synchronized planning-state docs for M20-P4.3 and stages M20-P4.4 next

## Scope boundaries
- no mutating web workflows
- no background jobs, SQLite/database, hosted services, framework rewrite, or external APIs
- no search overhaul or broader attention/health interpretation yet

## Validation
- uv run pytest tests/test_web.py -q
- uv run ruff format --check .
- uv run ruff check .
- uv run splendor lint
- uv run pytest
