### PR TITLE
M20-P5.1 isolate maintenance action from work footer

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P4.6`
-- Last action taken: `M20-P4.6` merged to main via PR #201 with recent insights and log rendering.
-- Current planned slice: `M20 post-cockpit follow-up selection (#202)`
-- Current PR sub-slice: `M20-P5.0`
+- Previous completed PR sub-slice: `M20-P5.0`
+- Last action taken: `M20-P5.0` merged to main via PR #203 with explicit post-cockpit follow-up selection.
+- Current planned slice: `M20 work-footer maintenance action isolation (#161)`
+- Current PR sub-slice: `M20-P5.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 work-footer maintenance action isolation (#161)`
-- Next planned PR sub-slice: `M20-P5.1`
+- Next planned slice: `M20 goal-sensitive read-first ranking refinement (#160)`
+- Next planned PR sub-slice: `M20-P5.2`
 - Current blockers: none
 
 ## Planning Notation
@@ -533,3 +533,4 @@
 - `M20-P4.6` Recent insights and log rendering
 - `M20-P5.0` Post-cockpit follow-up selection (#202)
 - `M20-P5.1` Work-footer maintenance action isolation (#161)
+- `M20-P5.2` Goal-sensitive read-first ranking refinement (#160)

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ non-draft GitHub PR with labels, milestone, and a clear description.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P4.6`
-- Current planned slice: `M20 post-cockpit follow-up selection (#202)`
-- Current PR sub-slice: `M20-P5.0`
+- Previous completed PR sub-slice: `M20-P5.0`
+- Current planned slice: `M20 work-footer maintenance action isolation (#161)`
+- Current PR sub-slice: `M20-P5.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 work-footer maintenance action isolation (#161)`
-- Next planned PR sub-slice: `M20-P5.1`
+- Next planned slice: `M20 goal-sensitive read-first ranking refinement (#160)`
+- Next planned PR sub-slice: `M20-P5.2`
 
 These planning-state lines are for contributors and agents. The detailed roadmap lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md).

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P4.6`
-- Current planned slice: `M20 post-cockpit follow-up selection (#202)`
-- Current PR sub-slice: `M20-P5.0`
+- Previous completed PR sub-slice: `M20-P5.0`
+- Current planned slice: `M20 work-footer maintenance action isolation (#161)`
+- Current PR sub-slice: `M20-P5.1`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 work-footer maintenance action isolation (#161)`
-- Next planned PR sub-slice: `M20-P5.1`
+- Next planned slice: `M20 goal-sensitive read-first ranking refinement (#160)`
+- Next planned PR sub-slice: `M20-P5.2`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1392,6 +1392,8 @@ the selected M20 implementation.
 - `M20-P5.0` Select the post-cockpit follow-up slice.
 - `M20-P5.1` Remove maintenance-only `wiki suggest` guidance from the work-context action footer
   (#161).
+- `M20-P5.2` Refine goal-sensitive read-first ranking so authority-cited implementation paths
+  remain visible under narrow goal phrasing (#160).
 
 `M20-P1.1` starts the retrieval product bet without crossing into heavyweight infrastructure. The
 first slice adds deterministic runtime acronym phrase expansion to `splendor query` and the
@@ -1448,6 +1450,7 @@ workflows stay out of scope for this slice. The ordered M20 sequence is therefor
 - `M20-P4.6` recent insights and log rendering.
 - `M20-P5.0` post-cockpit follow-up selection.
 - `M20-P5.1` work-footer maintenance action isolation.
+- `M20-P5.2` goal-sensitive read-first ranking refinement.
 
 `M20-P2.1` is a proposal-first slice for issue #119. It keeps the current local web UI read-only
 while defining the narrow first mutation paths worth implementing later: accept one reviewed
@@ -1551,6 +1554,14 @@ the maintenance-only `splendor wiki suggest <source-id>` action from the work fo
 preserving explicit maintenance guidance where it belongs. #160 remains a broader goal-sensitive
 ranking refinement, #162 is isolated no-diff `pr-summary` human-output polish, and #163 is a
 queue-clean JSON compatibility-contract cleanup.
+
+`M20-P5.1` (#161) implements the narrow work-footer maintenance isolation fix. Agent-context
+briefs now build their trailing next-action footer from work actions instead of the combined
+work-plus-maintenance suggestion list, and the standalone missing-synthesis `wiki suggest` footer
+line is removed. Explicit maintenance context still carries `splendor wiki suggest <source-id>`
+commands and wiki-maintenance notes, so operators can find the maintenance path without presenting
+it as default work. The next smallest handoff-polish follow-up is `M20-P5.2`: issue #160's
+goal-sensitive read-first ranking refinement.
 
 ---
 

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -672,7 +672,7 @@ def build_project_brief(
         authority_briefs=snapshot.authority_briefs,
         planning_items=snapshot.planning_items,
         warnings=snapshot.warnings,
-        suggested_actions=suggested_actions,
+        work_actions=work_actions,
     )
     return ProjectBrief(
         goal=snapshot.goal,
@@ -3137,13 +3137,13 @@ def _next_actions(
     authority_briefs: list[AuthorityBrief],
     planning_items: list[BriefPlanningItem],
     warnings: list[BriefWarning],
-    suggested_actions: list[SuggestedAction],
+    work_actions: list[SuggestedAction],
 ) -> list[str]:
     actions: list[str] = []
-    if suggested_actions:
+    if work_actions:
         actions.extend(
             f"{action.title}" + (f" (`{action.command}`)" if action.command is not None else "")
-            for action in suggested_actions[:5]
+            for action in work_actions[:5]
         )
     if status.queue_status_counts.get("pending", 0):
         actions.append(
@@ -3152,11 +3152,6 @@ def _next_actions(
         )
     if status.invalid_pages:
         actions.append("Fix invalid wiki pages before relying on synthesis or query output.")
-    if status.sources_missing_synthesis:
-        actions.append(
-            "Run `splendor wiki suggest <source-id>` for ingested sources missing "
-            "synthesis follow-up."
-        )
     if status.review_needed_synthesis_pages:
         actions.append("Review draft, stale, contested, or machine-generated synthesis pages.")
     if matches:

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -5109,12 +5109,23 @@ def test_implementation_handoff_keeps_maintenance_commands_below_work_context(
     assert payload["work_context"]["actions"]
     assert payload["maintenance_context"]["actions"]
     assert payload["maintenance_context"]["commands"]
+    maintenance_action_titles = {
+        action["title"] for action in payload["maintenance_context"]["actions"]
+    }
+    assert all("wiki suggest" not in action for action in payload["next_actions"])
+    assert maintenance_action_titles.isdisjoint(payload["next_actions"])
     assert all(
         action["category"] not in {"synthesis", "wiki-review", "source-freshness", "queue"}
         for action in payload["work_context"]["actions"]
     )
+    maintenance_commands = {
+        command["command"] for command in payload["maintenance_context"]["commands"]
+    }
+    assert f"splendor wiki suggest {added.source_id}" in maintenance_commands
     assert out.index("Work context:") < out.index("Splendor maintenance:")
     assert out.index("Splendor maintenance:") < out.index("Maintenance commands:")
+    next_actions_text = out.split("Next actions:", 1)[1]
+    assert "wiki suggest" not in next_actions_text
     assert "Wiki status:" not in out
 
 


### PR DESCRIPTION
## Summary
- build the brief next-action footer from work actions so maintenance-only suggestions are not presented as default work
- remove the standalone missing-synthesis `splendor wiki suggest <source-id>` footer line while preserving explicit maintenance commands
- update M20 planning state to make M20-P5.1 the active slice and point next to M20-P5.2 / #160

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run pytest`

Closes #161