### PR TITLE
M20-P5.4: Clarify mutation JSON contract

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,13 +3,13 @@
 ## Current System State
 
 - Active branch: `(set in active worktree)`
-- Previous completed PR sub-slice: `M20-P5.2`
-- Last action taken: `M20-P5.2` merged to main via PR #205 with goal-sensitive read-first authority ranking.
-- Current planned slice: `M20 no-diff pr-summary human output polish (#162)`
-- Current PR sub-slice: `M20-P5.3`
+- Previous completed PR sub-slice: `M20-P5.3`
+- Last action taken: `M20-P5.3` merged to main via PR #206 with loud compact no-diff pr-summary output.
+- Current planned slice: `M20 mutation JSON compatibility contract cleanup (#163)`
+- Current PR sub-slice: `M20-P5.4`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 mutation JSON compatibility contract cleanup (#163)`
-- Next planned PR sub-slice: `M20-P5.4`
+- Next planned slice: `M20 next-track selection pending`
+- Next planned PR sub-slice: `TBD`
 - Current blockers: none
 
 ## Planning Notation

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ non-draft GitHub PR with labels, milestone, and a clear description.
 
 ## What Comes Next
 
-- Previous completed PR sub-slice: `M20-P5.2`
-- Current planned slice: `M20 no-diff pr-summary human output polish (#162)`
-- Current PR sub-slice: `M20-P5.3`
+- Previous completed PR sub-slice: `M20-P5.3`
+- Current planned slice: `M20 mutation JSON compatibility contract cleanup (#163)`
+- Current PR sub-slice: `M20-P5.4`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 mutation JSON compatibility contract cleanup (#163)`
-- Next planned PR sub-slice: `M20-P5.4`
+- Next planned slice: `M20 next-track selection pending`
+- Next planned PR sub-slice: `TBD`
 
 These planning-state lines are for contributors and agents. The detailed roadmap lives in
 [docs/splendor_mvp_to_v1_roadmap.md](docs/splendor_mvp_to_v1_roadmap.md).

--- a/docs/releases/v0_5_2_release_notes.md
+++ b/docs/releases/v0_5_2_release_notes.md
@@ -22,6 +22,16 @@ This release packages the M20 current-work handoff ranking fix on top of `v0.5.1
   worker, mandatory external API, web workflow, database, or persisted index state.
 - The M20 mutating web review workflow work remains proposal-only and read-only in this release.
 
+## Compatibility Notes
+
+- `splendor queue clean --orphaned|--superseded|--completed --json` treats
+  `mutation.{mode,mutates,planned,written}` as the canonical cross-verb mutation contract.
+  `selectors` and `actions` remain queue-clean-specific payloads.
+- The legacy top-level queue-clean aliases `applied`, `summary`, `written`, and `skipped` remain
+  emitted for v0.5.x compatibility only. They are deprecated and planned for removal in v0.6.0;
+  consumers should migrate to `mutation` plus `actions`. `applied` records apply mode; it is not
+  equivalent to `mutation.mutates` for no-op apply runs.
+
 ## Trial Focus
 
 The intended retry question is narrow:

--- a/docs/schema_contracts.md
+++ b/docs/schema_contracts.md
@@ -219,7 +219,14 @@ Implemented fields:
   `done` queue records. JSON output includes `mutation.mode`, `mutation.mutates`,
   `mutation.planned`, and `mutation.written`; skipped records report invalid payloads, unsupported
   job types, active leases, queue filename/job ID mismatches, and source/job mismatches without
-  deleting them.
+  deleting them. For queue-clean JSON, `mutation.{mode,mutates,planned,written}` is the canonical
+  cross-verb mutation contract. `selectors` and `actions` are verb-specific queue-clean payloads
+  and remain supported. The legacy top-level `applied`, `summary`, `written`, and `skipped` fields
+  are deprecated v0.5.x compatibility aliases; consumers should move to `mutation` for mutation
+  state and `actions` for queue-clean action detail before the planned v0.6.0 alias removal.
+  `applied` describes whether the command ran in apply mode, while `mutation.mutates` describes
+  whether workspace state actually changed, so apply-mode no-ops can report `applied: true` and
+  `mutation.mutates: false`.
 - `splendor source reconcile <source-id|logical-id|title|path>` previews duplicate active source
   version repair for one canonical source-ref group. Without `--current`, an exact source ID keeps
   that source active; otherwise the latest active version by `(added_at, source_id)` is selected.
@@ -303,6 +310,10 @@ Implemented fields:
   deterministic planned write/delete records for preview mode, and `mutation.written` lists
   deterministic write/delete records for apply or direct-write mode. Records include `action`,
   `path`, `kind`, and `source_id` when source-scoped.
+- `queue clean --json` retains the older top-level aliases through the v0.5.x line for compatibility
+  only: `applied`, `summary`, `written`, and `skipped` duplicate or overlap data now represented by
+  canonical `mutation` state and verb-specific `actions`. New consumers should not treat those
+  aliases as a second mutation contract; they are scheduled for removal in v0.6.0.
 - `M19-P5.1` closes the V04-F1 contract debt for legacy mutating workflow commands:
   `ingest --pending`, `source refresh`, `source update-path`, and `workspace refresh` are
   preview-first surfaces with explicit `--apply`, deterministic mutation objects, and human output

--- a/docs/splendor_mvp_to_v1_roadmap.md
+++ b/docs/splendor_mvp_to_v1_roadmap.md
@@ -334,12 +334,12 @@ source-summary pages, structured source/page/run provenance in ingest artifacts,
 annotations plus linked review tasks for explicit conflicts, richer query metadata, and
 deterministic lint/health validation for those cross-links.
 
-- Previous completed PR sub-slice: `M20-P5.2`
-- Current planned slice: `M20 no-diff pr-summary human output polish (#162)`
-- Current PR sub-slice: `M20-P5.3`
+- Previous completed PR sub-slice: `M20-P5.3`
+- Current planned slice: `M20 mutation JSON compatibility contract cleanup (#163)`
+- Current PR sub-slice: `M20-P5.4`
 - Current PR lifecycle: `branch=in-progress; main=merged`
-- Next planned slice: `M20 mutation JSON compatibility contract cleanup (#163)`
-- Next planned PR sub-slice: `M20-P5.4`
+- Next planned slice: `M20 next-track selection pending`
+- Next planned PR sub-slice: `TBD`
 
 `M10-P0.1`, `M10-P0.2`, `M10-P0.3`, and `M9-P2.1` are implemented. The completed M13-P2 sequence
 responds to issue #70 by making source discovery safe, keeping source manifests curated, and
@@ -1396,6 +1396,14 @@ the selected M20 implementation.
   remain visible under narrow goal phrasing (#160).
 - `M20-P5.3` Make no-diff `pr-summary --since <ref>` human output loud and compact (#162).
 - `M20-P5.4` Clarify the canonical mutation JSON contract and legacy queue-clean aliases (#163).
+
+`M20-P5.4` closes the v0.5 SynthBanshee mutation-JSON compatibility finding without breaking the
+v0.5.x command surface. It documents and tests `mutation.{mode,mutates,planned,written}` as the
+single canonical cross-verb mutation contract for `queue clean --json`, keeps `selectors` and
+`actions` as supported queue-clean-specific payloads, and marks the redundant top-level
+`applied`, `summary`, `written`, and `skipped` fields as deprecated v0.5.x aliases planned for
+v0.6.0 removal. The regression coverage explicitly preserves the apply-mode no-op distinction:
+legacy `applied` can be true while canonical `mutation.mutates` remains false.
 
 `M20-P1.1` starts the retrieval product bet without crossing into heavyweight infrastructure. The
 first slice adds deterministic runtime acronym phrase expansion to `splendor query` and the

--- a/docs/splendor_product_spec.md
+++ b/docs/splendor_product_spec.md
@@ -951,7 +951,12 @@ Current implementation:
   `ingest --pending`, `source forget`, `source reconcile`, `source refresh`,
   `source update-path`, `workspace refresh`, and `queue clean` JSON include `mutation.mode`,
   `mutation.mutates`, `mutation.planned`, and `mutation.written`; human output labels preview mode
-  as non-mutating and apply/direct mode as writing workspace state.
+  as non-mutating and apply/direct mode as writing workspace state. Queue-clean JSON keeps
+  `selectors` and `actions` as verb-specific payloads. Its legacy top-level `applied`, `summary`,
+  `written`, and `skipped` fields are deprecated v0.5.x compatibility aliases, not a second
+  mutation contract; consumers should use `mutation` for cross-verb mutation state before those
+  aliases are removed in v0.6.0. `applied` is an apply-mode signal and can be true for no-op apply
+  runs where `mutation.mutates` is false.
 - `M19-P5.1` harmonizes the legacy V04-F1 direct-write surfaces named by external reviewers:
   `ingest --pending`, `source refresh`, `source update-path`, and `workspace refresh` are
   preview-first and require explicit `--apply` for state-changing workflow maintenance.

--- a/src/splendor/commands/queue.py
+++ b/src/splendor/commands/queue.py
@@ -268,6 +268,8 @@ def render_queue_retry_json(result: QueueRetryResult) -> str:
 def render_queue_clean_json(root: Path, result: QueueCleanResult) -> str:
     mutation_records = _queue_clean_mutation_records(root, result.actions)
     written_records = _queue_clean_mutation_records(root, result.written)
+    # Queue-clean JSON keeps these legacy top-level aliases through v0.5.x for
+    # compatibility. The cross-verb mutation contract below is canonical.
     return json.dumps(
         {
             "applied": result.applied,

--- a/tests/test_queue_commands.py
+++ b/tests/test_queue_commands.py
@@ -9,7 +9,13 @@ from splendor.cli import main
 from splendor.commands.add_source import add_source
 from splendor.commands.ingest import enqueue_ingest_job
 from splendor.commands.init import initialize_workspace
-from splendor.commands.queue import clean_queue, inspect_queue, inspect_queue_job, retry_queue_job
+from splendor.commands.queue import (
+    clean_queue,
+    inspect_queue,
+    inspect_queue_job,
+    render_queue_clean_json,
+    retry_queue_job,
+)
 from splendor.schemas import QueueItemRecord
 from splendor.state.runtime import load_queue_item, write_queue_item
 from splendor.state.source_registry import load_source_record
@@ -229,6 +235,79 @@ def test_queue_clean_previews_and_applies_orphaned_queue_records(tmp_path: Path)
 
     assert applied.applied is True
     assert not queue_path.exists()
+
+
+def test_queue_clean_json_marks_mutation_as_canonical_with_deprecated_aliases(
+    tmp_path: Path,
+) -> None:
+    initialize_workspace(tmp_path)
+    source = tmp_path / "brief.md"
+    source.write_text("# Brief\n\nhello\n", encoding="utf-8")
+    added = add_source(tmp_path, source)
+    queue_path = enqueue_ingest_job(tmp_path, added.source_id)
+    added.manifest_path.unlink()
+
+    preview = json.loads(render_queue_clean_json(tmp_path, clean_queue(tmp_path, orphaned=True)))
+
+    assert preview["selectors"] == ["orphaned"]
+    assert preview["actions"][0]["status"] == "planned"
+    assert preview["mutation"] == {
+        "mode": "preview",
+        "mutates": False,
+        "planned": [
+            {
+                "action": "delete",
+                "path": f"state/queue/ingest-{added.source_id}.json",
+                "kind": "queue_record",
+                "source_id": added.source_id,
+            }
+        ],
+        "written": [],
+    }
+    assert preview["applied"] is False
+    assert preview["mutation"]["mutates"] is False
+    assert preview["summary"]["planned"] == len(preview["mutation"]["planned"])
+    assert preview["summary"]["written"] == len(preview["mutation"]["written"])
+    assert preview["written"] == []
+    assert preview["skipped"] == []
+    assert queue_path.exists()
+
+    applied = json.loads(
+        render_queue_clean_json(tmp_path, clean_queue(tmp_path, orphaned=True, apply=True))
+    )
+
+    assert applied["mutation"] == {
+        "mode": "apply",
+        "mutates": True,
+        "planned": [],
+        "written": [
+            {
+                "action": "delete",
+                "path": f"state/queue/ingest-{added.source_id}.json",
+                "kind": "queue_record",
+                "source_id": added.source_id,
+            }
+        ],
+    }
+    assert applied["applied"] is True
+    assert applied["mutation"]["mutates"] is True
+    assert applied["summary"]["planned"] == 1
+    assert applied["summary"]["written"] == len(applied["mutation"]["written"])
+    assert [item["path"] for item in applied["written"]] == [
+        f"state/queue/ingest-{added.source_id}.json"
+    ]
+
+    no_op_apply = json.loads(
+        render_queue_clean_json(tmp_path, clean_queue(tmp_path, orphaned=True, apply=True))
+    )
+    assert no_op_apply["applied"] is True
+    assert no_op_apply["mutation"] == {
+        "mode": "apply",
+        "mutates": False,
+        "planned": [],
+        "written": [],
+    }
+    assert no_op_apply["summary"] == {"planned": 0, "written": 0, "skipped": 0}
 
 
 def test_queue_clean_selects_superseded_and_completed_records(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #163.

This PR resolves `M20-P5.4` by making the queue-clean mutation JSON contract explicit without breaking the v0.5.x compatibility surface:

- documents `mutation.{mode,mutates,planned,written}` as the canonical cross-verb mutation contract for `queue clean --json`
- keeps `selectors` and `actions` as supported queue-clean-specific payloads
- marks legacy top-level `applied`, `summary`, `written`, and `skipped` as deprecated v0.5.x compatibility aliases planned for removal in v0.6.0
- adds regression coverage proving the canonical-vs-compatibility split for preview, apply-with-writes, and apply-no-op output
- rolls planning state forward from `M20-P5.3` to `M20-P5.4`, with next-track selection pending

## Self-review

Prompt used: "Review the PR yourself, and take an outsider's view: Pretend you're a senior dev and you really don't like the way this PR is implemented; be brutally honest, and aim to make this PR much better with you feedback."

Finding: the first regression accidentally implied that legacy `applied` and canonical `mutation.mutates` are equivalent. That is wrong for apply-mode no-ops, where the command did run in apply mode but did not write or delete anything.

Recommended action/fix: make the docs and test distinguish legacy apply-mode compatibility from canonical mutation semantics. `applied` should be documented as deprecated command-mode compatibility only; `mutation.mutates` should remain the actual-write signal. Add regression coverage for an apply-mode no-op where `applied: true` and `mutation.mutates: false` coexist.

Fix applied: updated the docs/release-note/roadmap language and added the no-op apply assertion to the queue-clean JSON contract regression.

## Validation

- `uv run pytest tests/test_queue_commands.py -q` (`34 passed`)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run splendor lint`
- `uv run pytest` (`767 passed`)

## Follow-up

After this PR, the M20-P5 residual polish queue is exhausted. The next slice should be a small planning/selection slice for the next track.
