### PR TITLE
M20-P4.6: Add recent insights log view

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P4.4`
-- Last action taken: `M20-P4.4` merged to main via PR #197 with attention and health interpretation.
-- Current planned slice: `M20 knowledge-map navigation (#198)`
-- Current PR sub-slice: `M20-P4.5`
+- Previous completed PR sub-slice: `M20-P4.5`
+- Last action taken: `M20-P4.5` merged to main via PR #199 with knowledge-map navigation.
+- Current planned slice: `M20 recent insights and log rendering (#200)`
+- Current PR sub-slice: `M20-P4.6`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 recent insights and log rendering`
-- Next planned PR sub-slice: `M20-P4.6`
+- Next planned slice: `M20 follow-up selection pending`
+- Next planned PR sub-slice: `TBD`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ non-draft GitHub PR with labels, milestone, and a clear description.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P4.4`
-- Current planned slice: `M20 knowledge-map navigation (#198)`
-- Current PR sub-slice: `M20-P4.5`
+- Previous completed PR sub-slice: `M20-P4.5`
+- Current planned slice: `M20 recent insights and log rendering (#200)`
+- Current PR sub-slice: `M20-P4.6`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 recent insights and log rendering`
-- Next planned PR sub-slice: `M20-P4.6`
+- Next planned slice: `M20 follow-up selection pending`
+- Next planned PR sub-slice: `TBD`
 
 These planning-state lines are for contributors and agents. The detailed roadmap lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md).

--- a/docs/human_operator_cockpit.md
+++ b/docs/human_operator_cockpit.md
@@ -162,7 +162,7 @@ first implementation of each route may be modest, but the information hierarchy 
 | `/queue` | What work is pending, stuck, or failed? | Prioritize pending, retry-scheduled, failed, dead-letter, or stale-lease records with evidence and CLI hints; keep raw queue records visible. |
 | `/sources/*` | What source produced or changed this knowledge? | Show source title/path, source state, linked source-summary page, latest run, provenance, and affected synthesis suggestions before manifest internals. |
 | Future `/attention` | What needs inspection now? | Promote the shared attention read model once `/` and `/status` prove enough item types to justify a dedicated route. |
-| Future `/recent` | What changed or was learned recently? | Render `wiki/log.md` and durable run/page/planning timestamps without per-user last-seen state or filesystem mtime dependence. |
+| `/recent` | What changed or was learned recently? | Render `wiki/log.md` and durable run/page/planning timestamps without per-user last-seen state or filesystem mtime dependence. |
 
 Route implementations should share read models where the same judgment appears in more than one
 place. For example, "current work" should come from the current-work authority layer, and attention
@@ -287,9 +287,10 @@ from reverse local scans before the technical metadata block.
 
 ## Recent Insights And Log Contract
 
-`wiki/log.md` should become a first-class human recent-insights surface. It remains readable
-markdown. A renderer may parse headings and lightweight metadata when available, but must fall back
-to rendering the file as-is when the structure is absent.
+`M20-P4.6` makes `wiki/log.md` a first-class human recent-insights surface through `/recent`. The
+log remains readable markdown. The renderer parses headings and lightweight bullet/timestamp
+metadata when available, but falls back to rendering the file body as-is when the structure is
+absent.
 
 Recent activity can also include explicit durable records:
 

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P4.4`
-- Current planned slice: `M20 knowledge-map navigation (#198)`
-- Current PR sub-slice: `M20-P4.5`
+- Previous completed PR sub-slice: `M20-P4.5`
+- Current planned slice: `M20 recent insights and log rendering (#200)`
+- Current PR sub-slice: `M20-P4.6`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 recent insights and log rendering`
-- Next planned PR sub-slice: `M20-P4.6`
+- Next planned slice: `M20 follow-up selection pending`
+- Next planned PR sub-slice: `TBD`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1526,6 +1526,13 @@ before the raw document table, while document detail pages render related contex
 related-page, tag, source, run, provenance, planning, issue/PR, contradiction, and computed backlink
 inputs before technical metadata. Recent insights and `wiki/log.md` rendering remains the next
 cockpit-track follow-up in `M20-P4.6`.
+
+`M20-P4.6` (#200) makes recent durable activity a first-class read-only cockpit surface. `/recent`
+renders parsed `wiki/log.md` insights, the full markdown log body, and recent run-record events
+from local filesystem state while keeping raw log and run records reachable. It avoids per-user
+last-seen state, filesystem mtime ordering, mutation flows, background workers, databases, hosted
+services, and new persistent indexes. The `M20-P4` cockpit sequence is complete enough that the
+next roadmap sub-slice should be selected explicitly rather than inferred from this track.
 
 ---
 

--- a/src/splendor/web.py
+++ b/src/splendor/web.py
@@ -232,6 +232,23 @@ class _CockpitLink:
 
 
 @dataclass(frozen=True)
+class _LogInsight:
+    anchor: str
+    title: str
+    section: str
+    timestamp: str | None
+
+
+@dataclass(frozen=True)
+class _RecentReadModel:
+    log_path: str
+    log_exists: bool
+    log_body: str
+    log_insights: list[_LogInsight]
+    run_events: list[_CockpitLink]
+
+
+@dataclass(frozen=True)
 class _CockpitSection:
     title: str
     items: list[_CockpitLink]
@@ -295,6 +312,7 @@ def create_app(root: Path) -> FastAPI:
             "</form>"
             '<a class="button" href="/browse">Browse documents</a>'
             '<a class="button secondary" href="/planning">Planning</a>'
+            '<a class="button secondary" href="/recent">Recent</a>'
             '<a class="button secondary" href="/runs">Runs</a>'
             '<a class="button secondary" href="/queue">Queue</a>'
             '<a class="button secondary" href="/status">Status</a>'
@@ -521,6 +539,41 @@ def create_app(root: Path) -> FastAPI:
             f"<tbody>{rows}</tbody></table>"
         )
         return _page("Queue", body, root=workspace_root, layout=layout)
+
+    @app.get("/recent", response_class=HTMLResponse)
+    def recent() -> HTMLResponse:
+        layout = _layout_for(workspace_root)
+        read_model = _build_recent_read_model(workspace_root, layout)
+        if read_model.log_exists:
+            log_ref = (
+                f'<a href="/documents/{quote(read_model.log_path, safe="/")}">'
+                f"<code>{html.escape(read_model.log_path)}</code></a>"
+            )
+            log_article = (
+                f'<article class="markdown">{_render_markdown(read_model.log_body)}</article>'
+            )
+        else:
+            log_ref = f"<code>{html.escape(read_model.log_path)}</code> (missing)"
+            log_article = (
+                '<p class="empty">No <code>wiki/log.md</code> file exists yet. '
+                "Run <code>uv run splendor init</code> or restore the workspace log.</p>"
+            )
+        body = (
+            '<p class="breadcrumbs"><a href="/">Home</a> / Recent</p>'
+            '<p class="empty">Recent insights are derived from durable local files only: '
+            "<code>wiki/log.md</code> and run records. This page does not track per-user "
+            "last-seen state or mutate workspace files.</p>"
+            f"{_recent_insights_section(read_model.log_insights)}"
+            f"{_recent_runs_section(read_model.run_events)}"
+            "<h2>Rendered wiki log</h2>"
+            f"{log_article}"
+            '<details class="technical">'
+            "<summary>Raw recent records</summary>"
+            f"<p>Wiki log: {log_ref}</p>"
+            '<p>Run records: <a href="/runs">/runs</a></p>'
+            "</details>"
+        )
+        return _page("Recent", body, root=workspace_root, layout=layout)
 
     @app.get("/sources/{source_id}", response_class=HTMLResponse)
     def source_detail(source_id: str) -> HTMLResponse:
@@ -870,54 +923,147 @@ def _cockpit_knowledge_summary(
 
 
 def _cockpit_recent_activity(root: Path, layout: ResolvedLayout) -> list[_CockpitLink]:
+    read_model = _build_recent_read_model(
+        root,
+        layout,
+        run_limit=3,
+        log_limit=3,
+        include_log_body=False,
+    )
     items: list[_CockpitLink] = []
-    try:
-        for run in _run_records(root, layout)[:3]:
-            record = run.record
-            finished = record.finished_at or record.started_at
-            items.append(
-                _CockpitLink(
-                    title=f"{record.status} run {record.run_id}",
-                    href="/runs",
-                    detail=f"{finished} · {len(record.page_refs)} pages",
-                )
-            )
-    except (ValueError, ValidationError):
+    if read_model.log_insights:
+        latest_log = read_model.log_insights[0]
+        items.append(
+            _log_insight_link(latest_log),
+        )
+    items.extend(read_model.run_events[: max(0, 3 - len(items))])
+    for insight in read_model.log_insights[1 : max(1, 3 - len(items) + 1)]:
+        items.append(_log_insight_link(insight))
+    if not items and read_model.log_exists:
         items.append(
             _CockpitLink(
-                title="Run records need inspection",
-                href="/runs",
-                detail="At least one durable run record could not be parsed.",
+                title="Open wiki log",
+                href="/recent",
+                detail="Rendered recent-insights surface from wiki/log.md.",
             )
         )
-    items.extend(_cockpit_log_entries(layout, limit=max(0, 3 - len(items))))
     return items[:3]
 
 
-def _cockpit_log_entries(layout: ResolvedLayout, *, limit: int) -> list[_CockpitLink]:
+def _build_recent_read_model(
+    root: Path,
+    layout: ResolvedLayout,
+    *,
+    run_limit: int = 8,
+    log_limit: int = 12,
+    include_log_body: bool = True,
+) -> _RecentReadModel:
+    log_path = layout.log_file.relative_to(root).as_posix()
+    log_body = ""
+    log_exists = layout.log_file.is_file()
+    if log_exists and include_log_body:
+        try:
+            log_body = layout.log_file.read_text(encoding="utf-8")
+        except OSError:
+            log_exists = False
+            log_body = ""
+    return _RecentReadModel(
+        log_path=log_path,
+        log_exists=log_exists,
+        log_body=log_body,
+        log_insights=_parse_log_insights(layout, limit=log_limit),
+        run_events=_recent_run_events(root, layout, limit=run_limit),
+    )
+
+
+def _parse_log_insights(layout: ResolvedLayout, *, limit: int) -> list[_LogInsight]:
     if limit <= 0 or not layout.log_file.is_file():
         return []
-    entries: list[_CockpitLink] = []
+    entries: list[_LogInsight] = []
+    section = "Log"
     try:
         with layout.log_file.open("r", encoding="utf-8") as handle:
             for line in handle:
                 stripped = line.strip()
+                heading = _heading_from_line(stripped) or _subheading_from_line(stripped)
+                if heading:
+                    section = heading
+                    continue
                 if not stripped.startswith("- "):
                     continue
-                entry = stripped.removeprefix("- ").strip()
-                if not entry:
+                text = stripped.removeprefix("- ").strip()
+                if not text:
                     continue
-                log_path = layout.log_file.relative_to(layout.root).as_posix()
+                source_order = len(entries) + 1
+                timestamp, title = _split_log_timestamp(text)
                 entries.append(
-                    _CockpitLink(
-                        title=entry,
-                        href=f"/documents/{quote(log_path, safe='/')}",
-                        detail="wiki/log.md",
+                    _LogInsight(
+                        anchor=f"log-entry-{source_order}",
+                        title=title,
+                        section=section,
+                        timestamp=timestamp,
                     )
                 )
     except OSError:
         return []
     return list(reversed(entries[-limit:]))
+
+
+def _log_insight_link(insight: _LogInsight) -> _CockpitLink:
+    return _CockpitLink(
+        title=insight.title,
+        href=f"/recent#{insight.anchor}",
+        detail=_log_insight_detail(insight),
+    )
+
+
+def _subheading_from_line(line: str) -> str | None:
+    stripped = line.strip()
+    if stripped.startswith("## "):
+        return stripped.removeprefix("## ").strip()
+    if stripped.startswith("### "):
+        return stripped.removeprefix("### ").strip()
+    return None
+
+
+def _split_log_timestamp(text: str) -> tuple[str | None, str]:
+    match = re.match(
+        r"^(?P<timestamp>\d{4}-\d{2}-\d{2}(?:T[0-9:.+-]+| [0-9:.+-]+)?)\s+"
+        r"(?P<title>.+)$",
+        text,
+    )
+    if match is None:
+        return None, text
+    return match.group("timestamp"), match.group("title").strip()
+
+
+def _recent_run_events(root: Path, layout: ResolvedLayout, *, limit: int) -> list[_CockpitLink]:
+    if limit <= 0:
+        return []
+    try:
+        runs = _run_records(root, layout)
+    except (ValueError, ValidationError):
+        return [
+            _CockpitLink(
+                title="Run records need inspection",
+                href="/runs",
+                detail="At least one durable run record could not be parsed.",
+            )
+        ]
+    links: list[_CockpitLink] = []
+    for run in runs[:limit]:
+        record = run.record
+        finished = record.finished_at or record.started_at
+        sources = f"{len(record.source_ids)} sources"
+        pages = f"{len(record.page_refs)} pages"
+        links.append(
+            _CockpitLink(
+                title=f"{record.status} run {record.run_id}",
+                href="/runs",
+                detail=f"{finished} · {sources} · {pages}",
+            )
+        )
+    return links
 
 
 def _cockpit_inspect_next(
@@ -1319,6 +1465,62 @@ def _cockpit_secondary_sections(read_model: _CockpitHomeReadModel) -> str:
         _CockpitSection("Inspect next", read_model.inspect_next, "No inspection links yet."),
     ]
     return "".join(_cockpit_section(section) for section in sections)
+
+
+def _recent_insights_section(insights: list[_LogInsight]) -> str:
+    if not insights:
+        return (
+            '<section class="recent-panel">'
+            "<h2>Recent insights from wiki/log.md</h2>"
+            '<p class="empty">No bullet entries found in the wiki log yet.</p>'
+            "</section>"
+        )
+    items = "".join(_log_insight_item(insight) for insight in insights)
+    return (
+        '<section class="recent-panel">'
+        "<h2>Recent insights from wiki/log.md</h2>"
+        '<p class="empty">Latest parsed bullet entries, newest first by log order.</p>'
+        f"<ol>{items}</ol>"
+        "</section>"
+    )
+
+
+def _log_insight_item(insight: _LogInsight) -> str:
+    timestamp = ""
+    if insight.timestamp:
+        timestamp = f"<span>Time: <code>{html.escape(insight.timestamp)}</code></span>"
+    return (
+        f'<li id="{html.escape(insight.anchor)}">'
+        f"<strong>{html.escape(insight.title)}</strong>"
+        f"<span>{html.escape(_log_insight_detail(insight))}</span>"
+        f"{timestamp}"
+        "</li>"
+    )
+
+
+def _log_insight_detail(insight: _LogInsight) -> str:
+    detail = f"wiki/log.md · {insight.section}"
+    if insight.timestamp:
+        detail += f" · {insight.timestamp}"
+    return detail
+
+
+def _recent_runs_section(run_events: list[_CockpitLink]) -> str:
+    if not run_events:
+        return (
+            '<section class="recent-panel">'
+            "<h2>Durable run events</h2>"
+            '<p class="empty">No run records found.</p>'
+            "</section>"
+        )
+    items = "".join(_cockpit_link_item(event) for event in run_events)
+    return (
+        '<section class="recent-panel">'
+        "<h2>Durable run events</h2>"
+        '<p class="empty">Latest run records, sorted by recorded run timestamps.</p>'
+        f"<ul>{items}</ul>"
+        "</section>"
+    )
 
 
 def _cockpit_link_item(item: _CockpitLink) -> str:
@@ -2743,6 +2945,10 @@ def _page(
         "padding-top:0}"
         ".knowledge-panel a,.relationship-panel a{font-weight:600}"
         ".knowledge-panel span,.relationship-panel span{display:block;color:var(--muted)}"
+        ".recent-panel{border:1px solid var(--border);border-radius:8px;padding:14px;"
+        "background:var(--surface);margin:0 0 22px}"
+        ".recent-panel ol,.recent-panel ul{margin:10px 0 0;padding-left:22px}"
+        ".recent-panel li{padding:7px 0}.recent-panel span{display:block;color:var(--muted)}"
         ".stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px}"
         ".stats div,.metadata,.result,.empty-state{border:1px solid var(--border);"
         "border-radius:8px;"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -51,6 +51,7 @@ def test_home_page_loads_for_initialized_workspace(tmp_path: Path) -> None:
     assert "Wiki content pages" in response.text
     assert "/browse" in response.text
     assert "/planning" in response.text
+    assert "/recent" in response.text
     assert "/runs" in response.text
     assert "/queue" in response.text
     assert "/status" in response.text
@@ -255,6 +256,143 @@ def test_home_page_renders_cockpit_read_model(tmp_path: Path) -> None:
     assert "Added cockpit read model evidence." in response.text
     assert "Inspect next" in response.text
     assert "Raw workspace counts" in response.text
+
+
+def test_recent_page_renders_log_and_run_events(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    layout.log_file.write_text(
+        "# Project Log\n\n"
+        "Intro text that should still render when entries are parsed.\n\n"
+        "## Timeline\n\n"
+        "- 2026-05-01T09:00:00+00:00 Ingested initial source.\n"
+        "- Recorded untimed operator note.\n\n"
+        "## Decisions\n\n"
+        "- 2026-05-03 Accepted the log surface.\n",
+        encoding="utf-8",
+    )
+    write_run_record(
+        layout.runs_dir / "run-old.json",
+        RunRecord(
+            run_id="run-old",
+            job_id="ingest-old",
+            job_type="ingest_source",
+            started_at="2026-05-01T10:00:00+00:00",
+            finished_at="2026-05-01T10:01:00+00:00",
+            status="succeeded",
+            input_refs=[],
+            output_refs=[],
+            pipeline_version="test",
+        ),
+    )
+    write_run_record(
+        layout.runs_dir / "run-new.json",
+        RunRecord(
+            run_id="run-new",
+            job_id="ingest-new",
+            job_type="ingest_source",
+            started_at="2026-05-04T10:00:00+00:00",
+            finished_at="2026-05-04T10:01:00+00:00",
+            status="failed",
+            input_refs=["state/manifests/sources/src-new.json"],
+            output_refs=[],
+            pipeline_version="test",
+            source_ids=["src-new"],
+            page_refs=["wiki/sources/src-new.md"],
+        ),
+    )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/recent")
+
+    assert response.status_code == 200
+    assert "Recent insights from wiki/log.md" in response.text
+    assert "Durable run events" in response.text
+    assert "Rendered wiki log" in response.text
+    assert "<h1>Project Log</h1>" in response.text
+    assert "Intro text that should still render" in response.text
+    assert response.text.index("Accepted the log surface.") < response.text.index(
+        "Recorded untimed operator note."
+    )
+    assert "Time: <code>2026-05-03</code>" in response.text
+    assert response.text.index("failed run run-new") < response.text.index("succeeded run run-old")
+    assert "1 sources" in response.text
+    assert "1 pages" in response.text
+    assert 'href="/documents/wiki/log.md"' in response.text
+    assert 'href="/runs"' in response.text
+
+
+def test_recent_page_handles_missing_log_with_raw_run_access(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    layout.log_file.unlink()
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/recent")
+
+    assert response.status_code == 200
+    assert "No <code>wiki/log.md</code> file exists yet." in response.text
+    assert "No bullet entries found in the wiki log yet." in response.text
+    assert 'href="/documents/wiki/log.md"' not in response.text
+    assert 'href="/runs"' in response.text
+
+
+def test_home_recent_activity_promotes_latest_log_entry_over_run_noise(tmp_path: Path) -> None:
+    initialize_workspace(tmp_path)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    layout.log_file.write_text(
+        "# Project Log\n\n"
+        "## Timeline\n\n"
+        "- 2026-05-01T09:00:00+00:00 Old log entry.\n"
+        "- 2026-05-05T09:00:00+00:00 Latest operator insight.\n",
+        encoding="utf-8",
+    )
+    for index in range(4):
+        write_run_record(
+            layout.runs_dir / f"run-{index}.json",
+            RunRecord(
+                run_id=f"run-{index}",
+                job_id=f"ingest-{index}",
+                job_type="ingest_source",
+                started_at=f"2026-05-0{index + 1}T10:00:00+00:00",
+                finished_at=f"2026-05-0{index + 1}T10:01:00+00:00",
+                status="succeeded",
+                input_refs=[],
+                output_refs=[],
+                pipeline_version="test",
+            ),
+        )
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "Latest operator insight." in response.text
+    assert 'href="/recent#log-entry-2"' in response.text
+    assert response.text.index("Latest operator insight.") < response.text.index("run-3")
+
+
+def test_home_recent_activity_does_not_read_full_log_body(tmp_path: Path, monkeypatch) -> None:
+    initialize_workspace(tmp_path)
+    layout = resolve_layout(tmp_path, load_config(tmp_path))
+    layout.log_file.write_text(
+        "# Project Log\n\n## Timeline\n\n- Latest bounded log entry.\n" + ("body\n" * 500),
+        encoding="utf-8",
+    )
+    original_read_text = Path.read_text
+
+    def fail_full_log_read(path: Path, *args, **kwargs):
+        if path == layout.log_file:
+            raise AssertionError("home should not read the full wiki log body")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_full_log_read)
+    client = TestClient(create_app(tmp_path))
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "Latest bounded log entry." in response.text
 
 
 def test_home_page_reports_invalid_runtime_records_as_attention(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add a read-only `/recent` route that renders parsed `wiki/log.md` insights, recent durable run events, and the full markdown log body.
- Link the cockpit home route to the recent surface while preserving raw `/documents/wiki/log.md` and `/runs` access.
- Update the M20 cockpit docs and synchronized planning state for `M20-P4.6`.

## Scope notes
- Keeps the surface deterministic over local filesystem state.
- Does not add per-user last-seen state, filesystem mtime ordering, mutation flows, background workers, SQLite/databases, hosted services, or new persistent indexes.
- Leaves next roadmap sub-slice selection explicit because this completes the currently listed M20-P4 cockpit sequence.

Closes #200.

## Self-review findings and fixes
- Finding: the home route reused the `/recent` read model in a way that read the full log body for a compact home pane. Fix: add an `include_log_body` flag and keep home on bounded log-entry parsing only.
- Finding: three or more run records could crowd out `wiki/log.md` insights from the home recent pane. Fix: always promote the latest log insight first, then fill remaining slots with run events and additional log entries.
- Finding: the missing-log empty state linked to `/documents/wiki/log.md`, which would 404. Fix: render the raw log path as missing text while preserving the `/runs` raw record link.

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run pytest tests/test_web.py -q` (53 passed)
- `uv run pytest` (762 passed)
