### PR TITLE
M20-P5.2: Preserve authority read-first paths

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P5.0`
-- Last action taken: `M20-P5.0` merged to main via PR #203 with explicit post-cockpit follow-up selection.
-- Current planned slice: `M20 work-footer maintenance action isolation (#161)`
-- Current PR sub-slice: `M20-P5.1`
+- Previous completed PR sub-slice: `M20-P5.1`
+- Last action taken: `M20-P5.1` merged to main via PR #204 with work-footer maintenance action isolation.
+- Current planned slice: `M20 goal-sensitive read-first ranking refinement (#160)`
+- Current PR sub-slice: `M20-P5.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 goal-sensitive read-first ranking refinement (#160)`
-- Next planned PR sub-slice: `M20-P5.2`
+- Next planned slice: `M20 no-diff pr-summary human output polish (#162)`
+- Next planned PR sub-slice: `M20-P5.3`
 - Current blockers: none
 
 ## Planning Notation
@@ -534,3 +534,4 @@
 - `M20-P5.0` Post-cockpit follow-up selection (#202)
 - `M20-P5.1` Work-footer maintenance action isolation (#161)
 - `M20-P5.2` Goal-sensitive read-first ranking refinement (#160)
+- `M20-P5.3` No-diff pr-summary human output polish (#162)

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ non-draft GitHub PR with labels, milestone, and a clear description.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P5.0`
-- Current planned slice: `M20 work-footer maintenance action isolation (#161)`
-- Current PR sub-slice: `M20-P5.1`
+- Previous completed PR sub-slice: `M20-P5.1`
+- Current planned slice: `M20 goal-sensitive read-first ranking refinement (#160)`
+- Current PR sub-slice: `M20-P5.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 goal-sensitive read-first ranking refinement (#160)`
-- Next planned PR sub-slice: `M20-P5.2`
+- Next planned slice: `M20 no-diff pr-summary human output polish (#162)`
+- Next planned PR sub-slice: `M20-P5.3`
 
 These planning-state lines are for contributors and agents. The detailed roadmap lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md).

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P5.0`
-- Current planned slice: `M20 work-footer maintenance action isolation (#161)`
-- Current PR sub-slice: `M20-P5.1`
+- Previous completed PR sub-slice: `M20-P5.1`
+- Current planned slice: `M20 goal-sensitive read-first ranking refinement (#160)`
+- Current PR sub-slice: `M20-P5.2`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 goal-sensitive read-first ranking refinement (#160)`
-- Next planned PR sub-slice: `M20-P5.2`
+- Next planned slice: `M20 no-diff pr-summary human output polish (#162)`
+- Next planned PR sub-slice: `M20-P5.3`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1394,6 +1394,7 @@ the selected M20 implementation.
   (#161).
 - `M20-P5.2` Refine goal-sensitive read-first ranking so authority-cited implementation paths
   remain visible under narrow goal phrasing (#160).
+- `M20-P5.3` Make no-diff `pr-summary --since <ref>` human output loud and compact (#162).
 
 `M20-P1.1` starts the retrieval product bet without crossing into heavyweight infrastructure. The
 first slice adds deterministic runtime acronym phrase expansion to `splendor query` and the
@@ -1451,6 +1452,7 @@ workflows stay out of scope for this slice. The ordered M20 sequence is therefor
 - `M20-P5.0` post-cockpit follow-up selection.
 - `M20-P5.1` work-footer maintenance action isolation.
 - `M20-P5.2` goal-sensitive read-first ranking refinement.
+- `M20-P5.3` no-diff pr-summary human output polish.
 
 `M20-P2.1` is a proposal-first slice for issue #119. It keeps the current local web UI read-only
 while defining the narrow first mutation paths worth implementing later: accept one reviewed
@@ -1562,6 +1564,13 @@ line is removed. Explicit maintenance context still carries `splendor wiki sugge
 commands and wiki-maintenance notes, so operators can find the maintenance path without presenting
 it as default work. The next smallest handoff-polish follow-up is `M20-P5.2`: issue #160's
 goal-sensitive read-first ranking refinement.
+
+`M20-P5.2` (#160) refines `brief --agent-context` read-first ranking after the M19-P7.1
+policy-cited improvement. Authority docs can already name implementation and test files, but
+goal-specific git context can still crowd those files out of the bounded read-first list. This
+slice keeps the behavior deterministic by preserving a small bounded set of the highest-ranked
+authority-cited paths when git and GitHub context are noisy. The next narrow polish follow-up is
+`M20-P5.3`: issue #162's no-diff `pr-summary --since <ref>` human-output short-circuit.
 
 ---
 

--- a/src/splendor/commands/brief.py
+++ b/src/splendor/commands/brief.py
@@ -55,6 +55,8 @@ _MAINTENANCE_ACTION_LIMIT = 8
 _GIT_CONTEXT_LIMIT = 5
 _GIT_FILE_LIMIT = 8
 _AUTHORITY_READ_FIRST_LIMIT = 5
+# Keep authority-cited files visible without letting broad authority docs dominate read-first.
+_AUTHORITY_READ_FIRST_SURVIVAL_LIMIT = 4
 _RELATED_THREAD_FETCH_LIMIT = 5
 _GIT_COMMAND_TIMEOUT_SECONDS = 5
 _HANDOFF_COMPLETION_COMMIT_LIMIT = 12
@@ -3013,12 +3015,29 @@ def _read_first_paths(
             scored[path] = max(scored.get(path, 0), thread.relevance_score + 20)
     for path, score in authority_read_first_scores.items():
         scored[path] = max(scored.get(path, 0), score)
-    return _rank_read_first_scores(scored)
+    return _rank_read_first_scores(scored, required_paths=set(authority_read_first_scores))
 
 
-def _rank_read_first_scores(scored: dict[str, int]) -> list[str]:
+def _rank_read_first_scores(
+    scored: dict[str, int], *, required_paths: set[str] | None = None
+) -> list[str]:
     ranked = sorted(scored, key=lambda path: (-scored[path], path))
-    return ranked[:_GIT_FILE_LIMIT]
+    selected = set(ranked[:_GIT_FILE_LIMIT])
+    required_ranked = [
+        path for path in ranked if required_paths is not None and path in required_paths
+    ][:_AUTHORITY_READ_FIRST_SURVIVAL_LIMIT]
+    if not required_ranked or set(required_ranked) <= selected:
+        return ranked[:_GIT_FILE_LIMIT]
+
+    selected.update(required_ranked)
+    rank_index = {path: index for index, path in enumerate(ranked)}
+    required = set(required_ranked)
+    while len(selected) > _GIT_FILE_LIMIT:
+        removable = [path for path in selected if path not in required]
+        if not removable:
+            break
+        selected.remove(max(removable, key=lambda path: rank_index[path]))
+    return [path for path in ranked if path in selected][:_GIT_FILE_LIMIT]
 
 
 def _combined_read_first_paths(

--- a/tests/test_wiki_commands.py
+++ b/tests/test_wiki_commands.py
@@ -2156,6 +2156,98 @@ def test_agent_context_synthbanshee_retry_bar_is_git_aware_and_work_first(
     )
 
 
+def test_agent_context_authority_cited_files_survive_goal_git_competition(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    initialize_workspace(tmp_path)
+    config = load_config(tmp_path)
+    config.reviews.contradictions.enabled = False
+    config.briefing.authority_documents = [
+        AuthorityDocumentConfig(
+            path="CLAUDE.md",
+            role="current-authority",
+            purpose="M17 ASR authority-cited implementation surface.",
+            applies_to=["M17 ASR"],
+        )
+    ]
+    write_config(tmp_path, config)
+    (tmp_path / "CLAUDE.md").write_text(
+        "# CLAUDE\n\n"
+        "Current M17 ASR authority names synthbanshee/tts/renderer.py and "
+        "tests/unit/test_effective_prosody_cap.py as the files to inspect first.\n",
+        encoding="utf-8",
+    )
+    renderer = tmp_path / "synthbanshee" / "tts" / "renderer.py"
+    renderer.parent.mkdir(parents=True)
+    renderer.write_text("def render():\n    return 'asr'\n", encoding="utf-8")
+    renderer_test = tmp_path / "tests" / "unit" / "test_effective_prosody_cap.py"
+    renderer_test.parent.mkdir(parents=True, exist_ok=True)
+    renderer_test.write_text(
+        "def test_effective_prosody_cap():\n    assert True\n", encoding="utf-8"
+    )
+    _init_git_repo(tmp_path, repo="SynthBanshee/SynthBanshee")
+    _commit_all(tmp_path, "Initial SynthBanshee authority context")
+
+    competing = tmp_path / "handoff"
+    competing.mkdir()
+    for index in range(8):
+        (competing / f"pick-up-m17-asr-work-{index}.py").write_text(
+            "def marker():\n    return 'pick up M17 ASR work'\n",
+            encoding="utf-8",
+        )
+    _commit_all(tmp_path, "pick up M17 ASR work goal-specific handoff files")
+    for index in range(8):
+        (competing / f"current-state-synthbanshee-active-milestone-{index}.py").write_text(
+            "def marker():\n    return 'current state SynthBanshee active milestone'\n",
+            encoding="utf-8",
+        )
+    _commit_all(tmp_path, "current state SynthBanshee active milestone handoff files")
+    _install_fake_gh(tmp_path, monkeypatch, issues=[], prs=[])
+    capsys.readouterr()
+
+    scenarios = [
+        (
+            ["pick", "up", "M17", "ASR", "work"],
+            "handoff/pick-up-m17-asr-work-",
+        ),
+        (
+            [
+                "what's",
+                "the",
+                "current",
+                "state",
+                "of",
+                "the",
+                "SynthBanshee",
+                "active",
+                "milestone",
+            ],
+            "handoff/current-state-synthbanshee-active-milestone-",
+        ),
+    ]
+    for goal_args, competing_prefix in scenarios:
+        exit_code = main(
+            [
+                "--root",
+                str(tmp_path),
+                "brief",
+                "--agent-context",
+                *goal_args,
+                "--json",
+            ]
+        )
+
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        read_first = payload["git_context"]["read_first_paths"]
+        assert "synthbanshee/tts/renderer.py" in read_first
+        assert "tests/unit/test_effective_prosody_cap.py" in read_first
+        assert len(read_first) == brief_module._GIT_FILE_LIMIT
+        assert sum(path.startswith(competing_prefix) for path in read_first) == (
+            brief_module._GIT_FILE_LIMIT - 2
+        )
+
+
 def test_agent_context_authority_cited_files_do_not_require_git(tmp_path: Path, capsys) -> None:
     initialize_workspace(tmp_path)
     config = load_config(tmp_path)


### PR DESCRIPTION
## Summary
- preserve a bounded set of highest-scoring authority-cited read-first paths when git/goal context is noisy
- add a deterministic SynthBanshee-style regression where goal-specific git paths would otherwise crowd out authority-cited implementation and test files
- update M20 planning state to M20-P5.2 and select M20-P5.3 / #162 as the next polish slice

Closes #160

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run pytest tests/test_wiki_commands.py -k "authority_cited_files_survive_goal_git_competition or synthbanshee_retry_bar or authority_cited_files_do_not_require_git" -q`
- `uv run pytest` (`763 passed`)

## Follow-up
- M20-P5.3 / #162: make no-diff `pr-summary --since <ref>` human output loud and compact.