### PR TITLE
M20-P5.3: Make pr-summary no-diff output loud

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P5.1`
-- Last action taken: `M20-P5.1` merged to main via PR #204 with work-footer maintenance action isolation.
-- Current planned slice: `M20 goal-sensitive read-first ranking refinement (#160)`
-- Current PR sub-slice: `M20-P5.2`
+- Previous completed PR sub-slice: `M20-P5.2`
+- Last action taken: `M20-P5.2` merged to main via PR #205 with goal-sensitive read-first authority ranking.
+- Current planned slice: `M20 no-diff pr-summary human output polish (#162)`
+- Current PR sub-slice: `M20-P5.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 no-diff pr-summary human output polish (#162)`
-- Next planned PR sub-slice: `M20-P5.3`
+- Next planned slice: `M20 mutation JSON compatibility contract cleanup (#163)`
+- Next planned PR sub-slice: `M20-P5.4`
 - Current blockers: none
 
 ## Planning Notation
@@ -535,3 +535,4 @@
 - `M20-P5.1` Work-footer maintenance action isolation (#161)
 - `M20-P5.2` Goal-sensitive read-first ranking refinement (#160)
 - `M20-P5.3` No-diff pr-summary human output polish (#162)
+- `M20-P5.4` Mutation JSON compatibility contract cleanup (#163)

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ non-draft GitHub PR with labels, milestone, and a clear description.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P5.1`
-- Current planned slice: `M20 goal-sensitive read-first ranking refinement (#160)`
-- Current PR sub-slice: `M20-P5.2`
+- Previous completed PR sub-slice: `M20-P5.2`
+- Current planned slice: `M20 no-diff pr-summary human output polish (#162)`
+- Current PR sub-slice: `M20-P5.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 no-diff pr-summary human output polish (#162)`
-- Next planned PR sub-slice: `M20-P5.3`
+- Next planned slice: `M20 mutation JSON compatibility contract cleanup (#163)`
+- Next planned PR sub-slice: `M20-P5.4`
 
 These planning-state lines are for contributors and agents. The detailed roadmap lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md).

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P5.1`
-- Current planned slice: `M20 goal-sensitive read-first ranking refinement (#160)`
-- Current PR sub-slice: `M20-P5.2`
+- Previous completed PR sub-slice: `M20-P5.2`
+- Current planned slice: `M20 no-diff pr-summary human output polish (#162)`
+- Current PR sub-slice: `M20-P5.3`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 no-diff pr-summary human output polish (#162)`
-- Next planned PR sub-slice: `M20-P5.3`
+- Next planned slice: `M20 mutation JSON compatibility contract cleanup (#163)`
+- Next planned PR sub-slice: `M20-P5.4`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1395,6 +1395,7 @@ the selected M20 implementation.
 - `M20-P5.2` Refine goal-sensitive read-first ranking so authority-cited implementation paths
   remain visible under narrow goal phrasing (#160).
 - `M20-P5.3` Make no-diff `pr-summary --since <ref>` human output loud and compact (#162).
+- `M20-P5.4` Clarify the canonical mutation JSON contract and legacy queue-clean aliases (#163).
 
 `M20-P1.1` starts the retrieval product bet without crossing into heavyweight infrastructure. The
 first slice adds deterministic runtime acronym phrase expansion to `splendor query` and the
@@ -1453,6 +1454,7 @@ workflows stay out of scope for this slice. The ordered M20 sequence is therefor
 - `M20-P5.1` work-footer maintenance action isolation.
 - `M20-P5.2` goal-sensitive read-first ranking refinement.
 - `M20-P5.3` no-diff pr-summary human output polish.
+- `M20-P5.4` mutation JSON compatibility contract cleanup.
 
 `M20-P2.1` is a proposal-first slice for issue #119. It keeps the current local web UI read-only
 while defining the narrow first mutation paths worth implementing later: accept one reviewed
@@ -1571,6 +1573,12 @@ goal-specific git context can still crowd those files out of the bounded read-fi
 slice keeps the behavior deterministic by preserving a small bounded set of the highest-ranked
 authority-cited paths when git and GitHub context are noisy. The next narrow polish follow-up is
 `M20-P5.3`: issue #162's no-diff `pr-summary --since <ref>` human-output short-circuit.
+
+`M20-P5.3` (#162) makes the human `pr-summary --since <ref>` path loud when there is no current
+diff to review. JSON keeps its existing compact committed contract, while human output
+short-circuits before empty review groups when the changed-path count is zero, including the
+common `HEAD`-equals-merge-base case. The next narrow polish follow-up is `M20-P5.4`: issue
+#163's mutation JSON compatibility contract cleanup for `queue clean --orphaned --json`.
 
 ---
 

--- a/src/splendor/cli.py
+++ b/src/splendor/cli.py
@@ -2176,6 +2176,10 @@ def handle_pr_summary(args: argparse.Namespace) -> int:
         print(render_pr_summary_json(summary))
         return 0
 
+    if _is_no_diff_pr_summary(summary):
+        _print_no_diff_pr_summary(summary)
+        return 0
+
     print(f"PR summary since {summary.since}")
     print(f"Merge base: {summary.merge_base}")
     if summary.head is not None:
@@ -2221,6 +2225,32 @@ def handle_pr_summary(args: argparse.Namespace) -> int:
     for note in summary.reviewer_notes:
         print(f"- {note}")
     return 0
+
+
+def _is_no_diff_pr_summary(summary) -> bool:
+    return summary.changed_path_count == 0
+
+
+def _print_no_diff_pr_summary(summary) -> None:
+    print(f"PR summary since {summary.since}")
+    if summary.head is not None and summary.merge_base.startswith(summary.head):
+        print(f"No diff vs {summary.since} (head {summary.head} == merge_base).")
+    else:
+        print(f"No diff vs {summary.since} (Changed paths: {summary.changed_path_count}).")
+    maintenance_reports = [
+        (command, summary.maintenance.get(command))
+        for command in ("lint", "health")
+        if summary.maintenance.get(command) is not None
+    ]
+    if not maintenance_reports:
+        return
+    print("Latest local maintenance reports (not tied to current diff):")
+    for command, status in maintenance_reports:
+        print(
+            f"- {command}: {status.status} path={status.path} "
+            f"issues={status.issue_count if status.issue_count is not None else '-'}"
+        )
+        print(f"  Warning: {status.warning}")
 
 
 def _print_compact_review(compact_review) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3358,6 +3358,75 @@ def test_cli_pr_summary_human_output_is_path_first(tmp_path: Path, capsys) -> No
     assert "No local lint report was found" in out
 
 
+def test_cli_pr_summary_human_output_is_loud_when_head_equals_merge_base(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    _git_init_main(tmp_path)
+    head = _git_stdout(tmp_path, ["git", "rev-parse", "--short", "HEAD"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "pr-summary", "--since", "main"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert out.startswith(f"PR summary since main\nNo diff vs main (head {head} == merge_base).\n")
+    assert "Latest local maintenance reports" not in out
+    assert "Compact committed review:" not in out
+    assert "Review first:" not in out
+    assert "Curated sources:" not in out
+    assert "Reviewer notes:" not in out
+
+
+def test_cli_pr_summary_no_diff_labels_retained_maintenance_as_not_current_diff(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    _git_init_main(tmp_path)
+    main(["--root", str(tmp_path), "lint"])
+    _git_run(tmp_path, ["git", "add", "reports"])
+    _git_run(tmp_path, ["git", "commit", "-m", "record lint report"])
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "pr-summary", "--since", "main"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "No diff vs main" in out
+    assert "Latest local maintenance reports (not tied to current diff):" in out
+    assert "- lint: passed path=reports/lint/" in out
+    assert "- health:" not in out
+    assert "Compact committed review:" not in out
+
+
+def test_cli_pr_summary_human_output_is_loud_when_changed_paths_are_zero(
+    tmp_path: Path, capsys
+) -> None:
+    main(["--root", str(tmp_path), "init"])
+    _git_init_main(tmp_path)
+    _git_run(tmp_path, ["git", "switch", "-c", "feature"])
+    (tmp_path / "temporary.md").write_text("# Temporary\n", encoding="utf-8")
+    _git_run(tmp_path, ["git", "add", "temporary.md"])
+    _git_run(tmp_path, ["git", "commit", "-m", "add temporary"])
+    (tmp_path / "temporary.md").unlink()
+    _git_run(tmp_path, ["git", "add", "temporary.md"])
+    _git_run(tmp_path, ["git", "commit", "-m", "remove temporary"])
+    assert _git_stdout(tmp_path, ["git", "rev-parse", "--short", "HEAD"]) != _git_stdout(
+        tmp_path, ["git", "rev-parse", "--short", "main"]
+    )
+    capsys.readouterr()
+
+    exit_code = main(["--root", str(tmp_path), "pr-summary", "--since", "main"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert out.startswith("PR summary since main\nNo diff vs main (Changed paths: 0).\n")
+    assert "Latest local maintenance reports" not in out
+    assert "Compact committed review:" not in out
+    assert "Usually mechanical:" not in out
+    assert "Other changed paths" not in out
+
+
 def test_cli_pr_summary_uses_merge_base_when_main_advances(tmp_path: Path, capsys) -> None:
     main(["--root", str(tmp_path), "init"])
     _git_init_main(tmp_path)


### PR DESCRIPTION
## Summary
- short-circuit human `splendor pr-summary --since <ref>` output when there are zero changed paths
- print a loud no-diff message before empty review groups, using the `head == merge_base` wording when applicable
- keep JSON output/schema behavior unchanged
- retain maintenance report context only when an actual report exists, explicitly labeling it as not tied to the current diff
- advance planning state from M20-P5.2 to M20-P5.3 and point next to M20-P5.4 / #163

Closes #162.

## Self-review fix
The first draft still printed no-report maintenance boilerplate in the no-diff case. That was not compact enough, so this version only prints the maintenance section when a real latest report exists.

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run pytest` (766 passed)

## Notes
The short-circuit is keyed to `changed_path_count == 0` so worktree changes are still reviewed even when `HEAD` equals the merge base.